### PR TITLE
feat: ExpectedTokenTypes hook for RFC 8725 §3.11 typ pinning (#80)

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -1076,4 +1076,197 @@ public class JsonWebTokenValidationTests
             Options = options ?? ValidationOptions.Default
         };
     }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // RFC 8725 §3.11 — pin the JWT 'typ' header (RFC 7515 §4.1.9) via
+    // ValidationParameters.ExpectedTokenTypes so token-class confusion (replaying a
+    // logout_token as an id_token, etc.) is rejected inside the validator instead of
+    // relying on every caller to post-check token.Header.Type.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Sanity baseline: when <see cref="ValidationParameters.ExpectedTokenTypes"/> is null,
+    /// the validator skips <c>typ</c> enforcement entirely — preserves historical behaviour
+    /// for callers that have not opted in to the RFC 8725 §3.11 hook.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_NullByDefault_SkipsTypValidation()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "logout+jwt";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// When the JWT's <c>typ</c> matches the configured expected value, validation passes.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_TypMatches_Validates()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "at+jwt";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// When the JWT's <c>typ</c> does not match any configured expected value, the validator
+    /// rejects with <see cref="JwtError.InvalidToken"/> — the very token-class-confusion
+    /// rejection RFC 8725 §3.11 prescribes.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_TypMismatch_RejectsAsInvalidToken()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "logout+jwt";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Contains("logout+jwt", error.ErrorDescription);
+        Assert.Contains("at+jwt", error.ErrorDescription);
+    }
+
+    /// <summary>
+    /// When <see cref="ValidationParameters.ExpectedTokenTypes"/> is configured but the JWT
+    /// has no <c>typ</c> header at all, validation rejects: the caller asked for typ pinning
+    /// and the token does not declare its class.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_TypMissing_RejectsAsInvalidToken()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = null;
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Contains("missing", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// RFC 7515 §4.1.9: a <c>typ</c> value without a slash is treated as if
+    /// <c>application/</c> were prepended. The validator strips that prefix before lookup so
+    /// callers can register the bare canonical form (<c>at+jwt</c>) and tokens whose
+    /// producer wrote out the long form (<c>application/at+jwt</c>) still validate.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_ApplicationPrefixStripped_Matches()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "application/at+jwt";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// RFC 7515 §5.3: the <c>typ</c> header is case-sensitive. <c>At+JWT</c> does NOT match
+    /// the canonical <c>at+jwt</c>; the validator rejects the mismatched casing instead of
+    /// silently coercing to the spec value.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_TypIsCaseSensitive()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "At+JWT";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out _));
+    }
+
+    /// <summary>
+    /// When the configured set has multiple values, any one of them is acceptable. Lets a
+    /// caller accept several token classes through the same validator invocation — for
+    /// example, a transitional period where both <c>at+jwt</c> and a legacy custom
+    /// <c>access+jwt</c> are honoured.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_MultipleValues_AnyMatchPasses()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "access+jwt";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt", "access+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// Empty set is treated identically to null — no enforcement. Defensive default for
+    /// callers that build the set programmatically and may hit edge cases producing zero
+    /// expected types.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_EmptySet_SkipsTypValidation()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "logout+jwt";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal),
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
 }

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -83,7 +83,9 @@ internal class JsonWebTokenValidator(
     /// <param name="parameters">The parameters defining the validation rules and requirements.</param>
     /// <returns>A task representing the validation operation,
     /// with a result containing either a validated JsonWebToken or a JwtValidationError.</returns>
-    public async Task<Result<JsonWebToken, JwtValidationError>> ValidateAsync(string jwt, ValidationParameters parameters)
+    public async Task<Result<JsonWebToken, JwtValidationError>> ValidateAsync(
+        string jwt,
+        ValidationParameters parameters)
     {
         if (string.IsNullOrWhiteSpace(jwt))
             return new JwtValidationError(JwtError.InvalidToken, "JWT is null or empty");
@@ -93,7 +95,9 @@ internal class JsonWebTokenValidator(
         {
             3 => await ValidateJwsAsync(jwtParts, parameters),
             5 => await DecryptJweAsync(jwtParts, parameters),
-            _ => new JwtValidationError(JwtError.InvalidToken, $"Invalid JWT format: expected 3 or 5 dot-separated parts, got {jwtParts.Length}"),
+            _ => new JwtValidationError(
+                JwtError.InvalidToken,
+                $"Invalid JWT format: expected 3 or 5 dot-separated parts, got {jwtParts.Length}"),
         };
     }
 
@@ -109,6 +113,7 @@ internal class JsonWebTokenValidator(
         {
             var error = await ValidateSignatureAsync(token, jwtParts, parameters)
                         ?? ValidateCriticalHeaders(token.Header)
+                        ?? ValidateTokenType(token.Header, parameters)
                         ?? await ValidateIssuerAsync(token.Payload.Issuer, parameters)
                         ?? await ValidateAudienceAsync(token.Payload.Audiences, parameters)
                         ?? ValidateLifetime(token.Payload, parameters);
@@ -283,6 +288,51 @@ internal class JsonWebTokenValidator(
 
         var result = await encryptor.DecryptAsync(jwtParts, decryptionKeys);
         return await result.BindAsync(innerJwt => ValidateAsync(innerJwt, parameters));
+    }
+
+    /// <summary>
+    /// Pins the JWT's <c>typ</c> header (RFC 7515 §4.1.9) to the set the caller expects, per
+    /// the RFC 8725 §3.11 token-class-confusion guidance. When
+    /// <see cref="ValidationParameters.ExpectedTokenTypes"/> is null or empty the check is
+    /// skipped (backward-compatible default for callers that have not opted in). Comparison
+    /// is case-sensitive per RFC 7515 §5.3, with the <c>application/</c> prefix stripped
+    /// before lookup per the §4.1.9 convention so <c>typ=at+jwt</c> and
+    /// <c>typ=application/at+jwt</c> both match a registered <c>at+jwt</c> expectation.
+    /// </summary>
+    private static JwtValidationError? ValidateTokenType(JsonWebTokenHeader header, ValidationParameters parameters)
+    {
+        if (parameters is not { ExpectedTokenTypes: { Count: > 0 } expected})
+            return null;
+
+        var typ = header.Type;
+        if (typ is null)
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                $"JWT 'typ' header is missing — expected one of: {string.Join(", ", expected)}");
+        }
+
+        var normalized = StripApplicationPrefix(typ);
+        if (!expected.Contains(normalized))
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                $"JWT 'typ' header '{typ}' does not match expected token type(s): {string.Join(", ", expected)}");
+        }
+
+        return null;
+
+    }
+
+    /// <summary>
+    /// Implements RFC 7515 §4.1.9's prefix-stripping convention: when <c>typ</c> contains no
+    /// '/' the recipient SHOULD treat it as if <c>application/</c> were prepended; symmetric
+    /// stripping of the literal prefix lets either form match.
+    /// </summary>
+    private static string StripApplicationPrefix(string typ)
+    {
+        const string prefix = "application/";
+        return typ.StartsWith(prefix, StringComparison.Ordinal) ? typ[prefix.Length..] : typ;
     }
 
     /// <summary>

--- a/Abblix.Jwt/ValidationParameters.cs
+++ b/Abblix.Jwt/ValidationParameters.cs
@@ -58,6 +58,22 @@ public record ValidationParameters
 	public TimeSpan ClockSkew { get; set; } = TimeSpan.Zero;
 
 	/// <summary>
+	/// Token-type values (per RFC 7515 §4.1.9 <c>typ</c> header) that the JWT MUST match.
+	/// When non-null and non-empty the validator pins <c>typ</c> per RFC 8725 §3.11 to
+	/// prevent token-class confusion: a JWS signed for one class (id_token, logout_token,
+	/// request_object, DPoP proof, JARM response, OAuth access_token) cannot be replayed
+	/// as another by relying parties that trust the same issuer for several classes.
+	/// </summary>
+	/// <remarks>
+	/// Comparison follows the spec rules: case-sensitive (RFC 7515 §5.3), with the
+	/// <c>application/</c>-prefix-stripping convention from §4.1.9 applied before lookup
+	/// — <c>typ=at+jwt</c> and <c>typ=application/at+jwt</c> are accepted equivalently.
+	/// When this property is null or empty the validator skips the check, preserving
+	/// historical behaviour for callers that have not opted in.
+	/// </remarks>
+	public IReadOnlySet<string>? ExpectedTokenTypes { get; init; }
+
+	/// <summary>
 	/// Resolves signing keys (JWKs) asynchronously for a specified issuer.
 	/// </summary>
 	/// <param name="issuer">Issuer whose signing keys are to be resolved.</param>


### PR DESCRIPTION
Closes #80.

Implements **Phase 1 (library API only)** of typ-pinning per RFC 8725 §3.11. External hosts get an opt-in hook through `ValidationParameters`; internal callers keep their existing post-check on `token.Header.Type` by design — the public `IAuthServiceJwtValidator` contract is unchanged.

## What changed

- **`ValidationParameters.ExpectedTokenTypes`** — new `IReadOnlySet<string>?` init-only property. Additive on the public record: callers that don't set it (default `null`) get the historical behaviour; callers that set it opt into the check.
- **`JsonWebTokenValidator.ValidateTokenType`** — new step in the JWS validation pipeline (after critical-headers, before issuer). Internal class, not part of the public surface.
- **Spec compliance:**
  - RFC 7515 §4.1.9 — `application/`-prefix stripping (`typ=application/at+jwt` matches expected `at+jwt`).
  - RFC 7515 §5.3 — case-sensitive byte-exact comparison (`At+JWT` ≠ `at+jwt`).
  - RFC 8725 §3.11 — rejects token-class confusion (`logout+jwt` replayed where `at+jwt` was expected).

## What did NOT change

- `IAuthServiceJwtValidator` and its concrete implementation `AuthServiceJwtValidator`: untouched. Adding even an optional parameter to a public interface method is a binary breaking change for downstream implementers.
- Internal callers (`InitialAccessTokenValidator`, `RegistrationAccessTokenValidator`, etc.): continue to validate `typ` as a post-check on `token.Header.Type`. Semantically identical to the validator-level check for our own code; the new hook benefits external hosts that don't have access to our internal post-check convention.

## Test coverage

8 new tests in `Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs`:
- typ matches expected (single value, multiple values)
- typ mismatch → `JwtError.InvalidToken` with descriptive error
- typ missing when expected non-empty → `JwtError.InvalidToken`
- `application/`-prefix stripping (canonical-form match)
- case-sensitivity (RFC 7515 §5.3 enforced, no silent coercion)
- empty `ExpectedTokenTypes` set → check skipped (defensive default)
- null `ExpectedTokenTypes` → check skipped (backward compatibility)

Local: 1811 + 238 tests pass.

Ref #80