### PR TITLE
Enforce HMAC key length per RFC 7518 §3.2 (#77)

### DIFF
--- a/Abblix.Jwt.UnitTests/HmacSignerTests.cs
+++ b/Abblix.Jwt.UnitTests/HmacSignerTests.cs
@@ -1,0 +1,132 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Security.Cryptography;
+using Abblix.Jwt.Signing;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="HmacSigner"/> covering the minimum-key-length contract from
+/// RFC 7518 §3.2: HMAC keys for HS256/HS384/HS512 MUST be at least as long as the hash output
+/// (32/48/64 bytes respectively). Tests both the Sign path (which throws for short keys)
+/// and the Verify path (which returns false for short keys without performing the HMAC).
+/// </summary>
+public class HmacSignerTests
+{
+    private static readonly byte[] SampleData = "the quick brown fox"u8.ToArray();
+
+    /// <summary>
+    /// Verifies that <see cref="HmacSigner.Sign"/> rejects keys shorter than the algorithm's
+    /// hash output. Per RFC 7518 §3.2 a shorter key trivially weakens integrity below the
+    /// algorithm's nominal strength and must not be accepted.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.HS256, 31)]
+    [InlineData(SigningAlgorithms.HS384, 47)]
+    [InlineData(SigningAlgorithms.HS512, 63)]
+    public void Sign_WithKeyShorterThanHashOutput_Throws(string algorithm, int keyLengthBytes)
+    {
+        var signer = new HmacSigner(algorithm);
+        var key = new OctetJsonWebKey { KeyValue = new byte[keyLengthBytes] };
+
+        Assert.Throws<ArgumentException>(() => signer.Sign(key, SampleData));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HmacSigner.Sign"/> succeeds with a key exactly at the
+    /// minimum length required by RFC 7518 §3.2. Locks the boundary on the accepted side.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.HS256, 32)]
+    [InlineData(SigningAlgorithms.HS384, 48)]
+    [InlineData(SigningAlgorithms.HS512, 64)]
+    public void Sign_WithKeyAtMinimumLength_Succeeds(string algorithm, int keyLengthBytes)
+    {
+        var signer = new HmacSigner(algorithm);
+        var key = new OctetJsonWebKey { KeyValue = RandomBytes(keyLengthBytes) };
+
+        var signature = signer.Sign(key, SampleData);
+
+        Assert.NotEmpty(signature);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HmacSigner.Verify"/> returns false for keys shorter than the
+    /// algorithm's hash output even when the signature was computed correctly with the same
+    /// short key. The test bypasses the signer and computes the HMAC manually, since the
+    /// post-fix signer would refuse to produce that signature in the first place. Pre-fix the
+    /// validator accepts the short-key signature; post-fix it refuses without running the HMAC.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.HS256, 31)]
+    [InlineData(SigningAlgorithms.HS384, 47)]
+    [InlineData(SigningAlgorithms.HS512, 63)]
+    public void Verify_WithKeyShorterThanHashOutput_ReturnsFalseEvenForCorrectSignature(
+        string algorithm, int keyLengthBytes)
+    {
+        var key = new OctetJsonWebKey { KeyValue = RandomBytes(keyLengthBytes) };
+        var legitimateSignature = ComputeHmac(algorithm, key.KeyValue!, SampleData);
+        var signer = new HmacSigner(algorithm);
+
+        Assert.False(signer.Verify(key, SampleData, legitimateSignature));
+    }
+
+    /// <summary>
+    /// Round-trip sanity check: a key at the minimum required length signs and verifies cleanly.
+    /// Locks the contract that the length-floor enforcement does not over-restrict legitimate usage.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.HS256, 32)]
+    [InlineData(SigningAlgorithms.HS384, 48)]
+    [InlineData(SigningAlgorithms.HS512, 64)]
+    public void SignAndVerify_AtMinimumKeyLength_RoundTripsSuccessfully(
+        string algorithm, int keyLengthBytes)
+    {
+        var signer = new HmacSigner(algorithm);
+        var key = new OctetJsonWebKey { KeyValue = RandomBytes(keyLengthBytes) };
+
+        var signature = signer.Sign(key, SampleData);
+
+        Assert.True(signer.Verify(key, SampleData, signature));
+    }
+
+    private static byte[] RandomBytes(int length)
+    {
+        var bytes = new byte[length];
+        RandomNumberGenerator.Fill(bytes);
+        return bytes;
+    }
+
+    private static byte[] ComputeHmac(string algorithm, byte[] key, byte[] data)
+    {
+        using HMAC hmac = algorithm switch
+        {
+            SigningAlgorithms.HS256 => new HMACSHA256(key),
+            SigningAlgorithms.HS384 => new HMACSHA384(key),
+            SigningAlgorithms.HS512 => new HMACSHA512(key),
+            _ => throw new InvalidOperationException($"Unsupported HMAC algorithm: {algorithm}"),
+        };
+        return hmac.ComputeHash(data);
+    }
+}

--- a/Abblix.Jwt/Signing/HmacSigner.cs
+++ b/Abblix.Jwt/Signing/HmacSigner.cs
@@ -46,6 +46,13 @@ internal sealed class HmacSigner(string algorithm) : IDataSigner<OctetJsonWebKey
 		if (keyValue == null)
 			throw new ArgumentException("Octet key must have a KeyValue", nameof(octetKey));
 
+		var minLength = GetMinimumKeyLengthBytes();
+		if (keyValue.Length < minLength)
+			throw new ArgumentException(
+				$"{algorithm} requires a key of at least {minLength} bytes ({minLength * 8} bits) " +
+				$"per RFC 7518 §3.2; got {keyValue.Length} bytes.",
+				nameof(octetKey));
+
 		using var hmac = CreateHmac(keyValue);
 		return hmac.ComputeHash(data);
 	}
@@ -57,10 +64,28 @@ internal sealed class HmacSigner(string algorithm) : IDataSigner<OctetJsonWebKey
 		if (keyValue == null)
 			throw new ArgumentException("Octet key must have a KeyValue", nameof(octetKey));
 
+		// RFC 7518 §3.2: a key shorter than the hash output cannot satisfy the algorithm's
+		// nominal strength; reject without performing the HMAC so callers cannot silently
+		// downgrade integrity by registering a weak shared secret in a JWKS.
+		if (keyValue.Length < GetMinimumKeyLengthBytes())
+			return false;
+
 		using var hmac = CreateHmac(keyValue);
 		var computedSignature = hmac.ComputeHash(data);
 		return CryptographicOperations.FixedTimeEquals(signature, computedSignature);
 	}
+
+	/// <summary>
+	/// Returns the minimum key length in bytes required by RFC 7518 §3.2 for the configured
+	/// HMAC algorithm: 32 for HS256, 48 for HS384, 64 for HS512.
+	/// </summary>
+	private int GetMinimumKeyLengthBytes() => algorithm switch
+	{
+		SigningAlgorithms.HS256 => 32,
+		SigningAlgorithms.HS384 => 48,
+		SigningAlgorithms.HS512 => 64,
+		_ => throw new InvalidOperationException($"Unsupported HMAC algorithm: {algorithm}"),
+	};
 
 	/// <summary>
 	/// Creates an HMAC instance for the configured algorithm and key.

--- a/Abblix.Jwt/Signing/HmacSigner.cs
+++ b/Abblix.Jwt/Signing/HmacSigner.cs
@@ -49,7 +49,7 @@ internal sealed class HmacSigner(string algorithm) : IDataSigner<OctetJsonWebKey
 		var minLength = GetMinimumKeyLengthBytes();
 		if (keyValue.Length < minLength)
 			throw new ArgumentException(
-				$"{algorithm} requires a key of at least {minLength} bytes ({minLength * 8} bits) " +
+				$"{algorithm} requires a key of at least {minLength} bytes ({minLength << 3} bits) " +
 				$"per RFC 7518 §3.2; got {keyValue.Length} bytes.",
 				nameof(octetKey));
 
@@ -81,9 +81,9 @@ internal sealed class HmacSigner(string algorithm) : IDataSigner<OctetJsonWebKey
 	/// </summary>
 	private int GetMinimumKeyLengthBytes() => algorithm switch
 	{
-		SigningAlgorithms.HS256 => 32,
-		SigningAlgorithms.HS384 => 48,
-		SigningAlgorithms.HS512 => 64,
+		SigningAlgorithms.HS256 => 256 >> 3,
+		SigningAlgorithms.HS384 => 384 >> 3,
+		SigningAlgorithms.HS512 => 512 >> 3,
 		_ => throw new InvalidOperationException($"Unsupported HMAC algorithm: {algorithm}"),
 	};
 


### PR DESCRIPTION
## Summary

- `HmacSigner` accepted keys of any length. RFC 7518 §3.2 requires HMAC keys for HS256 / HS384 / HS512 to be at least as long as the hash output (32 / 48 / 64 bytes). A host or attacker controlling a JWKS could register a 16-byte HS256 key and silently downgrade integrity from 2^256 to 2^128.
- `Sign` now throws `ArgumentException` for short keys; `Verify` returns `false` without performing the HMAC so a weak shared secret cannot be used to silently accept downgraded signatures.
- New `GetMinimumKeyLengthBytes()` helper expresses the floor in terms of the algorithm's hash-output bit-length (`256 >> 3` for HS256, etc.) so the source matches the RFC's terminology.

New `HmacSignerTests` covering both paths at the boundary lengths (31/32, 47/48, 63/64). Solution-wide suite (2260 tests) green.

Closes #77.