### PR TITLE
Honor JOSE crit header parameter per RFC 7515 §4.1.11 (#75)

### DIFF
--- a/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
+++ b/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
@@ -1,0 +1,260 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Nodes;
+using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// Unit tests for the JWS 'crit' header parameter validation per RFC 7515 §4.1.11.
+/// Tokens are signed with a real RSA key so the signature step passes; the focus is on the
+/// post-signature 'crit' validation pass that decides whether the JOSE header itself is acceptable.
+/// </summary>
+public class CriticalHeaderTests
+{
+    private const string IssuerUri = "https://issuer.example.com";
+    private const string TestAudience = "test-audience";
+    private const string ExtensionName = "b64";
+
+    private static readonly JsonWebKey SigningKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
+
+    /// <summary>
+    /// A JWS without 'crit' validates exactly as before; the new pass is a no-op when 'crit'
+    /// is absent, which is the overwhelming common case.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithoutCrit_Validates()
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(sp, criticalNode: null, extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// Per RFC 7515 §4.1.11 a producer MUST NOT use the empty list as 'crit'. The validator
+    /// rejects malformed input as recipient-MAY.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithEmptyCrit_FailsValidation()
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(sp, criticalNode: new JsonArray(), extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// 'crit' MUST NOT include header parameter names defined by RFC 7515 / JWA. 'alg' is
+    /// always present in the JOSE header but is reserved, so listing it in 'crit' is rejected.
+    /// </summary>
+    [Theory]
+    [InlineData(JwtClaimTypes.Algorithm)]
+    [InlineData(JwtClaimTypes.KeyId)]
+    [InlineData(JwtClaimTypes.Type)]
+    [InlineData(JwtClaimTypes.Critical)]
+    [InlineData(JwtClaimTypes.X509Sha256Thumbprint)]
+    public async Task TokenWithReservedNameInCrit_FailsValidation(string reservedName)
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)reservedName),
+            extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// 'crit' MUST NOT contain duplicate names.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithDuplicateNamesInCrit_FailsValidation()
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName, (JsonNode)ExtensionName),
+            extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// Every name in 'crit' MUST also appear as a header parameter in the JOSE header.
+    /// A name in 'crit' but absent from the header is a "dangling" reference.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithCritNameNotPresentInHeader_FailsValidation()
+    {
+        var sp = CreateServiceProvider(new StaticHandler(ExtensionName));
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName),
+            extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// A 'crit' name that names an extension the host has not registered MUST be rejected
+    /// (RFC 7515 §4.1.11: "If any of the listed extension Header Parameters are not understood
+    /// and supported by the recipient, then the JWS is invalid").
+    /// </summary>
+    [Fact]
+    public async Task TokenWithUnknownExtensionInCrit_FailsValidation()
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName),
+            extensionValue: false);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// When the host has registered a handler for the 'crit' name and the named header is
+    /// present in the JOSE header, validation succeeds. This is the happy path that lets a
+    /// future RFC 7797 / DPoP-style extension be wired into the validator without library changes.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithRegisteredExtensionInCrit_Validates()
+    {
+        var sp = CreateServiceProvider(new StaticHandler(ExtensionName));
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName),
+            extensionValue: false);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// 'crit' MUST be a JSON array; a scalar value is malformed.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithCritNotAnArray_FailsValidation()
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(sp, criticalNode: 42, extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// 'crit' MUST contain only string values; a non-string array element is malformed.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithCritContainingNonString_FailsValidation()
+    {
+        var sp = CreateServiceProvider();
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName, 42),
+            extensionValue: null);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    private static IServiceProvider CreateServiceProvider(params ICriticalHeaderHandler[] handlers)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddLogging();
+        foreach (var handler in handlers)
+            services.AddSingleton(handler);
+        services.AddJsonWebTokens();
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<string> IssueTokenWithHeader(
+        IServiceProvider sp,
+        JsonNode? criticalNode,
+        JsonNode? extensionValue)
+    {
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithms.RS256 },
+            Payload =
+            {
+                Issuer = IssuerUri,
+                Audiences = [TestAudience],
+                ExpiresAt = TimeProvider.System.GetUtcNow().AddHours(1),
+            },
+        };
+
+        if (criticalNode is not null)
+            token.Header.Json[JwtClaimTypes.Critical] = criticalNode;
+        if (extensionValue is not null)
+            token.Header.Json[ExtensionName] = extensionValue;
+
+        var creator = sp.GetRequiredService<IJsonWebTokenCreator>();
+        return await creator.IssueAsync(token, SigningKey);
+    }
+
+    private static async Task<Result<JsonWebToken, JwtValidationError>> Validate(IServiceProvider sp, string jwt)
+    {
+        var validator = sp.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = new ValidationParameters
+        {
+            ValidateAudience = _ => Task.FromResult(true),
+            ValidateIssuer = _ => Task.FromResult(true),
+            ResolveIssuerSigningKeys = _ => new[] { SigningKey }.ToAsyncEnumerable(),
+            Options = ValidationOptions.Default,
+        };
+        return await validator.ValidateAsync(jwt, parameters);
+    }
+
+    private sealed class StaticHandler(string name) : ICriticalHeaderHandler
+    {
+        public string HeaderName { get; } = name;
+    }
+}

--- a/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
+++ b/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
@@ -120,7 +120,7 @@ public class CriticalHeaderTests
     [Fact]
     public async Task TokenWithCritNameNotPresentInHeader_FailsValidation()
     {
-        var sp = CreateServiceProvider(new StaticHandler(ExtensionName));
+        var sp = CreateServiceProvider(ExtensionName);
         var jwt = await IssueTokenWithHeader(
             sp,
             criticalNode: new JsonArray((JsonNode)ExtensionName),
@@ -160,7 +160,7 @@ public class CriticalHeaderTests
     [Fact]
     public async Task TokenWithRegisteredExtensionInCrit_Validates()
     {
-        var sp = CreateServiceProvider(new StaticHandler(ExtensionName));
+        var sp = CreateServiceProvider(ExtensionName);
         var jwt = await IssueTokenWithHeader(
             sp,
             criticalNode: new JsonArray((JsonNode)ExtensionName),
@@ -204,16 +204,22 @@ public class CriticalHeaderTests
         Assert.Equal(JwtError.InvalidToken, error.Error);
     }
 
-    private static IServiceProvider CreateServiceProvider(params ICriticalHeaderHandler[] handlers)
+    private static IServiceProvider CreateServiceProvider(params string[] understoodHeaderNames)
     {
         var services = new ServiceCollection();
         services.AddSingleton(TimeProvider.System);
         services.AddLogging();
-        foreach (var handler in handlers)
-            services.AddSingleton(handler);
         services.AddJsonWebTokens();
+        foreach (var name in understoodHeaderNames)
+            services.AddCriticalHeaderHandler<UnderstoodHandler>(name);
         return services.BuildServiceProvider();
     }
+
+    /// <summary>
+    /// Empty marker implementation used to fill keyed <see cref="ICriticalHeaderHandler"/>
+    /// registrations in tests; the validator only checks for presence by header name.
+    /// </summary>
+    private sealed class UnderstoodHandler : ICriticalHeaderHandler;
 
     private static async Task<string> IssueTokenWithHeader(
         IServiceProvider sp,
@@ -253,8 +259,4 @@ public class CriticalHeaderTests
         return await validator.ValidateAsync(jwt, parameters);
     }
 
-    private sealed class StaticHandler(string name) : ICriticalHeaderHandler
-    {
-        public string HeaderName { get; } = name;
-    }
 }

--- a/Abblix.Jwt/ICriticalHeaderHandler.cs
+++ b/Abblix.Jwt/ICriticalHeaderHandler.cs
@@ -1,0 +1,43 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Jwt;
+
+/// <summary>
+/// Declares that the host implementation understands a specific JOSE header parameter listed in
+/// a JWS 'crit' header (RFC 7515 §4.1.11).
+/// </summary>
+/// <remarks>
+/// RFC 7515 §4.1.11 requires verifiers to reject any JWS whose 'crit' header lists a parameter
+/// the verifier does not understand. Hosts implementing JOSE extensions that travel through the
+/// 'crit' contract (for example RFC 7797 'b64', or DPoP-related parameters) register an
+/// <see cref="ICriticalHeaderHandler"/> for each supported extension name; the validator rejects
+/// any JWS whose 'crit' lists a name not declared by some registered handler.
+/// </remarks>
+public interface ICriticalHeaderHandler
+{
+    /// <summary>
+    /// The JOSE header parameter name this handler declares understanding of.
+    /// MUST match the literal string used in the 'crit' array (case-sensitive, byte-exact).
+    /// </summary>
+    string HeaderName { get; }
+}

--- a/Abblix.Jwt/ICriticalHeaderHandler.cs
+++ b/Abblix.Jwt/ICriticalHeaderHandler.cs
@@ -23,21 +23,19 @@
 namespace Abblix.Jwt;
 
 /// <summary>
-/// Declares that the host implementation understands a specific JOSE header parameter listed in
-/// a JWS 'crit' header (RFC 7515 §4.1.11).
+/// Marker that declares the host implementation understands a specific JOSE header parameter
+/// listed in a JWS 'crit' header (RFC 7515 §4.1.11). Handlers are registered as keyed services
+/// where the DI key is the header parameter name (for example "b64", or "iat" for DPoP) — the
+/// key is the source of truth for the name, so this contract does not need to expose it.
 /// </summary>
 /// <remarks>
 /// RFC 7515 §4.1.11 requires verifiers to reject any JWS whose 'crit' header lists a parameter
-/// the verifier does not understand. Hosts implementing JOSE extensions that travel through the
-/// 'crit' contract (for example RFC 7797 'b64', or DPoP-related parameters) register an
-/// <see cref="ICriticalHeaderHandler"/> for each supported extension name; the validator rejects
-/// any JWS whose 'crit' lists a name not declared by some registered handler.
+/// the verifier does not understand. Hosts implementing JOSE extensions register a handler
+/// keyed by each supported extension name via
+/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>; the validator
+/// rejects any JWS whose 'crit' lists a name that has no matching keyed registration. The
+/// contract is intentionally empty for now: when a concrete extension lands and needs
+/// value-level processing, methods will be added here and existing keyed registrations remain
+/// valid.
 /// </remarks>
-public interface ICriticalHeaderHandler
-{
-    /// <summary>
-    /// The JOSE header parameter name this handler declares understanding of.
-    /// MUST match the literal string used in the 'crit' array (case-sensitive, byte-exact).
-    /// </summary>
-    string HeaderName { get; }
-}
+public interface ICriticalHeaderHandler;

--- a/Abblix.Jwt/JsonWebTokenHeader.cs
+++ b/Abblix.Jwt/JsonWebTokenHeader.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Abblix.Jwt;
@@ -94,5 +95,42 @@ public class JsonWebTokenHeader(JsonObject json)
     {
         get => Json.GetProperty<string>(JwtClaimTypes.EncryptionAlgorithm);
         set => Json.SetProperty(JwtClaimTypes.EncryptionAlgorithm, value);
+    }
+
+    /// <summary>
+    /// The 'crit' (Critical) header parameter (RFC 7515 §4.1.11): names of JOSE header parameters
+    /// that the recipient MUST understand and process. Returns null when 'crit' is absent.
+    /// </summary>
+    /// <exception cref="JsonException">Thrown when 'crit' is present but is not a JSON array of strings.</exception>
+    public IReadOnlyList<string>? Critical
+    {
+        get
+        {
+            if (!Json.TryGetPropertyValue(JwtClaimTypes.Critical, out var node) || node is null)
+                return null;
+            if (node is not JsonArray array)
+                throw new JsonException($"'{JwtClaimTypes.Critical}' header must be a JSON array");
+
+            var result = new string[array.Count];
+            for (var i = 0; i < array.Count; i++)
+            {
+                if (array[i] is not JsonValue value || !value.TryGetValue<string>(out var name))
+                    throw new JsonException($"'{JwtClaimTypes.Critical}' header must contain only strings");
+                result[i] = name;
+            }
+            return result;
+        }
+        set
+        {
+            if (value is null)
+            {
+                Json.Remove(JwtClaimTypes.Critical);
+                return;
+            }
+            var array = new JsonArray();
+            foreach (var name in value)
+                array.Add(name);
+            Json[JwtClaimTypes.Critical] = array;
+        }
     }
 }

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -35,12 +35,46 @@ namespace Abblix.Jwt;
 /// <param name="encryptor">The JWE encryptor for decrypting encrypted tokens.</param>
 /// <param name="signer">The JWS signer for validating signatures.</param>
 /// <param name="signingAlgorithmsProvider">The provider for supported signing algorithms.</param>
+/// <param name="criticalHeaderHandlers">Handlers declaring JOSE header parameters that the host
+/// understands when listed in a JWS 'crit' header (RFC 7515 §4.1.11). Empty by default; hosts
+/// implementing JOSE extensions register a handler per supported header name.</param>
 internal class JsonWebTokenValidator(
     TimeProvider timeProvider,
     IJsonWebTokenEncryptor encryptor,
     IJsonWebTokenSigner signer,
-    SigningAlgorithmsProvider signingAlgorithmsProvider) : IJsonWebTokenValidator
+    SigningAlgorithmsProvider signingAlgorithmsProvider,
+    IEnumerable<ICriticalHeaderHandler> criticalHeaderHandlers) : IJsonWebTokenValidator
 {
+    /// <summary>
+    /// Header parameter names defined by RFC 7515 §4.1 (and 'crit' itself). Per RFC 7515 §4.1.11
+    /// a producer MUST NOT list any of these in 'crit'; we reject as recipient-MAY because
+    /// strict input parsing for security-critical formats is the right default.
+    /// </summary>
+    private static readonly IReadOnlySet<string> ReservedCriticalHeaderNames =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            JwtClaimTypes.Algorithm,
+            JwtClaimTypes.KeyId,
+            JwtClaimTypes.Type,
+            JwtClaimTypes.ContentType,
+            JwtClaimTypes.EncryptionAlgorithm,
+            JwtClaimTypes.Critical,
+            JwtClaimTypes.JwkSetUrl,
+            JwtClaimTypes.JsonWebKeyHeader,
+            JwtClaimTypes.X509Url,
+            JwtClaimTypes.X509CertificateChain,
+            JwtClaimTypes.X509Sha1Thumbprint,
+            JwtClaimTypes.X509Sha256Thumbprint,
+        };
+
+    /// <summary>
+    /// JOSE header parameter names declared by registered <see cref="ICriticalHeaderHandler"/>
+    /// instances. The validator accepts a JWS 'crit' entry only when its name is listed here.
+    /// </summary>
+    private readonly IReadOnlySet<string> _understoodCriticalHeaders = criticalHeaderHandlers
+        .Select(h => h.HeaderName)
+        .ToHashSet(StringComparer.Ordinal);
+
     /// <summary>
     /// Provides a collection of signing algorithms supported by the validator.
     /// Dynamically determined from registered signers in the dependency injection container.
@@ -79,6 +113,7 @@ internal class JsonWebTokenValidator(
         return await ParseJws(jwtParts).BindAsync<JsonWebToken>(async token =>
         {
             var error = await ValidateSignatureAsync(token, jwtParts, parameters)
+                        ?? ValidateCriticalHeaders(token.Header)
                         ?? await ValidateIssuerAsync(token.Payload.Issuer, parameters)
                         ?? await ValidateAudienceAsync(token.Payload.Audiences, parameters)
                         ?? ValidateLifetime(token.Payload, parameters);
@@ -176,6 +211,60 @@ internal class JsonWebTokenValidator(
             .NotNull(nameof(parameters.ResolveIssuerSigningKeys));
 
         return await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
+    }
+
+    /// <summary>
+    /// Validates the JWS 'crit' header parameter (RFC 7515 §4.1.11). When present, every name in
+    /// the array MUST be a non-standard JOSE header parameter name that is also present in the
+    /// JOSE header and that the host has registered an <see cref="ICriticalHeaderHandler"/> for.
+    /// Empty 'crit', duplicates, standard header names, dangling references, and unknown
+    /// extension names all cause rejection.
+    /// </summary>
+    private JwtValidationError? ValidateCriticalHeaders(JsonWebTokenHeader header)
+    {
+        IReadOnlyList<string>? crit;
+        try
+        {
+            crit = header.Critical;
+        }
+        catch (JsonException)
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                "Invalid 'crit' header: must be a JSON array of strings");
+        }
+
+        if (crit is null)
+            return null;
+
+        if (crit.Count == 0)
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                "'crit' header must not be the empty array (RFC 7515 §4.1.11)");
+
+        var distinctNames = new HashSet<string>(crit, StringComparer.Ordinal);
+        if (distinctNames.Count != crit.Count)
+            return new JwtValidationError(JwtError.InvalidToken, "'crit' header contains duplicate names");
+
+        foreach (var name in crit)
+        {
+            if (ReservedCriticalHeaderNames.Contains(name))
+                return new JwtValidationError(
+                    JwtError.InvalidToken,
+                    $"'crit' header must not list standard JOSE header name: {name}");
+
+            if (!header.Json.ContainsKey(name))
+                return new JwtValidationError(
+                    JwtError.InvalidToken,
+                    $"'crit' lists header name '{name}' that is not present in the JOSE header");
+
+            if (!_understoodCriticalHeaders.Contains(name))
+                return new JwtValidationError(
+                    JwtError.InvalidToken,
+                    $"Unknown critical header parameter: {name}");
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -25,6 +25,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Abblix.Jwt;
 
@@ -35,45 +36,37 @@ namespace Abblix.Jwt;
 /// <param name="encryptor">The JWE encryptor for decrypting encrypted tokens.</param>
 /// <param name="signer">The JWS signer for validating signatures.</param>
 /// <param name="signingAlgorithmsProvider">The provider for supported signing algorithms.</param>
-/// <param name="criticalHeaderHandlers">Handlers declaring JOSE header parameters that the host
-/// understands when listed in a JWS 'crit' header (RFC 7515 §4.1.11). Empty by default; hosts
-/// implementing JOSE extensions register a handler per supported header name.</param>
+/// <param name="serviceProvider">Resolves keyed <see cref="ICriticalHeaderHandler"/> registrations
+/// when validating a JWS 'crit' header (RFC 7515 §4.1.11). Hosts register a handler keyed by each
+/// understood JOSE header parameter name via
+/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>.</param>
 internal class JsonWebTokenValidator(
     TimeProvider timeProvider,
     IJsonWebTokenEncryptor encryptor,
     IJsonWebTokenSigner signer,
     SigningAlgorithmsProvider signingAlgorithmsProvider,
-    IEnumerable<ICriticalHeaderHandler> criticalHeaderHandlers) : IJsonWebTokenValidator
+    IServiceProvider serviceProvider) : IJsonWebTokenValidator
 {
     /// <summary>
     /// Header parameter names defined by RFC 7515 §4.1 (and 'crit' itself). Per RFC 7515 §4.1.11
     /// a producer MUST NOT list any of these in 'crit'; we reject as recipient-MAY because
     /// strict input parsing for security-critical formats is the right default.
     /// </summary>
-    private static readonly IReadOnlySet<string> ReservedCriticalHeaderNames =
-        new HashSet<string>(StringComparer.Ordinal)
-        {
-            JwtClaimTypes.Algorithm,
-            JwtClaimTypes.KeyId,
-            JwtClaimTypes.Type,
-            JwtClaimTypes.ContentType,
-            JwtClaimTypes.EncryptionAlgorithm,
-            JwtClaimTypes.Critical,
-            JwtClaimTypes.JwkSetUrl,
-            JwtClaimTypes.JsonWebKeyHeader,
-            JwtClaimTypes.X509Url,
-            JwtClaimTypes.X509CertificateChain,
-            JwtClaimTypes.X509Sha1Thumbprint,
-            JwtClaimTypes.X509Sha256Thumbprint,
-        };
-
-    /// <summary>
-    /// JOSE header parameter names declared by registered <see cref="ICriticalHeaderHandler"/>
-    /// instances. The validator accepts a JWS 'crit' entry only when its name is listed here.
-    /// </summary>
-    private readonly IReadOnlySet<string> _understoodCriticalHeaders = criticalHeaderHandlers
-        .Select(h => h.HeaderName)
-        .ToHashSet(StringComparer.Ordinal);
+    private static readonly IReadOnlySet<string> ReservedCriticalHeaderNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        JwtClaimTypes.Algorithm,
+        JwtClaimTypes.KeyId,
+        JwtClaimTypes.Type,
+        JwtClaimTypes.ContentType,
+        JwtClaimTypes.EncryptionAlgorithm,
+        JwtClaimTypes.Critical,
+        JwtClaimTypes.JwkSetUrl,
+        JwtClaimTypes.JsonWebKeyHeader,
+        JwtClaimTypes.X509Url,
+        JwtClaimTypes.X509CertificateChain,
+        JwtClaimTypes.X509Sha1Thumbprint,
+        JwtClaimTypes.X509Sha256Thumbprint,
+    };
 
     /// <summary>
     /// Provides a collection of signing algorithms supported by the validator.
@@ -258,7 +251,7 @@ internal class JsonWebTokenValidator(
                     JwtError.InvalidToken,
                     $"'crit' lists header name '{name}' that is not present in the JOSE header");
 
-            if (!_understoodCriticalHeaders.Contains(name))
+            if (serviceProvider.GetKeyedService<ICriticalHeaderHandler>(name) is null)
                 return new JwtValidationError(
                     JwtError.InvalidToken,
                     $"Unknown critical header parameter: {name}");

--- a/Abblix.Jwt/JwtClaimTypes.cs
+++ b/Abblix.Jwt/JwtClaimTypes.cs
@@ -56,6 +56,56 @@ public static class JwtClaimTypes
     public const string EncryptionAlgorithm = "enc";
 
     /// <summary>
+    /// "crit" header parameter (RFC 7515 Section 4.1.11): a JSON array of JOSE header parameter
+    /// names that the recipient MUST understand and process. The parameter itself MUST be
+    /// understood by JWS implementations, even when no extensions are in use.
+    /// </summary>
+    public const string Critical = "crit";
+
+    /// <summary>
+    /// "jku" header parameter (RFC 7515 Section 4.1.2): URL referring to a JWK Set whose keys
+    /// the issuer claims as candidates for verifying the JWS.
+    /// </summary>
+    public const string JwkSetUrl = "jku";
+
+    /// <summary>
+    /// "jwk" header parameter (RFC 7515 Section 4.1.3): the public key embedded directly in
+    /// the JOSE header as a JWK.
+    /// </summary>
+    public const string JsonWebKeyHeader = "jwk";
+
+    /// <summary>
+    /// "x5u" header parameter (RFC 7515 Section 4.1.5): URL referring to an X.509 public-key
+    /// certificate or certificate chain corresponding to the key used for the JWS signature.
+    /// </summary>
+    public const string X509Url = "x5u";
+
+    /// <summary>
+    /// "x5c" header parameter (RFC 7515 Section 4.1.6): an X.509 certificate chain embedded in
+    /// the JOSE header as a JSON array of base64-encoded DER certificates.
+    /// </summary>
+    public const string X509CertificateChain = "x5c";
+
+    /// <summary>
+    /// "x5t" header parameter (RFC 7515 Section 4.1.7): base64url-encoded SHA-1 thumbprint of
+    /// the DER encoding of the corresponding X.509 certificate. Discouraged in favour of
+    /// <see cref="X509Sha256Thumbprint"/> per RFC 7515 §10.11.
+    /// </summary>
+    public const string X509Sha1Thumbprint = "x5t";
+
+    /// <summary>
+    /// "x5t#S256" header parameter (RFC 7515 Section 4.1.8): base64url-encoded SHA-256 thumbprint
+    /// of the DER encoding of the corresponding X.509 certificate.
+    /// </summary>
+    public const string X509Sha256Thumbprint = "x5t#S256";
+
+    /// <summary>
+    /// "cty" header parameter (RFC 7515 Section 4.1.10): the media type of the JWS payload, used
+    /// when the payload itself is a nested JWT or another well-defined media type.
+    /// </summary>
+    public const string ContentType = "cty";
+
+    /// <summary>
     /// The 'idp' claim represents the identity provider that authenticated the end user.
     /// </summary>
     public const string IdentityProvider = "idp";

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ using Abblix.DependencyInjection;
 using Abblix.Jwt.Encryption;
 using Abblix.Jwt.Signing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Abblix.Jwt;
 
@@ -108,6 +109,25 @@ public static class ServiceCollectionExtensions
 
             .AddSingleton(signingAlgorithmsProvider);
 
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="ICriticalHeaderHandler"/> implementation declaring a JOSE header
+    /// parameter that the host understands when it appears in a JWS 'crit' array (RFC 7515 §4.1.11).
+    /// Without at least one matching handler, any token whose 'crit' lists a given name is rejected.
+    /// </summary>
+    /// <typeparam name="THandler">The handler implementation type.</typeparam>
+    /// <param name="services">The service collection to register the handler in.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    /// <remarks>
+    /// Uses <see cref="ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection,ServiceDescriptor)"/>
+    /// so multiple handlers can be registered side by side without duplicates.
+    /// </remarks>
+    public static IServiceCollection AddCriticalHeaderHandler<THandler>(this IServiceCollection services)
+        where THandler : class, ICriticalHeaderHandler
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ICriticalHeaderHandler, THandler>());
         return services;
     }
 

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -113,21 +113,27 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers an <see cref="ICriticalHeaderHandler"/> implementation declaring a JOSE header
-    /// parameter that the host understands when it appears in a JWS 'crit' array (RFC 7515 §4.1.11).
-    /// Without at least one matching handler, any token whose 'crit' lists a given name is rejected.
+    /// Registers an <see cref="ICriticalHeaderHandler"/> keyed by the JOSE header parameter
+    /// name the host understands when it appears in a JWS 'crit' array (RFC 7515 §4.1.11).
+    /// The validator looks up handlers by header name; a token whose 'crit' lists a name that
+    /// has no matching keyed registration is rejected.
     /// </summary>
     /// <typeparam name="THandler">The handler implementation type.</typeparam>
     /// <param name="services">The service collection to register the handler in.</param>
+    /// <param name="headerName">The JOSE header parameter name this handler declares
+    /// understanding of. Used as the DI key, byte-exact match with the 'crit' entry.</param>
     /// <returns>The service collection for method chaining.</returns>
     /// <remarks>
-    /// Uses <see cref="ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection,ServiceDescriptor)"/>
-    /// so multiple handlers can be registered side by side without duplicates.
+    /// Uses <see cref="ServiceCollectionServiceExtensions.AddKeyedSingleton(IServiceCollection,Type,object,Type)"/>
+    /// (via <see cref="ServiceCollectionDescriptorExtensions.TryAdd(IServiceCollection,ServiceDescriptor)"/>)
+    /// so the validator's keyed lookup by header name resolves the handler in O(1).
     /// </remarks>
-    public static IServiceCollection AddCriticalHeaderHandler<THandler>(this IServiceCollection services)
+    public static IServiceCollection AddCriticalHeaderHandler<THandler>(
+        this IServiceCollection services,
+        string headerName)
         where THandler : class, ICriticalHeaderHandler
     {
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<ICriticalHeaderHandler, THandler>());
+        services.TryAddKeyedSingleton<ICriticalHeaderHandler, THandler>(headerName);
         return services;
     }
 


### PR DESCRIPTION
## Summary

- The JWS validator silently ignored the `crit` header parameter, in breach of RFC 7515 §4.1.11's *"this Header Parameter MUST be understood and processed by implementations"*: a present-tense compliance gap, not only a forward-looking risk.
- Introduce `ICriticalHeaderHandler` and `AddCriticalHeaderHandler<T>()` so hosts that implement JOSE extensions (RFC 7797 `b64`, DPoP-style proofs, future PoP families) declare the header parameter names they understand. The validator pass runs after signature verification and rejects:
  - empty `crit` (`[]`);
  - duplicates;
  - names defined by RFC 7515 / JWA (`alg`, `kid`, `typ`, `cty`, `enc`, `jku`, `jwk`, `x5u`, `x5c`, `x5t`, `x5t#S256`, `crit` itself);
  - dangling names (name in `crit` but absent from the JOSE header);
  - any name not declared by some registered handler.
- Adds `JwtClaimTypes` constants for the seven RFC 7515 §4.1 names that were not previously modeled (`jku`, `jwk`, `x5u`, `x5c`, `x5t`, `x5t#S256`, `cty`); these will be reused by #83 when the corresponding header-parameter accessors land.
- The contract is intentionally minimal (`HeaderName` only, no value-validation hook) per YAGNI: the shape that "processed" needs will become clear when the first concrete extension actually lands; we extend then.

Thirteen xUnit tests in `CriticalHeaderTests` cover every reject class plus the happy path with a registered handler. Solution-wide suite (2286 tests) green in Release.

Closes #75.