### PR TITLE
feat(Utils): Materialize<T> extension for one-shot enumeration

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Utils/EnumerableExtensionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Utils/EnumerableExtensionsTests.cs
@@ -1,0 +1,102 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections.Generic;
+using System.Linq;
+using Abblix.Utils;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Utils;
+
+public class EnumerableExtensionsTests
+{
+    [Fact]
+    public void Materialize_ArraySource_ReturnsSameInstance_NoCopy()
+    {
+        var source = new[] { 1, 2, 3 };
+
+        var materialized = source.Materialize();
+
+        Assert.Same(source, materialized);
+    }
+
+    [Fact]
+    public void Materialize_ListSource_ReturnsSameInstance_NoCopy()
+    {
+        var source = new List<int> { 1, 2, 3 };
+
+        var materialized = source.Materialize();
+
+        Assert.Same(source, materialized);
+    }
+
+    [Fact]
+    public void Materialize_HashSetSource_ReturnsSameInstance_NoCopy()
+    {
+        var source = new HashSet<int> { 1, 2, 3 };
+
+        var materialized = source.Materialize();
+
+        Assert.Same(source, materialized);
+    }
+
+    [Fact]
+    public void Materialize_LazyLinqSource_EvaluatesOnce_AndReturnsConcreteCollection()
+    {
+        var enumerationCount = 0;
+        IEnumerable<int> Lazy()
+        {
+            enumerationCount++;
+            yield return 1;
+            yield return 2;
+            yield return 3;
+        }
+
+        var materialized = Lazy().Materialize();
+
+        // Single materialization upfront…
+        Assert.Equal(1, enumerationCount);
+        // …and replay-many afterwards: subsequent enumerations do not
+        // re-execute the source iterator.
+        Assert.Equal([1, 2, 3], materialized);
+        Assert.Equal([1, 2, 3], materialized);
+        Assert.Equal(1, enumerationCount);
+    }
+
+    [Fact]
+    public void Materialize_LazyLinqSource_PreservesOrder()
+    {
+        var source = Enumerable.Range(1, 5).Where(x => x % 2 == 1);
+
+        var materialized = source.Materialize();
+
+        Assert.Equal([1, 3, 5], materialized);
+    }
+
+    [Fact]
+    public void Materialize_EmptySource_ReturnsEmptyCollection()
+    {
+        var materialized = Enumerable.Empty<int>().Materialize();
+
+        Assert.Empty(materialized);
+    }
+}

--- a/Abblix.Utils/EnumerableExtensions.cs
+++ b/Abblix.Utils/EnumerableExtensions.cs
@@ -37,6 +37,24 @@ public static class EnumerableExtensions
 		=> value ?? [];
 
 	/// <summary>
+	/// Forces a sequence to be evaluated once and returns the result as a non-lazy
+	/// <see cref="IReadOnlyCollection{T}"/> that callers can iterate any number of times.
+	/// Use at any site that needs to enumerate the same <see cref="IEnumerable{T}"/> more than once
+	/// (cost estimate + actual call, log + record, etc.) — a lazy LINQ pipeline or an iterator
+	/// method passed by an upstream caller would otherwise re-execute its source per enumeration.
+	/// </summary>
+	/// <remarks>
+	/// Skips the allocation when <paramref name="source"/> is already a concrete collection
+	/// (<c>T[]</c>, <c>List&lt;T&gt;</c>, <c>HashSet&lt;T&gt;</c>, etc.) — only lazy /
+	/// iterator-method sources pay for a one-shot copy.
+	/// </remarks>
+	/// <typeparam name="T">The type of elements in the sequence.</typeparam>
+	/// <param name="source">The sequence to materialize.</param>
+	/// <returns>A non-lazy collection holding all elements of <paramref name="source"/>.</returns>
+	public static IReadOnlyCollection<T> Materialize<T>(this IEnumerable<T> source)
+		=> source as IReadOnlyCollection<T> ?? [..source];
+
+	/// <summary>
 	/// Traverses a hierarchy upwards, starting from a specific item and moving to its parent, grandparent, etc.,
 	/// as determined by a parent selector function.
 	/// </summary>


### PR DESCRIPTION
## Summary

Adds `Materialize<T>()` to `Abblix.Utils.EnumerableExtensions` — a small but frequently-needed helper for «evaluate this `IEnumerable<T>` once, return a non-lazy collection that can be replayed any number of times».

The pattern arose in downstream Z-score detection work where the middleware needed to enumerate the same message sequence twice (cost estimate → actual provider call) and naively passing `IEnumerable<ChatMessage>` re-executed any lazy pipeline upstream. Promoting this to `Abblix.Utils` so other Abblix services pick it up in the next package version.

## Implementation
```csharp
public static IReadOnlyCollection<T> Materialize<T>(this IEnumerable<T> source)
    => source as IReadOnlyCollection<T> ?? [..source];
```

- Returns `IReadOnlyCollection<T>` (not `T[]`) so the contract communicates «enumerate-once, replay-many» rather than a specific implementation strategy.
- Skips the copy when source is already a concrete collection — `T[]`, `List<T>`, `HashSet<T>`, `Dictionary<,>.Values`, etc. all implement `IReadOnlyCollection<T>` in modern .NET.
- Uses the C# 12 collection-expression spread `[..source]` for the materialize-on-copy fallback path.

## Test plan
- [x] 6 new tests under `Abblix.Oidc.Server.UnitTests/Utils/EnumerableExtensionsTests.cs`:
  - array source returns same instance (no copy)
  - list source returns same instance (no copy)
  - hashset source returns same instance (no copy)
  - lazy LINQ source evaluates once, replay-many afterwards (counter check)
  - lazy source preserves order
  - empty source returns empty collection
- [x] `dotnet test` — full suite 1769 passed
- [ ] CI green