### PR TITLE
fix(par): return JSON error response, not 302 redirect to login

### DIFF
--- a/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/PushedAuthorizationResponseFormatterTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/PushedAuthorizationResponseFormatterTests.cs
@@ -21,7 +21,6 @@
 // info@abblix.com
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
@@ -77,9 +76,9 @@ public class PushedAuthorizationResponseFormatterTests
 
         var json = Assert.IsType<JsonResult>(result);
         Assert.Equal(StatusCodes.Status401Unauthorized, json.StatusCode);
-        var body = json.Value!.GetType().GetProperties();
-        Assert.Equal(ErrorCodes.InvalidClient, body.First(p => p.Name == "error").GetValue(json.Value));
-        Assert.Equal("Client authentication failed", body.First(p => p.Name == "error_description").GetValue(json.Value));
+        var body = Assert.IsType<ErrorResponse>(json.Value);
+        Assert.Equal(ErrorCodes.InvalidClient, body.Error);
+        Assert.Equal("Client authentication failed", body.ErrorDescription);
     }
 
     [Fact]

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/PushedAuthorizationResponseFormatterTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/PushedAuthorizationResponseFormatterTests.cs
@@ -1,0 +1,125 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+using Abblix.Oidc.Server.Endpoints.PushedAuthorization.Interfaces;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.Formatters;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+using ParApiModel = Abblix.Oidc.Server.Mvc.Model.PushedAuthorizationResponse;
+
+namespace Abblix.Oidc.Server.Mvc.UnitTests.Formatters;
+
+/// <summary>
+/// Regression coverage for the PAR response formatter: per RFC 9126 §2.3 PAR is a server-to-server
+/// endpoint, so responses must always be JSON and errors must never redirect to a browser-facing
+/// login page.
+/// </summary>
+public class PushedAuthorizationResponseFormatterTests
+{
+    private readonly PushedAuthorizationResponseFormatter _formatter = new();
+
+    [Fact]
+    public async Task FormatResponseAsync_PushedAuthorizationResponse_ReturnsJsonWith201()
+    {
+        var request = new AuthorizationRequest();
+        var response = new PushedAuthorizationResponse(
+            request,
+            new Uri("urn:ietf:params:oauth:request_uri:abc123"),
+            TimeSpan.FromSeconds(60));
+
+        var result = await _formatter.FormatResponseAsync(request, response);
+
+        var json = Assert.IsType<JsonResult>(result);
+        Assert.Equal(StatusCodes.Status201Created, json.StatusCode);
+        var body = Assert.IsType<ParApiModel>(json.Value);
+        Assert.Equal("urn:ietf:params:oauth:request_uri:abc123", body.RequestUri?.OriginalString);
+        Assert.Equal(TimeSpan.FromSeconds(60), body.ExpiresIn);
+    }
+
+    [Fact]
+    public async Task FormatResponseAsync_InvalidClientError_ReturnsJson401()
+    {
+        var request = new AuthorizationRequest();
+        var error = new AuthorizationError(
+            request,
+            ErrorCodes.InvalidClient,
+            "Client authentication failed",
+            ResponseMode: "query",
+            RedirectUri: null);
+
+        var result = await _formatter.FormatResponseAsync(request, error);
+
+        var json = Assert.IsType<JsonResult>(result);
+        Assert.Equal(StatusCodes.Status401Unauthorized, json.StatusCode);
+        var body = json.Value!.GetType().GetProperties();
+        Assert.Equal(ErrorCodes.InvalidClient, body.First(p => p.Name == "error").GetValue(json.Value));
+        Assert.Equal("Client authentication failed", body.First(p => p.Name == "error_description").GetValue(json.Value));
+    }
+
+    [Fact]
+    public async Task FormatResponseAsync_InvalidRequestError_ReturnsJson400()
+    {
+        var request = new AuthorizationRequest();
+        var error = new AuthorizationError(
+            request,
+            ErrorCodes.InvalidRequest,
+            "Missing required parameter",
+            ResponseMode: "query",
+            RedirectUri: null);
+
+        var result = await _formatter.FormatResponseAsync(request, error);
+
+        var json = Assert.IsType<JsonResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, json.StatusCode);
+    }
+
+    /// <summary>
+    /// Regression guard: PAR error responses must not redirect to a login page. Following
+    /// the redirect lands programmatic OAuth clients on the user-facing auth-app HTML and
+    /// breaks RFC 9126 conformance — the bug this formatter was rewritten to fix.
+    /// </summary>
+    [Fact]
+    public async Task FormatResponseAsync_AnyError_NeverReturnsRedirect()
+    {
+        var request = new AuthorizationRequest();
+        var error = new AuthorizationError(
+            request,
+            ErrorCodes.InvalidClient,
+            "test",
+            ResponseMode: "query",
+            RedirectUri: new Uri("https://example.com/cb"));
+
+        var result = await _formatter.FormatResponseAsync(request, error);
+
+        Assert.IsNotType<RedirectResult>(result);
+        Assert.IsNotType<LocalRedirectResult>(result);
+        Assert.IsNotType<RedirectToActionResult>(result);
+        Assert.IsType<JsonResult>(result);
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/Controllers/AuthenticationController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/AuthenticationController.cs
@@ -78,7 +78,7 @@ public sealed class AuthenticationController : ControllerBase
     /// </remarks>
     [HttpPost(Path.PushAuthorizationRequest)]
     [Consumes(MediaTypes.FormUrlEncoded)]
-    [Produces(MediaTypeNames.Text.Html, MediaTypeNames.Application.Json)]
+    [Produces(MediaTypeNames.Application.Json)]
     [EnabledBy(OidcEndpoints.PushedAuthorizationRequest)]
     public async Task<ActionResult<AuthorizationResponse>> PushAuthorizeAsync(
         [FromServices] IPushedAuthorizationHandler handler,

--- a/Abblix.Oidc.Server.Mvc/Formatters/PushedAuthorizationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/PushedAuthorizationResponseFormatter.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Exceptions;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Endpoints.PushedAuthorization.Interfaces;
@@ -33,9 +34,13 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// <summary>
 /// Implements response formatting for pushed authorization requests.
 /// </summary>
-/// <param name="errorFormatter">The formatter for handling authorization errors.</param>
-public class PushedAuthorizationResponseFormatter(IAuthorizationErrorFormatter errorFormatter)
-    : IPushedAuthorizationResponseFormatter
+/// <remarks>
+/// PAR is a server-to-server endpoint per RFC 9126; responses are always JSON. Error responses
+/// never redirect — that would land programmatic OAuth clients on a user-facing login page.
+/// For the same reason this formatter does not delegate to <see cref="IAuthorizationErrorFormatter"/>,
+/// which is intended for the authorization endpoint's browser flow.
+/// </remarks>
+public class PushedAuthorizationResponseFormatter : IPushedAuthorizationResponseFormatter
 {
     /// <summary>
     /// Asynchronously formats the response to a pushed authorization request.
@@ -47,27 +52,40 @@ public class PushedAuthorizationResponseFormatter(IAuthorizationErrorFormatter e
     /// <returns>A task that resolves to an action result suitable for returning from an MVC action,
     /// representing the formatted response. This could include setting specific HTTP status codes
     /// or returning error information.</returns>
-    public async Task<ActionResult> FormatResponseAsync(
+    public Task<ActionResult> FormatResponseAsync(
         AuthorizationRequest request,
         AuthorizationResponse response)
     {
-        switch (response)
+        ActionResult result = response switch
         {
-            case PushedAuthorizationResponse par:
-
-                var modelResponse = new Model.PushedAuthorizationResponse
+            PushedAuthorizationResponse par => new JsonResult(
+                new Model.PushedAuthorizationResponse
                 {
                     RequestUri = par.RequestUri,
                     ExpiresIn = par.ExpiresIn,
-                };
+                })
+            {
+                StatusCode = StatusCodes.Status201Created,
+            },
 
-                return new JsonResult(modelResponse) { StatusCode = StatusCodes.Status201Created };
+            AuthorizationError error => new JsonResult(
+                new
+                {
+                    error = error.Error,
+                    error_description = error.ErrorDescription,
+                    error_uri = error.ErrorUri?.OriginalString,
+                })
+            {
+                StatusCode = error.Error switch
+                {
+                    ErrorCodes.InvalidClient => StatusCodes.Status401Unauthorized,
+                    _ => StatusCodes.Status400BadRequest,
+                },
+            },
 
-            case AuthorizationError error:
-                return await errorFormatter.FormatResponseAsync(request, error);
+            _ => throw new UnexpectedTypeException(nameof(response), response.GetType()),
+        };
 
-            default:
-                throw new UnexpectedTypeException(nameof(response), response.GetType());
-        }
+        return Task.FromResult(result);
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Formatters/PushedAuthorizationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/PushedAuthorizationResponseFormatter.cs
@@ -68,13 +68,7 @@ public class PushedAuthorizationResponseFormatter : IPushedAuthorizationResponse
                 StatusCode = StatusCodes.Status201Created,
             },
 
-            AuthorizationError error => new JsonResult(
-                new
-                {
-                    error = error.Error,
-                    error_description = error.ErrorDescription,
-                    error_uri = error.ErrorUri?.OriginalString,
-                })
+            AuthorizationError error => new JsonResult(new ErrorResponse(error.Error, error.ErrorDescription))
             {
                 StatusCode = error.Error switch
                 {


### PR DESCRIPTION
Closes #118

## Summary
- removes `MediaTypeNames.Text.Html` from `[Produces]` on `PushAuthorizeAsync` (PAR has no browser flow per RFC 9126 §2.3)
- inlines JSON error formatting in `PushedAuthorizationResponseFormatter` so PAR errors return `application/json` with proper 4xx status, never a 302 redirect to the login page
- adds regression tests covering success path, `invalid_client` → 401, `invalid_request` → 400, and a never-redirect guard

## Why
Programmatic OAuth clients (including the OIDF FAPI 2.0 Conformance Suite) hit `POST /connect/par` and follow redirects by default. The previous behavior 302'd them to the login page, returning HTML, breaking RFC 9126 conformance.

## Test plan
- [x] `dotnet test Abblix.Oidc.Server.Mvc.UnitTests` — 70/70 pass
- [x] `dotnet test Abblix.Oidc.Server.UnitTests` — 1929/1929 pass (no regression)
- [ ] After 2.3.0-dev.* publish: bump AuthSvc, redeploy, re-run OIDF FAPI 2.0 happy-flow