### PR TITLE
Replace foreach-with-continue by FirstOrDefault in FlowTypeValidator

### DIFF
--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
@@ -65,13 +65,11 @@ public class FlowTypeValidator(
         // rejected here regardless of client-level AllowedResponseTypes configuration.
         if (responseType != null)
         {
-            foreach (var part in responseType)
+            var unsupportedPart = responseType.FirstOrDefault(part => !_supportedResponseTypeParts.Contains(part));
+            if (unsupportedPart != null)
             {
-                if (_supportedResponseTypeParts.Contains(part))
-                    continue;
-
-                logger.LogWarning("The response type part {Part} is not supported by this server", [part]);
-                return UnsupportedResponseType($"The response type '{part}' is not supported by this server");
+                logger.LogWarning("The response type part {Part} is not supported by this server", [unsupportedPart]);
+                return UnsupportedResponseType($"The response type '{unsupportedPart}' is not supported by this server");
             }
         }
 


### PR DESCRIPTION
## Summary

- Closes SonarCloud «Missed opportunity to use Where» on `FlowTypeValidator.Validate`.
- Replaces `foreach + if/continue + return` with a single `FirstOrDefault` that expresses the «first unsupported part wins» intent directly.
- No behaviour change — same logging key, same error message, same rejection semantics.

## Test plan

- [x] Run `dotnet test` filtered to `FullyQualifiedName~FlowTypeValidator` — 1811/1811 passed locally.
- [x] CI: SonarCloud rule resolution + Analyze (csharp) + Unit tests.