### PR TITLE
fix(jwt,dpop): graceful validation errors + RFC 9449 §7.1 multi-DPoP-header rejection

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -322,15 +322,16 @@ public class JsonWebTokenValidationTests
 
     /// <summary>
     /// Verifies that a 5-segment JWE-shaped input on a validation path that does not wire a
-    /// decryption-key resolver returns <see cref="JwtError.MalformedToken"/> instead of
-    /// throwing <see cref="InvalidOperationException"/>. Caught 2026-05-14 against the
-    /// DPoP-proof validation path (RFC 9449 §4.2 requires JWS proofs): when the OIDF
-    /// Conformance Suite sent a JWE-shaped DPoP proof to test rejection, the validator
-    /// surfaced an unhandled <c>ResolveTokenDecryptionKeys is expected to be not null</c>
-    /// and produced a 500 instead of a typed validation error.
+    /// decryption-key resolver returns <see cref="JwtError.InvalidToken"/> instead of
+    /// throwing <see cref="InvalidOperationException"/>. Caught 2026-05-14 at /connect/userinfo
+    /// against an OIDF FAPI 2.0 sub-test that injected two DPoP HTTP headers — ASP.NET Core
+    /// concatenated them with a comma producing a 5-segment string, which routed the
+    /// validator to the JWE branch and crashed it. The token itself may be a perfectly
+    /// well-formed JWE; the failure here is a callsite category mismatch (this path
+    /// validates JWS only), not malformed input.
     /// </summary>
     [Fact]
-    public async Task MalformedJwt_WithJweShapeAndNoDecryptionKeys_FailsValidation()
+    public async Task JweWithoutDecryptionKeys_ReturnsInvalidTokenError()
     {
         var jweShapedJwt = "header.encryptedKey.iv.ciphertext.tag";
 
@@ -340,8 +341,34 @@ public class JsonWebTokenValidationTests
         var result = await validator.ValidateAsync(jweShapedJwt, parameters);
 
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(JwtError.MalformedToken, error.Error);
+        Assert.Equal(JwtError.InvalidToken, error.Error);
         Assert.Contains("decryption keys", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Symmetric to <see cref="JweWithoutDecryptionKeys_ReturnsInvalidTokenError"/>: a 3-segment
+    /// JWS on the issuer-keys trust branch without a ResolveIssuerSigningKeys resolver returns
+    /// <see cref="JwtError.InvalidToken"/> rather than throwing
+    /// <see cref="InvalidOperationException"/>. Closes the second of the two NotNull-throw
+    /// hotspots in <c>JsonWebTokenValidator</c>.
+    /// </summary>
+    [Fact]
+    public async Task JwsWithoutSigningKeysResolver_ReturnsInvalidTokenError()
+    {
+        var token = CreateValidToken();
+        var signedJwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        // ValidationOptions.Default selects the issuer-resolved-keys trust branch, but the
+        // host did not provide a ResolveIssuerSigningKeys resolver — the validator must
+        // return a typed error, not throw an InvalidOperationException.
+        var parameters = new ValidationParameters { Options = ValidationOptions.Default };
+
+        var result = await validator.ValidateAsync(signedJwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Contains("ResolveIssuerSigningKeys", error.ErrorDescription);
     }
 
     /// <summary>

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -306,8 +306,18 @@ internal class JsonWebTokenValidator(
                 JwtError.InvalidToken, "Missing issuer in JWT payload for signature validation");
         }
 
-        var resolveIssuerSigningKeys = parameters.ResolveIssuerSigningKeys
-            .NotNull(nameof(parameters.ResolveIssuerSigningKeys));
+        // Symmetric with the JWE path: the validator's other trust mode looks up signing
+        // keys by issuer (via parameters.ResolveIssuerSigningKeys, typically the host's
+        // JWKS lookup). A caller routed here without wiring that delegate is a category
+        // mismatch — surface a typed JwtValidationError so the request fails with a 401,
+        // not an unhandled NotNull throw that propagates as 500.
+        var resolveIssuerSigningKeys = parameters.ResolveIssuerSigningKeys;
+        if (resolveIssuerSigningKeys is null)
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                "No signing-key resolver configured: this validation path expected to look up signing keys by 'iss' but the host did not provide ResolveIssuerSigningKeys.");
+        }
 
         return await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
     }
@@ -382,18 +392,19 @@ internal class JsonWebTokenValidator(
         string[] jwtParts,
         ValidationParameters parameters)
     {
-        // A JWE-shaped input where the caller didn't wire a decryption-key resolver is a
-        // category error in this validator's contract: most callsites validate JWS only
-        // (DPoP proofs per RFC 9449 §4.2, client_assertion per RFC 7521, etc.), and
-        // throwing an unhandled InvalidOperationException turns a malformed-input case
-        // into a 500 for the caller and a noisy server log. Surface the same outcome as a
-        // typed validation error so the inbound payload gets rejected gracefully.
+        // The token may be a perfectly well-formed JWE — the failure mode here is that
+        // this validation path was not wired with a decryption-key resolver. Most callsites
+        // validate JWS only (DPoP proofs per RFC 9449 §4.2, client_assertion per RFC 7521,
+        // etc.) and intentionally pass ResolveTokenDecryptionKeys = null. Throwing
+        // InvalidOperationException from .NotNull turns a category mismatch into a 500
+        // and a noisy server log; return a typed validation error instead so the caller
+        // can map it onto the right HTTP error.
         var resolveTokenDecryptionKeys = parameters.ResolveTokenDecryptionKeys;
         if (resolveTokenDecryptionKeys is null)
         {
             return new JwtValidationError(
-                JwtError.MalformedToken,
-                "Received a JWE-shaped token (5 segments) but no decryption keys are configured for this validation path.");
+                JwtError.InvalidToken,
+                "Received a JWE-encrypted token but no decryption keys are configured for this validation path; this endpoint accepts JWS only.");
         }
         var decryptionKeys = resolveTokenDecryptionKeys(string.Empty);
 

--- a/Abblix.Oidc.Server.UnitTests/Features/DPoP/ProofValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DPoP/ProofValidatorTests.cs
@@ -119,6 +119,33 @@ public class ProofValidatorTests
         Assert.True(result.TryGetSuccess(out _));
     }
 
+    /// <summary>
+    /// RFC 9449 §7.1: a request must carry at most one DPoP header. ASP.NET Core's string
+    /// FromHeader binder joins repeated header values with a comma — the proof string
+    /// arrives at the validator looking like "&lt;jwt1&gt;,&lt;jwt2&gt;". Because JWS
+    /// compact serialization (RFC 7515 §3.1) uses only base64url + '.', a comma is
+    /// unambiguous evidence of HTTP-level concatenation. The validator must reject before
+    /// the downstream JsonWebTokenValidator sees a string with 5 dot-separated parts,
+    /// which would route to the JWE branch and crash with "ResolveTokenDecryptionKeys is
+    /// expected to be not null". Caught 2026-05-14 against OIDF FAPI 2.0 DPoP-negative
+    /// "AddMultipleDpopHeaderForResourceEndpointRequest" sub-test (the multi-DPoP-header
+    /// scenario produced exactly this 500-instead-of-401 outcome at /connect/userinfo).
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_MultipleDpopHeaderValues_ReturnsMalformed()
+    {
+        var first = new DPoPProofBuilder(_time.GetUtcNow()).Build();
+        var second = new DPoPProofBuilder(_time.GetUtcNow()).Build();
+        var concatenated = $"{first},{second}";
+
+        var result = await _sut.ValidateAsync(concatenated, cancellationToken: Ct);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ProofErrorReasons.MalformedJwt, error.Reason);
+        Assert.NotNull(error.Detail);
+        Assert.Contains("RFC 9449", error.Detail);
+    }
+
     [Theory]
     [InlineData("openid+jwt")]
     [InlineData("JWT")]

--- a/Abblix.Oidc.Server/Features/DPoP/ProofValidator.cs
+++ b/Abblix.Oidc.Server/Features/DPoP/ProofValidator.cs
@@ -67,6 +67,20 @@ internal sealed class ProofValidator(
         string? accessToken = null,
         CancellationToken cancellationToken = default)
     {
+        // RFC 9449 §7.1: a request MUST carry at most one DPoP header. ASP.NET Core's
+        // string FromHeader binder joins repeated header values with a comma. The DPoP
+        // proof is JWS compact serialization (RFC 7515 §3.1), whose alphabet is
+        // base64url + '.' — no comma is permitted — so a comma in the proof string
+        // is unambiguous evidence that the client sent the header twice. Reject before
+        // the downstream JWS validator sees a string with 5 dot-separated parts (which
+        // it would route to the JWE branch and surface a category error).
+        if (proofJwt.Contains(','))
+        {
+            return new ProofError(
+                ProofErrorReasons.MalformedJwt,
+                "Multiple DPoP header values are not permitted (RFC 9449 §7.1).");
+        }
+
         var jwtResult = await jwtValidator.ValidateAsync(
             proofJwt,
             new ()


### PR DESCRIPTION
## Summary

Closes two NotNull throw hotspots in \`JsonWebTokenValidator\` and adds an explicit RFC 9449 §7.1 guard in \`ProofValidator\`.

Caught 2026-05-14 against the OIDF FAPI 2.0 DPoP-negative \`AddMultipleDpopHeaderForResourceEndpointRequest\` sub-test at \`/connect/userinfo\`: ASP.NET Core's string \`FromHeader\` binder joins repeated DPoP HTTP header values with a comma, the resulting \`<jwt1>,<jwt2>\` splits to 5 dot-separated parts, the validator routed it to the JWE branch, \`ResolveTokenDecryptionKeys\` was null on that callsite and the assertion threw \`InvalidOperationException\` → 500 instead of the expected 401 with \`invalid_dpop_proof\`.

## Changes

- \`JsonWebTokenValidator.DecryptJweAsync\`: typed \`JwtError.InvalidToken\` when callsite did not wire a decryption-key resolver. The token may be a well-formed JWE; the failure is a category mismatch, not malformed input.
- \`JsonWebTokenValidator.ValidateIssuerSignatureAsync\`: symmetric fix for the issuer-keys trust branch — typed \`JwtError.InvalidToken\` instead of throwing when \`ResolveIssuerSigningKeys\` is null.
- \`ProofValidator.ValidateAsync\`: pre-check for \`,\` in the proof string and reject with \`ProofErrorReasons.MalformedJwt\` referencing RFC 9449 §7.1. JWS compact serialization (RFC 7515 §3.1) is base64url + \`.\` only, so a comma is unambiguous evidence of multi-value concatenation.

## Test plan

- [x] \`JweWithoutDecryptionKeys_ReturnsInvalidTokenError\`
- [x] \`JwsWithoutSigningKeysResolver_ReturnsInvalidTokenError\`
- [x] \`ValidateAsync_MultipleDpopHeaderValues_ReturnsMalformed\`
- [x] Full suite green