### PR TITLE
Close 17 SonarCloud maintainability issues

### DIFF
--- a/.github/scripts/lint-no-inline-secrets.py
+++ b/.github/scripts/lint-no-inline-secrets.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import pathlib
 import re
 import sys
+from typing import Iterator
 
 import yaml
 
@@ -50,39 +51,42 @@ PATTERN = re.compile(
 WORKFLOWS_DIR = pathlib.Path(".github/workflows")
 
 
+def _iter_job_runs(job_name: str, job: dict) -> Iterator[tuple[str, str, str]]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return
+    for idx, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        yield job_name, step.get("name") or f"step #{idx}", run
+
+
+def _iter_run_blocks(doc: object) -> Iterator[tuple[str, str, str]]:
+    if not isinstance(doc, dict):
+        return
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    for job_name, job in jobs.items():
+        if isinstance(job, dict):
+            yield from _iter_job_runs(job_name, job)
+
+
 def scan_file(path: pathlib.Path) -> list[str]:
     try:
         doc = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
         return [f"{path}: YAML parse error: {exc}"]
 
-    if not isinstance(doc, dict):
-        return []
-
-    violations: list[str] = []
-    jobs = doc.get("jobs") or {}
-    if not isinstance(jobs, dict):
-        return []
-
-    for job_name, job in jobs.items():
-        if not isinstance(job, dict):
-            continue
-        steps = job.get("steps") or []
-        if not isinstance(steps, list):
-            continue
-        for idx, step in enumerate(steps):
-            if not isinstance(step, dict):
-                continue
-            run = step.get("run")
-            if not isinstance(run, str):
-                continue
-            for match in PATTERN.finditer(run):
-                step_label = step.get("name") or f"step #{idx}"
-                violations.append(
-                    f'{path}: job "{job_name}" / {step_label}: '
-                    f'inline "{match.group(0)}" inside run:'
-                )
-    return violations
+    return [
+        f'{path}: job "{job_name}" / {step_label}: '
+        f'inline "{match.group(0)}" inside run:'
+        for job_name, step_label, run in _iter_run_blocks(doc)
+        for match in PATTERN.finditer(run)
+    ]
 
 
 def main() -> int:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,20 @@
+sonar.projectKey=Abblix_Oidc.Server
+sonar.organization=abblix
+
+# Per-rule, per-path exclusions for SonarCloud Automatic Analysis.
+# Each `eN` block is independent; ruleKey + resourceKey are globs evaluated together.
+
+sonar.issue.ignore.multicriteria=e1,e2
+
+# S1075: hardcoded absolute URIs are test data inside *.UnitTests projects
+# (URI builders, interop fixtures, DI HttpClient routing). The URIs ARE the
+# subject under test — extracting them to constants would not improve clarity.
+sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S1075
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.UnitTests/**/*
+
+# S7764: the OIDC check_session_iframe (OpenID Connect Session Management 1.0)
+# is browser-only and addresses window.parent / window.addEventListener for
+# cross-frame postMessage. globalThis is equivalent in browsers but loses
+# intent; the file already disables an analogous eslint rule.
+sonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S7764
+sonar.issue.ignore.multicriteria.e2.resourceKey=Abblix.Oidc.Server/Features/SessionManagement/Resources/checkSession.html


### PR DESCRIPTION
## Summary
- Refactor `scan_file` in `.github/scripts/lint-no-inline-secrets.py`: split triple-nested loop into two flat generators. Closes the 1 HIGH-impact issue (S3776, cognitive complexity 22 → ~3 in `scan_file`).
- Add `sonar-project.properties` with two rule-level exclusions for SonarCloud Automatic Analysis:
  - `csharpsquid:S1075` in `**/*.UnitTests/**` — hardcoded URIs are test data (URI builder / interop / DI HttpClient fixtures), not real config. Closes 14 LOW issues.
  - `javascript:S7764` in `Abblix.Oidc.Server/Features/SessionManagement/Resources/checkSession.html` — the OIDC `check_session_iframe` (Session Management 1.0) needs `window.parent` / `window.addEventListener` for cross-frame postMessage; `globalThis` is equivalent in browsers but loses intent. Closes 1 LOW issue.

Behaviour of the lint script is unchanged — same regex, same output format, smoke-tested locally (`OK: no untrusted-input interpolation across 3 workflow file(s)`, exit 0).