### PR TITLE
chore(deps): drop Grpc.AspNetCore — use Google.Protobuf for ProtoBuf-only storage

### DIFF
--- a/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -52,7 +52,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+      <PackageReference Include="Google.Protobuf" Version="3.34.1" />
       <PackageReference Include="Grpc.Tools" Version="2.78.0" PrivateAssets="All" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- `Abblix.Oidc.Server` uses ProtoBuf only for Redis storage (`Features/Storages/Proto/*.proto` with `GrpcServices="None"`) and **never hosts gRPC endpoints** — `AddGrpc` / `MapGrpcService` / `Grpc.AspNetCore.Server` are not present in the codebase.
- The `Grpc.AspNetCore` umbrella is replaced with the runtime-only `Google.Protobuf` 3.34.1 (matches the `Abblix.Utils` version). `Grpc.Tools` 2.78.0 stays as the build-time driver for protoc / MSBuild.
- Aligns with the canonical pattern in [Docs/wiki/protobuf-redis-session-storage.md § MSBuild integration](https://github.com/Abblix/Docs/blob/master/wiki/protobuf-redis-session-storage.md) (updated today).
- All `<Protobuf>` includes already had `GrpcServices="None"` — no further change needed.

Cross-repo: parallel pull requests in the two downstream repositories apply the same approach.