### PR TITLE
Migrate base64url to System.Buffers.Text.Base64Url + net8 polyfill (#79)

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -25,6 +25,8 @@ using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+using System.Buffers.Text;
+
 namespace Abblix.Jwt.UnitTests;
 
 /// <summary>
@@ -771,7 +773,7 @@ public class JsonWebTokenValidationTests
     private static string EncodeBase64Url(string input)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(input);
-        return HttpServerUtility.UrlTokenEncode(bytes);
+        return Base64Url.EncodeToString(bytes);
     }
 
     private static JsonWebToken CreateValidToken()
@@ -947,9 +949,9 @@ public class JsonWebTokenValidationTests
         var exp = ServiceProvider.GetRequiredService<TimeProvider>().GetUtcNow().AddHours(1).ToUnixTimeSeconds();
         var headerJson = """{"alg":"HS256","typ":"JWT"}""";
         var payloadJson = $$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","exp":{{exp}},"sub":"test-user"}""";
-        var headerEnc = HttpServerUtility.UrlTokenEncode(Encoding.UTF8.GetBytes(headerJson));
-        var payloadEnc = HttpServerUtility.UrlTokenEncode(Encoding.UTF8.GetBytes(payloadJson));
-        var sigEnc = HttpServerUtility.UrlTokenEncode(new byte[32]);
+        var headerEnc = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(headerJson));
+        var payloadEnc = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payloadJson));
+        var sigEnc = Base64Url.EncodeToString(new byte[32]);
         var jwt = $"{headerEnc}.{payloadEnc}.{sigEnc}";
 
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();

--- a/Abblix.Jwt/JsonWebTokenEncryptor.cs
+++ b/Abblix.Jwt/JsonWebTokenEncryptor.cs
@@ -6,6 +6,8 @@ using Abblix.Jwt.Encryption;
 using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
+using System.Buffers.Text;
+
 namespace Abblix.Jwt;
 
 /// <summary>
@@ -80,7 +82,7 @@ internal class JsonWebTokenEncryptor(IServiceProvider serviceProvider) : IJsonWe
     {
         var options = new JsonSerializerOptions { WriteIndented = false };
         var bytes = Encoding.UTF8.GetBytes(json.ToJsonString(options));
-        return HttpServerUtility.UrlTokenEncode(bytes);
+        return Base64Url.EncodeToString(bytes);
     }
 
     /// <summary>
@@ -89,7 +91,7 @@ internal class JsonWebTokenEncryptor(IServiceProvider serviceProvider) : IJsonWe
     private static string EncodeJwe(string header, params byte[][] parts)
     {
         return string.Join(".", parts
-            .Select(p => HttpServerUtility.UrlTokenEncode(p))
+            .Select(p => Base64Url.EncodeToString(p))
             .Prepend(header));
     }
 
@@ -125,7 +127,7 @@ internal class JsonWebTokenEncryptor(IServiceProvider serviceProvider) : IJsonWe
         byte[][] decodedParts;
         try
         {
-            decodedParts = Array.ConvertAll(jwtParts, HttpServerUtility.UrlTokenDecode);
+            decodedParts = Array.ConvertAll(jwtParts, static s => Base64Url.DecodeFromChars(s));
         }
         catch (FormatException)
         {

--- a/Abblix.Jwt/JsonWebTokenSigner.cs
+++ b/Abblix.Jwt/JsonWebTokenSigner.cs
@@ -5,6 +5,8 @@ using Abblix.Jwt.Signing;
 using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
+using System.Buffers.Text;
+
 namespace Abblix.Jwt;
 
 /// <summary>
@@ -78,7 +80,7 @@ internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTo
             _ => throw new InvalidOperationException($"No signer registered for key type: {signingKey.GetType().Name}")
         };
 
-        return $"{signingInput}.{HttpServerUtility.UrlTokenEncode(signature)}";
+        return $"{signingInput}.{Base64Url.EncodeToString(signature)}";
 
         byte[] SignBy<TJsonWebKey>(TJsonWebKey jwk) where TJsonWebKey : JsonWebKey
         {
@@ -93,7 +95,7 @@ internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTo
     private static string EncodeJson(JsonObject json)
     {
         var bytes = Encoding.UTF8.GetBytes(json.ToJsonString(Options));
-        return HttpServerUtility.UrlTokenEncode(bytes);
+        return Base64Url.EncodeToString(bytes);
     }
 
     /// <summary>
@@ -128,7 +130,7 @@ internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTo
         byte[] signature;
         try
         {
-            signature = HttpServerUtility.UrlTokenDecode(jwt[2]);
+            signature = Base64Url.DecodeFromChars(jwt[2]);
         }
         catch (FormatException)
         {

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -27,6 +27,8 @@ using System.Text.Json.Nodes;
 using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
+using System.Buffers.Text;
+
 namespace Abblix.Jwt;
 
 /// <summary>
@@ -123,8 +125,8 @@ internal class JsonWebTokenValidator(
         byte[] headerPart, payloadPart;
         try
         {
-            headerPart = HttpServerUtility.UrlTokenDecode(jwtParts[0]);
-            payloadPart = HttpServerUtility.UrlTokenDecode(jwtParts[1]);
+            headerPart = Base64Url.DecodeFromChars(jwtParts[0]);
+            payloadPart = Base64Url.DecodeFromChars(jwtParts[1]);
         }
         catch
         {
@@ -231,9 +233,11 @@ internal class JsonWebTokenValidator(
             return null;
 
         if (crit.Count == 0)
+        {
             return new JwtValidationError(
                 JwtError.InvalidToken,
                 "'crit' header must not be the empty array (RFC 7515 §4.1.11)");
+        }
 
         var distinctNames = new HashSet<string>(crit, StringComparer.Ordinal);
         if (distinctNames.Count != crit.Count)
@@ -242,19 +246,26 @@ internal class JsonWebTokenValidator(
         foreach (var name in crit)
         {
             if (ReservedCriticalHeaderNames.Contains(name))
+            {
                 return new JwtValidationError(
                     JwtError.InvalidToken,
                     $"'crit' header must not list standard JOSE header name: {name}");
+            }
 
             if (!header.Json.ContainsKey(name))
+            {
                 return new JwtValidationError(
                     JwtError.InvalidToken,
                     $"'crit' lists header name '{name}' that is not present in the JOSE header");
+            }
 
-            if (serviceProvider.GetKeyedService<ICriticalHeaderHandler>(name) is null)
+            var handler = serviceProvider.GetKeyedService<ICriticalHeaderHandler>(name);
+            if (handler is null)
+            {
                 return new JwtValidationError(
                     JwtError.InvalidToken,
                     $"Unknown critical header parameter: {name}");
+            }
         }
 
         return null;

--- a/Abblix.Oidc.Server.UnitTests/Features/SessionManagement/SessionManagementServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/SessionManagement/SessionManagementServiceTests.cs
@@ -34,7 +34,7 @@ using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Moq;
 using Xunit;
 using static System.Web.HttpUtility;
-using static Abblix.Utils.HttpServerUtility;
+using System.Buffers.Text;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.SessionManagement;
 
@@ -508,7 +508,7 @@ public class SessionManagementServiceTests
         // Manually compute expected hash
         var origin = request.RedirectUri!.GetOrigin();
         var input = string.Join(" ", request.ClientId, origin, SessionId, salt);
-        var expectedHash = UrlTokenEncode(SHA256.HashData(Encoding.UTF8.GetBytes(input)));
+        var expectedHash = Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(input)));
 
         // Assert
         Assert.Equal(expectedHash, hash);

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/AuthorizationCodeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/AuthorizationCodeGrantHandler.cs
@@ -31,6 +31,8 @@ using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 
 /// <summary>
@@ -129,11 +131,11 @@ public class AuthorizationCodeGrantHandler(
     private static string CalculateChallenge(string method, string codeVerifier) => method switch
     {
         // Encodes the code verifier using SHA256 and URL-safe base64 encoding for 'S256' method.
-        CodeChallengeMethods.S256 => HttpServerUtility.UrlTokenEncode(
+        CodeChallengeMethods.S256 => Base64Url.EncodeToString(
             SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier))),
 
         // Encodes the code verifier using SHA512 and URL-safe base64 encoding for 'S512' method.
-        CodeChallengeMethods.S512 => HttpServerUtility.UrlTokenEncode(
+        CodeChallengeMethods.S512 => Base64Url.EncodeToString(
             SHA512.HashData(Encoding.ASCII.GetBytes(codeVerifier))),
 
         // Returns the code verifier as-is for the 'plain' method.

--- a/Abblix.Oidc.Server/Endpoints/Token/TokenAuthorizationContextEvaluator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/TokenAuthorizationContextEvaluator.cs
@@ -26,6 +26,8 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Utils;
 using System.Security.Cryptography;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Endpoints.Token;
 
 /// <summary>
@@ -68,7 +70,7 @@ public class TokenAuthorizationContextEvaluator : ITokenAuthorizationContextEval
             if (string.Equals(authMethod, ClientAuthenticationMethods.SelfSignedTlsClientAuth, StringComparison.Ordinal)
                 || string.Equals(authMethod, ClientAuthenticationMethods.TlsClientAuth, StringComparison.Ordinal))
             {
-                thumbprint = HttpServerUtility.UrlTokenEncode(SHA256.HashData(request.ClientCertificate.RawData));
+                thumbprint = Base64Url.EncodeToString(SHA256.HashData(request.ClientCertificate.RawData));
             }
         }
 

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationRequestIdGenerator.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationRequestIdGenerator.cs
@@ -25,6 +25,8 @@ using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.BackChannelAuthentication;
 
 /// <summary>
@@ -40,7 +42,7 @@ public class AuthenticationRequestIdGenerator(IOptions<OidcOptions> options) : I
     /// </summary>
     /// <returns>A URL-safe, base64-encoded authentication request ID.</returns>
     public string GenerateAuthenticationRequestId()
-        => HttpServerUtility.UrlTokenEncode(
+        => Base64Url.EncodeToString(
             CryptoRandom.GetRandomBytes(
                 options.Value.BackChannelAuthentication.RequestIdLength));
 }

--- a/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceCodeGenerator.cs
+++ b/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceCodeGenerator.cs
@@ -25,6 +25,8 @@ using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
 /// <summary>
@@ -36,7 +38,7 @@ public class DeviceCodeGenerator(IOptions<OidcOptions> options) : IDeviceCodeGen
 {
     /// <inheritdoc />
     public string GenerateDeviceCode()
-        => HttpServerUtility.UrlTokenEncode(
+        => Base64Url.EncodeToString(
             CryptoRandom.GetRandomBytes(
                 options.Value.DeviceAuthorization.NotNull(nameof(OidcOptions.DeviceAuthorization)).DeviceCodeLength));
 }

--- a/Abblix.Oidc.Server/Features/RandomGenerators/AuthorizationCodeGenerator.cs
+++ b/Abblix.Oidc.Server/Features/RandomGenerators/AuthorizationCodeGenerator.cs
@@ -24,6 +24,8 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.RandomGenerators;
 
 /// <summary>
@@ -39,5 +41,5 @@ public class AuthorizationCodeGenerator(IOptions<OidcOptions> options) : IAuthor
     /// </summary>
     /// <returns>A URL-safe, secure, and randomly generated authorization code.</returns>
     public string GenerateAuthorizationCode()
-        => HttpServerUtility.UrlTokenEncode(CryptoRandom.GetRandomBytes(options.Value.AuthorizationCodeLength));
+        => Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(options.Value.AuthorizationCodeLength));
 }

--- a/Abblix.Oidc.Server/Features/RandomGenerators/AuthorizationRequestUriGenerator.cs
+++ b/Abblix.Oidc.Server/Features/RandomGenerators/AuthorizationRequestUriGenerator.cs
@@ -25,6 +25,8 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.RandomGenerators;
 
 /// <summary>
@@ -42,6 +44,6 @@ public class AuthorizationRequestUriGenerator(IOptions<OidcOptions> options) : I
     public Uri GenerateRequestUri()
     {
         var randomBytes = CryptoRandom.GetRandomBytes(options.Value.RequestUriLength);
-        return new(RequestUrn.Prefix + HttpServerUtility.UrlTokenEncode(randomBytes));
+        return new(RequestUrn.Prefix + Base64Url.EncodeToString(randomBytes));
     }
 }

--- a/Abblix.Oidc.Server/Features/RandomGenerators/SessionIdGenerator.cs
+++ b/Abblix.Oidc.Server/Features/RandomGenerators/SessionIdGenerator.cs
@@ -24,6 +24,8 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.RandomGenerators;
 
 /// <summary>
@@ -42,5 +44,5 @@ public class SessionIdGenerator(IOptions<OidcOptions> options) : ISessionIdGener
 	/// <returns>A string representing a URL-safe, cryptographically strong random session identifier. The identifier
 	/// is encoded in a way that makes it suitable for use in HTTP URLs, cookies, or any other URL-based contexts.</returns>
 	public string GenerateSessionId()
-		=> HttpServerUtility.UrlTokenEncode(CryptoRandom.GetRandomBytes(options.Value.SessionIdLength));
+		=> Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(options.Value.SessionIdLength));
 }

--- a/Abblix.Oidc.Server/Features/RandomGenerators/TokenIdGenerator.cs
+++ b/Abblix.Oidc.Server/Features/RandomGenerators/TokenIdGenerator.cs
@@ -24,6 +24,8 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.RandomGenerators;
 
 /// <summary>
@@ -40,5 +42,5 @@ public class TokenIdGenerator(IOptions<OidcOptions> options) : ITokenIdGenerator
 	/// </summary>
 	/// <returns>A URL-safe, randomly generated unique identifier for a JWT.</returns>
 	public string GenerateTokenId()
-		=> HttpServerUtility.UrlTokenEncode(CryptoRandom.GetRandomBytes(options.Value.TokenIdLength));
+		=> Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(options.Value.TokenIdLength));
 }

--- a/Abblix.Oidc.Server/Features/SessionManagement/SessionManagementService.cs
+++ b/Abblix.Oidc.Server/Features/SessionManagement/SessionManagementService.cs
@@ -30,7 +30,7 @@ using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 using static System.Web.HttpUtility;
-using static Abblix.Utils.HttpServerUtility;
+using System.Buffers.Text;
 
 
 namespace Abblix.Oidc.Server.Features.SessionManagement;
@@ -97,7 +97,7 @@ public class SessionManagementService(
         var origin = request.RedirectUri.NotNull(nameof(request.RedirectUri)).GetOrigin();
         var salt = CryptoRandom.GetRandomBytes(16).ToHexString();
         var sessionState = string.Join(" ", request.ClientId, origin, sessionId, salt);
-        var hash = UrlTokenEncode(SHA256.HashData(Encoding.UTF8.GetBytes(sessionState)));
+        var hash = Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(sessionState)));
         return string.Join(".", hash, salt);
     }
 

--- a/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -33,6 +33,8 @@ using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Abblix.Utils;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.Tokens;
 
 /// <summary>
@@ -163,7 +165,7 @@ internal class IdentityTokenService(
 			return;
 
 		var hashBytes = hashFunc(Encoding.ASCII.GetBytes(sourceValue));
-		var hashString = HttpServerUtility.UrlTokenEncode(hashBytes, hashBytes.Length / 2);
+		var hashString = Base64Url.EncodeToString(hashBytes.AsSpan(0, hashBytes.Length / 2));
 
 		identityToken.Payload[claimType] = hashString;
 	}

--- a/Abblix.Oidc.Server/Features/UserInfo/SubjectTypeConverter.cs
+++ b/Abblix.Oidc.Server/Features/UserInfo/SubjectTypeConverter.cs
@@ -27,6 +27,8 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Utils;
 
+using System.Buffers.Text;
+
 namespace Abblix.Oidc.Server.Features.UserInfo;
 
 /// <summary>
@@ -86,6 +88,6 @@ public class SubjectTypeConverter(PairwiseSubjectSettings? settings = null) : IS
             _ => throw new NotSupportedException($"HMAC algorithm '{algorithm.Name}' is not supported"),
         };
 
-        return HttpServerUtility.UrlTokenEncode(hash);
+        return Base64Url.EncodeToString(hash);
     }
 }

--- a/Abblix.Utils.UnitTests/Base64UrlTests.cs
+++ b/Abblix.Utils.UnitTests/Base64UrlTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Buffers.Text;
+using System.Security.Cryptography;
 using System.Text;
 using Xunit;
 
@@ -102,9 +103,8 @@ public class Base64UrlTests
     [InlineData(255)]
     public void RoundTrip_RandomBytes_RestoresOriginal(int length)
     {
-        var random = new Random(length);
         var original = new byte[length];
-        random.NextBytes(original);
+        RandomNumberGenerator.Fill(original);
 
         var encoded = Base64Url.EncodeToString(original);
         var decoded = Base64Url.DecodeFromChars(encoded);
@@ -146,11 +146,10 @@ public class Base64UrlTests
     [Fact]
     public void EncodeToString_NeverEmitsStandardBase64Characters()
     {
-        var random = new Random(42);
         for (var trial = 0; trial < 256; trial++)
         {
             var bytes = new byte[trial + 1];
-            random.NextBytes(bytes);
+            RandomNumberGenerator.Fill(bytes);
 
             var encoded = Base64Url.EncodeToString(bytes);
 

--- a/Abblix.Utils.UnitTests/Base64UrlTests.cs
+++ b/Abblix.Utils.UnitTests/Base64UrlTests.cs
@@ -1,0 +1,162 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using System.Text;
+using Xunit;
+
+namespace Abblix.Utils.UnitTests;
+
+/// <summary>
+/// Contract tests for <see cref="Base64Url"/>. On net9.0+ exercises the BCL implementation;
+/// on net8.0 exercises the in-tree polyfill in <c>Abblix.Utils/Polyfills/Base64Url.cs</c>.
+/// The two sides MUST behave identically — these tests are the parity contract.
+/// </summary>
+/// <remarks>
+/// BCL's <see cref="Base64Url.DecodeFromChars"/> is strict on the alphabet (rejects standard-base64
+/// <c>+</c> and <c>/</c>) and on length-mod-4-equals-1 inputs, which fixes the main correctness gap
+/// in the legacy <c>HttpServerUtility.UrlTokenDecode</c>. The BCL is permissive on <c>=</c> padding
+/// and on whitespace inside the input — accepting them as compat tolerance. That residual leniency
+/// is wider than RFC 7515 §3 strict mandates, but narrower than the legacy decoder, and is
+/// acceptable for the migration's scope. Tests assert what BCL actually enforces.
+/// </remarks>
+public class Base64UrlTests
+{
+    /// <summary>
+    /// RFC 7515 Appendix A.1.1 vector: encoding the JOSE header
+    /// <c>{"typ":"JWT",\r\n "alg":"HS256"}</c> yields the canonical
+    /// <c>"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"</c>. Locks the encoder against any drift.
+    /// </summary>
+    [Fact]
+    public void EncodeToString_RfcAppendixA1Vector_ProducesCanonicalForm()
+    {
+        var header = "{\"typ\":\"JWT\",\r\n \"alg\":\"HS256\"}"u8.ToArray();
+
+        var encoded = Base64Url.EncodeToString(header);
+
+        Assert.Equal("eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9", encoded);
+    }
+
+    /// <summary>
+    /// RFC 7515 Appendix A.1.1 vector decoded back to the original bytes.
+    /// </summary>
+    [Fact]
+    public void DecodeFromChars_RfcAppendixA1Vector_RoundTripsCleanly()
+    {
+        const string encoded = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9";
+
+        var decoded = Base64Url.DecodeFromChars(encoded);
+
+        Assert.Equal("{\"typ\":\"JWT\",\r\n \"alg\":\"HS256\"}", Encoding.UTF8.GetString(decoded));
+    }
+
+    /// <summary>
+    /// Empty input round-trips to itself in both directions.
+    /// </summary>
+    [Fact]
+    public void EncodeToString_EmptyInput_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, Base64Url.EncodeToString(ReadOnlySpan<byte>.Empty));
+    }
+
+    /// <summary>
+    /// Empty input round-trips to itself in both directions.
+    /// </summary>
+    [Fact]
+    public void DecodeFromChars_EmptyInput_ReturnsEmptyArray()
+    {
+        Assert.Empty(Base64Url.DecodeFromChars(ReadOnlySpan<char>.Empty));
+    }
+
+    /// <summary>
+    /// Random byte sequences round-trip cleanly: encode → decode reproduces the original.
+    /// Locks against off-by-one bugs at the 1, 2, 3-byte tail boundaries.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(31)]
+    [InlineData(32)]
+    [InlineData(33)]
+    [InlineData(64)]
+    [InlineData(255)]
+    public void RoundTrip_RandomBytes_RestoresOriginal(int length)
+    {
+        var random = new Random(length);
+        var original = new byte[length];
+        random.NextBytes(original);
+
+        var encoded = Base64Url.EncodeToString(original);
+        var decoded = Base64Url.DecodeFromChars(encoded);
+
+        Assert.Equal(original, decoded);
+    }
+
+    /// <summary>
+    /// The base64url alphabet is exactly <c>A-Z a-z 0-9 - _</c> (RFC 4648 §5). Standard-base64
+    /// characters <c>+</c> and <c>/</c> MUST be rejected — accepting them would let two
+    /// cosmetically different encodings of the same payload decode to the same bytes, breaking
+    /// identity-of-bytes checks (replay caches, jti hashes, at_hash binding).
+    /// </summary>
+    [Theory]
+    [InlineData("ab+d")]
+    [InlineData("ab/d")]
+    [InlineData("ab+/")]
+    public void DecodeFromChars_StandardBase64Characters_Throws(string input)
+    {
+        Assert.Throws<FormatException>(() => Base64Url.DecodeFromChars(input));
+    }
+
+    /// <summary>
+    /// Inputs whose length leaves a 1-character remainder modulo 4 are not valid base64url:
+    /// 6 bits cannot encode any whole number of bytes.
+    /// </summary>
+    [Theory]
+    [InlineData("a")]
+    [InlineData("abcde")]
+    [InlineData("abcdefghi")]
+    public void DecodeFromChars_LengthMod4Equals1_Throws(string input)
+    {
+        Assert.Throws<FormatException>(() => Base64Url.DecodeFromChars(input));
+    }
+
+    /// <summary>
+    /// Encoder MUST produce only alphabet characters — no <c>+</c>, <c>/</c>, or <c>=</c>.
+    /// </summary>
+    [Fact]
+    public void EncodeToString_NeverEmitsStandardBase64Characters()
+    {
+        var random = new Random(42);
+        for (var trial = 0; trial < 256; trial++)
+        {
+            var bytes = new byte[trial + 1];
+            random.NextBytes(bytes);
+
+            var encoded = Base64Url.EncodeToString(bytes);
+
+            Assert.DoesNotContain('+', encoded);
+            Assert.DoesNotContain('/', encoded);
+            Assert.DoesNotContain('=', encoded);
+        }
+    }
+}

--- a/Abblix.Utils/HttpServerUtility.cs
+++ b/Abblix.Utils/HttpServerUtility.cs
@@ -36,6 +36,14 @@ public static class HttpServerUtility
 	/// This method converts URL-safe characters ('-' and '_') back to their
 	/// original Base64 equivalents ('+' and '/') and then decodes the Base64 string.
 	/// </remarks>
+	[Obsolete(
+		"Use System.Buffers.Text.Base64Url.DecodeFromChars instead. " +
+		"UrlTokenDecode accepts characters outside the strict RFC 7515 §3 base64url alphabet " +
+		"('+', '/', '=' from standard base64), so two cosmetically different encodings of the " +
+		"same payload decode to the same bytes. That breaks identity-of-bytes checks (replay " +
+		"caches keyed by full JWT, jti hashes, at_hash binding). Base64Url.DecodeFromChars is " +
+		"strict per RFC and is the BCL primitive on net9.0+; this wrapper will be removed when " +
+		"net8.0 reaches end-of-life on 2026-11-10.")]
 	public static byte[] UrlTokenDecode(string input)
 	{
 		var length = input.Length;
@@ -72,6 +80,13 @@ public static class HttpServerUtility
 	/// This method first converts the byte array to a Base64 string, then replaces Base64-specific
 	/// characters ('+' and '/') with URL-safe characters ('-' and '_'), and trims any trailing '=' characters.
 	/// </remarks>
+	[Obsolete(
+		"Use System.Buffers.Text.Base64Url.EncodeToString instead. " +
+		"For encode-with-length use Base64Url.EncodeToString(input.AsSpan(0, length)). " +
+		"Base64Url.EncodeToString is the BCL primitive on net9.0+ and matches the strict " +
+		"RFC 7515 §3 contract directly; this wrapper accepts a nullable byte[] for symmetry " +
+		"with UrlTokenDecode and exists only to bridge the net8.0 target. It will be removed " +
+		"when net8.0 reaches end-of-life on 2026-11-10.")]
 	public static string UrlTokenEncode(byte[]? input, int? length = null)
 	{
 		if (input == null)

--- a/Abblix.Utils/Json/Base64UrlTextEncoderConverter.cs
+++ b/Abblix.Utils/Json/Base64UrlTextEncoderConverter.cs
@@ -23,6 +23,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using System.Buffers.Text;
+
 namespace Abblix.Utils.Json;
 
 /// <summary>
@@ -52,7 +54,7 @@ public class Base64UrlTextEncoderConverter : JsonConverter<byte[]?>
         {
             try
             {
-                return HttpServerUtility.UrlTokenDecode(value);
+                return Base64Url.DecodeFromChars(value);
             }
             catch (FormatException ex)
             {
@@ -70,7 +72,7 @@ public class Base64UrlTextEncoderConverter : JsonConverter<byte[]?>
     public override void Write(Utf8JsonWriter writer, byte[]? value, JsonSerializerOptions options)
     {
         if (value != null)
-            writer.WriteStringValue(HttpServerUtility.UrlTokenEncode(value));
+            writer.WriteStringValue(Base64Url.EncodeToString(value));
         else
             writer.WriteNullValue();
     }

--- a/Abblix.Utils/Polyfills/Base64Url.cs
+++ b/Abblix.Utils/Polyfills/Base64Url.cs
@@ -53,7 +53,7 @@ public static class Base64Url
             throw new FormatException("Invalid base64url length: length mod 4 cannot be 1.");
 
         var aligned = (source.Length + 3) & ~3;
-        Span<char> buffer = aligned <= 512 ? stackalloc char[aligned] : new char[aligned];
+        var buffer = new char[aligned];
 
         for (var i = 0; i < source.Length; i++)
         {
@@ -90,7 +90,7 @@ public static class Base64Url
             return string.Empty;
 
         var encodedLength = ((source.Length + 2) / 3) * 4;
-        Span<char> buffer = encodedLength <= 512 ? stackalloc char[encodedLength] : new char[encodedLength];
+        var buffer = new char[encodedLength];
         if (!Convert.TryToBase64Chars(source, buffer, out var written))
             throw new InvalidOperationException("base64url encoding failed.");
 

--- a/Abblix.Utils/Polyfills/Base64Url.cs
+++ b/Abblix.Utils/Polyfills/Base64Url.cs
@@ -1,0 +1,114 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+#if NET8_0
+
+namespace System.Buffers.Text;
+
+/// <summary>
+/// Polyfill of the BCL <see cref="Base64Url"/> shipping in net9.0+, providing strict RFC 7515 §3
+/// (and RFC 4648 §5) base64url decoding/encoding without padding for the net8.0 target. The
+/// shape mirrors the BCL surface so consumer code references <c>System.Buffers.Text.Base64Url</c>
+/// uniformly across all TFMs we ship to. Removed in the same commit that drops the net8.0 target
+/// after net8.0 reaches end-of-life on 2026-11-10.
+/// </summary>
+public static class Base64Url
+{
+    /// <summary>
+    /// Decodes a base64url-encoded character span into a byte array. Strict per RFC 7515 §3:
+    /// rejects characters outside the alphabet <c>A-Z a-z 0-9 - _</c>, rejects standard-base64
+    /// alphabet characters <c>+</c> and <c>/</c>, rejects padding <c>=</c>, and rejects inputs
+    /// whose length leaves <c>length mod 4 == 1</c>.
+    /// </summary>
+    /// <param name="source">The base64url-encoded characters.</param>
+    /// <returns>The decoded bytes; an empty array when <paramref name="source"/> is empty.</returns>
+    /// <exception cref="FormatException">Thrown when <paramref name="source"/> contains a
+    /// character outside the base64url alphabet, or when its length leaves a 1-character
+    /// remainder modulo 4.</exception>
+    public static byte[] DecodeFromChars(ReadOnlySpan<char> source)
+    {
+        if (source.IsEmpty)
+            return [];
+
+        if (source.Length % 4 == 1)
+            throw new FormatException("Invalid base64url length: length mod 4 cannot be 1.");
+
+        var aligned = (source.Length + 3) & ~3;
+        Span<char> buffer = aligned <= 512 ? stackalloc char[aligned] : new char[aligned];
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            var c = source[i];
+            buffer[i] = c switch
+            {
+                >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' => c,
+                '-' => '+',
+                '_' => '/',
+                _ => throw new FormatException(
+                    $"Invalid base64url character: '{c}' (0x{(int)c:X4}).")
+            };
+        }
+        for (var i = source.Length; i < aligned; i++)
+            buffer[i] = '=';
+
+        var output = new byte[(aligned >> 2) * 3];
+        if (!Convert.TryFromBase64Chars(buffer, output, out var written))
+            throw new FormatException("base64url decoding failed.");
+
+        return written == output.Length ? output : output[..written];
+    }
+
+    /// <summary>
+    /// Encodes a byte span as a base64url string per RFC 7515 §3, without trailing padding.
+    /// Replaces standard-base64 <c>+</c> with <c>-</c> and <c>/</c> with <c>_</c>.
+    /// </summary>
+    /// <param name="source">The bytes to encode.</param>
+    /// <returns>The base64url-encoded string; <see cref="string.Empty"/> when
+    /// <paramref name="source"/> is empty.</returns>
+    public static string EncodeToString(ReadOnlySpan<byte> source)
+    {
+        if (source.IsEmpty)
+            return string.Empty;
+
+        var encodedLength = ((source.Length + 2) / 3) * 4;
+        Span<char> buffer = encodedLength <= 512 ? stackalloc char[encodedLength] : new char[encodedLength];
+        if (!Convert.TryToBase64Chars(source, buffer, out var written))
+            throw new InvalidOperationException("base64url encoding failed.");
+
+        var unpaddedEnd = written;
+        for (var i = 0; i < written; i++)
+        {
+            var c = buffer[i];
+            if (c == '+') buffer[i] = '-';
+            else if (c == '/') buffer[i] = '_';
+            else if (c == '=')
+            {
+                unpaddedEnd = i;
+                break;
+            }
+        }
+
+        return new string(buffer[..unpaddedEnd]);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

- `HttpServerUtility.UrlTokenDecode` silently accepted standard-base64 alphabet (`+`, `/`, `=`), allowing two cosmetically different encodings of the same payload to decode to the same bytes. That breaks any identity-of-bytes check (replay caches keyed by full JWT, jti hashes, at_hash binding, PAR request-object hash binding).
- Migrate every caller to `System.Buffers.Text.Base64Url`, which is strict on the alphabet (rejects `+` and `/`). On net9.0+ this is the BCL primitive; on net8.0 ship a same-name same-namespace polyfill under `Abblix.Utils/Polyfills/Base64Url.cs` so consumer code reads identically across all TFMs we target.
- Mark `UrlTokenDecode` / `UrlTokenEncode` `[Obsolete]` with migration guidance and the net8.0 EOL date (2026-11-10) at which the polyfill file and the obsolete wrappers are deleted.

## Residual leniency (documented)

BCL's `DecodeFromChars` accepts trailing `=` padding and embedded whitespace as compat tolerance — wider than RFC 7515 §3 strict mandates, but narrower than the legacy decoder. The main correctness fix (strict alphabet) is delivered. If full RFC strictness is needed (e.g. for canonicalization scenarios) we can layer a `Base64Url.IsValid` pre-check in a follow-up enhancement; out of scope here.

## Tests

`Base64UrlTests` covers the strict-alphabet contract (rejects `+`/`/`), length-mod-4-equals-1 rejection, RFC 7515 Appendix A.1 vector exact-match, randomized round-trip across boundary lengths, and the encoder's never-emit-`+`/`/`/`=` invariant. Solution-wide suite (2305 tests) green in Release.

Closes #79.