### PR TITLE
test: migrate UnitTests from Mock<TimeProvider> to FakeTimeProvider

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -38,6 +38,7 @@ using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -54,7 +55,7 @@ public class AuthorizationRequestProcessorTests
     private readonly Mock<IAuthorizationCodeService> _authorizationCodeService;
     private readonly Mock<IAccessTokenService> _accessTokenService;
     private readonly Mock<IIdentityTokenService> _identityTokenService;
-    private readonly Mock<TimeProvider> _timeProvider;
+    private readonly FakeTimeProvider _timeProvider;
     private readonly AuthorizationRequestProcessor _processor;
 
     public AuthorizationRequestProcessorTests()
@@ -64,7 +65,7 @@ public class AuthorizationRequestProcessorTests
         _authorizationCodeService = new Mock<IAuthorizationCodeService>(MockBehavior.Strict);
         _accessTokenService = new Mock<IAccessTokenService>(MockBehavior.Strict);
         _identityTokenService = new Mock<IIdentityTokenService>(MockBehavior.Strict);
-        _timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
+        _timeProvider = new FakeTimeProvider();
 
         _processor = new AuthorizationRequestProcessor(
             _authSessionService.Object,
@@ -72,7 +73,7 @@ public class AuthorizationRequestProcessorTests
             _authorizationCodeService.Object,
             _accessTokenService.Object,
             _identityTokenService.Object,
-            _timeProvider.Object);
+            _timeProvider);
     }
 
     private static ValidAuthorizationRequest CreateRequest(
@@ -550,14 +551,12 @@ public class AuthorizationRequestProcessorTests
     public async Task ProcessAsync_WithMaxAge_ShouldFilterOldSessions()
     {
         // Arrange
-        var now = DateTimeOffset.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         var maxAge = TimeSpan.FromMinutes(30);
         var request = CreateRequest(maxAge: maxAge);
 
         var oldSession = CreateAuthSession("old", authTime: now - TimeSpan.FromHours(1));
         var recentSession = CreateAuthSession("recent", authTime: now - TimeSpan.FromMinutes(10));
-
-        _timeProvider.Setup(t => t.GetUtcNow()).Returns(now);
 
         _authSessionService
             .Setup(s => s.GetAvailableAuthSessions())
@@ -1034,14 +1033,12 @@ public class AuthorizationRequestProcessorTests
     public async Task ProcessAsync_WithMaxAgeExcludingAllSessions_ShouldReturnLoginRequired()
     {
         // Arrange
-        var now = DateTimeOffset.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         var maxAge = TimeSpan.FromMinutes(30);
         var request = CreateRequest(maxAge: maxAge);
 
         var oldSession1 = CreateAuthSession("old1", authTime: now - TimeSpan.FromHours(2));
         var oldSession2 = CreateAuthSession("old2", authTime: now - TimeSpan.FromHours(1));
-
-        _timeProvider.Setup(t => t.GetUtcNow()).Returns(now);
 
         _authSessionService
             .Setup(s => s.GetAvailableAuthSessions())

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Revocation/RevocationRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Revocation/RevocationRequestProcessorTests.cs
@@ -28,6 +28,7 @@ using Abblix.Oidc.Server.Endpoints.Revocation.Interfaces;
 using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Features.Tokens.Revocation;
 using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -40,14 +41,14 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.Revocation;
 public class RevocationRequestProcessorTests
 {
     private readonly Mock<ITokenRegistry> _tokenRegistry;
-    private readonly Mock<TimeProvider> _clock;
+    private readonly FakeTimeProvider _clock;
     private readonly RevocationRequestProcessor _processor;
 
     public RevocationRequestProcessorTests()
     {
         _tokenRegistry = new Mock<ITokenRegistry>(MockBehavior.Strict);
-        _clock = new Mock<TimeProvider>(MockBehavior.Strict);
-        _processor = new RevocationRequestProcessor(_tokenRegistry.Object, _clock.Object);
+        _clock = new FakeTimeProvider();
+        _processor = new RevocationRequestProcessor(_tokenRegistry.Object, _clock);
     }
 
     private static RevocationRequest CreateRevocationRequest() => new()
@@ -56,11 +57,11 @@ public class RevocationRequestProcessorTests
         TokenTypeHint = "access_token",
     };
 
-    private static JsonWebToken CreateValidToken(string jwtId = "token_id_123")
+    private JsonWebToken CreateValidToken(string jwtId = "token_id_123")
     {
         var token = new JsonWebToken();
         token.Payload.JwtId = jwtId;
-        token.Payload.ExpiresAt = DateTimeOffset.UtcNow.AddHours(1);
+        token.Payload.ExpiresAt = _clock.GetUtcNow().AddHours(1);
         return token;
     }
 
@@ -82,7 +83,6 @@ public class RevocationRequestProcessorTests
         var request = CreateRevocationRequest();
         var token = CreateValidToken();
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
 
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
@@ -90,8 +90,6 @@ public class RevocationRequestProcessorTests
                 JsonWebTokenStatus.Revoked,
                 token.Payload.ExpiresAt!.Value))
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -117,9 +115,7 @@ public class RevocationRequestProcessorTests
         // Arrange
         var request = CreateRevocationRequest();
         var validRequest = CreateValidRevocationRequest(request);
-        var now = DateTimeOffset.UtcNow;
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
+        var now = _clock.GetUtcNow();
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -144,6 +140,7 @@ public class RevocationRequestProcessorTests
         var token = CreateValidToken();
         var validRequest = CreateValidRevocationRequest(request, token);
         var now = new DateTimeOffset(2025, 11, 7, 12, 0, 0, TimeSpan.Zero);
+        _clock.SetUtcNow(now);
 
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
@@ -152,15 +149,12 @@ public class RevocationRequestProcessorTests
                 It.IsAny<DateTimeOffset>()))
             .Returns(Task.CompletedTask);
 
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
-
         // Act
         var result = await _processor.ProcessAsync(validRequest);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var revoked));
         Assert.Equal(now, revoked.RevokedAt);
-        _clock.Verify(c => c.GetUtcNow(), Times.Once);
     }
 
     /// <summary>
@@ -174,7 +168,6 @@ public class RevocationRequestProcessorTests
         var request = CreateRevocationRequest();
         var token = CreateValidToken();
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
 
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
@@ -182,8 +175,6 @@ public class RevocationRequestProcessorTests
                 JsonWebTokenStatus.Revoked,
                 token.Payload.ExpiresAt!.Value))
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         await _processor.ProcessAsync(validRequest);
@@ -208,7 +199,6 @@ public class RevocationRequestProcessorTests
         var request = CreateRevocationRequest();
         var token = CreateValidToken("custom_jwt_id_456");
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
 
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
@@ -216,8 +206,6 @@ public class RevocationRequestProcessorTests
                 JsonWebTokenStatus.Revoked,
                 It.IsAny<DateTimeOffset>()))
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -242,7 +230,6 @@ public class RevocationRequestProcessorTests
         };
         var token = CreateValidToken();
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
 
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
@@ -250,8 +237,6 @@ public class RevocationRequestProcessorTests
                 JsonWebTokenStatus.Revoked,
                 It.IsAny<DateTimeOffset>()))
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -271,10 +256,9 @@ public class RevocationRequestProcessorTests
         // Arrange
         var request = CreateRevocationRequest();
         var token = CreateValidToken();
-        var expiresAt = DateTimeOffset.UtcNow.AddHours(2);
+        var expiresAt = _clock.GetUtcNow().AddHours(2);
         token.Payload.ExpiresAt = expiresAt;
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
         DateTimeOffset? capturedExpiresAt = null;
 
         _tokenRegistry
@@ -284,8 +268,6 @@ public class RevocationRequestProcessorTests
                 It.IsAny<DateTimeOffset>()))
             .Callback<string, JsonWebTokenStatus, DateTimeOffset>((_, _, exp) => capturedExpiresAt = exp)
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         await _processor.ProcessAsync(validRequest);
@@ -318,11 +300,8 @@ public class RevocationRequestProcessorTests
         var request = CreateRevocationRequest();
         var token = new JsonWebToken();
         token.Payload.JwtId = null;
-        token.Payload.ExpiresAt = DateTimeOffset.UtcNow.AddHours(1);
+        token.Payload.ExpiresAt = _clock.GetUtcNow().AddHours(1);
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -346,9 +325,6 @@ public class RevocationRequestProcessorTests
         token.Payload.JwtId = "token_id_123";
         token.Payload.ExpiresAt = null;
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -370,9 +346,6 @@ public class RevocationRequestProcessorTests
         // Arrange
         var request = CreateRevocationRequest();
         var validRequest = CreateValidRevocationRequest(request);
-        var now = DateTimeOffset.UtcNow;
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result = await _processor.ProcessAsync(validRequest);
@@ -392,7 +365,6 @@ public class RevocationRequestProcessorTests
         var request = CreateRevocationRequest();
         var token = CreateValidToken();
         var validRequest = CreateValidRevocationRequest(request, token);
-        var now = DateTimeOffset.UtcNow;
 
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
@@ -400,8 +372,6 @@ public class RevocationRequestProcessorTests
                 JsonWebTokenStatus.Revoked,
                 It.IsAny<DateTimeOffset>()))
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         await _processor.ProcessAsync(validRequest);
@@ -431,8 +401,6 @@ public class RevocationRequestProcessorTests
         var token2 = CreateValidToken("token_2");
         var validRequest2 = CreateValidRevocationRequest(request2, token2);
 
-        var now = DateTimeOffset.UtcNow;
-
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(
                 "token_1",
@@ -446,8 +414,6 @@ public class RevocationRequestProcessorTests
                 JsonWebTokenStatus.Revoked,
                 token2.Payload.ExpiresAt!.Value))
             .Returns(Task.CompletedTask);
-
-        _clock.Setup(c => c.GetUtcNow()).Returns(now);
 
         // Act
         var result1 = await _processor.ProcessAsync(validRequest1);

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -36,6 +36,7 @@ using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 using BackChannelAuthenticationRequest = Abblix.Oidc.Server.Features.BackChannelAuthentication.BackChannelAuthenticationRequest;
@@ -63,8 +64,7 @@ public class BackChannelAuthenticationGrantHandlerTests
     {
         _storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
         _parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var options = Options.Create(new OidcOptions
         {
@@ -79,7 +79,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _handler = new BackChannelAuthenticationGrantHandler(
             _storage.Object,
             _parameterValidator.Object,
-            timeProvider.Object,
+            timeProvider,
             options,
             serviceProvider);
     }
@@ -686,8 +686,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
         var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var statusNotifier = new Mock<IBackChannelLongPollingService>(MockBehavior.Strict);
 
@@ -705,7 +704,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
             parameterValidator.Object,
-            timeProvider.Object,
+            timeProvider,
             options,
             serviceProvider,
             statusNotifier.Object);
@@ -780,8 +779,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
         var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var statusNotifier = new Mock<IBackChannelLongPollingService>(MockBehavior.Strict);
 
@@ -799,7 +797,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
             parameterValidator.Object,
-            timeProvider.Object,
+            timeProvider,
             options,
             serviceProvider,
             statusNotifier.Object);
@@ -889,8 +887,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
         var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var options = Options.Create(new OidcOptions
         {
@@ -906,7 +903,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
             parameterValidator.Object,
-            timeProvider.Object,
+            timeProvider,
             options,
             serviceProvider); // Status notifier is null
 
@@ -948,8 +945,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
         var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var statusNotifier = new Mock<IBackChannelLongPollingService>(MockBehavior.Strict);
 
@@ -968,7 +964,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
             parameterValidator.Object,
-            timeProvider.Object,
+            timeProvider,
             options,
             serviceProvider,
             statusNotifier.Object);

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/ClientCredentialsGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/ClientCredentialsGrantHandlerTests.cs
@@ -28,6 +28,7 @@ using Abblix.Oidc.Server.Endpoints.Token.Grants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -181,9 +182,8 @@ public class ClientCredentialsGrantHandlerTests
         var sessionIdGenerator = new Mock<ISessionIdGenerator>(MockBehavior.Strict);
         sessionIdGenerator.Setup(g => g.GenerateSessionId()).Returns("session_123");
         var fixedTime = new DateTimeOffset(2024, 11, 6, 12, 0, 0, TimeSpan.Zero);
-        var timeProvider = new Mock<TimeProvider>();
-        timeProvider.Setup(t => t.GetUtcNow()).Returns(fixedTime);
-        var handler = new ClientCredentialsGrantHandler(sessionIdGenerator.Object, timeProvider.Object);
+        var timeProvider = new FakeTimeProvider(fixedTime);
+        var handler = new ClientCredentialsGrantHandler(sessionIdGenerator.Object, timeProvider);
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest();
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -34,6 +34,7 @@ using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Common.Configuration;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 using StoredDeviceAuthorizationRequest = Abblix.Oidc.Server.Features.DeviceAuthorization.DeviceAuthorizationRequest;
@@ -62,8 +63,7 @@ public class DeviceCodeGrantHandlerTests
     {
         _storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Strict);
         _parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var options = Options.Create(new OidcOptions
         {
@@ -80,7 +80,7 @@ public class DeviceCodeGrantHandlerTests
         _handler = new DeviceCodeGrantHandler(
             _storage.Object,
             _parameterValidator.Object,
-            timeProvider.Object,
+            timeProvider,
             options);
     }
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -34,6 +34,7 @@ using Abblix.Oidc.Server.Features.JwtBearer;
 using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -596,7 +597,7 @@ public class JwtBearerGrantHandlerTests
 		Mock<IJwtBearerIssuerProvider> IssuerProvider,
 		Mock<IRequestInfoProvider> RequestInfoProvider,
 		Mock<ISessionIdGenerator> SessionIdGenerator,
-		Mock<TimeProvider> TimeProvider);
+		FakeTimeProvider TimeProvider);
 
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("SonarAnalyzer", "S1172",
 		Justification = "allowedAlgorithms is kept for call-site symmetry with SetupTrustedIssuer; tests set algorithms on the trusted issuer, not the handler.")]
@@ -616,15 +617,13 @@ public class JwtBearerGrantHandlerTests
 		var issuerProvider = new Mock<IJwtBearerIssuerProvider>(MockBehavior.Strict);
 		var requestInfoProvider = new Mock<IRequestInfoProvider>(MockBehavior.Strict);
 		var sessionIdGenerator = new Mock<ISessionIdGenerator>(MockBehavior.Strict);
-		var timeProvider = new Mock<TimeProvider>();
+		var timeProvider = fixedTime.HasValue
+			? new FakeTimeProvider(fixedTime.Value)
+			: new FakeTimeProvider();
 
 		sessionIdGenerator
 			.Setup(g => g.GenerateSessionId())
 			.Returns(sessionIdFactory ?? (() => "session_123"));
-
-		timeProvider
-			.Setup(t => t.GetUtcNow())
-			.Returns(fixedTime ?? DateTimeOffset.UtcNow);
 
 		var options = new JwtBearerOptions { RequireJti = requireJti ?? false };
 		if (strictAudienceValidation.HasValue)
@@ -663,7 +662,7 @@ public class JwtBearerGrantHandlerTests
 			issuerProvider.Object,
 			requestInfoProvider.Object,
 			sessionIdGenerator.Object,
-			timeProvider.Object,
+			timeProvider,
 			logger.Object);
 
 		return (handler, new Mocks(jwtValidator, issuerProvider, requestInfoProvider, sessionIdGenerator, timeProvider));

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAuthenticatorTestsBase.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAuthenticatorTestsBase.cs
@@ -30,6 +30,7 @@ using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -270,12 +271,11 @@ public abstract class ClientAuthenticatorTestsBase<TAuthenticator>
     public async Task ExpiredClientSecret_ShouldReturnNull()
     {
         // Arrange
-        var now = DateTimeOffset.UtcNow;
-        var timeProvider = new Mock<TimeProvider>();
-        timeProvider.Setup(t => t.GetUtcNow()).Returns(now);
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow();
 
         var clientInfoProvider = new Mock<IClientInfoProvider>(MockBehavior.Strict);
-        var authenticator = CreateAuthenticator(clientInfoProvider, timeProvider.Object);
+        var authenticator = CreateAuthenticator(clientInfoProvider, timeProvider);
 
         var clientInfo = new ClientInfo(ClientId)
         {
@@ -338,12 +338,11 @@ public abstract class ClientAuthenticatorTestsBase<TAuthenticator>
     public async Task MultipleSecrets_OneValid_ShouldAuthenticate()
     {
         // Arrange
-        var now = DateTimeOffset.UtcNow;
-        var timeProvider = new Mock<TimeProvider>();
-        timeProvider.Setup(t => t.GetUtcNow()).Returns(now);
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow();
 
         var clientInfoProvider = new Mock<IClientInfoProvider>(MockBehavior.Strict);
-        var authenticator = CreateAuthenticator(clientInfoProvider, timeProvider.Object);
+        var authenticator = CreateAuthenticator(clientInfoProvider, timeProvider);
 
         var clientInfo = new ClientInfo(ClientId)
         {

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretAuthenticatorTests.cs
@@ -29,6 +29,7 @@ using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Hashing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 using HashAlg = Abblix.Oidc.Server.Features.Hashing.HashAlgorithm;
@@ -43,7 +44,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
 public class ClientSecretAuthenticatorTests
 {
     private readonly Mock<IClientInfoProvider> _clientInfoProvider;
-    private readonly Mock<TimeProvider> _clock;
+    private readonly FakeTimeProvider _clock;
     private readonly Mock<IHashService> _hashService;
     private readonly TestClientSecretAuthenticator _authenticator;
 
@@ -51,13 +52,13 @@ public class ClientSecretAuthenticatorTests
     {
         var logger = new Mock<ILogger<ClientSecretAuthenticator>>();
         _clientInfoProvider = new Mock<IClientInfoProvider>(MockBehavior.Strict);
-        _clock = new Mock<TimeProvider>();
+        _clock = new FakeTimeProvider();
         _hashService = new Mock<IHashService>(MockBehavior.Strict);
 
         _authenticator = new TestClientSecretAuthenticator(
             logger.Object,
             _clientInfoProvider.Object,
-            _clock.Object,
+            _clock,
             _hashService.Object);
     }
 
@@ -289,10 +290,6 @@ public class ClientSecretAuthenticatorTests
             .Setup(h => h.Sha(HashAlg.Sha256, secret))
             .Returns(secretHash);
 
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
-
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(
             clientId, secret, ClientAuthenticationMethods.ClientSecretBasic);
@@ -326,10 +323,6 @@ public class ClientSecretAuthenticatorTests
         _hashService
             .Setup(h => h.Sha(HashAlg.Sha512, secret))
             .Returns(secretHash);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(
@@ -389,7 +382,7 @@ public class ClientSecretAuthenticatorTests
         var clientId = "test-client";
         var secret = "test-secret";
         var secretHash = ComputeSha256(secret);
-        var expirationTime = DateTimeOffset.UtcNow.AddDays(-1);
+        var expirationTime = _clock.GetUtcNow().AddDays(-1);
         var clientInfo = new ClientInfo(clientId)
         {
             ClientSecrets =
@@ -414,10 +407,6 @@ public class ClientSecretAuthenticatorTests
         _hashService
             .Setup(h => h.Sha(HashAlg.Sha256, secret))
             .Returns(secretHash);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(
@@ -438,7 +427,7 @@ public class ClientSecretAuthenticatorTests
         var clientId = "test-client";
         var secret = "test-secret";
         var secretHash = ComputeSha256(secret);
-        var expirationTime = DateTimeOffset.UtcNow.AddDays(30);
+        var expirationTime = _clock.GetUtcNow().AddDays(30);
         var clientInfo = new ClientInfo(clientId)
         {
             ClientSecrets =
@@ -464,10 +453,6 @@ public class ClientSecretAuthenticatorTests
             .Setup(h => h.Sha(HashAlg.Sha256, secret))
             .Returns(secretHash);
 
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
-
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(
             clientId, secret, ClientAuthenticationMethods.ClientSecretBasic);
@@ -487,8 +472,8 @@ public class ClientSecretAuthenticatorTests
         var clientId = "test-client";
         var secret = "test-secret";
         var secretHash = ComputeSha256(secret);
-        var oldExpiration = DateTimeOffset.UtcNow.AddDays(10);
-        var newExpiration = DateTimeOffset.UtcNow.AddDays(30);
+        var oldExpiration = _clock.GetUtcNow().AddDays(10);
+        var newExpiration = _clock.GetUtcNow().AddDays(30);
         var clientInfo = new ClientInfo(clientId)
         {
             ClientSecrets =
@@ -510,10 +495,6 @@ public class ClientSecretAuthenticatorTests
         _hashService
             .Setup(h => h.Sha(HashAlg.Sha256, secret))
             .Returns(secretHash);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(
@@ -550,10 +531,6 @@ public class ClientSecretAuthenticatorTests
         _hashService
             .Setup(h => h.Sha(HashAlg.Sha512, secret))
             .Returns(sha512Hash);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(
@@ -604,10 +581,6 @@ public class ClientSecretAuthenticatorTests
             .Setup(h => h.Sha(HashAlg.Sha256, secret))
             .Returns(sha256Hash);
 
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
-
         // Act
         await _authenticator.TestTryAuthenticateAsync(
             clientId, secret, ClientAuthenticationMethods.ClientSecretBasic);
@@ -653,10 +626,6 @@ public class ClientSecretAuthenticatorTests
         _hashService
             .Setup(h => h.Sha(HashAlg.Sha256, secret))
             .Returns(secretHash);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         // Act
         var result = await _authenticator.TestTryAuthenticateAsync(

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
@@ -34,6 +34,7 @@ using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Features.Tokens.Revocation;
 using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 using JsonWebToken = Abblix.Jwt.JsonWebToken;
@@ -56,7 +57,7 @@ public class ClientSecretJwtAuthenticatorTests
     private readonly Mock<IJsonWebTokenValidator> _tokenValidator;
     private readonly Mock<IClientInfoProvider> _clientInfoProvider;
     private readonly Mock<IRequestInfoProvider> _requestInfoProvider;
-    private readonly Mock<TimeProvider> _clock;
+    private readonly FakeTimeProvider _clock;
     private readonly Mock<ITokenRegistry> _tokenRegistry;
     private readonly ClientSecretJwtAuthenticator _authenticator;
 
@@ -66,7 +67,7 @@ public class ClientSecretJwtAuthenticatorTests
         _tokenValidator = new Mock<IJsonWebTokenValidator>(MockBehavior.Strict);
         _clientInfoProvider = new Mock<IClientInfoProvider>(MockBehavior.Strict);
         _requestInfoProvider = new Mock<IRequestInfoProvider>(MockBehavior.Strict);
-        _clock = new Mock<TimeProvider>();
+        _clock = new FakeTimeProvider();
         _tokenRegistry = new Mock<ITokenRegistry>(MockBehavior.Strict);
 
         _requestInfoProvider
@@ -78,7 +79,7 @@ public class ClientSecretJwtAuthenticatorTests
             _tokenValidator.Object,
             _clientInfoProvider.Object,
             _requestInfoProvider.Object,
-            _clock.Object,
+            _clock,
             _tokenRegistry.Object);
     }
 
@@ -175,7 +176,7 @@ public class ClientSecretJwtAuthenticatorTests
     {
         // Arrange
         var jwtId = "unique-jwt-id-123";
-        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        var expiresAt = _clock.GetUtcNow().AddMinutes(5);
         var jwt = "valid.jwt.token";
 
         var clientInfo = new ClientInfo(ClientId)
@@ -211,10 +212,6 @@ public class ClientSecretJwtAuthenticatorTests
         _tokenRegistry
             .Setup(r => r.SetStatusAsync(jwtId, JsonWebTokenStatus.Used, It.IsAny<DateTimeOffset>()))
             .Returns(Task.CompletedTask);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         var request = new ClientRequest
         {
@@ -275,7 +272,7 @@ public class ClientSecretJwtAuthenticatorTests
             ClientSecrets = [new ClientSecret { Value = ClientSecret }]
         };
 
-        var token = CreateMockToken(ClientId, ClientId, [RequestUri], "jti", DateTimeOffset.UtcNow.AddMinutes(5));
+        var token = CreateMockToken(ClientId, ClientId, [RequestUri], "jti", _clock.GetUtcNow().AddMinutes(5));
 
         _tokenValidator
             .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationParameters>()))
@@ -298,10 +295,6 @@ public class ClientSecretJwtAuthenticatorTests
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(ClientId))
             .ReturnsAsync(clientInfo);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         var request = new ClientRequest
         {
@@ -332,7 +325,7 @@ public class ClientSecretJwtAuthenticatorTests
             ClientSecrets = [new ClientSecret { Value = ClientSecret }]
         };
 
-        var token = CreateMockToken(ClientId, "different-subject", [RequestUri], "jti", DateTimeOffset.UtcNow.AddMinutes(5));
+        var token = CreateMockToken(ClientId, "different-subject", [RequestUri], "jti", _clock.GetUtcNow().AddMinutes(5));
 
         _tokenValidator
             .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationParameters>()))
@@ -355,10 +348,6 @@ public class ClientSecretJwtAuthenticatorTests
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(ClientId))
             .ReturnsAsync(clientInfo);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         var request = new ClientRequest
         {
@@ -389,7 +378,7 @@ public class ClientSecretJwtAuthenticatorTests
             ClientSecrets = [new ClientSecret { Value = ClientSecret }]
         };
 
-        var token = CreateMockToken(ClientId, ClientId, [RequestUri], null, DateTimeOffset.UtcNow.AddMinutes(5));
+        var token = CreateMockToken(ClientId, ClientId, [RequestUri], null, _clock.GetUtcNow().AddMinutes(5));
 
         _tokenValidator
             .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationParameters>()))
@@ -412,10 +401,6 @@ public class ClientSecretJwtAuthenticatorTests
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(ClientId))
             .ReturnsAsync(clientInfo);
-
-        _clock
-            .Setup(c => c.GetUtcNow())
-            .Returns(DateTimeOffset.UtcNow);
 
         var request = new ClientRequest
         {

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
@@ -32,6 +32,7 @@ using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -60,8 +61,7 @@ public class AccessTokenServiceTests
         var issuerProvider = new Mock<IIssuerProvider>(MockBehavior.Strict);
         issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
 
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var tokenIdGenerator = new Mock<ITokenIdGenerator>(MockBehavior.Strict);
         tokenIdGenerator.Setup(g => g.GenerateTokenId()).Returns(TokenId);
@@ -70,7 +70,7 @@ public class AccessTokenServiceTests
 
         _service = new AccessTokenService(
             issuerProvider.Object,
-            timeProvider.Object,
+            timeProvider,
             tokenIdGenerator.Object,
             _jwtFormatter.Object);
     }

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -35,6 +35,7 @@ using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -66,15 +67,14 @@ public class IdentityTokenServiceTests
         var issuerProvider = new Mock<IIssuerProvider>(MockBehavior.Strict);
         issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
 
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         _jwtFormatter = new Mock<IClientJwtFormatter>(MockBehavior.Strict);
         _userClaimsProvider = new Mock<IUserClaimsProvider>(MockBehavior.Strict);
 
         _service = new IdentityTokenService(
             issuerProvider.Object,
-            timeProvider.Object,
+            timeProvider,
             _jwtFormatter.Object,
             _userClaimsProvider.Object);
     }

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
@@ -33,6 +33,7 @@ using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Moq;
 using Xunit;
@@ -64,8 +65,7 @@ public class LogoutTokenServiceTests
         var logger = new Mock<ILogger<LogoutTokenService>>();
         _currentTime = new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.Zero);
 
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         _subjectTypeConverter = new Mock<ISubjectTypeConverter>(MockBehavior.Strict);
         _jwtFormatter = new Mock<IClientJwtFormatter>(MockBehavior.Strict);
@@ -78,7 +78,7 @@ public class LogoutTokenServiceTests
 
         _service = new LogoutTokenService(
             logger.Object,
-            timeProvider.Object,
+            timeProvider,
             _subjectTypeConverter.Object,
             _jwtFormatter.Object,
             _tokenIdGenerator.Object);

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -35,6 +35,7 @@ using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.Tokens.Revocation;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -65,8 +66,7 @@ public class RefreshTokenServiceTests
         var issuerProvider = new Mock<IIssuerProvider>(MockBehavior.Strict);
         issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
 
-        var timeProvider = new Mock<TimeProvider>(MockBehavior.Strict);
-        timeProvider.Setup(tp => tp.GetUtcNow()).Returns(_currentTime);
+        var timeProvider = new FakeTimeProvider(_currentTime);
 
         var tokenIdGenerator = new Mock<ITokenIdGenerator>(MockBehavior.Strict);
         tokenIdGenerator.Setup(g => g.GenerateTokenId()).Returns(TokenId);
@@ -77,7 +77,7 @@ public class RefreshTokenServiceTests
 
         _service = new RefreshTokenService(
             issuerProvider.Object,
-            timeProvider.Object,
+            timeProvider,
             tokenIdGenerator.Object,
             _jwtFormatter.Object,
             _tokenRegistry.Object);


### PR DESCRIPTION
## Summary

- Replace `Mock<TimeProvider>` with `Microsoft.Extensions.Time.Testing.FakeTimeProvider` across 13 unit-test files. `FakeTimeProvider` drives `CreateTimer`, `PeriodicTimer`, `Task.Delay(span, timeProvider)`, and rate limiters deterministically; `Mock<TimeProvider>` only covered `GetUtcNow`.
- Convert mid-test re-setup patterns (`Setup(...).Returns(later)`) to `SetUtcNow()` / direct `_clock.GetUtcNow()` reads, dropping redundant `Setup` calls that re-asserted the default.
- Fix latent `ClientSecretAuthenticatorTests` bug where `expirationTime = DateTimeOffset.UtcNow.AddDays(-1)` was a real-wall-clock-vs-FakeTimeProvider-default-year-2000 cross-up: the secret was actually in the future, so the "expired" assertions accidentally still passed against the old `Mock<TimeProvider>`. Now derived from `_clock.GetUtcNow()`.

## Files migrated (13)

- `Endpoints/Token/JwtBearerGrantHandlerTests.cs`
- `Endpoints/Token/DeviceCodeGrantHandlerTests.cs`
- `Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs`
- `Endpoints/Token/ClientCredentialsGrantHandlerTests.cs`
- `Endpoints/Revocation/RevocationRequestProcessorTests.cs`
- `Endpoints/Authorization/AuthorizationRequestProcessorTests.cs`
- `Features/ClientAuthentication/ClientSecretAuthenticatorTests.cs`
- `Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs`
- `Features/ClientAuthentication/ClientAuthenticatorTestsBase.cs`
- `Features/Tokens/RefreshTokenServiceTests.cs`
- `Features/Tokens/IdentityTokenServiceTests.cs`
- `Features/Tokens/LogoutTokenServiceTests.cs`
- `Features/Tokens/AccessTokenServiceTests.cs`

The `Microsoft.Extensions.TimeProvider.Testing` package was already present on develop; this PR only changes test code.