### PR TITLE
feat(discovery): RFC 8414 §2.1 signed_metadata as opt-in JWS (#126)

### DIFF
--- a/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/Abblix.Jwt/Abblix.Jwt.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix JWT JSON-Web-Token Authentication Security Token API-Security OAuth OAuth2 AccessToken Identity ASP.NET-Security Web-Security</PackageTags>
+    <PackageTags>Abblix JWT JSON-Web-Token Authentication Security Token API-Security OAuth OAuth2 AccessToken Identity ASP.NET-Security Web-Security JWK-Thumbprint DPoP</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/Abblix.Jwt/README.md
+++ b/Abblix.Jwt/README.md
@@ -23,6 +23,7 @@
 - **JSON Web Signature (JWS)**: [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
 - **JSON Web Encryption (JWE)**: [RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516)
 - **JSON Web Key (JWK)**: [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)
+- **JWK Thumbprint**: [RFC 7638](https://datatracker.ietf.org/doc/html/rfc7638)
 - **JSON Web Algorithms (JWA)**: [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518)
 - **JSON Web Token (JWT)**: [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519)
 

--- a/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -15,7 +15,7 @@
         <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageTags>Abblix OIDC OpenID OpenID-Connect Authentication Authorization Security Identity OAuth OAuth2 SSO Single-Sign-On ASP.NET IdentityServer Federation Claims WebApi</PackageTags>
+        <PackageTags>Abblix OIDC OpenID OpenID-Connect Authentication Authorization Security Identity OAuth OAuth2 SSO Single-Sign-On ASP.NET IdentityServer Federation Claims WebApi DPoP Proof-of-Possession</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
@@ -20,10 +20,16 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Mvc.Controllers;
 using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
+using Abblix.Utils.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using EndpointResponse = Abblix.Oidc.Server.Endpoints.Configuration.Interfaces.ConfigurationResponse;
@@ -36,14 +42,28 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// </summary>
 public class ConfigurationResponseFormatter(
 	IOptionsSnapshot<OidcOptions> options,
-	IEndpointResolver endpointResolver) : IConfigurationResponseFormatter
+	IEndpointResolver endpointResolver,
+	IJsonWebTokenCreator jwtCreator,
+	IAuthServiceKeysProvider serviceKeysProvider,
+	TimeProvider clock) : IConfigurationResponseFormatter
 {
+	/// <summary>
+	/// Serializes the metadata into the <c>signed_metadata</c> JWS payload with the same
+	/// null-omission semantics the wire JSON uses (see <see cref="JsonIgnoreNullsModifier"/>
+	/// wired in <c>AddOidcControllers</c>). Without re-attaching the modifier here the signed
+	/// copy would carry <c>"field": null</c> entries the plain JSON omits, and RFC 8414 §2.1
+	/// "signed values take precedence" would then assert those nulls onto clients.
+	/// </summary>
+	private static readonly JsonSerializerOptions SignedMetadataSerializerOptions = new()
+	{
+		TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(JsonIgnoreNullsModifier.Apply),
+	};
 	/// <summary>
 	/// Formats the configuration response by mapping metadata and adding endpoint URLs.
 	/// </summary>
 	/// <param name="response">Framework-agnostic configuration response with metadata.</param>
 	/// <returns>An action result with the MVC-enriched configuration response including URLs.</returns>
-	public Task<ActionResult<ModelResponse>> FormatResponseAsync(EndpointResponse response)
+	public async Task<ActionResult<ModelResponse>> FormatResponseAsync(EndpointResponse response)
 	{
 		var tokenEndpoint = Resolve<TokenController>(nameof(TokenController.TokenAsync), OidcEndpoints.Token);
 		var revocationEndpoint = Resolve<TokenController>(nameof(TokenController.RevocationAsync), OidcEndpoints.Revocation);
@@ -130,7 +150,57 @@ public class ConfigurationResponseFormatter(
 			};
 		}
 
-		return Task.FromResult<ActionResult<ModelResponse>>(mvcResponse);
+		if (options.Value.Discovery.SignedMetadata)
+		{
+			mvcResponse = mvcResponse with { SignedMetadata = await SignAsync(mvcResponse) };
+		}
+
+		return mvcResponse;
+	}
+
+	/// <summary>
+	/// Produces the RFC 8414 §2.1 <c>signed_metadata</c> value: a compact JWS whose payload
+	/// restates the supplied metadata plus a mandatory <c>iss</c> claim. The result is always
+	/// a pure JWS — <see cref="IJsonWebTokenCreator.IssueAsync"/> is called without an
+	/// encryption key, so a deployment that also issues JWE access tokens does not turn this
+	/// into a JWE the client cannot verify against <c>jwks_uri</c>.
+	/// </summary>
+	/// <param name="metadata">The fully assembled metadata, including resolved endpoint URLs
+	/// and mTLS aliases, but without <c>signed_metadata</c> itself.</param>
+	/// <returns>The compact-serialized JWS string.</returns>
+	private async Task<string> SignAsync(ModelResponse metadata)
+	{
+		var signingKey = await serviceKeysProvider.GetSigningKeys(true).FirstOrDefaultAsync();
+		if (signingKey is null)
+		{
+			throw new InvalidOperationException(
+				$"{nameof(DiscoveryOptions)}.{nameof(DiscoveryOptions.SignedMetadata)} is enabled but no signing keys are configured. " +
+				"Configure signing certificates so the discovery document can be signed (RFC 8414 §2.1).");
+		}
+
+		// Serialized before signed_metadata is set on the outer object, so the signed payload
+		// never contains signed_metadata itself (RFC 8414 §2.1).
+		var payload = JsonSerializer.SerializeToNode(metadata, SignedMetadataSerializerOptions) switch
+		{
+			JsonObject jsonObject => jsonObject,
+
+			_ => throw new InvalidOperationException(
+				"Discovery metadata serialized to a non-object JSON node. The metadata must serialize to a JSON object so it " +
+				"can form the signed_metadata JWS payload (RFC 8414 §2.1); " +
+				"a different node kind indicates a broken serializer or type-info resolver."),
+		};
+
+		var token = new JsonWebToken
+		{
+			Header = { Algorithm = signingKey.Algorithm },
+			Payload = new JsonWebTokenPayload(payload)
+			{
+				Issuer = metadata.Issuer,
+				IssuedAt = clock.GetUtcNow(),
+			},
+		};
+
+		return await jwtCreator.IssueAsync(token, signingKey);
 	}
 
 	/// <summary>

--- a/Abblix.Oidc.Server.Mvc/README.md
+++ b/Abblix.Oidc.Server.Mvc/README.md
@@ -52,7 +52,7 @@ app.Run();
 
 This package provides ASP.NET MVC endpoints for the full suite of standards implemented by the Abblix OIDC Server core, including:
 
-- **OAuth 2.0**: Authorization Code, Implicit, Client Credentials, Device Authorization ([RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749), [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)), PKCE ([RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636)), PAR ([RFC 9126](https://datatracker.ietf.org/doc/html/rfc9126)), JAR ([RFC 9101](https://datatracker.ietf.org/doc/html/rfc9101))
+- **OAuth 2.0**: Authorization Code, Implicit, Client Credentials, Device Authorization ([RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749), [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)), PKCE ([RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636)), PAR ([RFC 9126](https://datatracker.ietf.org/doc/html/rfc9126)), JAR ([RFC 9101](https://datatracker.ietf.org/doc/html/rfc9101)), DPoP ([RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449))
 - **OpenID Connect**: Core 1.0, Discovery, Dynamic Client Registration, Session Management, RP-Initiated/Front-Channel/Back-Channel Logout, CIBA
 - **JWT**: JWS ([RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)), JWE ([RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516)), JWT Access Tokens ([RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068))
 

--- a/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
@@ -22,11 +22,14 @@
 
 using System;
 using System.Threading.Tasks;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
 using Abblix.Oidc.Server.Mvc.Formatters;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -62,7 +65,14 @@ public class DiscoveryControllerMtlsTests
 
         SetupEndpointResolver();
 
-        _formatter = new ConfigurationResponseFormatter(_optionsMock.Object, _endpointResolverMock.Object);
+        // SignedMetadata defaults off in these fixtures, so the signing collaborators are
+        // never exercised — supplied only to satisfy the constructor.
+        _formatter = new ConfigurationResponseFormatter(
+            _optionsMock.Object,
+            _endpointResolverMock.Object,
+            Mock.Of<IJsonWebTokenCreator>(),
+            Mock.Of<IAuthServiceKeysProvider>(),
+            new FakeTimeProvider());
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
@@ -1,0 +1,172 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
+using Abblix.Oidc.Server.Mvc.Formatters;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+using EndpointResponse = Abblix.Oidc.Server.Endpoints.Configuration.Interfaces.ConfigurationResponse;
+using JsonWebKey = Abblix.Jwt.JsonWebKey;
+
+namespace Abblix.Oidc.Server.UnitTests.Mvc.Controllers;
+
+/// <summary>
+/// Unit tests for <see cref="ConfigurationResponseFormatter"/> verifying RFC 8414 §2.1
+/// <c>signed_metadata</c> emission: opt-in gating, pure-JWS production (never JWE), the
+/// mandatory <c>iss</c> claim, and the requirement that the signed payload restate the
+/// metadata without containing <c>signed_metadata</c> itself.
+/// </summary>
+public class DiscoverySignedMetadataTests
+{
+    private const string Issuer = TestConstants.DefaultIssuer;
+    private const string SignedJws = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ4In0.sig";
+
+    private readonly Mock<IOptionsSnapshot<OidcOptions>> _optionsMock = new();
+    private readonly Mock<IEndpointResolver> _endpointResolverMock = new();
+    private readonly Mock<IJsonWebTokenCreator> _jwtCreatorMock = new(MockBehavior.Strict);
+    private readonly Mock<IAuthServiceKeysProvider> _keysProviderMock = new(MockBehavior.Strict);
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 5, 19, 10, 0, 0, TimeSpan.Zero));
+    private readonly OidcOptions _oidcOptions;
+    private readonly ConfigurationResponseFormatter _formatter;
+    private readonly JsonWebKey _signingKey = new RsaJsonWebKey { KeyId = "sig", Algorithm = SigningAlgorithms.RS256 };
+
+    public DiscoverySignedMetadataTests()
+    {
+        _oidcOptions = new OidcOptions
+        {
+            Discovery = new DiscoveryOptions { AllowEndpointPathsDiscovery = true },
+            EnabledEndpoints = OidcEndpoints.Token,
+        };
+        _optionsMock.Setup(x => x.Value).Returns(_oidcOptions);
+
+        _endpointResolverMock
+            .Setup(x => x.Resolve("Token", "Token"))
+            .Returns(new Uri("https://example.com/token"));
+
+        _formatter = new ConfigurationResponseFormatter(
+            _optionsMock.Object,
+            _endpointResolverMock.Object,
+            _jwtCreatorMock.Object,
+            _keysProviderMock.Object,
+            _clock);
+    }
+
+    /// <summary>
+    /// When the opt-in flag is off, the discovery document carries no <c>signed_metadata</c>
+    /// and the signing pipeline is never touched (safe-by-default).
+    /// </summary>
+    [Fact]
+    public async Task SignedMetadataDisabled_OmitsFieldAndDoesNotSign()
+    {
+        _oidcOptions.Discovery.SignedMetadata = false;
+
+        var result = await _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer });
+
+        Assert.NotNull(result.Value);
+        Assert.Null(result.Value.SignedMetadata);
+        _jwtCreatorMock.Verify(
+            c => c.IssueAsync(It.IsAny<JsonWebToken>(), It.IsAny<JsonWebKey?>(), It.IsAny<JsonWebKey?>(),
+                It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// When enabled, the field carries the JWS produced by the creator, and the token is
+    /// issued as a pure JWS — no encryption key is passed even though a deployment may have
+    /// encryption keys, so the result stays verifiable against <c>jwks_uri</c>.
+    /// </summary>
+    [Fact]
+    public async Task SignedMetadataEnabled_EmitsPureJws()
+    {
+        _oidcOptions.Discovery.SignedMetadata = true;
+        _keysProviderMock.Setup(p => p.GetSigningKeys(true)).Returns(new[] { _signingKey }.ToAsyncEnumerable());
+
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreatorMock
+            .Setup(c => c.IssueAsync(It.IsAny<JsonWebToken>(), It.IsAny<JsonWebKey?>(), It.IsAny<JsonWebKey?>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey?, JsonWebKey?, string, string>(
+                (_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(SignedJws);
+
+        var result = await _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer });
+
+        Assert.Equal(SignedJws, result.Value!.SignedMetadata);
+        Assert.Null(capturedEncryptionKey);
+    }
+
+    /// <summary>
+    /// The signed payload must restate the metadata (resolved endpoints included), carry the
+    /// mandatory <c>iss</c> claim (RFC 8414 §2.1) and an <c>iat</c>, and must NOT contain
+    /// <c>signed_metadata</c> itself.
+    /// </summary>
+    [Fact]
+    public async Task SignedMetadataEnabled_PayloadRestatesMetadataWithIssAndNoSelfReference()
+    {
+        _oidcOptions.Discovery.SignedMetadata = true;
+        _keysProviderMock.Setup(p => p.GetSigningKeys(true)).Returns(new[] { _signingKey }.ToAsyncEnumerable());
+
+        JsonWebToken? capturedToken = null;
+        _jwtCreatorMock
+            .Setup(c => c.IssueAsync(It.IsAny<JsonWebToken>(), It.IsAny<JsonWebKey?>(), It.IsAny<JsonWebKey?>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey?, JsonWebKey?, string, string>((t, _, _, _, _) => capturedToken = t)
+            .ReturnsAsync(SignedJws);
+
+        await _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer });
+
+        Assert.NotNull(capturedToken);
+        var payload = capturedToken!.Payload.Json;
+
+        Assert.Equal(Issuer, (string?)payload["iss"]);
+        Assert.Equal(Issuer, (string?)payload["issuer"]);
+        Assert.Equal("https://example.com/token", (string?)payload["token_endpoint"]);
+        Assert.True(payload.ContainsKey("iat"));
+        Assert.False(payload.ContainsKey("signed_metadata"));
+        // Null-omission parity with the wire JSON: an unset optional field must be absent,
+        // not serialized as null, otherwise "signed values take precedence" asserts the null.
+        Assert.False(payload.ContainsKey("acr_values_supported"));
+    }
+
+    /// <summary>
+    /// Enabling the feature without configured signing keys is a misconfiguration that must
+    /// fail loudly rather than emit an unsigned or absent field.
+    /// </summary>
+    [Fact]
+    public async Task SignedMetadataEnabled_NoSigningKeys_Throws()
+    {
+        _oidcOptions.Discovery.SignedMetadata = true;
+        _keysProviderMock.Setup(p => p.GetSigningKeys(true)).Returns(AsyncEnumerable.Empty<JsonWebKey>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer }));
+    }
+}

--- a/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -13,7 +13,7 @@
         <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageTags>Abblix OIDC OpenID OpenID-Connect Authentication Authorization Security Identity OAuth OAuth2 SSO Single-Sign-On ASP.NET IdentityServer Federation Claims WebApi</PackageTags>
+        <PackageTags>Abblix OIDC OpenID OpenID-Connect Authentication Authorization Security Identity OAuth OAuth2 SSO Single-Sign-On ASP.NET IdentityServer Federation Claims WebApi DPoP Proof-of-Possession</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/Abblix.Oidc.Server/Common/Configuration/DiscoveryOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/DiscoveryOptions.cs
@@ -33,6 +33,16 @@ public class DiscoveryOptions
     public bool AllowEndpointPathsDiscovery { get; set; } = true;
 
     /// <summary>
+    /// RFC 8414 §2.1: when enabled, the discovery document additionally carries a
+    /// <c>signed_metadata</c> JWS whose payload is the same metadata set, signed with the
+    /// authorization server's signing key. This lets relying parties verify the
+    /// configuration's origin independently of the TLS layer (relevant behind CDNs, API
+    /// gateways, or aggressive caches). Off by default: clients that do not validate the
+    /// signature gain nothing from it, and an unconsumed field only adds payload weight.
+    /// </summary>
+    public bool SignedMetadata { get; set; }
+
+    /// <summary>
     /// RFC 8705: Optional mTLS endpoint aliases to advertise.
     /// Configure with absolute URIs hosted on an mTLS-enabled origin.
     /// </summary>

--- a/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
@@ -210,6 +210,11 @@ public record ConfigurationResponse
         /// <summary>The <c>authorization_response_iss_parameter_supported</c> metadata flag advertising
         /// inclusion of the <c>iss</c> parameter in authorization responses (RFC 9207).</summary>
         public const string AuthorizationResponseIssParameterSupported = "authorization_response_iss_parameter_supported";
+
+        /// <summary>The <c>signed_metadata</c> field carrying a JWS whose claims duplicate this
+        /// metadata, signed by the provider so clients can verify its origin (RFC 8414 §2.1).
+        /// </summary>
+        public const string SignedMetadata = "signed_metadata";
     }
 
     /// <summary>
@@ -488,4 +493,15 @@ public record ConfigurationResponse
     /// </summary>
     [JsonPropertyName(Parameters.AuthorizationResponseIssParameterSupported)]
     public bool? AuthorizationResponseIssParameterSupported { get; init; }
+
+    /// <summary>
+    /// RFC 8414 §2.1: a JWS whose payload restates this entire metadata set, signed with the
+    /// provider's signing key. When present, a client that verifies the signature against the
+    /// keys at <see cref="JwksUri"/> may trust the configuration's origin beyond the TLS layer;
+    /// signed values take precedence over the corresponding plain-JSON fields. Emitted only
+    /// when <c>DiscoveryOptions.SignedMetadata</c> is enabled, and computed last so the signed
+    /// payload never contains this field itself.
+    /// </summary>
+    [JsonPropertyName(Parameters.SignedMetadata)]
+    public string? SignedMetadata { get; init; }
 }

--- a/Abblix.Oidc.Server/README.md
+++ b/Abblix.Oidc.Server/README.md
@@ -28,6 +28,7 @@ Abblix OIDC Server implements a comprehensive suite of standards for authorizati
 - **Device Authorization Grant**: [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)
 - **Dynamic Client Registration**: [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) and [RFC 7592](https://datatracker.ietf.org/doc/html/rfc7592)
 - **Mutual-TLS Client Authentication**: [RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705)
+- **Demonstrating Proof of Possession (DPoP)**: [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)
 - **Resource Indicators**: [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)
 - **JWT Access Tokens**: [RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068)
 - **JWT-Secured Authorization Request (JAR)**: [RFC 9101](https://datatracker.ietf.org/doc/html/rfc9101)


### PR DESCRIPTION
Closes the last RFC 8414 gap: the optional `signed_metadata` field (§2.1).

## What

Adds an opt-in `signed_metadata` to the discovery document — a pure JWS over the fully assembled metadata (resolved endpoint URLs and mTLS aliases included). Lets a client verify the configuration's origin beyond the TLS layer (relevant behind CDNs, gateways, aggressive caches).

## Design notes

- **Opt-in, off by default** (`DiscoveryOptions.SignedMetadata`). An unconsumed signature is dead payload weight, and "signed values take precedence" couples any validating client — deployments opt in deliberately.
- **Pure JWS, never JWE.** Signed via `IJsonWebTokenCreator` with `encryptionKey: null` rather than reusing `IAuthServiceJwtFormatter`, which auto-encrypts when encryption keys are present. A deployment that also issues JWE access tokens would otherwise produce a `signed_metadata` no client can verify against `jwks_uri`.
- **Payload parity.** Serialized with the same null-omitting modifier as the wire JSON, and before `signed_metadata` is set on the outer object — so the signed copy matches plain JSON field-for-field and never contains `signed_metadata` itself (RFC 8414 §2.1). Mandatory `iss` claim plus `iat` included.
- Signing must happen in the MVC formatter: resolved endpoint URLs only exist after `ConfigurationResponseFormatter` assembles them; the framework-agnostic handler has no URLs.

## Tests

`DiscoverySignedMetadataTests`: opt-in gating, pure-JWS (no encryption key passed), payload restates metadata with `iss` and no self-reference, throws when no signing keys configured. Full solution suite green (2535 tests).

Ref #126
