### PR TITLE
Pin JWS verification key to its declared "alg" (#78)

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -719,6 +719,76 @@ public class JsonWebTokenValidationTests
         // On Linux, validation may succeed - this is acceptable platform-specific behavior
     }
 
+    /// <summary>
+    /// Verifies that a JWS is rejected when the resolved verification key declares an 'alg'
+    /// pinning it to a different algorithm than the one in the token header.
+    /// Per RFC 7517 §4.4, when a JWK declares its 'alg', recipients MUST NOT use that key
+    /// with any other algorithm. Pre-fix the validator ignored key.Algorithm and would happily
+    /// verify (e.g.) an RS256 token with a key declared as PS256-only, opening within-family
+    /// algorithm-confusion. Post-fix the key is filtered out by the validator before
+    /// verification is attempted, and validation fails as no usable key remains.
+    /// </summary>
+    [Fact]
+    public async Task Validate_VerifyKeyAlgPinnedToDifferentAlg_FailsValidation()
+    {
+        var unpinnedKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
+        var token = CreateValidToken();
+        var jwt = await IssueToken(token, unpinnedKey);
+
+        var pinnedKey = unpinnedKey with { Algorithm = SigningAlgorithms.PS256 };
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(pinnedKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// Sanity check that a verify-key whose declared 'alg' matches the token header alg
+    /// validates successfully. Locks the contract that the per-key alg pinning fix does not
+    /// over-restrict legitimate matched-alg verification.
+    /// </summary>
+    [Fact]
+    public async Task Validate_VerifyKeyAlgMatchesHeaderAlg_VerifiesSuccessfully()
+    {
+        var unpinnedKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
+        var token = CreateValidToken();
+        var jwt = await IssueToken(token, unpinnedKey);
+
+        var pinnedKey = unpinnedKey with { Algorithm = SigningAlgorithms.RS256 };
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(pinnedKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// Sanity check that a verify-key with no declared 'alg' validates any compatible signature.
+    /// Per RFC 7517 §4.4 the 'alg' parameter on a JWK is OPTIONAL; absence means the key may be
+    /// used with any algorithm appropriate for its key type. Locks the contract that the
+    /// alg-pinning filter only kicks in when key.Algorithm is non-null.
+    /// </summary>
+    [Fact]
+    public async Task Validate_VerifyKeyHasNoAlgPin_VerifiesSuccessfully()
+    {
+        var unpinnedKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
+        var token = CreateValidToken();
+        var jwt = await IssueToken(token, unpinnedKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(unpinnedKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
     private static string EncodeBase64Url(string input)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(input);

--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -720,73 +720,52 @@ public class JsonWebTokenValidationTests
     }
 
     /// <summary>
+    /// Verifies that a verify-key whose declared 'alg' is compatible with the token header alg
+    /// validates successfully. Per RFC 7517 §4.4 the JWK 'alg' is OPTIONAL: a null value means
+    /// the key may be used with any compatible algorithm; a matching value pins the key to that
+    /// algorithm exactly. Both cases must succeed. Locks the contract that the per-key alg
+    /// pinning fix does not over-restrict legitimate verification.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.RS256)]
+    [InlineData(null)]
+    public async Task Validate_VerifyKeyAlgCompatibleWithHeaderAlg_VerifiesSuccessfully(string? verifyKeyAlg)
+    {
+        var result = await ValidateTokenWithVerifyKeyAlg(verifyKeyAlg);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
     /// Verifies that a JWS is rejected when the resolved verification key declares an 'alg'
-    /// pinning it to a different algorithm than the one in the token header.
-    /// Per RFC 7517 §4.4, when a JWK declares its 'alg', recipients MUST NOT use that key
-    /// with any other algorithm. Pre-fix the validator ignored key.Algorithm and would happily
-    /// verify (e.g.) an RS256 token with a key declared as PS256-only, opening within-family
-    /// algorithm-confusion. Post-fix the key is filtered out by the validator before
-    /// verification is attempted, and validation fails as no usable key remains.
+    /// pinning it to a different algorithm than the one in the token header. Per RFC 7517 §4.4,
+    /// when a JWK declares its 'alg', recipients MUST NOT use that key with any other algorithm.
+    /// Pre-fix the validator ignored key.Algorithm and would happily verify (e.g.) an RS256 token
+    /// with a key declared as PS256-only, opening within-family algorithm-confusion. Post-fix the
+    /// key is filtered out by the validator before verification is attempted, and validation
+    /// fails as no usable key remains.
     /// </summary>
     [Fact]
     public async Task Validate_VerifyKeyAlgPinnedToDifferentAlg_FailsValidation()
     {
-        var unpinnedKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
-        var token = CreateValidToken();
-        var jwt = await IssueToken(token, unpinnedKey);
-
-        var pinnedKey = unpinnedKey with { Algorithm = SigningAlgorithms.PS256 };
-
-        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
-        var parameters = CreateValidationParameters(pinnedKey);
-
-        var result = await validator.ValidateAsync(jwt, parameters);
+        var result = await ValidateTokenWithVerifyKeyAlg(SigningAlgorithms.PS256);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(JwtError.InvalidToken, error.Error);
     }
 
-    /// <summary>
-    /// Sanity check that a verify-key whose declared 'alg' matches the token header alg
-    /// validates successfully. Locks the contract that the per-key alg pinning fix does not
-    /// over-restrict legitimate matched-alg verification.
-    /// </summary>
-    [Fact]
-    public async Task Validate_VerifyKeyAlgMatchesHeaderAlg_VerifiesSuccessfully()
+    private static async Task<Result<JsonWebToken, JwtValidationError>> ValidateTokenWithVerifyKeyAlg(
+        string? verifyKeyAlg)
     {
         var unpinnedKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
         var token = CreateValidToken();
         var jwt = await IssueToken(token, unpinnedKey);
 
-        var pinnedKey = unpinnedKey with { Algorithm = SigningAlgorithms.RS256 };
-
+        var verifyKey = unpinnedKey with { Algorithm = verifyKeyAlg };
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
-        var parameters = CreateValidationParameters(pinnedKey);
+        var parameters = CreateValidationParameters(verifyKey);
 
-        var result = await validator.ValidateAsync(jwt, parameters);
-
-        Assert.True(result.TryGetSuccess(out _));
-    }
-
-    /// <summary>
-    /// Sanity check that a verify-key with no declared 'alg' validates any compatible signature.
-    /// Per RFC 7517 §4.4 the 'alg' parameter on a JWK is OPTIONAL; absence means the key may be
-    /// used with any algorithm appropriate for its key type. Locks the contract that the
-    /// alg-pinning filter only kicks in when key.Algorithm is non-null.
-    /// </summary>
-    [Fact]
-    public async Task Validate_VerifyKeyHasNoAlgPin_VerifiesSuccessfully()
-    {
-        var unpinnedKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
-        var token = CreateValidToken();
-        var jwt = await IssueToken(token, unpinnedKey);
-
-        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
-        var parameters = CreateValidationParameters(unpinnedKey);
-
-        var result = await validator.ValidateAsync(jwt, parameters);
-
-        Assert.True(result.TryGetSuccess(out _));
+        return await validator.ValidateAsync(jwt, parameters);
     }
 
     private static string EncodeBase64Url(string input)

--- a/Abblix.Jwt/JsonWebTokenSigner.cs
+++ b/Abblix.Jwt/JsonWebTokenSigner.cs
@@ -109,8 +109,14 @@ internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTo
         if (algorithm == null)
             return new JwtValidationError(JwtError.InvalidToken, "Missing algorithm in JWT header");
 
-        // Per RFC 7517 Section 4.4, 'alg' parameter in JWK is OPTIONAL
-        // Filter only by kid when present - algorithm compatibility is validated during signature verification
+        // Per RFC 7517 Section 4.4, 'alg' parameter in JWK is OPTIONAL but binding when present:
+        // a key declaring its alg MUST NOT be used with any other algorithm. Filter such keys out
+        // before reaching crypto so a key registered for (say) RS256 cannot be misused to verify
+        // PS256 or RS384 tokens, closing within-family algorithm-confusion alongside the
+        // cross-family protection already provided by the generic keyed-DI dispatch.
+        signingKeys = signingKeys.Where(key => key.Algorithm == null || key.Algorithm == algorithm);
+
+        // Per RFC 7515 Section 4.1.4, 'kid' parameter helps select the key
         var keyId = header.KeyId;
         if (keyId.HasValue())
             signingKeys = signingKeys.Where(key => string.Equals(key.KeyId, keyId, StringComparison.Ordinal));


### PR DESCRIPTION
## Summary

- `JsonWebTokenSigner.ValidateAsync` did not consult `key.Algorithm` when selecting a key from the JWKS to verify a JWS. Per RFC 7517 §4.4, when a JWK declares its `alg`, recipients MUST NOT use that key with any other algorithm. Without this filter an RSA key registered as `RS256` could also be used to verify `PS256` / `RS384` / `RS512` tokens, exposing within-family algorithm-confusion alongside the cross-family protection already provided by the generic keyed-DI dispatch on `IDataSigner<TJsonWebKey>`.
- Filter `signingKeys` before iteration so keys whose declared `alg` differs from the header `alg` are skipped; null-alg keys remain eligible per the RFC's OPTIONAL semantics.
- The Sign side already enforces this at `JsonWebTokenSigner.cs:41-46` (throws on header / key alg mismatch); this change harmonizes the verify path.

Three new xUnit tests in `JsonWebTokenValidationTests`: bug repro on alg-mismatched verify-key, sanity on alg-matched verify-key, and null-alg verify-key (RFC's OPTIONAL case). Solution-wide suite (2261 tests) green in Release.

Closes #78.