### PR TITLE
refactor(jwt): generic-ify WithJwksFromConfiguration to preserve derived ClientInfo types

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientJwksConfigurationExtensionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientJwksConfigurationExtensionsTests.cs
@@ -277,6 +277,46 @@ public class ClientJwksConfigurationExtensionsTests
         }
     }
 
+    /// <summary>
+    /// Host-defined ClientInfo subtype (mirrors AuthSvc's
+    /// <c>Authentication.DomainModel.Entities.ClientInfo</c> inheriting from the OIDC-Server base) —
+    /// used to verify the generic extension preserves the array's runtime AND static type when
+    /// consumers pass derived ClientInfo collections.
+    /// </summary>
+    private record DerivedTestClient(string Id) : ClientInfo(Id)
+    {
+        public string? ExtraProperty { get; init; }
+    }
+
+    [Fact]
+    public void PreservesDerivedClientInfoArrayType()
+    {
+        const string json = """
+            {
+              "Clients": [
+                {
+                  "ClientId": "derived-client",
+                  "Jwks": {
+                    "keys": [{ "kty": "RSA", "kid": "d", "n": "AQAB", "e": "AQAB" }]
+                  }
+                }
+              ]
+            }
+            """;
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            .Build();
+
+        var clients = new[] { new DerivedTestClient("derived-client") { ExtraProperty = "preserved" } };
+
+        DerivedTestClient[] result = clients.WithJwksFromConfiguration(config.GetSection("Clients"));
+
+        Assert.IsType<DerivedTestClient[]>(result);
+        Assert.Same(clients, result);
+        Assert.Equal("preserved", result.Single().ExtraProperty);
+        Assert.NotNull(result.Single().Jwks);
+    }
+
     [Fact]
     public void OidcOptionsWrapper_DelegatesToClientArrayExtension()
     {

--- a/Abblix.Oidc.Server/Common/Configuration/ClientJwksConfigurationExtensions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ClientJwksConfigurationExtensions.cs
@@ -76,11 +76,12 @@ public static class ClientJwksConfigurationExtensions
     /// with a missing or unsupported <c>kty</c> discriminator.</exception>
     /// <exception cref="FormatException">A byte-array member of a JWK is not valid
     /// base64url.</exception>
-    public static ClientInfo[] WithJwksFromConfiguration(
-        this IEnumerable<ClientInfo> clients,
+    public static T[] WithJwksFromConfiguration<T>(
+        this IEnumerable<T> clients,
         IConfigurationSection clientsSection)
+        where T : ClientInfo
     {
-        var array = clients as ClientInfo[] ?? clients.ToArray();
+        var array = clients as T[] ?? clients.ToArray();
         if (!clientsSection.Exists() || array.Length == 0)
             return array;
 


### PR DESCRIPTION
## Summary

- Generic-ifies the `WithJwksFromConfiguration` extension method so `T` inferred from the input collection survives the mutation-and-return chain:
  ```diff
  - public static ClientInfo[] WithJwksFromConfiguration(this IEnumerable<ClientInfo> clients, ...)
  + public static T[] WithJwksFromConfiguration<T>(this IEnumerable<T> clients, ...) where T : ClientInfo
  ```
- Unblocks consumers that hold derived `ClientInfo` collections (e.g. AuthSvc's `Authentication.DomainModel.Entities.ClientInfo : ClientInfo`). C# array covariance is upcast-only — `Derived[]` is-a `Base[]`, not vice versa, so the old return type forced casts or discarded returns at the call site.
- Existing call sites that pass `IEnumerable<ClientInfo>` directly compile unchanged via `T = ClientInfo` inference.

## Regression coverage

`PreservesDerivedClientInfoArrayType` verifies that a derived `ClientInfo` array is returned as the derived type AND that extra subtype-specific properties survive the round-trip via mutation-in-place (`Same(clients, result)` + `Assert.IsType<DerivedTestClient[]>`).

Follow-up to #115. Ref #114.