### PR TITLE
ci: derive version from git tags via MinVer; auto-publish dev builds

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -4,18 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Explicit version (e.g., 2.0) - leave empty for auto-increment'
-        required: false
+        description: 'Version to release (e.g., 2.3.0 or 2.3.0-beta3)'
+        required: true
         type: string
-      version_bump:
-        description: 'Version bump type (used if version not specified)'
-        required: false
-        default: 'patch'
-        type: choice
-        options:
-        - patch
-        - minor
-        - major
       pre_release:
         description: 'Create pre-release'
         required: false
@@ -46,25 +37,12 @@ jobs:
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$ ]]; then
-              echo "Error: invalid version format: $INPUT_VERSION"
-              exit 1
-            fi
-            VERSION="$INPUT_VERSION"
-            echo "Using explicit version: $VERSION"
-          else
-            VERSION=$(grep -oP '<PackageVersion>\K[^<]+' Abblix.Oidc.Server/Abblix.Oidc.Server.csproj || echo "")
-            if [ -z "$VERSION" ]; then
-              echo "Error: could not extract version from project files"
-              exit 1
-            fi
-            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$ ]]; then
-              echo "Error: invalid version format from project file: $VERSION"
-              exit 1
-            fi
-            echo "Using project file version: $VERSION"
+          if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Error: invalid version format: $INPUT_VERSION"
+            exit 1
           fi
+          VERSION="$INPUT_VERSION"
+          echo "Using explicit version: $VERSION"
 
           PREVIOUS_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$PREVIOUS_VERSION" ]; then
@@ -84,18 +62,25 @@ jobs:
       VERSION: ${{ needs.versioning.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.0'
       - name: Restore dependencies
         run: dotnet restore
+      # MinVerVersionOverride forces MinVer to use the workflow-supplied
+      # version verbatim, bypassing the tag/height computation. The
+      # subsequent create-release job then tags this exact version, so
+      # the produced .nupkg files and the resulting GitHub Release stay
+      # in lock-step.
       - name: Build
-        run: dotnet build --no-restore -c Release -p:AssemblyVersion="$VERSION.0" -p:PackageVersion="$VERSION"
+        run: dotnet build --no-restore -c Release -p:MinVerVersionOverride="$VERSION"
       - name: Test
         run: dotnet test --no-build -c Release --verbosity normal
       - name: Pack
-        run: dotnet pack --no-build -c Release -o nupkg -p:AssemblyVersion="$VERSION.0" -p:PackageVersion="$VERSION"
+        run: dotnet pack --no-build -c Release -o nupkg -p:MinVerVersionOverride="$VERSION"
       - name: Upload NuGet packages as artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -18,6 +18,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # MinVer (referenced in Directory.Build.props) reads the latest tag
+          # plus commit height from git to derive the version. fetch-depth: 0
+          # disables the shallow clone so all tags and commits are visible.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -1,0 +1,105 @@
+name: Publish dev build to GitHub Packages
+
+# Triggered on every push to develop. MinVer (configured in Directory.Build.props)
+# computes the package version from git tags + commit height; this workflow just
+# packs and pushes the resulting .nupkg files to nuget.pkg.github.com/Abblix.
+#
+# Example version (with MinVerMinimumMajorMinor=2.3 and DefaultPreReleaseIdentifiers=dev.0):
+#   pre-tag develop, 5 commits since v2.2  ->  2.3.0-dev.0.5
+#   tagged v2.3.0-beta1                    ->  2.3.0-beta1
+#   tagged v2.3.0                          ->  2.3.0
+#
+# Releases (canonical 2.3.0, 2.3.0-beta1, etc.) flow through the manual
+# enhanced-release.yml — this workflow does not produce them.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '**/*.props'
+      - '**/*.targets'
+      - '**/*.slnx'
+      - '**/*.sln'
+      - 'NuGet.config'
+      - '.github/workflows/publish-dev-builds.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Only the latest develop commit needs to land in the feed; cancel an
+  # in-progress run if a newer commit arrives.
+  group: publish-dev-builds-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pack-and-publish:
+    name: Pack and publish dev build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Harden runner (audit egress)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-telemetry: true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # MinVer needs the full commit history and tag refs to derive
+          # the version. fetch-depth: 0 disables shallow clone.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '10.0'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        run: dotnet test --no-build -c Release --verbosity normal
+
+      - name: Pack
+        run: dotnet pack --no-build -c Release -o nupkg
+
+      - name: Push to GitHub Packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for pkg in nupkg/*.nupkg; do
+            echo "Publishing $(basename "$pkg") to nuget.pkg.github.com/Abblix..."
+            dotnet nuget push "$pkg" \
+              --api-key "$GH_TOKEN" \
+              --source https://nuget.pkg.github.com/Abblix/index.json \
+              --skip-duplicate
+          done
+
+      - name: Summary
+        run: |
+          set -euo pipefail
+          # Pick any one package — they all share the same MinVer-derived version.
+          PKG=$(find nupkg -maxdepth 1 -name 'Abblix.Oidc.Server.*.nupkg' | head -1 || true)
+          if [ -n "$PKG" ]; then
+            VERSION=$(basename "$PKG" .nupkg | sed 's|^Abblix.Oidc.Server.||')
+            {
+              echo "## Dev build published"
+              echo ""
+              echo "Version: \`$VERSION\` (derived by MinVer from git tags + height)"
+              echo ""
+              echo "Feed: https://github.com/Abblix/Oidc.Server/packages"
+              echo ""
+              echo "Consumers floating \`2.3.0-dev.*\` will pick this up on next \`dotnet restore\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -20,9 +20,6 @@
     <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.2</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.2.0</AssemblyVersion>
-    <FileVersion>2.2.0</FileVersion>
-    <PackageVersion>2.2</PackageVersion>
 
     <!-- Deterministic builds for reproducible binaries -->
     <Deterministic>true</Deterministic>

--- a/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/Abblix.Jwt/Abblix.Jwt.csproj
@@ -20,9 +20,6 @@
     <PackageReleaseNotes>Custom JWT implementation replacing Microsoft.IdentityModel.Tokens, JWK operation capability validation, improved JWK serialization, and RFC 7523 audience validation fix. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.2</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.2.0</AssemblyVersion>
-    <FileVersion>2.2.0</FileVersion>
-    <PackageVersion>2.2</PackageVersion>
 
     <!-- Deterministic builds for reproducible binaries -->
     <Deterministic>true</Deterministic>

--- a/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -21,9 +21,6 @@
         <PackageReleaseNotes>Template-based front-channel logout with CSP nonce support and streamlined authorization response formatting. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.2</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <AssemblyVersion>2.2.0</AssemblyVersion>
-        <FileVersion>2.2.0</FileVersion>
-        <PackageVersion>2.2</PackageVersion>
 
         <!-- Deterministic builds for reproducible binaries -->
         <Deterministic>true</Deterministic>

--- a/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -19,9 +19,6 @@
         <PackageReleaseNotes>ACR values support with RFC 8176 AMR compliance, front-channel logout with CSP nonce support, configurable session cookie path, and dynamic client registration JWKS validation fix. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.2</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <AssemblyVersion>2.2.0</AssemblyVersion>
-        <FileVersion>2.2.0</FileVersion>
-        <PackageVersion>2.2</PackageVersion>
 
         <!-- Deterministic builds for reproducible binaries -->
         <Deterministic>true</Deterministic>

--- a/Abblix.Utils/Abblix.Utils.csproj
+++ b/Abblix.Utils/Abblix.Utils.csproj
@@ -20,9 +20,6 @@
     <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.2</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.2.0</AssemblyVersion>
-    <FileVersion>2.2.0</FileVersion>
-    <PackageVersion>2.2</PackageVersion>
 
     <!-- Deterministic builds for reproducible binaries -->
     <Deterministic>true</Deterministic>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,26 @@
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
+  <!-- MinVer derives PackageVersion / AssemblyVersion / FileVersion / InformationalVersion
+       from git tags. The latest tag (e.g. v2.2) sets the base; commits since the tag bump
+       the patch and append the height + pre-release suffix.
+
+       MinVerMinimumMajorMinor pins the develop branch's next-target line ahead of releases:
+       even before tagging v2.3.0 the dev builds publish as 2.3.0-dev.0.<height>, so
+       AuthenticationService can float Abblix.* on 2.3.0-dev.* immediately. Bump this when
+       the next-target moves (2.3 -> 2.4).
+
+       MinVerDefaultPreReleaseIdentifiers replaces the default "alpha.0" with "dev.0", so
+       the floating range AuthSvc consumes (2.3.0-dev.*) is unambiguous. Tagged releases
+       drop the suffix automatically (v2.3.0 -> 2.3.0). -->
+  <PropertyGroup>
+    <MinVerMinimumMajorMinor>2.3</MinVerMinimumMajorMinor>
+    <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- MTP0001 is raised by Microsoft.Testing.Platform when VSTest-specific MSBuild
        properties (VSTestTestAdapterPath, VSTestTestCaseFilter) are set by the .NET
        SDK's test-project defaults. MTP ignores them; the warning is informational. -->


### PR DESCRIPTION
## Summary

Replaces the manually maintained `<PackageVersion>` / `<AssemblyVersion>` / `<FileVersion>` in 5 csproj with **MinVer** — a tiny SDK that derives the version from git tags + commit height at build time. Adds `publish-dev-builds.yml`, which auto-publishes a fresh dev package on every push to `develop`. Downstream AuthenticationService can then float `Abblix.* 2.3.0-dev.*` in `Directory.Packages.props` and pick up every Oidc.Server commit on the next `dotnet restore`.

## Why MinVer

Until now, releasing a new version required a coordinated bump across 5 csproj files **and** a corresponding bump in AuthenticationService's `Directory.Packages.props`. Cutting `2.3.0-beta3` after `2.3.0-beta2` meant editing 6 files for a number that already lived in the git tag. With MinVer:

- `git tag v2.3.0-beta3 && git push` produces `2.3.0-beta3`.
- Untagged commits on develop (between releases) produce `2.3.0-dev.0.<height>` automatically.
- `<PackageVersion>` lives nowhere in the source tree — single source of truth is the git tag history.

## How

`Directory.Build.props` adds:

```xml
<PropertyGroup>
  <MinVerMinimumMajorMinor>2.3</MinVerMinimumMajorMinor>
  <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>
</PropertyGroup>
<ItemGroup>
  <PackageReference Include=\"MinVer\" Version=\"6.0.0\" PrivateAssets=\"all\" />
</ItemGroup>
```

* `MinVerMinimumMajorMinor=2.3` pins the develop branch's next-target line. Even before `v2.3.0` is tagged, dev builds publish as `2.3.0-dev.0.<height>`. Bump this when the next-target moves (`2.3` → `2.4`).
* `MinVerDefaultPreReleaseIdentifiers=dev.0` replaces the default `alpha.0` so the pre-release suffix matches the floating range AuthSvc is wired to consume.

## Workflows touched

* **`publish-dev-builds.yml` (new)** — push to `develop` ⇒ pack with MinVer-derived version ⇒ `dotnet nuget push` to `nuget.pkg.github.com/Abblix`.
* **`enhanced-release.yml`** — `version` input becomes required, csproj-fallback path removed, build/pack steps now pass `-p:MinVerVersionOverride=$VERSION` so the user-supplied release version is used verbatim and the produced `.nupkg` files match the tag the workflow then creates.
* **`pr-tests.yml`** — `fetch-depth: 0` on `actions/checkout` so MinVer can see all tags during PR validation.

## Sequencing for AuthenticationService

This PR alone doesn't change AuthSvc behaviour. After it merges, the first push to develop produces (e.g.) `2.3.0-dev.0.1` on the feed. **Then** a follow-up PR in `Abblix/AuthenticationService` flips `Directory.Packages.props` from `Abblix.* 2.3.0-beta2` to `Abblix.* 2.3.0-dev.*` — at which point AuthSvc starts consuming dev builds automatically, with no further version-bumping needed.

## Test plan

- [ ] `pr-tests.yml` (Unit tests) green on this PR
- [ ] After merge: `publish-dev-builds.yml` runs on develop, packs MinVer-derived `2.3.0-dev.0.<height>`, pushes to GH Packages
- [ ] `https://github.com/Abblix/Oidc.Server/packages` shows the new dev version
- [ ] Manual `enhanced-release.yml` invocation with `version=2.3.0-rc1` (or similar) still works end-to-end
- [ ] AuthenticationService follow-up PR resolves `2.3.0-dev.*` against the new packages