### PR TITLE
ci: migrate test projects to xunit v3 + Microsoft Testing Platform

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,11 +56,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -74,7 +74,7 @@ jobs:
     # Custom manual build steps for C# using dotnet
     - if: matrix.build-mode == 'manual' && matrix.language == 'csharp'
       name: Install .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: '10.x'
 
@@ -87,6 +87,6 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,7 +25,7 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.sln', '**/Directory.Packages.props', '**/packages.lock.json', 'global.json') }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.sln', '**/Directory.Packages.props', '**/packages.lock.json', 'global.json') }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: |

--- a/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
+++ b/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
@@ -1,10 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,14 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
+++ b/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -7,6 +7,8 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,14 +19,9 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -131,7 +131,7 @@ public class JsonWebTokenValidationTests
 
         var jwt = await IssueToken(token, SigningKey);
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
         var parameters = CreateValidationParameters(SigningKey);
@@ -186,7 +186,7 @@ public class JsonWebTokenValidationTests
 
         var jwt = await IssueToken(token, SigningKey);
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
         var options = ValidationOptions.Default & ~ValidationOptions.ValidateLifetime;
@@ -840,7 +840,7 @@ public class JsonWebTokenValidationTests
         };
 
         var jwt = await IssueToken(token, SigningKey);
-        await Task.Delay(100); // Token already expired (created 2 minutes ago)
+        await Task.Delay(100, TestContext.Current.CancellationToken); // Token already expired (created 2 minutes ago)
 
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
         var parameters = CreateValidationParameters(SigningKey);

--- a/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
+++ b/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
@@ -112,7 +112,7 @@ public class JwtEncryptionTests
         var address = result.Payload.Json["address"]?.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
         Assert.Equal("{\"street\":\"123 Main St\",\"city\":\"Springfield\",\"state\":\"IL\",\"zip\":\"62701\"}", address);
 
-        await Task.Delay(expiresIn);
+        await Task.Delay(expiresIn, TestContext.Current.CancellationToken);
 
         var result2 = await validator.ValidateAsync(jwt, parameters);
         Assert.True(result2.TryGetFailure(out var error));

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
@@ -1,10 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<OutputType>Exe</OutputType>
+		<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -12,14 +15,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="8.0.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -1,8 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,13 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/HttpNotificationDeliveryServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/HttpNotificationDeliveryServiceTests.cs
@@ -91,7 +91,7 @@ public class HttpNotificationDeliveryServiceTests
             h => h == $"Bearer {ClientNotificationToken}");
 
         // Verify payload
-        var content = await capturedRequest.Content!.ReadAsStringAsync();
+        var content = await capturedRequest.Content!.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var deserializedPayload = JsonSerializer.Deserialize<JsonElement>(content);
         Assert.Equal(AuthReqId, deserializedPayload.GetProperty("auth_req_id").GetString());
     }

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretAuthenticatorTests.cs
@@ -39,6 +39,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
 /// Unit tests for <see cref="ClientSecretAuthenticator"/> verifying client authentication
 /// per OAuth 2.0 and OpenID Connect specifications.
 /// </summary>
+[Collection("License")]
 public class ClientSecretAuthenticatorTests
 {
     private readonly Mock<IClientInfoProvider> _clientInfoProvider;

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseCheckerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseCheckerTests.cs
@@ -45,8 +45,10 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 /// This is an inherent limitation of testing static classes with mutable state.
 /// The tests verify correct behavior but are not completely independent.
 /// </remarks>
+[Collection("License")]
 public class LicenseCheckerTests
 {
+
     #region CheckClientLicense Tests
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
@@ -194,7 +194,7 @@ public class LicenseLoadingServiceTests
             yield return "test.license.jwt";
         }
 
-        var provider = new MockLicenseJwtProvider(SlowLicenses());
+        var provider = new MockLicenseJwtProvider(SlowLicenses(TestContext.Current.CancellationToken));
         var service = new LicenseLoadingService(loggerFactory, provider);
         var cts = new CancellationTokenSource();
 

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
@@ -269,11 +269,7 @@ public class LicenseLoggerTests
     /// <summary>
     /// Verifies that concurrent calls with same key result in only one allowed call.
     /// </summary>
-    // Exposes a real race in LicenseLogger.IsAllowed: ConcurrentDictionary.AddOrUpdate
-    // may invoke its factory lambdas multiple times during CAS retries, but the method
-    // sets wasAllowed=true inside the factory without atomic commit. Fix requires
-    // rewriting IsAllowed with explicit TryAdd / TryUpdate loop. Tracked as follow-up.
-    [Fact(Skip = "Surfaces race condition in LicenseLogger.IsAllowed; fix is out of scope for MTP migration.")]
+    [Fact]
     public void IsAllowed_ConcurrentCallsSameKey_OnlyOneAllowed()
     {
         // Arrange

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
@@ -269,7 +269,11 @@ public class LicenseLoggerTests
     /// <summary>
     /// Verifies that concurrent calls with same key result in only one allowed call.
     /// </summary>
-    [Fact]
+    // Exposes a real race in LicenseLogger.IsAllowed: ConcurrentDictionary.AddOrUpdate
+    // may invoke its factory lambdas multiple times during CAS retries, but the method
+    // sets wasAllowed=true inside the factory without atomic commit. Fix requires
+    // rewriting IsAllowed with explicit TryAdd / TryUpdate loop. Tracked as follow-up.
+    [Fact(Skip = "Surfaces race condition in LicenseLogger.IsAllowed; fix is out of scope for MTP migration.")]
     public void IsAllowed_ConcurrentCallsSameKey_OnlyOneAllowed()
     {
         // Arrange

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -196,7 +196,7 @@ public class LicenseManagerTests
                     exceptions.Add(ex);
                 }
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         var writeTask = Task.Run(() =>
         {
@@ -217,7 +217,7 @@ public class LicenseManagerTests
                     exceptions.Add(ex);
                 }
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         await Task.WhenAll(readTask, writeTask);
 

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseProvidersTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseProvidersTests.cs
@@ -51,7 +51,7 @@ public class LicenseProvidersTests
 
         // Act
         var licenses = provider.GetLicenseJwtAsync();
-        var licenseList = await licenses.ToListAsync();
+        var licenseList = await licenses.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(licenseList);
@@ -70,7 +70,7 @@ public class LicenseProvidersTests
 
         // Act
         var licenses = provider.GetLicenseJwtAsync();
-        var licenseList = await licenses.ToListAsync();
+        var licenseList = await licenses.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(licenseList);
@@ -89,8 +89,8 @@ public class LicenseProvidersTests
         var provider = new StaticLicenseJwtProvider(jwt);
 
         // Act
-        var licenses1 = await provider.GetLicenseJwtAsync().ToListAsync();
-        var licenses2 = await provider.GetLicenseJwtAsync().ToListAsync();
+        var licenses1 = await provider.GetLicenseJwtAsync().ToListAsync(TestContext.Current.CancellationToken);
+        var licenses2 = await provider.GetLicenseJwtAsync().ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(licenses1, licenses2);
@@ -113,7 +113,7 @@ public class LicenseProvidersTests
 
         // Act
         var licenses = provider.GetLicenseJwtAsync();
-        var licenseList = await licenses!.ToListAsync();
+        var licenseList = await licenses!.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(licenseList);
@@ -150,7 +150,7 @@ public class LicenseProvidersTests
 
         // Act
         var licenses = provider.GetLicenseJwtAsync();
-        var licenseList = await licenses!.ToListAsync();
+        var licenseList = await licenses!.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(licenseList);
@@ -170,8 +170,8 @@ public class LicenseProvidersTests
         var provider = new OptionsLicenseJwtProvider(options);
 
         // Act
-        var licenses1 = await provider.GetLicenseJwtAsync()!.ToListAsync();
-        var licenses2 = await provider.GetLicenseJwtAsync()!.ToListAsync();
+        var licenses1 = await provider.GetLicenseJwtAsync()!.ToListAsync(TestContext.Current.CancellationToken);
+        var licenses2 = await provider.GetLicenseJwtAsync()!.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(licenses1, licenses2);

--- a/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandlerTests.cs
@@ -76,7 +76,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://localhost/api"));
+            () => client.GetAsync("https://localhost/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("Hostname 'localhost' matches internal hostname pattern", exception.Message);
     }
@@ -93,7 +93,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://127.0.0.1/api"));
+            () => client.GetAsync("https://127.0.0.1/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("IP address '127.0.0.1' is private/internal", exception.Message);
     }
@@ -110,7 +110,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://192.168.1.1/api"));
+            () => client.GetAsync("https://192.168.1.1/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("IP address '192.168.1.1' is private/internal", exception.Message);
     }
@@ -127,7 +127,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://myserver.local/api"));
+            () => client.GetAsync("https://myserver.local/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("Hostname 'myserver.local' matches internal hostname pattern", exception.Message);
     }
@@ -144,7 +144,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://intranet/api"));
+            () => client.GetAsync("https://intranet/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("Hostname 'intranet' matches internal hostname pattern", exception.Message);
     }
@@ -290,7 +290,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("http://example.com/api"));
+            () => client.GetAsync("http://example.com/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("URI scheme 'http' is not allowed", exception.Message);
     }
@@ -365,7 +365,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://10.0.0.1/api"));
+            () => client.GetAsync("https://10.0.0.1/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("IP address '10.0.0.1' is private/internal", exception.Message);
     }
@@ -382,7 +382,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://172.16.0.1/api"));
+            () => client.GetAsync("https://172.16.0.1/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("IP address '172.16.0.1' is private/internal", exception.Message);
     }
@@ -399,7 +399,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://169.254.169.254/api"));
+            () => client.GetAsync("https://169.254.169.254/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("IP address '169.254.169.254' is private/internal", exception.Message);
     }
@@ -416,7 +416,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://[::1]/api"));
+            () => client.GetAsync("https://[::1]/api", TestContext.Current.CancellationToken));
 
         Assert.Contains("is private/internal", exception.Message);
     }
@@ -433,7 +433,7 @@ public class SsrfValidatingHttpMessageHandlerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            () => client.GetAsync("https://api.internal/data"));
+            () => client.GetAsync("https://api.internal/data", TestContext.Current.CancellationToken));
 
         Assert.Contains("Hostname 'api.internal' matches internal hostname pattern", exception.Message);
     }

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/AuthServiceJwtValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/AuthServiceJwtValidatorTests.cs
@@ -463,7 +463,7 @@ public class AuthServiceJwtValidatorTests
 
         // Assert
         Assert.NotNull(capturedParams);
-        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(null!).ToArrayAsync();
+        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(null!).ToArrayAsync(TestContext.Current.CancellationToken);
         Assert.Equal(signingKeys.Length, resolvedKeys.Length);
     }
 
@@ -498,7 +498,7 @@ public class AuthServiceJwtValidatorTests
 
         // Assert
         Assert.NotNull(capturedParams);
-        var resolvedKeys = await capturedParams!.ResolveTokenDecryptionKeys!(null!).ToArrayAsync();
+        var resolvedKeys = await capturedParams!.ResolveTokenDecryptionKeys!(null!).ToArrayAsync(TestContext.Current.CancellationToken);
         Assert.Equal(encryptionKeys.Length, resolvedKeys.Length);
 
         // Verify GetEncryptionKeys was called with includePrivate=true
@@ -532,7 +532,7 @@ public class AuthServiceJwtValidatorTests
 
         // Assert
         Assert.NotNull(capturedParams);
-        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(null!).ToArrayAsync();
+        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(null!).ToArrayAsync(TestContext.Current.CancellationToken);
         Assert.Empty(resolvedKeys);
     }
 

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
@@ -347,7 +347,7 @@ public class ClientJwtValidatorTests
             {
                 capturedParams = p;
                 if (p.ValidateIssuer != null)
-                    await p.ValidateIssuer(ValidClientId);
+                    await p.ValidateIssuer(unknownIssuer);
             })
             .ReturnsAsync(new JwtValidationError(JwtError.InvalidToken, "Unknown issuer"));
 
@@ -568,7 +568,7 @@ public class ClientJwtValidatorTests
             {
                 capturedParams = p;
                 if (p.ValidateIssuer != null)
-                    await p.ValidateIssuer(ValidClientId);
+                    await p.ValidateIssuer(unknownIssuer);
             })
             .ReturnsAsync(new JwtValidationError(JwtError.InvalidToken, "Unknown issuer"));
 

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
@@ -506,7 +506,7 @@ public class ClientJwtValidatorTests
 
         // Assert
         Assert.NotNull(capturedParams);
-        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(ValidClientId).ToArrayAsync();
+        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(ValidClientId).ToArrayAsync(TestContext.Current.CancellationToken);
         Assert.Equal(signingKeys.Length, resolvedKeys.Length);
 
         _clientKeysProvider.Verify(p => p.GetSigningKeys(clientInfo), Times.Once);
@@ -547,7 +547,7 @@ public class ClientJwtValidatorTests
 
         // Assert
         Assert.NotNull(capturedParams);
-        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(ValidClientId).ToArrayAsync();
+        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(ValidClientId).ToArrayAsync(TestContext.Current.CancellationToken);
         Assert.Empty(resolvedKeys);
     }
 
@@ -581,7 +581,7 @@ public class ClientJwtValidatorTests
 
         // Assert
         Assert.NotNull(capturedParams);
-        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(unknownIssuer).ToArrayAsync();
+        var resolvedKeys = await capturedParams!.ResolveIssuerSigningKeys!(unknownIssuer).ToArrayAsync(TestContext.Current.CancellationToken);
         Assert.Empty(resolvedKeys);
 
         // Verify GetSigningKeys was never called for unknown client

--- a/Abblix.Oidc.Server/Features/Licensing/LicenseLogger.cs
+++ b/Abblix.Oidc.Server/Features/Licensing/LicenseLogger.cs
@@ -140,25 +140,25 @@ internal class LicenseLogger: ILogger
     public bool IsAllowed(object key, DateTimeOffset utcNow, TimeSpan period)
     {
         var newTime = utcNow + period;
-        var wasAllowed = false;
 
-        _nextAllowedTimes.AddOrUpdate(
-            key,
-            _ =>
+        // Use explicit CAS primitives rather than AddOrUpdate's delegate form:
+        // AddOrUpdate may invoke its factory lambdas on retry after a failed CAS,
+        // and any side effect set inside the factory (e.g. wasAllowed=true) then
+        // leaks into the update branch, incorrectly signalling a successful grant.
+        while (true)
+        {
+            if (_nextAllowedTimes.TryGetValue(key, out var existingTime))
             {
-                wasAllowed = true;
-                return newTime;
-            },
-            (_, existingTime) =>
-            {
-                if (existingTime < utcNow)
-                {
-                    wasAllowed = true;
-                    return newTime;
-                }
-                return existingTime;
-            });
+                if (existingTime >= utcNow)
+                    return false;
 
-        return wasAllowed;
+                if (_nextAllowedTimes.TryUpdate(key, newTime, existingTime))
+                    return true;
+            }
+            else if (_nextAllowedTimes.TryAdd(key, newTime))
+            {
+                return true;
+            }
+        }
     }
 }

--- a/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -7,6 +7,8 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,13 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Abblix.Utils.UnitTests/DistributedCacheExtensionsTests.cs
+++ b/Abblix.Utils.UnitTests/DistributedCacheExtensionsTests.cs
@@ -46,17 +46,17 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "test-key";
 		var value = Encoding.UTF8.GetBytes("test-value");
-		await cache.SetAsync(key, value);
+		await cache.SetAsync(key, value, TestContext.Current.CancellationToken);
 
 		// Act
-		var result = await cache.TryGetAndRemoveAsync(key);
+		var result = await cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.NotNull(result);
 		Assert.Equal(value, result);
 
 		// Verify value was removed
-		var afterRemove = await cache.GetAsync(key);
+		var afterRemove = await cache.GetAsync(key, TestContext.Current.CancellationToken);
 		Assert.Null(afterRemove);
 	}
 
@@ -68,7 +68,7 @@ public class DistributedCacheExtensionsTests
 		const string key = "nonexistent-key";
 
 		// Act
-		var result = await cache.TryGetAndRemoveAsync(key);
+		var result = await cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.Null(result);
@@ -81,11 +81,11 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "concurrent-key";
 		var value = Encoding.UTF8.GetBytes("concurrent-value");
-		await cache.SetAsync(key, value);
+		await cache.SetAsync(key, value, TestContext.Current.CancellationToken);
 
 		// Act - simulate race condition with 10 concurrent threads
 		var tasks = Enumerable.Range(0, 10)
-			.Select(_ => cache.TryGetAndRemoveAsync(key))
+			.Select(_ => cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken))
 			.ToArray();
 
 		var results = await Task.WhenAll(tasks);
@@ -99,7 +99,7 @@ public class DistributedCacheExtensionsTests
 		Assert.Equal(9, results.Count(r => r == null));
 
 		// Verify value was removed
-		var afterRemove = await cache.GetAsync(key);
+		var afterRemove = await cache.GetAsync(key, TestContext.Current.CancellationToken);
 		Assert.Null(afterRemove);
 	}
 
@@ -110,21 +110,21 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "lock-expiry-key";
 		var value = Encoding.UTF8.GetBytes("lock-expiry-value");
-		await cache.SetAsync(key, value);
+		await cache.SetAsync(key, value, TestContext.Current.CancellationToken);
 
 		// Act
-		var result = await cache.TryGetAndRemoveAsync(key);
+		var result = await cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Assert - operation succeeded
 		Assert.NotNull(result);
 		Assert.Equal(value, result);
 
 		// Wait for lock to expire (5 seconds + buffer)
-		await Task.Delay(TimeSpan.FromSeconds(6));
+		await Task.Delay(TimeSpan.FromSeconds(6), TestContext.Current.CancellationToken);
 
 		// Verify lock was cleaned up (either explicitly or via expiration)
 		var lockKey = $"lock:{key}";
-		var lockValue = await cache.GetAsync(lockKey);
+		var lockValue = await cache.GetAsync(lockKey, TestContext.Current.CancellationToken);
 		Assert.Null(lockValue);
 	}
 
@@ -137,12 +137,12 @@ public class DistributedCacheExtensionsTests
 		const string key2 = "key2";
 		var value1 = Encoding.UTF8.GetBytes("value1");
 		var value2 = Encoding.UTF8.GetBytes("value2");
-		await cache.SetAsync(key1, value1);
-		await cache.SetAsync(key2, value2);
+		await cache.SetAsync(key1, value1, TestContext.Current.CancellationToken);
+		await cache.SetAsync(key2, value2, TestContext.Current.CancellationToken);
 
 		// Act - concurrent operations on different keys
-		var task1 = cache.TryGetAndRemoveAsync(key1);
-		var task2 = cache.TryGetAndRemoveAsync(key2);
+		var task1 = cache.TryGetAndRemoveAsync(key1, cancellationToken: TestContext.Current.CancellationToken);
+		var task2 = cache.TryGetAndRemoveAsync(key2, cancellationToken: TestContext.Current.CancellationToken);
 		var results = await Task.WhenAll(task1, task2);
 
 		// Assert - both should succeed independently
@@ -152,8 +152,8 @@ public class DistributedCacheExtensionsTests
 		Assert.Equal(value2, results[1]);
 
 		// Verify both values were removed
-		Assert.Null(await cache.GetAsync(key1));
-		Assert.Null(await cache.GetAsync(key2));
+		Assert.Null(await cache.GetAsync(key1, TestContext.Current.CancellationToken));
+		Assert.Null(await cache.GetAsync(key2, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -163,17 +163,17 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "empty-key";
 		var emptyValue = Array.Empty<byte>();
-		await cache.SetAsync(key, emptyValue);
+		await cache.SetAsync(key, emptyValue, TestContext.Current.CancellationToken);
 
 		// Act
-		var result = await cache.TryGetAndRemoveAsync(key);
+		var result = await cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.NotNull(result);
 		Assert.Empty(result);
 
 		// Verify value was removed
-		var afterRemove = await cache.GetAsync(key);
+		var afterRemove = await cache.GetAsync(key, TestContext.Current.CancellationToken);
 		Assert.Null(afterRemove);
 	}
 
@@ -184,7 +184,7 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "cancellation-key";
 		var value = Encoding.UTF8.GetBytes("cancellation-value");
-		await cache.SetAsync(key, value);
+		await cache.SetAsync(key, value, TestContext.Current.CancellationToken);
 		var cts = new CancellationTokenSource();
 
 		// Act - verify method accepts cancellation token without throwing
@@ -203,7 +203,7 @@ public class DistributedCacheExtensionsTests
 
 		// Act & Assert
 		await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-			await cache!.TryGetAndRemoveAsync("key"));
+			await cache!.TryGetAndRemoveAsync("key", cancellationToken: TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -214,7 +214,7 @@ public class DistributedCacheExtensionsTests
 
 		// Act & Assert
 		await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-			await cache.TryGetAndRemoveAsync(null!));
+			await cache.TryGetAndRemoveAsync(null!, cancellationToken: TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -224,11 +224,11 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "high-concurrency-key";
 		var value = Encoding.UTF8.GetBytes("high-concurrency-value");
-		await cache.SetAsync(key, value);
+		await cache.SetAsync(key, value, TestContext.Current.CancellationToken);
 
 		// Act - simulate high concurrency with 100 threads
 		var tasks = Enumerable.Range(0, 100)
-			.Select(_ => cache.TryGetAndRemoveAsync(key))
+			.Select(_ => cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken))
 			.ToArray();
 
 		var results = await Task.WhenAll(tasks);
@@ -249,11 +249,11 @@ public class DistributedCacheExtensionsTests
 		var cache = CreateCache();
 		const string key = "sequential-key";
 		var value = Encoding.UTF8.GetBytes("sequential-value");
-		await cache.SetAsync(key, value);
+		await cache.SetAsync(key, value, TestContext.Current.CancellationToken);
 
 		// Act
-		var firstResult = await cache.TryGetAndRemoveAsync(key);
-		var secondResult = await cache.TryGetAndRemoveAsync(key);
+		var firstResult = await cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken);
+		var secondResult = await cache.TryGetAndRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.NotNull(firstResult);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,11 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
+
+  <!-- MTP0001 is raised by Microsoft.Testing.Platform when VSTest-specific MSBuild
+       properties (VSTestTestAdapterPath, VSTestTestCaseFilter) are set by the .NET
+       SDK's test-project defaults. MTP ignores them; the warning is informational. -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <NoWarn>$(NoWarn);MTP0001</NoWarn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## What

Migrates all 5 test projects from xunit v2 / VSTest to **xunit.v3 3.2.2 + Microsoft Testing Platform (MTP)**.

### Package changes per test project

- Removed: `xunit` (v2.9.3), `xunit.runner.visualstudio` (3.1.5), `Microsoft.NET.Test.Sdk` (18.3.0)
- Added: `xunit.v3` 3.2.2
- Upgraded: `coverlet.collector` 8.0.0 → 10.0.0 (required for MTP coverage)

### Project-level changes

- `<OutputType>Exe</OutputType>` — xunit v3 test projects are standalone MTP processes, not hosted under vstest.console
- `<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>` — makes `dotnet test` delegate to MTP

### Test hygiene surfaced by v3

- Fixed a copy-paste bug in two validation tests where an async Moq `.Callback` passed the wrong argument. xunit v2 silently swallowed the resulting strict-mock exception from the fire-and-forget async callback; v3's stricter async handling surfaces it.
- Attached two affected test classes to an existing collection fixture to reset shared state between tests — v2's serial defaults hid the state coupling.
- Fixed a concurrency bug in a shared rate-limiting helper: `ConcurrentDictionary.AddOrUpdate` may invoke its factory lambdas multiple times under contention, and a side-effect flag set inside the factory leaked across CAS retries. Replaced with an explicit `TryGetValue` / `TryAdd` / `TryUpdate` loop.
- Fixed all 59 xUnit1051 analyzer hints across 10 test files (pass `TestContext.Current.CancellationToken` to methods accepting a token).
- Suppressed MTP0001 in `Directory.Build.props` for test projects: the flagged VSTest properties are auto-injected by the .NET SDK / `dotnet test` CLI and have no project-file opt-out.

### Workflow hardening

- SHA-pinned all actions in `pr-tests.yml` and `codeql-analysis.yml`, matching the pattern in `enhanced-release.yml`. Protects against tag-hijacking where an attacker re-publishes a tag after compromising the action's repo.
- Bump `actions/checkout` → v6.0.2, `actions/cache` → v5.0.5, `actions/upload-artifact` → v7.0.1 (Node.js 24 runtime).

## Why

- MTP is the future of .NET testing; VSTest is in maintenance mode.
- Faster test startup (~300ms vs ~2s), better parallelism, Native AOT compatible.
- Smaller test footprint (no vstest.console.exe host, no reflection-based discovery).
- Unblocks future coverage-in-Sonar wiring via coverlet 10.