### PR TITLE
feat(jwt): bind ClientInfo.Jwks from configuration

### DIFF
--- a/Abblix.Jwt/JsonWebKeyConverter.cs
+++ b/Abblix.Jwt/JsonWebKeyConverter.cs
@@ -30,6 +30,34 @@ namespace Abblix.Jwt;
 /// based on the "kty" (key type) discriminator while ensuring the KeyType property is serialized
 /// in both polymorphic and direct serialization scenarios.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Looks superficially replaceable by <c>[JsonPolymorphic(TypeDiscriminatorPropertyName = "kty")]</c>
+/// + <c>[JsonDerivedType]</c>. It is not, because of how this hierarchy emits "kty" today:
+/// each concrete subtype overrides <see cref="JsonWebKey.KeyType"/> with
+/// <c>[JsonPropertyName("kty")]</c> and <c>[JsonInclude]</c>, which guarantees "kty" appears
+/// both in polymorphic writes (<c>JsonSerializer.Serialize&lt;JsonWebKey&gt;(rsaKey)</c>) and in
+/// direct concrete-type writes (<c>JsonSerializer.Serialize(rsaKey)</c> where the compile-time
+/// type is <c>RsaJsonWebKey</c>).
+/// </para>
+/// <para>
+/// Switching to <c>[JsonPolymorphic]</c> alone breaks one of those two scenarios:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Keep the derived <c>[JsonInclude]</c> override AND add <c>[JsonPolymorphic]</c>
+/// → "kty" gets written twice in polymorphic context (once by STJ as the discriminator, once by
+/// the derived property), producing invalid JSON.</description></item>
+/// <item><description>Drop the derived <c>[JsonInclude]</c> override → "kty" disappears whenever a
+/// concrete subtype is serialized directly, because <c>[JsonPolymorphic]</c> only writes the
+/// discriminator when STJ sees the abstract base type.</description></item>
+/// </list>
+/// <para>
+/// This converter bridges both write modes by always serializing through the concrete subtype's
+/// own attribute set, so "kty" lands once regardless of the call site. A future replacement is
+/// possible but must also touch every <c>KeyType</c> override and ship with a round-trip
+/// regression test that covers polymorphic AND direct serialization paths.
+/// </para>
+/// </remarks>
 public class JsonWebKeyConverter : JsonConverter<JsonWebKey>
 {
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientJwksConfigurationExtensionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientJwksConfigurationExtensionsTests.cs
@@ -1,0 +1,314 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Verifies that <see cref="ClientJwksConfigurationExtensions"/> populates
+/// <c>ClientInfo.Jwks</c> from configuration sections the standard binder leaves
+/// unbound, dispatches the correct concrete <c>JsonWebKey</c> subtype by <c>kty</c>,
+/// and stays a no-op when the host has already supplied <c>Jwks</c>.
+/// </summary>
+public class ClientJwksConfigurationExtensionsTests
+{
+    [Fact]
+    public void AssignsJwks_WhenSectionPresentAndJwksNull()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "test-client",
+                  "Jwks": {
+                    "Keys": [
+                      {
+                        "kty": "RSA",
+                        "kid": "k1",
+                        "use": "sig",
+                        "alg": "RS256",
+                        "n": "AQAB",
+                        "e": "AQAB"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        var clients = ApplyConfig(json, new ClientInfo("test-client"));
+
+        var jwks = clients.Single().Jwks;
+        Assert.NotNull(jwks);
+        var key = Assert.IsType<RsaJsonWebKey>(jwks.Keys.Single());
+        Assert.Equal("k1", key.KeyId);
+        Assert.Equal("sig", key.Usage);
+        Assert.Equal("RS256", key.Algorithm);
+    }
+
+    [Fact]
+    public void SkipsAssignment_WhenJwksAlreadyPopulated()
+    {
+        var existing = new JsonWebKeySet([new RsaJsonWebKey { KeyId = "preset" }]);
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "test-client",
+                  "Jwks": {
+                    "Keys": [
+                      { "kty": "RSA", "kid": "would-be-overwritten", "n": "AQAB", "e": "AQAB" }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        var clients = ApplyConfig(json, new ClientInfo("test-client") { Jwks = existing });
+
+        Assert.Same(existing, clients.Single().Jwks);
+        Assert.Equal("preset", clients.Single().Jwks!.Keys.Single().KeyId);
+    }
+
+    [Fact]
+    public void SkipsAssignment_WhenClientIdInConfigHasNoMatchInOptions()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "config-only-client",
+                  "Jwks": {
+                    "Keys": [{ "kty": "RSA", "kid": "k1", "n": "AQAB", "e": "AQAB" }]
+                  }
+                }
+              ]
+            }
+            """;
+        var clients = ApplyConfig(json, new ClientInfo("different-client"));
+
+        Assert.Null(clients.Single().Jwks);
+    }
+
+    [Fact]
+    public void LeavesJwksNull_WhenNoJwksSection()
+    {
+        const string json = """
+            {
+              "Clients": [
+                { "ClientId": "test-client", "TokenEndpointAuthMethod": "none" }
+              ]
+            }
+            """;
+        var clients = ApplyConfig(json, new ClientInfo("test-client"));
+
+        Assert.Null(clients.Single().Jwks);
+    }
+
+    [Fact]
+    public void DispatchesByKty_ResolvesConcreteSubtypes()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "rsa-client",
+                  "Jwks": {
+                    "Keys": [{ "kty": "RSA", "kid": "r", "n": "AQAB", "e": "AQAB" }]
+                  }
+                },
+                {
+                  "ClientId": "ec-client",
+                  "Jwks": {
+                    "Keys": [
+                      { "kty": "EC", "kid": "e", "crv": "P-256", "x": "AQAB", "y": "AQAB" }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        var clients = ApplyConfig(json,
+            new ClientInfo("rsa-client"),
+            new ClientInfo("ec-client"));
+
+        var rsa = clients.First(c => c.ClientId == "rsa-client").Jwks!.Keys.Single();
+        var ec = clients.First(c => c.ClientId == "ec-client").Jwks!.Keys.Single();
+        Assert.IsType<RsaJsonWebKey>(rsa);
+        Assert.IsType<EllipticCurveJsonWebKey>(ec);
+    }
+
+    [Fact]
+    public void AcceptsPascalCasePropertyNames_AsWellAsLowercase()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "pascal-client",
+                  "Jwks": {
+                    "Keys": [
+                      {
+                        "Kty": "RSA",
+                        "Kid": "pk",
+                        "Use": "sig",
+                        "Alg": "RS256",
+                        "N": "AQAB",
+                        "E": "AQAB"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        var clients = ApplyConfig(json, new ClientInfo("pascal-client"));
+
+        var key = Assert.IsType<RsaJsonWebKey>(clients.Single().Jwks!.Keys.Single());
+        Assert.Equal("pk", key.KeyId);
+    }
+
+    [Fact]
+    public void Throws_WhenJwksKtyIsUnknown()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "broken",
+                  "Jwks": { "Keys": [{ "kty": "UNKNOWN_TYPE" }] }
+                }
+              ]
+            }
+            """;
+        Assert.Throws<InvalidOperationException>(() => ApplyConfig(json, new ClientInfo("broken")));
+    }
+
+    [Fact]
+    public void Throws_WhenJwksKtyIsMissing()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "missing-kty",
+                  "Jwks": { "Keys": [{ "kid": "no-kty" }] }
+                }
+              ]
+            }
+            """;
+        Assert.Throws<InvalidOperationException>(() => ApplyConfig(json, new ClientInfo("missing-kty")));
+    }
+
+    [Fact]
+    public void LoadsFromAppsettingsJsonFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"appsettings-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(path, """
+                {
+                  "Clients": [
+                    {
+                      "ClientId": "from-file-client",
+                      "TokenEndpointAuthMethod": "private_key_jwt",
+                      "Jwks": {
+                        "Keys": [
+                          {
+                            "kty": "RSA",
+                            "kid": "file-k1",
+                            "use": "sig",
+                            "alg": "PS256",
+                            "n": "AQAB",
+                            "e": "AQAB"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """);
+
+            var config = new ConfigurationBuilder()
+                .AddJsonFile(path, optional: false)
+                .Build();
+
+            var clients = new[] { new ClientInfo("from-file-client") }
+                .WithJwksFromConfiguration(config.GetSection("Clients"));
+
+            var jwks = clients.Single().Jwks;
+            Assert.NotNull(jwks);
+            var key = Assert.IsType<RsaJsonWebKey>(jwks.Keys.Single());
+            Assert.Equal("file-k1", key.KeyId);
+            Assert.Equal("PS256", key.Algorithm);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OidcOptionsWrapper_DelegatesToClientArrayExtension()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "wrap",
+                  "Jwks": {
+                    "Keys": [{ "kty": "RSA", "kid": "w", "n": "AQAB", "e": "AQAB" }]
+                  }
+                }
+              ]
+            }
+            """;
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            .Build();
+
+        var opts = new OidcOptions { Clients = [new ClientInfo("wrap")] };
+        opts.AddClientJwksFromConfiguration(config.GetSection("Clients"));
+
+        var key = Assert.IsType<RsaJsonWebKey>(opts.Clients.First().Jwks!.Keys.Single());
+        Assert.Equal("w", key.KeyId);
+    }
+
+    private static ClientInfo[] ApplyConfig(string json, params ClientInfo[] clients)
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            .Build();
+
+        return clients.WithJwksFromConfiguration(config.GetSection("Clients"));
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/ClientJwksConfigurationExtensions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ClientJwksConfigurationExtensions.cs
@@ -1,0 +1,118 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Microsoft.Extensions.Configuration;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Configuration-time extensions that populate <see cref="ClientInfo.Jwks"/> from raw
+/// configuration sections by binding into <see cref="JsonWebKeySetSettings"/> (a flat
+/// DTO that <see cref="Microsoft.Extensions.Configuration"/> can handle natively) and
+/// mapping to the polymorphic <see cref="JsonWebKey"/> hierarchy.
+/// </summary>
+/// <remarks>
+/// The same primitive is exposed at two layers so the host can apply the fix as close
+/// to the source binding as practical:
+/// <list type="bullet">
+/// <item><description>
+/// <c>settings.Clients.WithJwksFromConfiguration(section)</c> — eager, runs right after
+/// <c>configuration.Get&lt;Settings&gt;()</c>, so every later consumer of
+/// <c>settings.Clients</c> sees populated <c>Jwks</c>.
+/// </description></item>
+/// <item><description>
+/// <c>options.AddClientJwksFromConfiguration(section)</c> — convenience inside the
+/// <c>AddOidcServices</c> options lambda, equivalent to mutating
+/// <c>options.Clients</c> through <c>WithJwksFromConfiguration</c>.
+/// </description></item>
+/// </list>
+/// </remarks>
+public static class ClientJwksConfigurationExtensions
+{
+    /// <summary>
+    /// Returns the same client collection with <see cref="ClientInfo.Jwks"/> populated for
+    /// each entry whose configuration counterpart includes an inline <c>Jwks</c> sub-section.
+    /// Mutates in place when the input is already a <see cref="ClientInfo"/> array; otherwise
+    /// materialises a fresh array.
+    /// </summary>
+    /// <param name="clients">The clients whose <c>Jwks</c> should be populated.</param>
+    /// <param name="clientsSection">The configuration section that holds the Clients tree —
+    /// typically <c>configuration.GetSection("Clients")</c>.</param>
+    /// <returns>The same clients (as an array) with any newly populated <c>Jwks</c>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Per-client self-correcting: an entry whose <see cref="ClientInfo.Jwks"/> is already
+    /// non-null (because the host populated it programmatically or a future TFM's binder
+    /// gained native polymorphic support) is skipped.
+    /// </para>
+    /// <para>
+    /// Configuration entries without a matching <c>ClientId</c> in <paramref name="clients"/>
+    /// are silently skipped, so the same <c>appsettings.json</c> can declare clients that only
+    /// some deployments load.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">A <c>Jwks</c> sub-section contains a key
+    /// with a missing or unsupported <c>kty</c> discriminator.</exception>
+    /// <exception cref="FormatException">A byte-array member of a JWK is not valid
+    /// base64url.</exception>
+    public static ClientInfo[] WithJwksFromConfiguration(
+        this IEnumerable<ClientInfo> clients,
+        IConfigurationSection clientsSection)
+    {
+        var array = clients as ClientInfo[] ?? clients.ToArray();
+        if (!clientsSection.Exists() || array.Length == 0)
+            return array;
+
+        foreach (var entry in clientsSection.GetChildren())
+        {
+            var clientId = entry[nameof(ClientInfo.ClientId)];
+            if (string.IsNullOrEmpty(clientId))
+                continue;
+
+            var jwksSection = entry.GetSection(nameof(ClientInfo.Jwks));
+            if (!jwksSection.Exists())
+                continue;
+
+            var client = Array.Find(array, c => c.ClientId == clientId);
+            if (client is null || client.Jwks is not null)
+                continue;
+
+            if (jwksSection.Get<JsonWebKeySetSettings>() is {} jwks)
+                client.Jwks = jwks;
+        }
+
+        return array;
+    }
+
+    /// <summary>
+    /// Convenience wrapper for use inside the <c>AddOidcServices</c> options lambda:
+    /// equivalent to <c>options.Clients = options.Clients.WithJwksFromConfiguration(section)</c>.
+    /// </summary>
+    public static void AddClientJwksFromConfiguration(
+        this OidcOptions options,
+        IConfigurationSection clientsSection)
+    {
+        options.Clients = options.Clients.WithJwksFromConfiguration(clientsSection);
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/JsonWebKeySetSettings.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/JsonWebKeySetSettings.cs
@@ -1,0 +1,48 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Microsoft.Extensions.Configuration;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Flat configuration DTO for a <see cref="JsonWebKeySet"/>, mirroring RFC 7517 Section 5
+/// (a JSON object with a single <c>keys</c> array). See <see cref="JsonWebKeySettings"/>
+/// for the per-key DTO and the design rationale.
+/// </summary>
+public sealed class JsonWebKeySetSettings
+{
+    /// <summary>The set of keys. Maps to the <c>keys</c> array per RFC 7517 §5.</summary>
+    [ConfigurationKeyName("keys")]
+    public List<JsonWebKeySettings>? Keys { get; init; }
+
+    /// <summary>Maps this flat DTO to <see cref="JsonWebKeySet"/> by invoking
+    /// <see cref="JsonWebKeySettings.ToJsonWebKey"/> on each entry.</summary>
+    public JsonWebKeySet ToJsonWebKeySet() => new(
+        (Keys ?? []).Select(k => k.ToJsonWebKey()).ToArray());
+
+    /// <summary>Convenience implicit conversion to <see cref="JsonWebKeySet"/>;
+    /// delegates to <see cref="ToJsonWebKeySet"/>.</summary>
+    public static implicit operator JsonWebKeySet(JsonWebKeySetSettings settings)
+        => settings.ToJsonWebKeySet();
+}

--- a/Abblix.Oidc.Server/Common/Configuration/JsonWebKeySettings.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/JsonWebKeySettings.cs
@@ -1,0 +1,202 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using Abblix.Jwt;
+using Microsoft.Extensions.Configuration;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Flat configuration DTO for a single JSON Web Key, suitable for binding via
+/// <c>Microsoft.Extensions.Configuration</c> which cannot instantiate the abstract
+/// <see cref="JsonWebKey"/> base type directly. All cryptographic byte-array members
+/// are bound as base64url-encoded strings per RFC 7517; <see cref="ToJsonWebKey"/>
+/// decodes them and maps the flat shape to the correct concrete subtype based on
+/// <see cref="Kty"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Design rationale: a flat DTO that mirrors the RFC 7517 wire format keeps the
+/// configuration path free of <c>System.Text.Json</c> roundtrips and custom converters.
+/// Every JWK member binds out-of-the-box as a nullable string, the mapper handles
+/// base64url decoding and the <c>kty</c> dispatch in one place, and the schema lives as
+/// explicit C# code — refactor-safe and IntelliSense-friendly. The configuration binder
+/// itself produces path-aware error messages on invalid input, so operators do not have
+/// to translate generic JSON exceptions back to config paths.
+/// </para>
+/// <para>
+/// Each property carries a <see cref="ConfigurationKeyNameAttribute"/> pointing at the
+/// RFC 7517 wire name from <see cref="JsonWebKeyPropertyNames"/>, so config keys can be
+/// written exactly as JWK consumers expect them (<c>kty</c>, <c>n</c>, <c>e</c>, …) and
+/// the binder maps them unambiguously to the C# properties.
+/// </para>
+/// <para>
+/// A native polymorphic binding via <c>[JsonPolymorphic]</c> + <c>[JsonDerivedType]</c>
+/// was considered and rejected after empirical verification on net8.0 / net9.0 / net10.0:
+/// <c>Microsoft.Extensions.Configuration.Binder</c> does not honour these
+/// <c>System.Text.Json</c> attributes and still throws «Cannot create instance of
+/// abstract type» on <see cref="JsonWebKey"/>. The flat DTO is the practical workaround
+/// until the binder gains its own polymorphism support.
+/// </para>
+/// <para>
+/// Adding support for a new JWK type that the RFC introduces (for example OKP per
+/// RFC 8037 for Ed25519 / X25519 keys) is a fully localised change: add the new fields
+/// to this DTO and a new branch in the <c>Kty</c> switch inside <see cref="ToJsonWebKey"/>.
+/// No changes required in the polymorphic <see cref="JsonWebKey"/> hierarchy beyond the
+/// new concrete subtype itself.
+/// </para>
+/// </remarks>
+public sealed class JsonWebKeySettings
+{
+    /// <summary>Key type discriminator: <c>RSA</c>, <c>EC</c>, or <c>oct</c>.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.KeyType)]
+    public string? Kty { get; init; }
+
+    /// <summary>Key ID for selection in multi-key environments.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.KeyId)]
+    public string? Kid { get; init; }
+
+    /// <summary>Public key use: <c>sig</c> or <c>enc</c>.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.Usage)]
+    public string? Use { get; init; }
+
+    /// <summary>Algorithm intended for use with this key.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.Algorithm)]
+    public string? Alg { get; init; }
+
+    /// <summary>RSA modulus (n).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.Modulus)]
+    public string? N { get; init; }
+
+    /// <summary>RSA public exponent (e).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.Exponent)]
+    public string? E { get; init; }
+
+    /// <summary>RSA or EC private exponent / key (d).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.PrivateExponent)]
+    public string? D { get; init; }
+
+    /// <summary>RSA first prime factor (p).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.FirstPrimeFactor)]
+    public string? P { get; init; }
+
+    /// <summary>RSA second prime factor (q).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.SecondPrimeFactor)]
+    public string? Q { get; init; }
+
+    /// <summary>RSA first factor CRT exponent (dp).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.FirstFactorCrtExponent)]
+    public string? Dp { get; init; }
+
+    /// <summary>RSA second factor CRT exponent (dq).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.SecondFactorCrtExponent)]
+    public string? Dq { get; init; }
+
+    /// <summary>RSA first CRT coefficient (qi).</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.FirstCrtCoefficient)]
+    public string? Qi { get; init; }
+
+    /// <summary>EC curve identifier (crv): <c>P-256</c>, <c>P-384</c>, or <c>P-521</c>.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.Curve)]
+    public string? Crv { get; init; }
+
+    /// <summary>EC X coordinate.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.EllipticCurveX)]
+    public string? X { get; init; }
+
+    /// <summary>EC Y coordinate.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.EllipticCurveY)]
+    public string? Y { get; init; }
+
+    /// <summary>Symmetric (oct) key value.</summary>
+    [ConfigurationKeyName(JsonWebKeyPropertyNames.KeyValue)]
+    public string? K { get; init; }
+
+    /// <summary>Maps this flat DTO to the corresponding concrete <see cref="JsonWebKey"/> subtype.</summary>
+    /// <exception cref="InvalidOperationException"><see cref="Kty"/> is missing or not <c>RSA</c>/<c>EC</c>/<c>oct</c>.</exception>
+    /// <exception cref="FormatException">A byte-array member is not valid base64url.</exception>
+    public JsonWebKey ToJsonWebKey() => Kty switch
+    {
+        JsonWebKeyTypes.Rsa => ToRsaJsonWebKey(),
+        JsonWebKeyTypes.EllipticCurve => ToEllipticCurveJsonWebKey(),
+        JsonWebKeyTypes.Octet => ToOctetJsonWebKey(),
+
+        null or "" => throw new InvalidOperationException(
+            $"JsonWebKey settings require the '{nameof(Kty)}' discriminator to be set."),
+
+        _ => throw new InvalidOperationException(
+            $"Unsupported JsonWebKey type '{Kty}'. Expected one of: " +
+            $"{JsonWebKeyTypes.Rsa}, {JsonWebKeyTypes.EllipticCurve}, {JsonWebKeyTypes.Octet}."),
+    };
+
+    private RsaJsonWebKey ToRsaJsonWebKey()
+    {
+        return new RsaJsonWebKey
+        {
+            KeyId = Kid,
+            Usage = Use,
+            Algorithm = Alg,
+            Modulus = Decode(N),
+            Exponent = Decode(E),
+            PrivateExponent = Decode(D),
+            FirstPrimeFactor = Decode(P),
+            SecondPrimeFactor = Decode(Q),
+            FirstFactorCrtExponent = Decode(Dp),
+            SecondFactorCrtExponent = Decode(Dq),
+            FirstCrtCoefficient = Decode(Qi),
+        };
+    }
+
+    private EllipticCurveJsonWebKey ToEllipticCurveJsonWebKey()
+    {
+        return new EllipticCurveJsonWebKey
+        {
+            KeyId = Kid,
+            Usage = Use,
+            Algorithm = Alg,
+            Curve = Crv,
+            X = Decode(X),
+            Y = Decode(Y),
+            PrivateKey = Decode(D),
+        };
+    }
+
+    private OctetJsonWebKey ToOctetJsonWebKey()
+    {
+        return new OctetJsonWebKey
+        {
+            KeyId = Kid,
+            Usage = Use,
+            Algorithm = Alg,
+            KeyValue = Decode(K),
+        };
+    }
+
+    /// <summary>Convenience implicit conversion to <see cref="JsonWebKey"/>;
+    /// delegates to <see cref="ToJsonWebKey"/>.</summary>
+    public static implicit operator JsonWebKey(JsonWebKeySettings settings)
+        => settings.ToJsonWebKey();
+
+    private static byte[]? Decode(string? value)
+        => value is not null ? Base64Url.DecodeFromChars(value) : null;
+}


### PR DESCRIPTION
## Summary

- Adds `IEnumerable<ClientInfo>.WithJwksFromConfiguration(section)` and `OidcOptions.AddClientJwksFromConfiguration(section)` extensions that populate `ClientInfo.Jwks` from raw configuration sections.
- Each `Jwks` sub-section binds into a flat `JsonWebKeySetSettings` / `JsonWebKeySettings` DTO with `[ConfigurationKeyName(JsonWebKeyPropertyNames.X)]` attributes that point at the canonical RFC 7517 wire names (`kty`, `kid`, `n`, `e`, `use`, `alg`, `d`, `p`, `q`, `dp`, `dq`, `qi`, `crv`, `x`, `y`, `k`). The configuration binder handles the DTO natively; an implicit conversion to `JsonWebKey` / `JsonWebKeySet` then dispatches to the concrete polymorphic subtype by the `kty` discriminator and base64url-decodes byte-array members.
- Per-client self-correcting via `Jwks != null` — consumers that gain native polymorphic binding on a future TFM see the extension become a no-op.
- Documents in `JsonWebKeyConverter.cs` why a swap to `[JsonPolymorphic]` is not a drop-in replacement (wire-format edge case with derived `[JsonInclude]` overrides on `kty`).

Ref #114