### PR TITLE
Fix byte-exact alg comparison and extract HasAnyFlag (#76)

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -912,6 +912,103 @@ public class JsonWebTokenValidationTests
         Assert.Equal(JwtError.InvalidToken, error.Error);
     }
 
+    /// <summary>
+    /// Verifies that JWTs with case-variant 'none' algorithm are rejected even when RequireSignedTokens is cleared.
+    /// Per RFC 7515 §5.3 and §10.13, JOSE algorithm names must be compared verbatim (byte-exact).
+    /// Pre-fix: validator silently accepts alg="None"/"NONE"/"nOnE" as unsigned because the comparison uses
+    /// OrdinalIgnoreCase. Post-fix: rejects them as unknown algorithm. Reproduces the bug from #76.
+    /// </summary>
+    [Theory]
+    [InlineData("None")]
+    [InlineData("NONE")]
+    [InlineData("nOnE")]
+    public async Task TokenWithCaseVariantNoneAlg_RejectedWhenSigningOptional(string algValue)
+    {
+        var exp = ServiceProvider.GetRequiredService<TimeProvider>().GetUtcNow().AddHours(1).ToUnixTimeSeconds();
+        var headerJson = $$"""{"alg":"{{algValue}}","typ":"JWT"}""";
+        var payloadJson = $$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","exp":{{exp}},"sub":"test-user"}""";
+        var headerEnc = EncodeBase64Url(headerJson);
+        var payloadEnc = EncodeBase64Url(payloadJson);
+        var jwt = $"{headerEnc}.{payloadEnc}.";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var options = ValidationOptions.Default & ~ValidationOptions.RequireSignedTokens;
+        var parameters = CreateValidationParameters(SigningKey, options: options);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// Sanity check that the legitimate alg="none" still passes when RequireSignedTokens is cleared.
+    /// Locks the contract that the strict-comparison fix did not over-tighten the unsigned-token path.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithLowercaseNoneAlg_AcceptedWhenSigningOptional()
+    {
+        var exp = ServiceProvider.GetRequiredService<TimeProvider>().GetUtcNow().AddHours(1).ToUnixTimeSeconds();
+        var headerJson = $$"""{"alg":"none","typ":"JWT"}""";
+        var payloadJson = $$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","exp":{{exp}},"sub":"test-user"}""";
+        var headerEnc = EncodeBase64Url(headerJson);
+        var payloadEnc = EncodeBase64Url(payloadJson);
+        var jwt = $"{headerEnc}.{payloadEnc}.";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var options = ValidationOptions.Default & ~ValidationOptions.RequireSignedTokens;
+        var parameters = CreateValidationParameters(SigningKey, options: options);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// Verifies that case-variant 'none' alg is also rejected under default options (which include RequireSignedTokens).
+    /// Defense-in-depth: confirms the default-config invariant holds across both the legacy and the fixed code paths.
+    /// </summary>
+    [Theory]
+    [InlineData("None")]
+    [InlineData("NONE")]
+    [InlineData("nOnE")]
+    public async Task TokenWithCaseVariantNoneAlg_RejectedWithDefaultOptions(string algValue)
+    {
+        var exp = ServiceProvider.GetRequiredService<TimeProvider>().GetUtcNow().AddHours(1).ToUnixTimeSeconds();
+        var headerJson = $$"""{"alg":"{{algValue}}","typ":"JWT"}""";
+        var payloadJson = $$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","exp":{{exp}},"sub":"test-user"}""";
+        var headerEnc = EncodeBase64Url(headerJson);
+        var payloadEnc = EncodeBase64Url(payloadJson);
+        var jwt = $"{headerEnc}.{payloadEnc}.";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// Verifies that signing a token whose header explicitly carries case-variant 'none' fails to issue.
+    /// Adjacent verification for JsonWebTokenSigner.cs:49: the existing byte-exact == comparison there
+    /// means a header alg of 'None'/'NONE'/'nOnE' is treated as an unknown algorithm, not as the
+    /// special unsigned-token contradiction. With an RSA signing key (declared alg=RS256), signing
+    /// fails at the algorithm-mismatch check; either way it throws InvalidOperationException.
+    /// </summary>
+    [Theory]
+    [InlineData("None")]
+    [InlineData("NONE")]
+    [InlineData("nOnE")]
+    public async Task TokenSigning_WithCaseVariantNoneAlgInHeader_FailsToIssue(string algValue)
+    {
+        var token = CreateValidToken();
+        token.Header.Algorithm = algValue;
+
+        await Assert.ThrowsAnyAsync<InvalidOperationException>(() => IssueToken(token, SigningKey));
+    }
+
     private static ValidationParameters CreateValidationParameters(
         JsonWebKey signingKey,
         JsonWebKey? decryptionKey = null,

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -145,32 +145,35 @@ internal class JsonWebTokenValidator(
         if (algorithm == null)
             return new JwtValidationError(JwtError.InvalidToken, "Missing algorithm in JWT header");
 
-        var shouldValidate = parameters.Options.HasFlag(ValidationOptions.ValidateIssuerSigningKey) ||
-                             parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens);
-
         // 'alg' is byte-exact per RFC 7515 §5.3 / §10.13: switching on the const string ensures
         // case-variants like "None"/"NONE" never match the unsecured-JWS branch.
         switch (algorithm)
         {
             case SigningAlgorithms.None when parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens):
-                return new JwtValidationError(JwtError.InvalidToken, "Unsigned tokens are not allowed");
+                return new JwtValidationError(
+                    JwtError.InvalidToken, "Unsigned tokens are not allowed");
 
             case SigningAlgorithms.None when jwtParts[2].HasValue():
-                return new JwtValidationError(JwtError.InvalidToken, "Unsigned token must have empty signature");
+                return new JwtValidationError(
+                    JwtError.InvalidToken, "Unsigned token must have empty signature");
 
-            case SigningAlgorithms.None:
-                return null;
+            case not SigningAlgorithms.None
+                when parameters.Options.HasAnyFlag(ValidationOptions.RequireSignedTokens | ValidationOptions.ValidateIssuerSigningKey):
+                break;
 
-            case var _ when !shouldValidate:
+            default:
                 return null;
+        }
+
+        var issuer = token.Payload.Issuer;
+        if (issuer == null)
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken, "Missing issuer in JWT payload for signature validation");
         }
 
         var resolveIssuerSigningKeys = parameters.ResolveIssuerSigningKeys
             .NotNull(nameof(parameters.ResolveIssuerSigningKeys));
-
-        var issuer = token.Payload.Issuer;
-        if (issuer == null)
-            return new JwtValidationError(JwtError.InvalidToken, "Missing issuer in JWT payload for signature validation");
 
         return await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
     }
@@ -194,14 +197,12 @@ internal class JsonWebTokenValidator(
     /// </summary>
     private static async Task<JwtValidationError?> ValidateIssuerAsync(string? issuer, ValidationParameters parameters)
     {
-        var shouldValidate = parameters.Options.HasFlag(ValidationOptions.ValidateIssuer) ||
-                             parameters.Options.HasFlag(ValidationOptions.RequireIssuer);
-
         if (issuer != null)
         {
-            if (shouldValidate)
+            if (parameters.Options.HasAnyFlag(ValidationOptions.RequireIssuer | ValidationOptions.ValidateIssuer))
             {
                 var validateIssuer = parameters.ValidateIssuer.NotNull(nameof(parameters.ValidateIssuer));
+
                 if (!await validateIssuer(issuer))
                     return new JwtValidationError(JwtError.InvalidToken, $"Invalid issuer: {issuer}");
             }
@@ -226,10 +227,7 @@ internal class JsonWebTokenValidator(
         if (parameters.Options.HasFlag(ValidationOptions.RequireAudience) && audiencesList.Count == 0)
             return new JwtValidationError(JwtError.InvalidToken, "Missing audience in JWT payload");
 
-        var shouldValidate = parameters.Options.HasFlag(ValidationOptions.ValidateAudience) ||
-                             parameters.Options.HasFlag(ValidationOptions.RequireAudience);
-
-        if (shouldValidate && audiencesList.Count > 0)
+        if (parameters.Options.HasAnyFlag(ValidationOptions.RequireAudience | ValidationOptions.ValidateAudience) && audiencesList.Count > 0)
         {
             var validateAudience = parameters.ValidateAudience.NotNull(nameof(parameters.ValidateAudience));
             if (!await validateAudience(audiencesList))

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -145,33 +145,34 @@ internal class JsonWebTokenValidator(
         if (algorithm == null)
             return new JwtValidationError(JwtError.InvalidToken, "Missing algorithm in JWT header");
 
-        if (SigningAlgorithms.None.Equals(algorithm, StringComparison.OrdinalIgnoreCase))
+        var shouldValidate = parameters.Options.HasFlag(ValidationOptions.ValidateIssuerSigningKey) ||
+                             parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens);
+
+        // 'alg' is byte-exact per RFC 7515 §5.3 / §10.13: switching on the const string ensures
+        // case-variants like "None"/"NONE" never match the unsecured-JWS branch.
+        switch (algorithm)
         {
-            if (parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens))
+            case SigningAlgorithms.None when parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens):
                 return new JwtValidationError(JwtError.InvalidToken, "Unsigned tokens are not allowed");
 
-            if (jwtParts[2].HasValue())
+            case SigningAlgorithms.None when jwtParts[2].HasValue():
                 return new JwtValidationError(JwtError.InvalidToken, "Unsigned token must have empty signature");
-        }
-        else
-        {
-            var shouldValidate = parameters.Options.HasFlag(ValidationOptions.ValidateIssuerSigningKey) ||
-                                 parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens);
 
-            if (shouldValidate)
-            {
-                var resolveIssuerSigningKeys = parameters.ResolveIssuerSigningKeys
-                    .NotNull(nameof(parameters.ResolveIssuerSigningKeys));
+            case SigningAlgorithms.None:
+                return null;
 
-                var issuer = token.Payload.Issuer;
-                if (issuer == null)
-                    return new JwtValidationError(JwtError.InvalidToken, "Missing issuer in JWT payload for signature validation");
-
-                return await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
-            }
+            case var _ when !shouldValidate:
+                return null;
         }
 
-        return null;
+        var resolveIssuerSigningKeys = parameters.ResolveIssuerSigningKeys
+            .NotNull(nameof(parameters.ResolveIssuerSigningKeys));
+
+        var issuer = token.Payload.Issuer;
+        if (issuer == null)
+            return new JwtValidationError(JwtError.InvalidToken, "Missing issuer in JWT payload for signature validation");
+
+        return await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
     }
 
     /// <summary>

--- a/Abblix.Utils/EnumExtensions.cs
+++ b/Abblix.Utils/EnumExtensions.cs
@@ -1,0 +1,45 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Utils;
+
+/// <summary>
+/// Extension methods for <see cref="Enum"/> values that complement the BCL surface.
+/// </summary>
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Returns <c>true</c> when at least one flag in <paramref name="mask"/> is set in
+    /// <paramref name="value"/>. The OR-counterpart to <see cref="Enum.HasFlag"/>:
+    /// <c>HasFlag(mask)</c> requires every bit of <paramref name="mask"/> to be set, while this
+    /// method is satisfied by any single bit. Callers should build the mask inline by OR-ing the
+    /// individual flags they want to test for, rather than reusing a named composite enum member
+    /// whose semantics may match <see cref="Enum.HasFlag"/> (all-of) instead of any-of.
+    /// </summary>
+    /// <typeparam name="T">A <c>[Flags]</c> enum type.</typeparam>
+    /// <param name="value">The flag value to inspect.</param>
+    /// <param name="mask">An OR of the flags to test for.</param>
+    /// <returns><c>true</c> when any flag in <paramref name="mask"/> is set in
+    /// <paramref name="value"/>; otherwise <c>false</c>.</returns>
+    public static bool HasAnyFlag<T>(this T value, T mask) where T : struct, Enum
+        => (Convert.ToInt64(value) & Convert.ToInt64(mask)) != 0;
+}


### PR DESCRIPTION
## Summary

- Replace `OrdinalIgnoreCase` with byte-exact `==` for the `"none"` algorithm name in `JsonWebTokenValidator.ValidateSignatureAsync`, per RFC 7515 §5.3 / §10.13. Closes a path where `alg="None"`/`"NONE"`/`"nOnE"` was silently treated as the unsigned branch when `RequireSignedTokens` was cleared.
- Restructure `ValidateSignatureAsync` as a switch with `not <const>` pattern: three explicit None-cases for the unsigned branch, a `not None` case-when for the signed path, and `default` returns null when no validation is requested.
- Extract the recurring `Validate*` || `Require*` flag-pair test into a generic `Abblix.Utils.EnumExtensions.HasAnyFlag<T>` extension. Each callsite spells the OR of individual flags inline; the existing `RequireValid*` composites in `ValidationOptions` carry `HasFlag`-style (all-of) semantics and are unsuitable as any-of arguments.

Four new xUnit tests in `JsonWebTokenValidationTests`: bug repro on case-variant alg with `RequireSignedTokens` cleared, sanity check on legitimate `alg="none"`, defense-in-depth on default options, and adjacent signer-path coverage. Solution-wide suite (2258 tests) green.

Closes #76.