### PR TITLE
feat(jwt): distinguish empty-JWKS from kid/alg-filter failure (#84)

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -101,7 +101,7 @@ public class JsonWebTokenValidationTests
     /// Returns JwtError.InvalidToken - unable to verify signature without keys.
     /// </summary>
     [Fact]
-    public async Task ValidToken_WithNoSigningKey_FailsValidation()
+    public async Task ValidToken_WithNoSigningKey_FailsValidationWithSpecificError()
     {
         var token = CreateValidToken();
         var jwt = await IssueToken(token, SigningKey);
@@ -118,6 +118,36 @@ public class JsonWebTokenValidationTests
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(JwtError.InvalidToken, error.Error);
+        // Empty-JWKS case must surface differently from the wrong-kid case so audit logs
+        // can tell a misconfigured issuer (zero keys) from a stale-cache kid mismatch.
+        Assert.Contains("no signing keys configured", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that when the issuer has signing keys but the token's <c>kid</c> header does
+    /// not match any of them, validation fails with an error description that distinguishes
+    /// this case from "issuer has no keys at all" (RFC 7515 §4.1.4 / §6 — observability).
+    /// Both still surface as <see cref="JwtError.InvalidToken"/>; the distinction lives in
+    /// the description text and (separately) in the structured log event.
+    /// </summary>
+    [Fact]
+    public async Task ValidToken_WithKidNotInIssuerKeys_FailsWithSpecificError()
+    {
+        // Sign with one key; expose only a different key (different kid) to the validator.
+        // Models the kid-rotation incident from RFC 7515 §4.1.4: the relying party's cached
+        // JWKS no longer contains the kid the issuer used to sign this token.
+        var token = CreateValidToken();
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(WrongSigningKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Contains("kid", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(SigningKey.KeyId!, error.ErrorDescription);
     }
 
     /// <summary>

--- a/Abblix.Jwt/JsonWebTokenSigner.cs
+++ b/Abblix.Jwt/JsonWebTokenSigner.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using Abblix.Jwt.Signing;
 using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using System.Buffers.Text;
 
@@ -13,7 +14,12 @@ namespace Abblix.Jwt;
 /// Handles signing and signature verification of JSON Web Signature (JWS) tokens.
 /// </summary>
 /// <param name="serviceProvider">The service provider for resolving signers by algorithm.</param>
-internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTokenSigner
+/// <param name="logger">Records signature-verification outcomes as structured events. The
+/// caller-facing <see cref="JwtValidationError"/> carries a human-readable description, but
+/// FAPI 2.0 audit-logging requires a granular event-type on every key-resolution failure
+/// (kid mismatch vs. empty issuer JWKS) so a SOC operator can tell a key-rotation incident
+/// from a misconfigured issuer without parsing free-form text.</param>
+internal partial class JsonWebTokenSigner(IServiceProvider serviceProvider, ILogger<JsonWebTokenSigner> logger) : IJsonWebTokenSigner
 {
     private static readonly JsonSerializerOptions Options = new() { WriteIndented = false };
 
@@ -111,17 +117,45 @@ internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTo
         if (algorithm == null)
             return new JwtValidationError(JwtError.InvalidToken, "Missing algorithm in JWT header");
 
+        // Materialize once: we need to distinguish 'issuer returned zero keys' (configuration
+        // problem) from 'returned keys but none survived alg/kid filters' (kid-rotation /
+        // mis-cached-JWKS). Streaming the IAsyncEnumerable conflates the two cases at the
+        // foreach level. JWKS responses are bounded (typically 1-3 keys), so materializing
+        // is cheap; lazy-streaming would only matter for hosts that fan out per-issuer to
+        // unbounded sources, which is not a supported pattern.
+        var allKeys = new List<JsonWebKey>();
+        await foreach (var key in signingKeys)
+            allKeys.Add(key);
+
+        var keyId = header.KeyId;
+        if (allKeys.Count == 0)
+        {
+            LogNoSigningKeys(algorithm, keyId);
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                "No signing keys configured for issuer (RFC 7515 §6: cannot verify signature without keys)");
+        }
+
         // Per RFC 7517 Section 4.4, 'alg' parameter in JWK is OPTIONAL but binding when present:
         // a key declaring its alg MUST NOT be used with any other algorithm. Filter such keys out
         // before reaching crypto so a key registered for (say) RS256 cannot be misused to verify
         // PS256 or RS384 tokens, closing within-family algorithm-confusion alongside the
         // cross-family protection already provided by the generic keyed-DI dispatch.
-        signingKeys = signingKeys.Where(key => key.Algorithm == null || key.Algorithm == algorithm);
+        // Per RFC 7515 Section 4.1.4, 'kid' parameter helps select the key.
+        var candidates = allKeys
+            .Where(key => key.Algorithm == null || key.Algorithm == algorithm)
+            .Where(key => !keyId.HasValue() || string.Equals(key.KeyId, keyId, StringComparison.Ordinal))
+            .ToList();
 
-        // Per RFC 7515 Section 4.1.4, 'kid' parameter helps select the key
-        var keyId = header.KeyId;
-        if (keyId.HasValue())
-            signingKeys = signingKeys.Where(key => string.Equals(key.KeyId, keyId, StringComparison.Ordinal));
+        if (candidates.Count == 0)
+        {
+            LogNoMatchingKey(algorithm, keyId, allKeys.Count);
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                keyId.HasValue()
+                    ? $"No signing key matched header constraints: kid='{keyId}', alg='{algorithm}' (issuer has {allKeys.Count} key(s), none usable)"
+                    : $"No signing key matched header constraints: alg='{algorithm}' (issuer has {allKeys.Count} key(s), none usable)");
+        }
 
         // Signing input is BASE64URL(header) + '.' + BASE64URL(payload)
         var signingInput = Encoding.UTF8.GetBytes($"{jwt[0]}.{jwt[1]}");
@@ -137,18 +171,26 @@ internal class JsonWebTokenSigner(IServiceProvider serviceProvider) : IJsonWebTo
             return new JwtValidationError(JwtError.InvalidToken, "Invalid signature encoding");
         }
 
-        var keyFound = false;
-        await foreach (var key in signingKeys)
+        foreach (var key in candidates)
         {
-            keyFound = true;
             if (VerifySignature(key, algorithm, signingInput, signature))
                 return null;
         }
 
-        return new JwtValidationError(
-            JwtError.InvalidToken,
-            keyFound ? "Invalid signature" : "No signing keys found");
+        return new JwtValidationError(JwtError.InvalidToken, "Invalid signature");
     }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Warning,
+        Message = "JWS signature validation failed: no signing keys configured for issuer (alg='{Algorithm}', kid='{KeyId}'). FAPI category: NoKeysAvailable.")]
+    private partial void LogNoSigningKeys(string Algorithm, string? KeyId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Warning,
+        Message = "JWS signature validation failed: no signing key matched header (alg='{Algorithm}', kid='{KeyId}'); issuer has {IssuerKeyCount} key(s). FAPI category: UnknownKid.")]
+    private partial void LogNoMatchingKey(string Algorithm, string? KeyId, int IssuerKeyCount);
 
     /// <summary>
     /// Verifies a signature using the appropriate signer based on the key type and algorithm.

--- a/Abblix.Jwt/JsonWebTokenSigner.cs
+++ b/Abblix.Jwt/JsonWebTokenSigner.cs
@@ -123,12 +123,10 @@ internal partial class JsonWebTokenSigner(IServiceProvider serviceProvider, ILog
         // foreach level. JWKS responses are bounded (typically 1-3 keys), so materializing
         // is cheap; lazy-streaming would only matter for hosts that fan out per-issuer to
         // unbounded sources, which is not a supported pattern.
-        var allKeys = new List<JsonWebKey>();
-        await foreach (var key in signingKeys)
-            allKeys.Add(key);
+        var allKeys = await signingKeys.ToArrayAsync();
 
         var keyId = header.KeyId;
-        if (allKeys.Count == 0)
+        if (allKeys.Length == 0)
         {
             LogNoSigningKeys(algorithm, keyId);
             return new JwtValidationError(
@@ -143,18 +141,19 @@ internal partial class JsonWebTokenSigner(IServiceProvider serviceProvider, ILog
         // cross-family protection already provided by the generic keyed-DI dispatch.
         // Per RFC 7515 Section 4.1.4, 'kid' parameter helps select the key.
         var candidates = allKeys
-            .Where(key => key.Algorithm == null || key.Algorithm == algorithm)
-            .Where(key => !keyId.HasValue() || string.Equals(key.KeyId, keyId, StringComparison.Ordinal))
-            .ToList();
+            .Where(key =>
+                (key.Algorithm == null || key.Algorithm == algorithm) &&
+                (!keyId.HasValue() || string.Equals(key.KeyId, keyId, StringComparison.Ordinal)))
+            .ToArray();
 
-        if (candidates.Count == 0)
+        if (candidates.Length == 0)
         {
-            LogNoMatchingKey(algorithm, keyId, allKeys.Count);
+            LogNoMatchingKey(algorithm, keyId, allKeys.Length);
             return new JwtValidationError(
                 JwtError.InvalidToken,
                 keyId.HasValue()
-                    ? $"No signing key matched header constraints: kid='{keyId}', alg='{algorithm}' (issuer has {allKeys.Count} key(s), none usable)"
-                    : $"No signing key matched header constraints: alg='{algorithm}' (issuer has {allKeys.Count} key(s), none usable)");
+                    ? $"No signing key matched header constraints: kid='{keyId}', alg='{algorithm}' (issuer has {allKeys.Length} key(s), none usable)"
+                    : $"No signing key matched header constraints: alg='{algorithm}' (issuer has {allKeys.Length} key(s), none usable)");
         }
 
         // Signing input is BASE64URL(header) + '.' + BASE64URL(payload)
@@ -171,13 +170,11 @@ internal partial class JsonWebTokenSigner(IServiceProvider serviceProvider, ILog
             return new JwtValidationError(JwtError.InvalidToken, "Invalid signature encoding");
         }
 
-        foreach (var key in candidates)
-        {
-            if (VerifySignature(key, algorithm, signingInput, signature))
-                return null;
-        }
+        if (!candidates.Any(key => VerifySignature(key, algorithm, signingInput, signature)))
+            return new JwtValidationError(JwtError.InvalidToken, "Invalid signature");
 
-        return new JwtValidationError(JwtError.InvalidToken, "Invalid signature");
+        return null;
+
     }
 
     [LoggerMessage(


### PR DESCRIPTION
Closes #84.

`JsonWebTokenSigner.ValidateAsync` collapsed two distinct key-resolution failures into one generic `"No signing keys found"` description: issuer returns zero keys (misconfiguration) vs. issuer returns keys but none survive `alg`/`kid` filters (stale-cache kid rotation). FAPI 2.0 audit logs need to tell them apart so a key-rotation incident is not mistaken for an issuer outage.

## What changed

- `JsonWebTokenSigner.ValidateAsync` now materializes the `IAsyncEnumerable<JsonWebKey>` once before applying alg/kid filters. The empty-issuer case branches off before the filter; the filtered-empty case branches off after. The original streaming `keyFound`-flag pattern conflated the two.
- `ErrorDescription` text differs for each case:
  - Empty issuer JWKS → `"No signing keys configured for issuer (RFC 7515 §6: cannot verify signature without keys)"`.
  - Kid/alg mismatch → `"No signing key matched header constraints: kid='<kid>', alg='<alg>' (issuer has N key(s), none usable)"`.
- Structured log event added via `[LoggerMessage]` source generator, with explicit `FAPI category` field (`NoKeysAvailable` / `UnknownKid`) so log aggregators filter on the field, not regex.
- Constructor of `JsonWebTokenSigner` (internal class) now also takes `ILogger<JsonWebTokenSigner>`. Microsoft DI auto-resolves; no public surface affected.

## What did NOT change

- Public `JwtError` enum is unchanged. The original draft of #84 proposed two new values (`UnknownKid`, `NoKeysAvailable`); review found those names are not standardized in any RFC, and the audit-log use case is served by structured logs + descriptive text without locking the public taxonomy. Issue body updated to reflect this.
- All callers of the validator continue to receive `JwtError.InvalidToken` for both cases. The single non-test consumer (`UserIdentityValidator.cs:103`, `error.Error != JwtError.InvalidToken`) is unaffected.

## Test coverage

- `ValidToken_WithNoSigningKey_FailsValidationWithSpecificError` — strengthened the existing test to assert the empty-JWKS-specific phrasing.
- `ValidToken_WithKidNotInIssuerKeys_FailsWithSpecificError` — new. Signs with `SigningKey`, exposes only `WrongSigningKey` (different kid) to the validator. Asserts the description names the original kid.

Local: 1811 + 260 tests pass.

Ref #84