### PR TITLE
fix(jwt): return MalformedToken instead of throwing on JWE without decryption keys

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -321,6 +321,30 @@ public class JsonWebTokenValidationTests
     }
 
     /// <summary>
+    /// Verifies that a 5-segment JWE-shaped input on a validation path that does not wire a
+    /// decryption-key resolver returns <see cref="JwtError.MalformedToken"/> instead of
+    /// throwing <see cref="InvalidOperationException"/>. Caught 2026-05-14 against the
+    /// DPoP-proof validation path (RFC 9449 §4.2 requires JWS proofs): when the OIDF
+    /// Conformance Suite sent a JWE-shaped DPoP proof to test rejection, the validator
+    /// surfaced an unhandled <c>ResolveTokenDecryptionKeys is expected to be not null</c>
+    /// and produced a 500 instead of a typed validation error.
+    /// </summary>
+    [Fact]
+    public async Task MalformedJwt_WithJweShapeAndNoDecryptionKeys_FailsValidation()
+    {
+        var jweShapedJwt = "header.encryptedKey.iv.ciphertext.tag";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = new ValidationParameters { Options = ValidationOptions.Default };
+
+        var result = await validator.ValidateAsync(jweShapedJwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.MalformedToken, error.Error);
+        Assert.Contains("decryption keys", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Verifies that empty string input fails validation.
     /// Tests edge case of completely empty token input.
     /// Returns JwtError.MalformedToken.

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -382,7 +382,19 @@ internal class JsonWebTokenValidator(
         string[] jwtParts,
         ValidationParameters parameters)
     {
-        var resolveTokenDecryptionKeys = parameters.ResolveTokenDecryptionKeys.NotNull(nameof(parameters.ResolveTokenDecryptionKeys));
+        // A JWE-shaped input where the caller didn't wire a decryption-key resolver is a
+        // category error in this validator's contract: most callsites validate JWS only
+        // (DPoP proofs per RFC 9449 §4.2, client_assertion per RFC 7521, etc.), and
+        // throwing an unhandled InvalidOperationException turns a malformed-input case
+        // into a 500 for the caller and a noisy server log. Surface the same outcome as a
+        // typed validation error so the inbound payload gets rejected gracefully.
+        var resolveTokenDecryptionKeys = parameters.ResolveTokenDecryptionKeys;
+        if (resolveTokenDecryptionKeys is null)
+        {
+            return new JwtValidationError(
+                JwtError.MalformedToken,
+                "Received a JWE-shaped token (5 segments) but no decryption keys are configured for this validation path.");
+        }
         var decryptionKeys = resolveTokenDecryptionKeys(string.Empty);
 
         var result = await encryptor.DecryptAsync(jwtParts, decryptionKeys);


### PR DESCRIPTION
## Summary

`JsonWebTokenValidator.DecryptJweAsync` previously threw `InvalidOperationException` from `parameters.ResolveTokenDecryptionKeys.NotNull(...)` when a 5-segment JWE-shaped input arrived on a validation path that did not wire a decryption-key resolver. Most validation callsites only validate JWS — DPoP proofs (RFC 9449 §4.2), client assertions (RFC 7521), etc. — and intentionally do not wire decryption keys. A 5-segment input on those paths is malformed input, not a server defect, and should be rejected with a typed validation error.

## How it surfaced

OIDF FAPI 2.0 Conformance Suite DPoP-negative tests against \`account.abblix.com\` userinfo endpoint. The suite sent a JWE-shaped DPoP proof to verify rejection; \`ProofValidator\` → \`JsonWebTokenValidator\` threw, the exception bubbled all the way to \`AuthenticationController.UserInfoAsync\` and the conformance suite recorded a 500 instead of the expected 401 with \`error="invalid_dpop_proof"\`.

\`\`\`
System.InvalidOperationException: ResolveTokenDecryptionKeys is expected to be not null
   at Abblix.Utils.ObjectExtensions.NotNull
   at Abblix.Jwt.JsonWebTokenValidator.DecryptJweAsync
   at Abblix.Jwt.JsonWebTokenValidator.ValidateAsync
   at Abblix.Oidc.Server.Features.Tokens.Revocation.TokenStatusValidatorDecorator.ValidateAsync
   at Abblix.Oidc.Server.Features.DPoP.ProofValidator.ValidateAsync
   at Abblix.Oidc.Server.Endpoints.UserInfo.Validation.DPoPUserInfoValidator.ValidateAsync
\`\`\`

## Fix

Replace the \`NotNull\` assertion with an early return of \`JwtError.MalformedToken\` describing the JWE-without-decryption-keys condition. The downstream \`ProofValidator.MapValidationError\` already maps \`MalformedToken\` → \`ProofErrorReasons.MalformedJwt\`, so the DPoP path now produces the correct 401 + dpop-friendly error description.

## Test plan

- [x] New regression test \`MalformedJwt_WithJweShapeAndNoDecryptionKeys_FailsValidation\` — fails on the old throw-on-null behavior, passes after the fix
- [x] Full test suite (1931 unit tests across Abblix.Jwt + Abblix.Oidc.Server + .Mvc) — all green
- [ ] Re-run OIDF FAPI 2.0 DPoP-negative-tests against prod after dev-build publishes; expect 401 \`invalid_dpop_proof\` instead of 500