### PR TITLE
fix: re-enable code coverage in CI (#96)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,19 +46,18 @@ jobs:
         run: |
           dotnet test Abblix.Oidc.slnx --configuration Release --no-build -- \
             --report-trx --report-trx-filename test-results.trx \
+            --coverage --coverage-output-format cobertura \
             --results-directory ./TestResults
 
       # `dotnet test Abblix.Oidc.slnx -- --results-directory ./TestResults` resolves
       # the relative path PER TEST PROJECT (each MTP runner uses its own working
       # directory), not at solution root. Files land at <Project>/TestResults/.
-      # Coverage collection is disabled by design: Abblix.Oidc.Server's license-terms
-      # check rejects the in-flight assembly fingerprint produced by MTP coverage
-      # instrumentation (Microsoft.Testing.Extensions.CodeCoverage). Re-add the
-      # package and `--coverage` flag if and when the license check is reconciled.
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
-          path: '**/TestResults/*.trx'
+          path: |
+            **/TestResults/*.trx
+            **/TestResults/**/*.cobertura.xml
           retention-days: 7

--- a/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
+++ b/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
   </ItemGroup>
 

--- a/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
+++ b/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
@@ -21,6 +21,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
         <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     </ItemGroup>
 

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
@@ -17,6 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
   </ItemGroup>
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestProcessorTests.cs
@@ -300,7 +300,7 @@ public class UserInfoRequestProcessorTests
         // Arrange
         var validRequest = CreateValidUserInfoRequest();
         var userClaims = CreateUserClaims();
-        var issuer = "https://auth.example.org";
+        var issuer = TestConstants.DefaultIssuer;
 
         _userClaimsProvider
             .Setup(p => p.GetUserClaimsAsync(

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/AuthServiceJwtValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/AuthServiceJwtValidatorTests.cs
@@ -42,7 +42,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Validation;
 /// </summary>
 public class AuthServiceJwtValidatorTests
 {
-    private const string ExpectedIssuer = "https://auth.example.com";
+    private const string ExpectedIssuer = TestConstants.DefaultIssuer;
     private const string ValidClientId = TestConstants.DefaultClientId;
     private const string InvalidClientId = "invalid_client";
     private const string ValidJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature";

--- a/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
Coverage was dropped in #95 because of two tests failing with "license terms violation detected" under --coverage. Turned out to be the same static-state leak in LicenseChecker._knownIssuers that #98 already fixed by standardizing on TestConstants.DefaultIssuer. Coverage instrumentation slowed test execution and widened the race window enough to surface it.

With #98 merged, --coverage now runs clean locally. This puts Microsoft.Testing.Extensions.CodeCoverage back into Directory.Packages.props, references it from each test project, and re-enables --coverage + cobertura reporting in the workflow. Coverage artifacts upload alongside TRX so SonarCloud and review tooling can consume them again.

Closes #96.