### PR TITLE
fix: RFC 6750/7235 compliance for protected resource endpoints

### DIFF
--- a/Abblix.Oidc.Server.Mvc/ActionResults/ActionResultExtensions.cs
+++ b/Abblix.Oidc.Server.Mvc/ActionResults/ActionResultExtensions.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Model;
@@ -109,24 +110,63 @@ public static class ActionResultExtensions
 		=> new ActionResultDecorator(innerResult, SetNoCacheHeaders);
 
 	/// <summary>
-	/// Formats an <see cref="OidcError"/> as an appropriate HTTP error response.
-	/// Per RFC 6750 Section 3, Bearer token errors return 401 Unauthorized with a
-	/// <c>WWW-Authenticate</c> header. All other errors use the specified fallback status code.
+	/// Formats an <see cref="OidcError"/> as an appropriate HTTP error response per RFC 6750 Section 3.
+	/// Bearer token errors (<c>invalid_token</c>) return HTTP 401 with only a <c>WWW-Authenticate</c> header
+	/// and no response body. Scope errors (<c>insufficient_scope</c>) return HTTP 403 with the header.
+	/// All other errors use the specified fallback status code with a JSON body.
 	/// </summary>
 	/// <param name="error">The OIDC error to format.</param>
 	/// <param name="fallbackStatusCode">The HTTP status code to use for non-token errors.</param>
+	/// <param name="realm">Optional realm value identifying the protection space (typically the issuer URI).</param>
 	/// <returns>An <see cref="ActionResult"/> with the appropriate status code and headers.</returns>
-	public static ActionResult Format(this OidcError error, int fallbackStatusCode)
+	public static ActionResult Format(this OidcError error, int fallbackStatusCode, string? realm = null)
 	{
-		var response = new ErrorResponse(error.Error, error.ErrorDescription);
+		var challenge = FormatBearerChallenge(error, realm);
 
-		return error.Error switch
+		return (error.Error, fallbackStatusCode) switch
 		{
-			ErrorCodes.InvalidToken => new UnauthorizedObjectResult(response).WithHeader(
-				HeaderNames.WWWAuthenticate,
-				$"{TokenTypes.Bearer} error=\"{error.Error}\""),
+			(ErrorCodes.InvalidToken, _) => new UnauthorizedResult()
+				.WithHeader(HeaderNames.WWWAuthenticate, challenge),
 
-			_ => new ObjectResult(response) { StatusCode = fallbackStatusCode }
+			(ErrorCodes.InsufficientScope, _) => new StatusCodeResult(StatusCodes.Status403Forbidden)
+				.WithHeader(HeaderNames.WWWAuthenticate, challenge),
+
+			(_, StatusCodes.Status400BadRequest)
+				=> new BadRequestObjectResult(new ErrorResponse(error.Error, error.ErrorDescription)),
+
+			(_, StatusCodes.Status401Unauthorized)
+				=> new UnauthorizedObjectResult(new ErrorResponse(error.Error, error.ErrorDescription)),
+
+			_ => new ObjectResult(new ErrorResponse(error.Error, error.ErrorDescription))
+				{ StatusCode = fallbackStatusCode },
 		};
+	}
+
+	/// <summary>
+	/// Builds a <c>WWW-Authenticate: Bearer</c> challenge value per RFC 6750 Section 3,
+	/// including optional realm, error, and error_description attributes.
+	/// </summary>
+	private static string FormatBearerChallenge(OidcError error, string? realm)
+	{
+		var sb = new StringBuilder(TokenTypes.Bearer);
+		var first = true;
+		Append(sb, ref first, "realm", realm);
+		Append(sb, ref first, "error", error.Error);
+		Append(sb, ref first, "error_description", error.ErrorDescription);
+		return sb.ToString();
+
+		static void Append(StringBuilder sb, ref bool first, string name, string? value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return;
+
+			sb.Append(first ? " " : ", ")
+				.Append(name)
+				.Append("=\"")
+				.Append(value.Replace("\"", "'"))
+				.Append('"');
+
+			first = false;
+		}
 	}
 }

--- a/Abblix.Oidc.Server.Mvc/Controllers/AuthenticationController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/AuthenticationController.cs
@@ -252,7 +252,7 @@ public sealed class AuthenticationController : ControllerBase
         var mappedAuthenticationRequest = authenticationRequest.Map();
         var mappedClientRequest = clientRequest.Map();
         var response = await handler.HandleAsync(mappedAuthenticationRequest, mappedClientRequest);
-        return await formatter.FormatResponseAsync(mappedAuthenticationRequest, response);
+        return await formatter.FormatResponseAsync(mappedAuthenticationRequest, mappedClientRequest, response);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.Mvc/Formatters/BackChannelAuthenticationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/BackChannelAuthenticationResponseFormatter.cs
@@ -21,12 +21,16 @@
 // info@abblix.com
 
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Exceptions;
+using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.ActionResults;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 
 namespace Abblix.Oidc.Server.Mvc.Formatters;
 
@@ -35,7 +39,8 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// This class ensures that the appropriate HTTP responses are generated based on the type of back-channel
 /// authentication response, encapsulating success or error scenarios as defined by OAuth 2.0 standards.
 /// </summary>
-public class BackChannelAuthenticationResponseFormatter : IBackChannelAuthenticationResponseFormatter
+public class BackChannelAuthenticationResponseFormatter(
+    IIssuerProvider issuerProvider) : IBackChannelAuthenticationResponseFormatter
 {
     /// <summary>
     /// This method transforms the back-channel authentication response into a suitable HTTP response,
@@ -43,18 +48,21 @@ public class BackChannelAuthenticationResponseFormatter : IBackChannelAuthentica
     /// as HTTP status codes and payloads.
     /// </summary>
     /// <param name="request">The original back-channel authentication request that triggered the response.</param>
+    /// <param name="clientRequest">The client request containing authentication details.</param>
     /// <param name="response">The back-channel authentication response result that needs to be formatted into an HTTP result.
     /// </param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation,
     /// with the formatted response as an <see cref="ActionResult"/>.</returns>
     /// <remarks>
-    /// This method formats successful authentication requests as `200 OK`, client-related errors as `401 Unauthorized`
-    /// or `403 Forbidden`, and general errors as `400 Bad Request`.
-    /// It provides consistent handling for different response types,
-    /// ensuring the API behaves predictably according to the OAuth 2.0 back-channel authentication specification.
+    /// This method formats successful authentication requests as <c>200 OK</c>,
+    /// client-related errors as <c>401 Unauthorized</c> or <c>403 Forbidden</c>,
+    /// and general errors as <c>400 Bad Request</c>.
+    /// Per RFC 7235 Section 3.1, all <c>401</c> responses include a <c>WWW-Authenticate</c> header
+    /// matching the client's authentication scheme per RFC 6749 Section 5.2.
     /// </remarks>
     public Task<ActionResult> FormatResponseAsync(
         BackChannelAuthenticationRequest request,
+        ClientRequest clientRequest,
         Result<BackChannelAuthenticationSuccess, OidcError> response)
     {
         return Task.FromResult(response.Match<ActionResult>(
@@ -64,10 +72,12 @@ public class BackChannelAuthenticationResponseFormatter : IBackChannelAuthentica
                 return error switch
                 {
                     BackChannelAuthenticationUnauthorized { Error: var err, ErrorDescription: var description }
-                        => new UnauthorizedObjectResult(new ErrorResponse(err, description)),
+                        => new UnauthorizedObjectResult(new ErrorResponse(err, description))
+                            .WithHeader(HeaderNames.WWWAuthenticate, FormatClientChallenge(clientRequest)),
 
                     BackChannelAuthenticationForbidden { Error: var err, ErrorDescription: var description }
-                        => new ObjectResult(new ErrorResponse(err, description)) { StatusCode = StatusCodes.Status403Forbidden },
+                        => new ObjectResult(new ErrorResponse(err, description))
+                            { StatusCode = StatusCodes.Status403Forbidden },
 
                     { Error: var err, ErrorDescription: var description }
                         => new BadRequestObjectResult(new ErrorResponse(err, description)),
@@ -75,5 +85,20 @@ public class BackChannelAuthenticationResponseFormatter : IBackChannelAuthentica
                     _ => throw new UnexpectedTypeException(nameof(error), error.GetType()),
                 };
             }));
+    }
+
+    /// <summary>
+    /// Builds the <c>WWW-Authenticate</c> challenge matching the client's authentication scheme.
+    /// Per RFC 6749 Section 5.2, the challenge scheme MUST match what the client attempted.
+    /// Falls back to <c>Bearer</c> when the client did not use the <c>Authorization</c> header
+    /// (e.g., <c>client_secret_post</c> or <c>private_key_jwt</c>).
+    /// </summary>
+    private string FormatClientChallenge(ClientRequest clientRequest)
+    {
+        var scheme = TokenTypes.Basic.Equals(clientRequest.AuthorizationHeader?.Scheme, StringComparison.OrdinalIgnoreCase)
+            ? TokenTypes.Basic
+            : TokenTypes.Bearer;
+
+        return $"{scheme} realm=\"{issuerProvider.GetIssuer()}\"";
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Formatters/Interfaces/IBackChannelAuthenticationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/Interfaces/IBackChannelAuthenticationResponseFormatter.cs
@@ -36,11 +36,14 @@ public interface IBackChannelAuthenticationResponseFormatter
     /// Formats a back-channel authentication response asynchronously.
     /// </summary>
     /// <param name="request">The back-channel authentication request.</param>
+    /// <param name="clientRequest">The client request containing authentication details
+    /// (needed to determine the correct <c>WWW-Authenticate</c> scheme per RFC 6749 Section 5.2).</param>
     /// <param name="response">The back-channel authentication response result to be formatted.</param>
     /// <returns>
     /// A <see cref="Task"/> representing the asynchronous operation, with the formatted response as an <see cref="ActionResult"/>.
     /// </returns>
     Task<ActionResult> FormatResponseAsync(
         BackChannelAuthenticationRequest request,
+        ClientRequest clientRequest,
         Result<BackChannelAuthenticationSuccess, OidcError> response);
 }

--- a/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
@@ -24,9 +24,12 @@ using Abblix.Oidc.Server.Common;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
+using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.ActionResults;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Abblix.Oidc.Server.Mvc.Formatters;
@@ -34,7 +37,8 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// <summary>
 /// Provides a response formatter for introspection responses.
 /// </summary>
-public class IntrospectionResponseFormatter : IIntrospectionResponseFormatter
+public class IntrospectionResponseFormatter(
+    IIssuerProvider issuerProvider) : IIntrospectionResponseFormatter
 {
     /// <summary>
     /// Formats an introspection response asynchronously.
@@ -52,7 +56,7 @@ public class IntrospectionResponseFormatter : IIntrospectionResponseFormatter
     {
         return Task.FromResult(response.Match(
             onSuccess: FormatSuccess,
-            onFailure: error => new UnauthorizedObjectResult(new ErrorResponse(error.Error, error.ErrorDescription))));
+            onFailure: error => error.Format(StatusCodes.Status401Unauthorized, issuerProvider.GetIssuer())));
     }
 
     private static ActionResult FormatSuccess(IntrospectionSuccess success)

--- a/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
@@ -24,10 +24,13 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.UserInfo.Interfaces;
+using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.ActionResults;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Abblix.Oidc.Server.Mvc.Formatters;
@@ -37,7 +40,8 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// </summary>
 public class UserInfoResponseFormatter(
     TimeProvider clock,
-    IClientJwtFormatter clientJwtFormatter) : IUserInfoResponseFormatter
+    IClientJwtFormatter clientJwtFormatter,
+    IIssuerProvider issuerProvider) : IUserInfoResponseFormatter
 {
     /// <summary>
     /// Asynchronously formats the response for a user information request.
@@ -57,8 +61,8 @@ public class UserInfoResponseFormatter(
     {
         return await response.MatchAsync(
             onSuccess: FormatSuccessAsync,
-            onFailure: error => Task.FromResult<ActionResult>(
-                new BadRequestObjectResult(new ErrorResponse(error.Error, error.ErrorDescription))));
+            onFailure: error => Task.FromResult(
+                error.Format(StatusCodes.Status400BadRequest, issuerProvider.GetIssuer())));
     }
 
     private async Task<ActionResult> FormatSuccessAsync(UserInfoFoundResponse found)

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoHandlerTests.cs
@@ -138,7 +138,7 @@ public class UserInfoHandlerTests
         var userInfoRequest = CreateUserInfoRequest();
         var clientRequest = CreateClientRequest();
         var error = new OidcError(
-            ErrorCodes.InvalidGrant,
+            ErrorCodes.InvalidToken,
             "Access token is invalid or expired");
 
         _validator
@@ -268,7 +268,7 @@ public class UserInfoHandlerTests
         var userInfoRequest = CreateUserInfoRequest();
         var clientRequest = CreateClientRequest();
         var error = new OidcError(
-            ErrorCodes.InvalidGrant,
+            ErrorCodes.InvalidToken,
             "Access token is invalid");
 
         _validator
@@ -282,7 +282,7 @@ public class UserInfoHandlerTests
         Assert.True(result.TryGetFailure(out var failure));
         Assert.NotNull(failure.Error);
         Assert.NotEmpty(failure.Error);
-        Assert.Equal(ErrorCodes.InvalidGrant, failure.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, failure.Error);
     }
 
     /// <summary>
@@ -323,7 +323,7 @@ public class UserInfoHandlerTests
         // Arrange
         var userInfoRequest = CreateUserInfoRequest();
         var clientRequest = CreateClientRequest();
-        var error = new OidcError(ErrorCodes.InvalidGrant, "Token not authorized");
+        var error = new OidcError(ErrorCodes.InvalidToken, "Token not authorized");
 
         _validator
             .Setup(v => v.ValidateAsync(userInfoRequest, clientRequest))

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestProcessorTests.cs
@@ -151,7 +151,7 @@ public class UserInfoRequestProcessorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("user claims", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
@@ -205,7 +205,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("'Basic' is not supported", error.ErrorDescription);
     }
 
@@ -226,7 +226,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("not in both sources", error.ErrorDescription);
     }
 
@@ -246,7 +246,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("none of them specified", error.ErrorDescription);
     }
 
@@ -267,7 +267,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("must be specified", error.ErrorDescription);
     }
 
@@ -297,7 +297,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Equal("Token is expired", error.ErrorDescription);
     }
 
@@ -327,7 +327,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("Invalid token type", error.ErrorDescription);
         Assert.Contains("id+jwt", error.ErrorDescription);
     }
@@ -366,7 +366,7 @@ public class UserInfoRequestValidatorTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
         Assert.Contains("'unknown_client' is not found", error.ErrorDescription);
     }
 

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -226,7 +226,7 @@ public record OidcOptions
 	/// When <c>true</c>, POST requests to the registration endpoint must include a valid
 	/// Bearer token. When <c>false</c>, open registration is allowed.
 	/// </summary>
-	public bool RequireInitialAccessToken { get; set; } = false;
+	public bool RequireInitialAccessToken { get; set; } = true;
 
 	/// <summary>
 	/// The set of revoked initial access token identifiers (JWT subject claims).

--- a/Abblix.Oidc.Server/Common/Constants/ErrorCodes.cs
+++ b/Abblix.Oidc.Server/Common/Constants/ErrorCodes.cs
@@ -246,4 +246,12 @@ public static class ErrorCodes
 	/// Per RFC 6750 Section 3.1, the resource server MUST respond with HTTP 401 (Unauthorized).
 	/// </summary>
 	public const string InvalidToken = "invalid_token";
+
+	/// <summary>
+	/// The request requires higher privileges than provided by the access token.
+	/// Per RFC 6750 Section 3.1, the resource server MUST respond with HTTP 403 (Forbidden)
+	/// and SHOULD include the <c>scope</c> attribute in the <c>WWW-Authenticate</c> header
+	/// listing the required scopes.
+	/// </summary>
+	public const string InsufficientScope = "insufficient_scope";
 }

--- a/Abblix.Oidc.Server/Common/Constants/TokenTypes.cs
+++ b/Abblix.Oidc.Server/Common/Constants/TokenTypes.cs
@@ -28,6 +28,12 @@ namespace Abblix.Oidc.Server.Common.Constants;
 public static class TokenTypes
 {
     /// <summary>
+    /// Indicates the Basic authentication scheme per RFC 7617, where client credentials
+    /// are transmitted as a Base64-encoded <c>client_id:client_secret</c> pair.
+    /// </summary>
+    public const string Basic = "Basic";
+
+    /// <summary>
     /// Indicates the Bearer token type, often used in OAuth 2.0 for securing API requests.
     /// </summary>
     public const string Bearer = "Bearer";

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestProcessor.cs
@@ -57,7 +57,7 @@ public class UserInfoRequestProcessor(IIssuerProvider issuerProvider, IUserClaim
 			request.ClientInfo);
 
 		if (userInfo == null)
-			return new OidcError(ErrorCodes.InvalidGrant, "The user claims aren't found");
+			return new OidcError(ErrorCodes.InvalidToken, "The user claims aren't found");
 
 		var issuer = LicenseChecker.CheckIssuer(issuerProvider.GetIssuer());
 		return new UserInfoFoundResponse(userInfo, request.ClientInfo, issuer);

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
@@ -67,14 +67,14 @@ public class UserInfoRequestValidator(
 			if (authorizationHeader.Scheme != TokenTypes.Bearer)
 			{
 				return new OidcError(
-					ErrorCodes.InvalidGrant,
+					ErrorCodes.InvalidToken,
 					$"The scheme name '{authorizationHeader.Scheme}' is not supported");
 			}
 
 			if (userInfoRequest.AccessToken != null)
 			{
 				return new OidcError(
-					ErrorCodes.InvalidGrant,
+					ErrorCodes.InvalidToken,
 					$"The access token must be passed via '{HttpRequestHeaders.Authorization}' header " +
 					$"or '{Parameters.AccessToken}' parameter, but not in both sources at the same time");
 			}
@@ -82,7 +82,7 @@ public class UserInfoRequestValidator(
 			if (authorizationHeader.Parameter == null)
 			{
 				return new OidcError(
-					ErrorCodes.InvalidGrant,
+					ErrorCodes.InvalidToken,
 					$"The access token must be specified via '{HttpRequestHeaders.Authorization}' header");
 			}
 
@@ -91,7 +91,7 @@ public class UserInfoRequestValidator(
 		else if (userInfoRequest.AccessToken == null)
 		{
 			return new OidcError(
-				ErrorCodes.InvalidGrant,
+				ErrorCodes.InvalidToken,
 				$"The access token must be passed via '{HttpRequestHeaders.Authorization}' header " +
 				$"or '{Parameters.AccessToken}' parameter, but none of them specified");
 		}
@@ -103,7 +103,7 @@ public class UserInfoRequestValidator(
 		var result = await jwtValidator.ValidateAsync(jwtAccessToken, ValidationOptions.Default & ~ValidationOptions.RequireValidAudience);
 
 		if (result.TryGetFailure(out var error))
-			return new OidcError(ErrorCodes.InvalidGrant, error.ToString());
+			return new OidcError(ErrorCodes.InvalidToken, error.ToString());
 
 		var token = result.GetSuccess();
 
@@ -111,7 +111,7 @@ public class UserInfoRequestValidator(
 		if (tokenType != JwtTypes.AccessToken)
 		{
 			return new OidcError(
-				ErrorCodes.InvalidGrant,
+				ErrorCodes.InvalidToken,
 				$"Invalid token type: {tokenType}");
 		}
 
@@ -121,7 +121,7 @@ public class UserInfoRequestValidator(
 		if (clientInfo == null)
 		{
 			return new OidcError(
-				ErrorCodes.InvalidGrant,
+				ErrorCodes.InvalidToken,
 				$"The client '{authContext.ClientId}' is not found");
 		}
 

--- a/Abblix.Oidc.Server/README.md
+++ b/Abblix.Oidc.Server/README.md
@@ -21,7 +21,7 @@ Abblix OIDC Server implements a comprehensive suite of standards for authorizati
 
 ### OAuth 2.0
 - **The OAuth 2.0 Authorization Framework**: [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749)
-- **Bearer Token Usage**: [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)
+- **Bearer Token Usage**: [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750), **HTTP Authentication**: [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235)
 - **Token Revocation**: [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)
 - **Token Introspection**: [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)
 - **Proof Key for Code Exchange (PKCE)**: [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636)


### PR DESCRIPTION
## Summary

- UserInfo endpoint now returns `invalid_token` (RFC 6750) instead of `invalid_grant`, correctly reflecting its role as a protected resource
- Response formatting produces proper `WWW-Authenticate` headers with realm, error, and error_description per RFC 6750 Section 3 and RFC 7235
- HTTP 401 for `invalid_token` (no body), HTTP 403 for `insufficient_scope`, with Bearer challenge headers
- CIBA endpoint `WWW-Authenticate` matches the client's authentication scheme (Basic vs Bearer) per RFC 7235
- Added `InvalidToken`, `InsufficientScope` error codes and `TokenTypes.Basic` constant
- Updated README with RFC 7235 reference