### PR TITLE
Configurable Route Tokens Support for OIDC Server Controllers

### DIFF
--- a/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -20,17 +20,17 @@
     <PackageReleaseNotes>For detailed release notes, visit: https://github.com/Abblix/Oidc.Server/releases</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
-    <PackageVersion>1.3.1.0</PackageVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <PackageVersion>1.4.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
@@ -129,6 +129,13 @@ public static class ServiceCollectionExtensions
         return services.Replace(decoratorDescriptor);
     }
 
+    /// <summary>
+    /// Appends an element to the end of the array.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the array.</typeparam>
+    /// <param name="source">The source array.</param>
+    /// <param name="element">The element to append.</param>
+    /// <returns>A new array with the appended element, or a resized array if the source had elements.</returns>
     private static T[] Append<T>(this T[] source, T element)
     {
         switch (source)
@@ -143,6 +150,15 @@ public static class ServiceCollectionExtensions
         }
     }
 
+    /// <summary>
+    /// Retrieves the registered <see cref="ServiceDescriptor"/> for a given interface type.
+    /// </summary>
+    /// <typeparam name="TInterface">The service interface type.</typeparam>
+    /// <param name="services">The service collection to query.</param>
+    /// <returns>The matching <see cref="ServiceDescriptor"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the service is not registered in the collection.
+    /// </exception>
     private static ServiceDescriptor GetDescriptor<TInterface>(this IServiceCollection services)
         where TInterface : class
     {
@@ -150,6 +166,18 @@ public static class ServiceCollectionExtensions
                ?? throw new InvalidOperationException($"{typeof(TInterface).Name} is not registered");
     }
 
+    /// <summary>
+    /// Resolves or creates an instance from a <see cref="ServiceDescriptor"/> using the specified service provider.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider to resolve dependencies from.</param>
+    /// <param name="descriptor">The service descriptor to use.</param>
+    /// <returns>An instance of the service described by the descriptor.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the descriptor does not contain a valid instance, factory, or type.
+    /// </exception>
+    /// <remarks>
+    /// Helps simulate or replicate DI container behavior for specific descriptors.
+    /// </remarks>
     private static object CreateService(this IServiceProvider serviceProvider, ServiceDescriptor descriptor)
     {
         return descriptor switch
@@ -161,11 +189,32 @@ public static class ServiceCollectionExtensions
         };
     }
 
+    /// <summary>
+    /// Creates an instance of the specified service type <typeparamref name="T"/> using the provided dependencies.
+    /// </summary>
+    /// <typeparam name="T">The type of service to create.</typeparam>
+    /// <param name="serviceProvider">The service provider to resolve required services from.</param>
+    /// <param name="dependencies">A list of explicitly provided dependencies.</param>
+    /// <returns>An instance of type <typeparamref name="T"/>.</returns>
+    /// <remarks>
+    /// This overload simplifies strongly typed creation of services with custom dependency injection.
+    /// </remarks>
     public static T CreateService<T>(this IServiceProvider serviceProvider, params Dependency[] dependencies)
     {
         return (T)serviceProvider.CreateService(typeof(T), dependencies);
     }
 
+    /// <summary>
+    /// Creates an instance of the specified type using the provided dependencies.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider to resolve required services from.</param>
+    /// <param name="type">The type of service to create.</param>
+    /// <param name="dependencies">A list of explicitly provided dependencies.</param>
+    /// <returns>An instance of the specified <paramref name="type"/>.</returns>
+    /// <remarks>
+    /// This method allows partial control over dependency injection by mixing resolved and custom parameters.
+    /// Useful in plugin scenarios, factory setups, or advanced test setups.
+    /// </remarks>
     public static object CreateService(this IServiceProvider serviceProvider,
         Type type, params Dependency[] dependencies)
     {
@@ -208,7 +257,8 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="T">The type of the service to add.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
-    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies required by the service.</param>
+    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies
+    /// required by the service.</param>
     /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddScoped<T>(this IServiceCollection services, params Dependency[] dependencies)
         where T : class
@@ -224,7 +274,8 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TService">The type of the service to add.</typeparam>
     /// <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
-    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies required by the service.</param>
+    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies
+    /// required by the service.</param>
     /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddScoped<TService, TImplementation>(this IServiceCollection services,
         params Dependency[] dependencies)
@@ -240,7 +291,8 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="T">The type of the service to add.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
-    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies required by the service.</param>
+    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies
+    /// required by the service.</param>
     /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddSingleton<T>(this IServiceCollection services, params Dependency[] dependencies)
         where T : class
@@ -255,7 +307,8 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TService">The type of the service to add.</typeparam>
     /// <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
-    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies required by the service.</param>
+    /// <param name="dependencies">An array of <see cref="Dependency"/> objects representing additional dependencies
+    /// required by the service.</param>
     /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
 
     public static IServiceCollection AddSingleton<TService, TImplementation>(this IServiceCollection services,
@@ -265,4 +318,89 @@ public static class ServiceCollectionExtensions
     {
         return services.AddSingleton<TService, TImplementation>(sp => sp.CreateService<TImplementation>(dependencies));
     }
+
+
+    /// <summary>
+    /// Changes the lifetime of a registered service of type <typeparamref name="T"/>
+    /// to the specified <paramref name="lifetime"/>.
+    /// </summary>
+    /// <typeparam name="T">The service type whose lifetime is to be changed.</typeparam>
+    /// <param name="services">The service collection to operate on.</param>
+    /// <param name="lifetime">The new <see cref="ServiceLifetime"/> to apply.</param>
+    /// <returns>The modified <see cref="IServiceCollection"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the service descriptor for <typeparamref name="T"/> has an unexpected format.
+    /// </exception>
+    /// <remarks>
+    /// Useful when you need to override the lifetime of an existing registration (e.g., from Singleton to Scoped).
+    /// </remarks>
+    public static IServiceCollection ChangeLifetime<T>(this IServiceCollection services, ServiceLifetime lifetime)
+    {
+        var serviceType = typeof(T);
+
+        var serviceDescriptor = services.FindRequired<T>() switch
+        {
+            { ImplementationFactory: { } factory }
+                => ServiceDescriptor.Describe(serviceType, factory, lifetime),
+
+            { ImplementationType: { } implementationType }
+                => ServiceDescriptor.Describe(serviceType, implementationType, lifetime),
+
+            _ => throw new InvalidOperationException($"The unexpected service descriptor for type {serviceType}"),
+        };
+
+        services.Replace(serviceDescriptor);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Removes all registrations of type <typeparamref name="T"/> from the service collection.
+    /// </summary>
+    /// <typeparam name="T">The service type to remove.</typeparam>
+    /// <param name="services">The service collection to operate on.</param>
+    /// <returns>
+    /// <c>true</c> if any descriptors were removed; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// Can be used to clean up pre-registered services before adding custom implementations.
+    /// </remarks>
+    public static ServiceDescriptor[] RemoveAll<T>(this IServiceCollection services)
+    {
+        var serviceDescriptors = services.FindAll<T>().ToArray();
+        Array.ForEach(serviceDescriptors, serviceDescriptor => services.Remove(serviceDescriptor));
+        return serviceDescriptors;
+    }
+
+    /// <summary>
+    /// Finds the first registered service descriptor for type <typeparamref name="T"/>.
+    /// Throws if no descriptor is found.
+    /// </summary>
+    /// <typeparam name="T">The service type to locate.</typeparam>
+    /// <param name="services">The service collection to search.</param>
+    /// <returns>The matching <see cref="ServiceDescriptor"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if no descriptor is found for the specified type.
+    /// </exception>
+    public static ServiceDescriptor FindRequired<T>(this IServiceCollection services)
+        => services.Find<T>() ?? throw new InvalidOperationException($"A service descriptor was not found for type {typeof(T)}");
+
+    /// <summary>
+    /// Finds the first registered service descriptor for type <typeparamref name="T"/>,
+    /// or returns <c>null</c> if none exists.
+    /// </summary>
+    /// <typeparam name="T">The service type to locate.</typeparam>
+    /// <param name="services">The service collection to search.</param>
+    /// <returns>The matching <see cref="ServiceDescriptor"/>, or <c>null</c> if not found.</returns>
+    public static ServiceDescriptor? Find<T>(this IServiceCollection services)
+        => services.SingleOrDefault(s => s.ServiceType == typeof(T));
+
+    /// <summary>
+    /// Finds all registered service descriptors for type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The service type to locate.</typeparam>
+    /// <param name="services">The service collection to search.</param>
+    /// <returns>An <see cref="IEnumerable{T}"/> of matching <see cref="ServiceDescriptor"/> instances.</returns>
+    public static IEnumerable<ServiceDescriptor> FindAll<T>(this IServiceCollection services)
+        => services.Where(s => s.ServiceType == typeof(T));
 }

--- a/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/Abblix.Jwt/Abblix.Jwt.csproj
@@ -20,17 +20,17 @@
     <PackageReleaseNotes>For detailed release notes, visit: https://github.com/Abblix/Oidc.Server/releases</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
-    <PackageVersion>1.3.1.0</PackageVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <PackageVersion>1.4.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -21,9 +21,9 @@
         <PackageReleaseNotes>For detailed release notes, visit: https://github.com/Abblix/Oidc.Server/releases</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <AssemblyVersion>1.3.1.0</AssemblyVersion>
-        <FileVersion>1.3.1.0</FileVersion>
-        <PackageVersion>1.3.1.0</PackageVersion>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+        <FileVersion>1.4.0.0</FileVersion>
+        <PackageVersion>1.4.0.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
@@ -50,7 +50,7 @@ public class TokenController : ControllerBase
     /// </summary>
     /// <param name="handler">The service responsible for handling token issuance logic.</param>
     /// <param name="formatter">The service tasked with formatting the token issuance response.</param>
-    /// <param name="tokenRequest">Details of the token request, including grant type and required parameters.</param>
+    /// <param name="tokenRequest">Details of the token request, including a grant type and required parameters.</param>
     /// <param name="clientRequest">Contextual information about the client making the request.</param>
     /// <returns>A task that results in an action containing the token response, formatted as per OIDC specifications.
     /// </returns>
@@ -84,7 +84,8 @@ public class TokenController : ControllerBase
     /// <param name="handler">The service responsible for processing token revocation requests.</param>
     /// <param name="formatter">The service responsible for formatting the revocation response.</param>
     /// <param name="revocationRequest">Details of the revocation request, including the token to be revoked.</param>
-    /// <param name="clientRequest">Additional contextual information about the client making the revocation request.</param>
+    /// <param name="clientRequest">Additional contextual information about the client making the revocation request.
+    /// </param>
     /// <returns>A task that results in an action indicating the outcome of the revocation process.</returns>
     /// <remarks>
     /// Adheres to the OAuth 2.0 Token Revocation standard, allowing clients to manage the lifecycle of their tokens
@@ -120,8 +121,8 @@ public class TokenController : ControllerBase
     /// <returns>A task that results in an action providing detailed information about the state of the queried token.
     /// </returns>
     /// <remarks>
-    /// Implements the OAuth 2.0 Token Introspection specification, allowing clients to verify the status of tokens in
-    /// a secure manner.
+    /// Implements the OAuth 2.0 Token Introspection specification, allowing clients to verify the status of tokens
+    /// securely.
     /// <see href="https://www.rfc-editor.org/rfc/rfc7662#section-2">OAuth 2.0 Token Introspection Documentation</see>
     /// </remarks>
     [HttpPost(Path.Introspection)]

--- a/Abblix.Oidc.Server.Mvc/Features/ConfigurableRoutes/ConfigurableRouteConvention.cs
+++ b/Abblix.Oidc.Server.Mvc/Features/ConfigurableRoutes/ConfigurableRouteConvention.cs
@@ -1,0 +1,123 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+// 
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+// 
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+// 
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+// 
+// For full licensing terms, please visit:
+// 
+// https://oidc.abblix.com/license
+// 
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.Extensions.Configuration;
+
+namespace Abblix.Oidc.Server.Mvc.Features.ConfigurableRoutes;
+
+/// <summary>
+/// A convention that resolves tokenized route templates using configuration values,
+/// supporting fallback values with the syntax: [route:TokenName??FallbackValue].
+/// </summary>
+public class ConfigurableRouteConvention : IApplicationModelConvention
+{
+    private const string TokenGroup = "token";
+    private const string FallbackGroup = "fallback";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurableRouteConvention"/> class.
+    /// </summary>
+    /// <param name="prefix">The token prefix to recognize in route templates. Defaults to "route".</param>
+    /// <param name="configSection">The configuration section to use for token resolution.</param>
+    /// <remarks>
+    /// Tokens must follow the format: [route:MyToken] or [route:MyToken?FallbackValue].
+    /// </remarks>
+    public ConfigurableRouteConvention(string prefix = "route", IConfigurationSection? configSection = null)
+    {
+        _configSection = configSection;
+        _routeRegex = new Regex(
+            $@"\[{prefix}:(?<{TokenGroup}>\w+)(\?(?<{FallbackGroup}>[^\]]+))?\]",
+            RegexOptions.Compiled);
+    }
+
+    private readonly IConfigurationSection? _configSection;
+    private readonly Regex _routeRegex;
+
+    /// <summary>
+    /// Applies the route token resolution to all controllers and actions in the application model.
+    /// </summary>
+    /// <param name="application">The application model to apply the convention to.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if a route token is not found in the configuration.
+    /// </exception>
+    public void Apply(ApplicationModel application)
+    {
+        foreach (var controller in application.Controllers)
+        foreach (var action in controller.Actions)
+        foreach (var selector in action.Selectors)
+        {
+            Apply(selector);
+        }
+    }
+
+    /// <summary>
+    /// Applies token replacement to a single selector's route template.
+    /// </summary>
+    /// <param name="selector">The <see cref="SelectorModel"/> whose route template may contain tokens.</param>
+    private void Apply(SelectorModel selector)
+    {
+        var model = selector.AttributeRouteModel;
+        if (!string.IsNullOrEmpty(model?.Template))
+            model.Template = Resolve(model.Template);
+    }
+
+    /// <summary>
+    /// Replaces all recognized route tokens in the format [route:TokenName?Fallback] with their resolved values.
+    /// </summary>
+    /// <param name="template">The original template string.</param>
+    /// <returns>The resolved route template string.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if a token cannot be resolved and no fallback is provided.
+    /// </exception>
+    private string Resolve(string template)
+    {
+        bool replaced;
+        do
+        {
+            replaced = false;
+
+            template = _routeRegex.Replace(
+                template,
+                match =>
+                {
+                    replaced = true;
+
+                    var token = match.Groups[TokenGroup].Value;
+
+                    var resolvedPath = _configSection?.GetValue<string>(token);
+                    if (resolvedPath != null)
+                        return resolvedPath;
+
+                    var fallbackGroup = match.Groups[FallbackGroup];
+                    if (fallbackGroup.Success)
+                        return fallbackGroup.Value;
+
+                    throw new InvalidOperationException($"Can't resolve the route {token}");
+                });
+
+        } while (replaced);
+
+        return template;
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/Features/ConfigurableRoutes/ConfigurableRoutesExtensions.cs
+++ b/Abblix.Oidc.Server.Mvc/Features/ConfigurableRoutes/ConfigurableRoutesExtensions.cs
@@ -1,0 +1,103 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Abblix.Oidc.Server.Mvc.Features.ConfigurableRoutes;
+
+/// <summary>
+/// Provides extension methods for enabling support for tokenized route templates like
+/// <c>[route:MyToken?Fallback]</c> in ASP.NET Core controllers.
+/// </summary>
+public static class ConfigurableRoutesExtensions
+{
+    /// <summary>
+    /// Enables the resolution of route tokens such as <c>[route:MyToken?Fallback]</c> using values from the specified
+    /// configuration section.
+    /// </summary>
+    /// <param name="services">The service collection to register services with.</param>
+    /// <param name="configSection">The configuration section that contains token-to-value mappings.</param>
+    /// <param name="prefix">
+    /// The token prefix used in route templates. Defaults to <c>"route"</c>, which supports templates like
+    /// <c>[route:MyToken?Fallback]</c>.
+    /// </param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance to support method chaining.</returns>
+    /// <remarks>
+    /// This method allows route templates in controllers to include tokens that are dynamically resolved
+    /// at application startup using values from configuration. If a token is not found, an optional fallback
+    /// value can be specified using the <c>?</c> delimiter.
+    ///
+    /// Example:
+    /// <code>
+    /// [Route("[route:ApiPrefix?v1]/users")]
+    /// public class UsersController : ControllerBase { ... }
+    /// </code>
+    ///
+    /// With configuration:
+    /// <code>
+    /// "Routes": {
+    ///   "ApiPrefix": "v2"
+    /// }
+    /// </code>
+    /// The resulting route will be <c>v2/users</c>. If "ApiPrefix" is not configured, it falls back to <c>v1</c>.
+    /// </remarks>
+    public static IServiceCollection ConfigureRoutes(
+        this IServiceCollection services,
+        IConfigurationSection configSection,
+        string prefix = Path.RoutePrefix)
+    {
+        services.Configure<MvcOptions>(options =>
+        {
+            options.Conventions.Add(new ConfigurableRouteConvention(prefix, configSection));
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a fallback-only route token resolution convention that uses only the fallback values
+    /// specified in templates like <c>[route:MyToken?Fallback]</c>, ignoring configuration.
+    /// </summary>
+    /// <param name="services">The service collection to register services with.</param>
+    /// <param name="prefix">
+    /// The token prefix used in route templates. Defaults to <c>"route"</c>, which supports templates like
+    /// <c>[route:MyToken?Fallback]</c>.
+    /// </param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance to support method chaining.</returns>
+    /// <remarks>
+    /// This method ensures that route tokens are resolved to fallback values even if the consumer
+    /// of the component does not explicitly provide a configuration section.
+    /// </remarks>
+    public static IServiceCollection ConfigureRoutesFallback(
+        this IServiceCollection services,
+        string prefix = Path.RoutePrefix)
+    {
+        services.PostConfigure<MvcOptions>(options =>
+        {
+            options.Conventions.Add(new ConfigurableRouteConvention(prefix));
+        });
+
+        return services;
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/Features/EndpointResolving/EndpointResolver.cs
+++ b/Abblix.Oidc.Server.Mvc/Features/EndpointResolving/EndpointResolver.cs
@@ -1,0 +1,122 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
+
+/// <summary>
+/// Resolves a fully qualified URI for a specific controller and action based on ASP.NET Core's endpoint routing.
+/// </summary>
+public class EndpointResolver : IEndpointResolver
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EndpointResolver"/> class.
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="endpointDataSource">
+    /// The endpoint data source that provides access to all configured route endpoints in the application.
+    /// </param>
+    /// <param name="httpContextAccessor">
+    /// The HTTP context accessor used to determine the base URL of the current request.
+    /// </param>
+    public EndpointResolver(
+        ILogger<EndpointResolver> logger,
+        EndpointDataSource endpointDataSource,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        _logger = logger;
+        _endpointDataSource = endpointDataSource;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    private readonly ILogger _logger;
+    private readonly EndpointDataSource _endpointDataSource;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    /// <summary>
+    /// Resolves the absolute URI for a given controller and action based on the configured routes.
+    /// </summary>
+    /// <param name="controllerName">The name of the controller (without the "Controller" suffix).</param>
+    /// <param name="actionName">The name of the action method.</param>
+    /// <returns>
+    /// A <see cref="Uri"/> representing the absolute route to the specified controller and action,
+    /// or <c>null</c> if no matching route was found.
+    /// </returns>
+    /// <remarks>
+    /// This method matches endpoints based on <see cref="ControllerActionDescriptor"/> metadata.
+    /// The resulting URI is based on the route pattern's raw template and the base URL from the current request context.
+    /// </remarks>
+    public Uri? Resolve(string controllerName, string actionName)
+    {
+        var endpoint = _endpointDataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .FirstOrDefault(e =>
+            {
+                var descriptor = e.Metadata.GetMetadata<ControllerActionDescriptor>();
+                if (descriptor == null)
+                    return false;
+
+                _logger.LogDebug("Controller: {ControllerName}, Action: {ActionName}", descriptor.ControllerName, descriptor.ActionName);
+
+                return string.Equals(descriptor.ControllerName, controllerName, StringComparison.OrdinalIgnoreCase) &&
+                       string.Equals(descriptor.ActionName, actionName, StringComparison.OrdinalIgnoreCase);
+            });
+
+        var actionUri = endpoint?.RoutePattern.RawText;
+        if (string.IsNullOrEmpty(actionUri))
+            return null;
+
+        var httpContext = _httpContextAccessor.HttpContext;
+        return MakeAbsoluteUri(httpContext.NotNull(nameof(httpContext)).Request, actionUri);
+    }
+
+    /// <summary>
+    /// Converts a relative route template into an absolute URI using the base URL from the given
+    /// <see cref="HttpRequest"/>.
+    /// </summary>
+    /// <param name="httpRequest">The HTTP request used to determine the application's base URL.</param>
+    /// <param name="template">
+    /// The route template to resolve. If it starts with <c>"~/"</c>, it is treated as application-relative.
+    /// Otherwise, it is resolved as a relative path from the root.
+    /// </param>
+    /// <returns>
+    /// A fully qualified <see cref="Uri"/> representing the resolved absolute URL,
+    /// or <c>null</c> if the input template is invalid.
+    /// </returns>
+    /// <remarks>
+    /// This method uses <c>~/</c> as an indicator of application-relative paths (e.g., <c>~/dashboard</c>),
+    /// and resolves them accordingly.
+    /// </remarks>
+    private static Uri MakeAbsoluteUri(HttpRequest httpRequest, string template)
+    {
+        var appUrl = httpRequest.GetAppUrl();
+
+        return template.StartsWith("~/")
+            ? new Uri(appUrl + template[1..], UriKind.Absolute)
+            : new Uri(new Uri(appUrl, UriKind.Absolute), template);
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/Features/EndpointResolving/IEndpointResolver.cs
+++ b/Abblix.Oidc.Server.Mvc/Features/EndpointResolving/IEndpointResolver.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 // 
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -20,15 +20,22 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-namespace Abblix.Oidc.Server.Common.Configuration;
+namespace Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
 
 /// <summary>
-/// Defines discovery endpoint options.
+/// Defines a service that resolves the absolute URI for a specific controller action
+/// based on the application's endpoint routing configuration.
 /// </summary>
-public class DiscoveryOptions
+public interface IEndpointResolver
 {
-	/// <summary>
-	/// Allows exposing exact paths to OIDC endpoints via discovery manifest.
-	/// </summary>
-	public bool AllowEndpointPathsDiscovery { get; set; } = true;
+    /// <summary>
+    /// Resolves the absolute URI for a given controller and action name.
+    /// </summary>
+    /// <param name="controllerName">The name of the controller (without the "Controller" suffix).</param>
+    /// <param name="actionName">The name of the action method.</param>
+    /// <returns>
+    /// A <see cref="Uri"/> representing the full route to the specified controller action,
+    /// or <c>null</c> if no matching route was found.
+    /// </returns>
+    Uri? Resolve(string controllerName, string actionName);
 }

--- a/Abblix.Oidc.Server.Mvc/Model/BackChannelAuthenticationRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/BackChannelAuthenticationRequest.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Mvc.Binders;
 using Microsoft.AspNetCore.Mvc;
 using Core = Abblix.Oidc.Server.Model;

--- a/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
@@ -20,10 +20,8 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using Abblix.Jwt;
-using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.DeclarativeValidation;
 using Abblix.Oidc.Server.Mvc.Binders;

--- a/Abblix.Oidc.Server.Mvc/MvcUtils.cs
+++ b/Abblix.Oidc.Server.Mvc/MvcUtils.cs
@@ -73,13 +73,7 @@ public static class MvcUtils
 	public static string TrimAsync(string action)
 	{
 		const string asyncSuffix = "Async";
-		if (!action.EndsWith(asyncSuffix))
-		{
-			throw new InvalidOperationException(
-				$"Naming convention is broken, because the name of the action {action} must end with {asyncSuffix}");
-		}
-
-		return action[..^asyncSuffix.Length];
+		return action.EndsWith(asyncSuffix) ? action[..^asyncSuffix.Length] : action;
 	}
 
 	private static readonly RequiredAttribute RequiredAttribute = new();

--- a/Abblix.Oidc.Server.Mvc/Path.cs
+++ b/Abblix.Oidc.Server.Mvc/Path.cs
@@ -28,70 +28,74 @@ namespace Abblix.Oidc.Server.Mvc;
 /// </summary>
 public static class Path
 {
-    private const string Base = "~/connect";
+    internal const string RoutePrefix = "route";
+    
+    private const string Base = "[" + RoutePrefix + ":base?~/connect]";
 
     /// <summary>
     /// Path for the authorization endpoint.
     /// </summary>
-    public const string Authorize = Base + "/authorize";
+    public const string Authorize = "[" + RoutePrefix + ":authorize?" + Base + "/authorize]";
 
     /// <summary>
     /// Path for the pushed authorization request (PAR) endpoint.
     /// </summary>
-    public const string PushAuthorizationRequest = Base + "/par";
+    public const string PushAuthorizationRequest = "[" + RoutePrefix + ":par?" + Base + "/par]";
 
     /// <summary>
     /// Path for the user information endpoint.
     /// </summary>
-    public const string UserInfo = Base + "/userinfo";
+    public const string UserInfo = "[" + RoutePrefix + ":userinfo?" + Base + "/userinfo]";
 
     /// <summary>
     /// Path for the end session endpoint.
     /// </summary>
-    public const string EndSession = Base + "/endsession";
+    public const string EndSession = "[" + RoutePrefix + ":endsession?" + Base + "/endsession]";
 
     /// <summary>
     /// Path for the session checking endpoint.
     /// </summary>
-    public const string CheckSession = Base + "/checksession";
+    public const string CheckSession = "[" + RoutePrefix + ":checksession?" + Base + "/checksession]";
 
     /// <summary>
     /// Path for the token endpoint.
     /// </summary>
-    public const string Token = Base + "/token";
+    public const string Token = "[" + RoutePrefix + ":token?" + Base + "/token]";
 
     /// <summary>
     /// Path for the token revocation endpoint.
     /// </summary>
-    public const string Revocation = Base + "/revoke";
+    public const string Revocation = "[" + RoutePrefix + ":revoke?" + Base + "/revoke]";
 
     /// <summary>
     /// Path for the token introspection endpoint.
     /// </summary>
-    public const string Introspection = Base + "/introspect";
+    public const string Introspection = "[" + RoutePrefix + ":introspect?" + Base + "/introspect]";
 
     /// <summary>
     /// Path for the backchannel authentication endpoint.
     /// </summary>
-    public const string BackChannelAuthentication = Base + "/bc-authorize";
+    public const string BackChannelAuthentication = "[" + RoutePrefix + ":bc_authorize?" + Base + "/bc-authorize]";
 
     /// <summary>
     /// Path for the device authorization endpoint.
     /// </summary>
-    public const string DeviceAuthorization = Base + "/deviceauthorization";
+    public const string DeviceAuthorization = "[" + RoutePrefix + ":deviceauthorization?" + Base + "/deviceauthorization]";
 
     /// <summary>
     /// Path for the client registration endpoint.
     /// </summary>
-    public const string Register = Base + "/register";
+    public const string Register = "[" + RoutePrefix + ":register?" + Base + "/register]";
+
+    private const string WellKnown = "[" + RoutePrefix + ":well_known?~/.well-known]";
 
     /// <summary>
     /// Path for the OpenID configuration document.
     /// </summary>
-    public const string Configuration = "~/.well-known/openid-configuration";
+    public const string Configuration = "[" + RoutePrefix + ":configuration?" + WellKnown + "/openid-configuration]";
 
     /// <summary>
     /// Path for the JSON Web Key Set (JWKS) endpoint.
     /// </summary>
-    public const string Keys = "~/.well-known/jwks";
+    public const string Keys = "[" + RoutePrefix + ":jwks?" + WellKnown + "/jwks]";
 }

--- a/Abblix.Oidc.Server.Mvc/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server.Mvc/ServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Mvc.Binders;
 using Abblix.Oidc.Server.Mvc.Configuration;
+using Abblix.Oidc.Server.Mvc.Features.ConfigurableRoutes;
+using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
 using Abblix.Oidc.Server.Mvc.Features.SessionManagement;
 using Abblix.Oidc.Server.Mvc.Formatters;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
@@ -52,7 +54,6 @@ public static class ServiceCollectionExtensions
 	/// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
 	/// <param name="configureOptions">A delegate to configure the <see cref="OidcOptions"/>.</param>
 	/// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained.</returns>
-
 	public static IServiceCollection AddOidcServices(this IServiceCollection services, Action<OidcOptions> configureOptions)
 	{
 		return services.AddOidcServices((options, _) => configureOptions(options));
@@ -82,13 +83,15 @@ public static class ServiceCollectionExtensions
     {
 		services
 			.AddOidcControllers()
+			.ConfigureRoutesFallback()
 			.AddHttpContextAccessor()
 
 		    .AddSingleton<IParameterValidator, ParameterValidator>()
 			.AddSingleton<IParametersProvider, ParametersProvider>()
 		    .AddSingleton<IRequestInfoProvider, HttpRequestInfoAdapter>()
-			.AddSingleton<IAuthSessionService, AuthenticationSchemeAdapter>()
+			.AddScoped<IAuthSessionService, AuthenticationSchemeAdapter>()
 			.AddSingleton<IUriResolver, UriResolver>()
+			.AddScoped<IEndpointResolver, EndpointResolver>()
 			.AddSingleton<IActionContextAccessor, ActionContextAccessor>()
 			.AddSingleton<IUrlHelperFactory, UrlHelperFactory>()
 			.AddScoped<IAuthorizationResponseFormatter, AuthorizationResponseFormatter>()

--- a/Abblix.Oidc.Server.Tests/Abblix.Oidc.Server.Tests.csproj
+++ b/Abblix.Oidc.Server.Tests/Abblix.Oidc.Server.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -19,9 +19,9 @@
         <PackageReleaseNotes>For detailed release notes, visit: https://github.com/Abblix/Oidc.Server/releases</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <AssemblyVersion>1.3.1.0</AssemblyVersion>
-        <FileVersion>1.3.1.0</FileVersion>
-        <PackageVersion>1.3.1.0</PackageVersion>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+        <FileVersion>1.4.0.0</FileVersion>
+        <PackageVersion>1.4.0.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -33,17 +33,21 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.*" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.*" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.*" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="9.*" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.*" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.*" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="8.*" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Grpc.AspNetCore" Version="2.70.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ErrorFactory.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ErrorFactory.cs
@@ -22,7 +22,6 @@
 
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
-using Abblix.Oidc.Server.Endpoints.Authorization.RequestFetching;
 
 namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -37,7 +37,7 @@ using ClientRegistrationResponse = Abblix.Oidc.Server.Endpoints.DynamicClientMan
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 
 /// <summary>
-/// Handles the registration of new clients by generating necessary credentials and adding client information to
+/// Handles the registration of new clients by generating the necessary credentials and adding client information to
 /// the system. Ensures the secure and compliant registration of clients as per OAuth 2.0 and OpenID Connect standards.
 /// </summary>
 public class RegisterClientRequestProcessor : IRegisterClientRequestProcessor
@@ -145,17 +145,6 @@ public class RegisterClientRequestProcessor : IRegisterClientRequestProcessor
     {
         var clientInfo = new ClientInfo(clientId)
         {
-            ClientSecrets = clientSecret.HasValue()
-                ? new[]
-                {
-                    new ClientSecret
-                    {
-                        Sha512Hash = _hashService.Sha(HashAlgorithm.Sha512, clientSecret),
-                        ExpiresAt = expiresAt,
-                    }
-                }
-                : null,
-
             TokenEndpointAuthMethod = model.TokenEndpointAuthMethod,
             AllowedResponseTypes = model.ResponseTypes,
             AllowedGrantTypes = model.GrantTypes,
@@ -175,7 +164,39 @@ public class RegisterClientRequestProcessor : IRegisterClientRequestProcessor
             BackChannelClientNotificationEndpoint = model.BackChannelClientNotificationEndpoint,
             BackChannelAuthenticationRequestSigningAlg = model.BackChannelAuthenticationRequestSigningAlg,
             BackChannelUserCodeParameter = model.BackChannelUserCodeParameter,
+            ApplicationType = model.ApplicationType,
+            Contacts = model.Contacts,
+            ClientName = model.ClientName,
+            ClientUri = model.ClientUri,
+            DefaultMaxAge = model.DefaultMaxAge,
+            RequireAuthTime = model.RequireAuthTime,
+            DefaultAcrValues = model.DefaultAcrValues,
+            IdentityTokenEncryptedResponseAlgorithm = model.IdTokenEncryptedResponseAlg,
+            IdentityTokenEncryptedResponseEncryption = model.IdTokenEncryptedResponseEnc,
+            UserInfoEncryptedResponseAlgorithm = model.UserInfoEncryptedResponseAlg,
+            UserInfoEncryptedResponseEncryption = model.UserInfoEncryptedResponseEnc,
+            RequestObjectSigningAlgorithm = model.RequestObjectSigningAlg,
+            RequestObjectEncryptionAlgorithm = model.RequestObjectEncryptionAlg,
+            RequestObjectEncryptionMethod = model.RequestObjectEncryptionEnc,
+            TokenEndpointAuthSigningAlgorithm = model.TokenEndpointAuthSigningAlg,
         };
+
+        if (clientSecret.HasValue())
+        {
+            clientInfo.ClientSecrets = new[]
+            {
+                new ClientSecret
+                {
+                    Sha512Hash = _hashService.Sha(HashAlgorithm.Sha512, clientSecret),
+                    ExpiresAt = expiresAt,
+                }
+            };
+        }
+
+        if (model.RequestUris != null)
+        {
+            clientInfo.RequestUris = model.RequestUris;
+        }
 
         if (model.UserInfoSignedResponseAlg.HasValue())
         {

--- a/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -241,10 +241,89 @@ public record ClientInfo(string ClientId)
     /// The list of allowed URI values to validate the <c>request_uri</c> parameter in authorization requests.
     /// </summary>
     /// <remarks>
-    /// The <c>request_uri</c> parameter references a hosted authorization request object.
-    /// This property defines the valid URIs
-    /// that can be used in the <c>request_uri</c> parameter for authorization requests,
-    /// ensuring that only authorized and pre-approved URIs are accepted by the server.
+    /// The <c>request_uri</c> parameter references a pre-hosted authorization request object.
+    /// This property specifies the valid URIs that can be included in the <c>request_uri</c> parameter.
+    /// By defining this list, the server ensures that only pre-approved and secure URIs are accepted,
+    /// mitigating risks such as unauthorized or malicious requests.
     /// </remarks>
     public Uri[] RequestUris { get; set; } = Array.Empty<Uri>();
+
+    /// <summary>
+    /// Describes the type of application represented by the client, such as "web" or "native".
+    /// </summary>
+    public string ApplicationType { get; set; } = ApplicationTypes.Web;
+
+    /// <summary>
+    /// An array of contact email addresses associated with the client, primarily used for support purposes.
+    /// </summary>
+    public string[]? Contacts { get; set; }
+
+    /// <summary>
+    /// A human-readable name for the client application,
+    /// which can be displayed to users during the authorization process.
+    /// </summary>
+    public string? ClientName { get; set; }
+
+    /// <summary>
+    /// A URL pointing to a web page providing information about the client application.
+    /// This is typically used to offer additional context to users during the authorization process.
+    /// </summary>
+    public Uri? ClientUri { get; set; }
+
+    /// <summary>
+    /// The maximum time in seconds since the user's authentication that the client accepts.
+    /// Requests exceeding this time will require re-authentication of the user.
+    /// </summary>
+    public TimeSpan? DefaultMaxAge { get; set; }
+
+    /// <summary>
+    /// Indicates whether the authorization server must include the `auth_time` claim in the ID token.
+    /// </summary>
+    public bool? RequireAuthTime { get; set; }
+
+    /// <summary>
+    /// Specifies the default Authentication Context Class Reference (ACR) values for the client.
+    /// These values indicate the types of authentication methods or levels of assurance required.
+    /// </summary>
+    public string[]? DefaultAcrValues { get; set; }
+
+    /// <summary>
+    /// Specifies the algorithm used to encrypt identity tokens issued to the client.
+    /// </summary>
+    public string? IdentityTokenEncryptedResponseAlgorithm { get; set; }
+
+    /// <summary>
+    /// Specifies the encryption method used to encrypt identity tokens issued to the client.
+    /// </summary>
+    public string? IdentityTokenEncryptedResponseEncryption { get; set; }
+
+    /// <summary>
+    /// Specifies the algorithm used to encrypt UserInfo responses returned to the client.
+    /// </summary>
+    public string? UserInfoEncryptedResponseAlgorithm { get; set; }
+
+    /// <summary>
+    /// Specifies the encryption method used to encrypt UserInfo responses returned to the client.
+    /// </summary>
+    public string? UserInfoEncryptedResponseEncryption { get; set; }
+
+    /// <summary>
+    /// Specifies the algorithm required for signing request objects sent to the authorization server.
+    /// </summary>
+    public string? RequestObjectSigningAlgorithm { get; set; }
+
+    /// <summary>
+    /// Specifies the algorithm required for encrypting request objects sent to the authorization server.
+    /// </summary>
+    public string? RequestObjectEncryptionAlgorithm { get; set; }
+
+    /// <summary>
+    /// Specifies the encryption method required for encrypting request objects sent to the authorization server.
+    /// </summary>
+    public string? RequestObjectEncryptionMethod { get; set; }
+
+    /// <summary>
+    /// Specifies the algorithm used to sign client authentication requests at the token endpoint.
+    /// </summary>
+    public string? TokenEndpointAuthSigningAlgorithm { get; set; }
 }

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -262,7 +262,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddIdentityToken(this IServiceCollection services)
     {
         return services
-            .AddSingleton<IIdentityTokenService, IdentityTokenService>();
+            .AddScoped<IIdentityTokenService, IdentityTokenService>();
     }
 
     /// <summary>
@@ -384,7 +384,7 @@ public static class ServiceCollectionExtensions
     /// modifications and additions to be chained.</returns>
     public static IServiceCollection AddUserInfo(this IServiceCollection services)
     {
-        services.TryAddSingleton<IUserClaimsProvider, UserClaimsProvider>();
+        services.TryAddScoped<IUserClaimsProvider, UserClaimsProvider>();
         services.TryAddSingleton<ISubjectTypeConverter, SubjectTypeConverter>();
         services.TryAddSingleton<IScopeClaimsProvider, ScopeClaimsProvider>();
         services.TryAddSingleton<IScopeManager, ScopeManager>();

--- a/Abblix.Utils/Abblix.Utils.csproj
+++ b/Abblix.Utils/Abblix.Utils.csproj
@@ -20,9 +20,9 @@
     <PackageReleaseNotes>For detailed release notes, visit: https://github.com/Abblix/Oidc.Server/releases</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
-    <PackageVersion>1.3.1.0</PackageVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <PackageVersion>1.4.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### ✨ Summary

This PR introduces support for dynamic, **configuration-driven route resolution** via tokenized route templates in controller attributes, enabling highly customizable and environment-specific endpoint paths in the Abblix OIDC Server.

It adds:

- `ConfigurableRouteConvention`: a reusable convention for resolving `[route:Token?Fallback]` placeholders in route attributes using `IConfiguration`.
- `ConfigureRoutes` and `ConfigureRoutesFallback` extensions to wire it into `IServiceCollection`.
- Controller integration (e.g., `AuthenticationController`, `TokenController`, etc.) using route templates referencing the centralized `Path` constants, which in turn now support `[route:token?fallback]` syntax.
- `EndpointResolver`: used at runtime to resolve full URIs for configured endpoints, used by the Discovery controller and compliant with ASP.NET Core endpoint routing.

---

### 🏗️ Motivation

In OpenID Connect and OAuth2 contexts, endpoint paths (like `/token`, `/authorize`, `/userinfo`) may vary depending on deployment environments, base prefixes, or multi-tenant scenarios. This change enables:

- 🧩 Centralized control of all endpoint routes via configuration  
- 🔀 Easy customization without modifying controller logic  
- 🛠 Runtime discovery (via `IEndpointResolver`)  
- ✅ Compatibility with Swagger/OpenAPI  

---

### 🚀 Key Features

#### 1. **Route Token Resolution with Optional Fallbacks**

Controller actions can now declare route templates like:

```csharp
[HttpGet("[route:authorize?[route:base?~/connect]/authorize]")]
```

- Resolved based on the `"Routes"` configuration section
- Supports recursive resolution of nested tokens
- Optional fallbacks are honored if config value is missing

---

#### 2. **Convention-Based Replacement**

The new `ConfigurableRouteConvention` class:

- Parses `[route:Token?Fallback]` using regex
- Resolves tokens from an `IConfigurationSection`
- Falls back gracefully or throws with descriptive errors
- Injected via `MvcOptions.Conventions`

---

#### 3. **Fluent Integration with DI**

Using the new `ConfigureRoutes(...)` extension:

```csharp
services.ConfigureRoutes(Configuration.GetSection("Routes"));
```

Optionally fallback-only (applied by Abblix.Oidc.Server.Mvc out-of-the-box):

```csharp
services.ConfigureRoutesFallback();
```

---

#### 4. **Runtime URI Resolution**

`IEndpointResolver` is introduced to:

- Programmatically resolve the fully qualified URI for any controller/action
- Used in `DiscoveryController` to populate `openid-configuration` dynamically
- Leverages `EndpointDataSource` and `ControllerActionDescriptor` matching

Example:

```csharp
endpointResolver.Resolve("Authentication", "AuthorizeAsync");
```

---

### 🧩 How `ConfigurableRouteConvention` Works

`ConfigurableRouteConvention` is an implementation of `IApplicationModelConvention` that allows route templates like `[route:token?fallback]` to be dynamically resolved from configuration at runtime.

#### 🔍 Syntax Supported

- `[route:token]` — replaces with the value of `Routes:token` from configuration.
- `[route:token?fallback]` — uses the fallback string if `Routes:token` is not defined.
- Nested resolution is supported:  
  `[route:authorize?[route:base?~/connect]/authorize]`  
  will first resolve `base`, then interpolate the result into `authorize`.

#### 🔧 Resolution Process

1. **Scans All Action Methods**  
   For every controller action, the convention inspects each route template from `[HttpGet]`, `[HttpPost]`, etc.

2. **Parses Route Tokens**  
   Using a regex, it matches route patterns like `[route:token?fallback]`, extracting:
   - `token` — the config key to look up
   - `fallback` — an optional fallback string if the config key is missing

3. **Recursively Resolves Tokens**  
   If a value like `[route:base]/authorize` is returned from config, it will also be scanned for nested tokens and resolved.

4. **Logs Resolution Events**  
   Every token replacement is logged using Serilog for full traceability.

5. **Applies Final Template**  
   Once resolved, the updated route template is assigned back to the controller action’s `AttributeRouteModel.Template`.

---

### 🔧 Example Configuration

```json
"Routes": {
  "base": "~/connect",
  "authorize": "[route:base]/authorize",
  "token": "[route:base]/token",
  "userinfo": "[route:base]/userinfo",
  "endsession": "[route:base]/endsession",
  "jwks": "~/.well-known/jwks",
  "configuration": "[route:well_known]/openid-configuration",
  "register": "[route:base]/register"
}
```

