### PR TITLE
test(rfc9449): E2E coverage for DPoP

### DIFF
--- a/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -33,7 +33,7 @@ builder.Services.AddOidcServices(options =>
     options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature)];
     var secret = new ClientSecret { Sha512Hash = SHA512.HashData(Encoding.UTF8.GetBytes(TestConstants.ConfidentialClientSecret)) };
     var redirect = new Uri(TestConstants.RedirectUri, UriKind.Absolute);
-    static ClientInfo Mint(string id, ClientSecret secret, Uri redirect, string[]? allowlist, bool idTokenRar) =>
+    static ClientInfo Mint(string id, ClientSecret secret, Uri redirect, string[]? allowlist, bool idTokenRar, bool requireDPoP = false) =>
         new(id)
         {
             ClientSecrets = [secret],
@@ -48,6 +48,7 @@ builder.Services.AddOidcServices(options =>
             AuthorizationDetailsTypes = allowlist,
             ForceAuthorizationDetailsInIdentityToken = idTokenRar,
             OfflineAccessAllowed = true,
+            RequireDPoP = requireDPoP,
         };
 
     options.Clients =
@@ -56,6 +57,10 @@ builder.Services.AddOidcServices(options =>
         Mint(TestConstants.IdTokenRarClientId, secret, redirect, [TestConstants.PaymentInitiationType], idTokenRar: true),
         Mint(TestConstants.EmptyAllowlistClientId, secret, redirect, [], idTokenRar: false),
         Mint(TestConstants.UnrestrictedClientId, secret, redirect, allowlist: null, idTokenRar: false),
+        // RFC 9449 mandatory-binding client: token endpoint rejects any request without a valid proof.
+        Mint(TestConstants.DPoPRequiredClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: true),
+        // RFC 9449 opportunistic-binding client: proof optional; when present, AS binds the issued token.
+        Mint(TestConstants.DPoPOpportunisticClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: false),
     ];
 });
 

--- a/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -33,11 +33,17 @@ builder.Services.AddOidcServices(options =>
     options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature)];
     var secret = new ClientSecret { Sha512Hash = SHA512.HashData(Encoding.UTF8.GetBytes(TestConstants.ConfidentialClientSecret)) };
     var redirect = new Uri(TestConstants.RedirectUri, UriKind.Absolute);
-    static ClientInfo Mint(string id, ClientSecret secret, Uri redirect, string[]? allowlist, bool idTokenRar, bool requireDPoP = false) =>
+    static ClientInfo Mint(string id, ClientSecret secret, Uri redirect, string[]? allowlist, bool idTokenRar, bool requireDPoP = false, bool isPublic = false) =>
         new(id)
         {
-            ClientSecrets = [secret],
-            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+            // Public clients carry no shared secret; the AS gates them on PKCE + (when DPoP
+            // is in play) on the proof-of-possession key. TokenEndpointAuthMethod = "none"
+            // flips ClientInfo.ClientType to Public, which in turn forces RFC 9449 §5
+            // same-key refresh binding (no client-auth fallback to sender-constrain).
+            ClientSecrets = isPublic ? [] : [secret],
+            TokenEndpointAuthMethod = isPublic
+                ? ClientAuthenticationMethods.None
+                : ClientAuthenticationMethods.ClientSecretPost,
             // RFC 8693 Token Exchange is admitted on the confidential client so the E2E suite can
             // exercise the impersonation + delegation flows against a real access token issued by
             // the auth-code path. TokenExchangeAllowedSubjectTokenTypes is null = no per-client
@@ -61,6 +67,8 @@ builder.Services.AddOidcServices(options =>
         Mint(TestConstants.DPoPRequiredClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: true),
         // RFC 9449 opportunistic-binding client: proof optional; when present, AS binds the issued token.
         Mint(TestConstants.DPoPOpportunisticClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: false),
+        // RFC 9449 §5 public client: same-key MUST be presented on refresh.
+        Mint(TestConstants.DPoPPublicClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: false, isPublic: true),
     ];
 });
 

--- a/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -39,6 +39,16 @@ public static class TestConstants
     /// (only the per-type validator gates).</summary>
     public const string UnrestrictedClientId = "e2e-unrestricted";
 
+    /// <summary>Client with <c>RequireDPoP = true</c> — every token request MUST carry a
+    /// valid DPoP proof or the AS rejects with <c>invalid_dpop_proof</c>. RFC 9449 §5.2
+    /// mandatory-binding posture.</summary>
+    public const string DPoPRequiredClientId = "e2e-dpop-required";
+
+    /// <summary>Client with <c>RequireDPoP = false</c> — token requests may carry a proof
+    /// (and the AS opportunistically binds the issued access token) or omit it (Bearer
+    /// issued). RFC 9449 §5.2 opportunistic-binding posture.</summary>
+    public const string DPoPOpportunisticClientId = "e2e-dpop-opportunistic";
+
     /// <summary>Shared secret across every pre-seeded client.</summary>
     public const string ConfidentialClientSecret = "e2e-secret";
 

--- a/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -49,6 +49,11 @@ public static class TestConstants
     /// issued). RFC 9449 §5.2 opportunistic-binding posture.</summary>
     public const string DPoPOpportunisticClientId = "e2e-dpop-opportunistic";
 
+    /// <summary>Public DPoP client (no client secret, <c>token_endpoint_auth_method = none</c>).
+    /// RFC 9449 §5 mandates same-key binding on refresh for public clients — sender
+    /// constraint comes from DPoP alone, not from client authentication.</summary>
+    public const string DPoPPublicClientId = "e2e-dpop-public";
+
     /// <summary>Shared secret across every pre-seeded client.</summary>
     public const string ConfidentialClientSecret = "e2e-secret";
 

--- a/Abblix.Oidc.Server.E2E.Tests/FormPostHelpers.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/FormPostHelpers.cs
@@ -1,0 +1,51 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+// 
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+// 
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+// 
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+// 
+// For full licensing terms, please visit:
+// 
+// https://oidc.abblix.com/license
+// 
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+
+namespace Abblix.Oidc.Server.E2E.Tests;
+
+internal static class FormPostHelpers
+{
+    /// <summary>
+    /// Posts <paramref name="form"/> as <c>application/x-www-form-urlencoded</c> to
+    /// <paramref name="endpoint"/>, optionally attaching a DPoP proof header. Returns
+    /// the raw response so callers can inspect status, body, and headers. Used by every
+    /// E2E helper that hits /par, /token, /refresh, or other form-based OAuth endpoints
+    /// — keeps the HttpRequestMessage + FormUrlEncodedContent + WithDPoPHeader plumbing
+    /// in one place.
+    /// </summary>
+    public static async Task<HttpResponseMessage> PostFormAsync(
+        HttpClient client,
+        Uri endpoint,
+        IEnumerable<KeyValuePair<string, string>> form,
+        string? dpopProof = null)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        if (dpopProof is not null)
+            request.WithDPoPHeader(dpopProof);
+        return await client.SendAsync(request);
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
@@ -30,6 +30,9 @@ public sealed record DiscoveryDocument
     [JsonPropertyName("introspection_endpoint")]
     public string? IntrospectionEndpoint { get; init; }
 
+    [JsonPropertyName("userinfo_endpoint")]
+    public string? UserInfoEndpoint { get; init; }
+
     [JsonPropertyName("jwks_uri")]
     public string JwksUri { get; init; } = null!;
 
@@ -38,4 +41,8 @@ public sealed record DiscoveryDocument
 
     [JsonPropertyName("grant_types_supported")]
     public string[]? GrantTypesSupported { get; init; }
+
+    /// <summary>RFC 9449 §5.1: JWS algorithms the AS accepts for DPoP proofs.</summary>
+    [JsonPropertyName("dpop_signing_alg_values_supported")]
+    public string[]? DPoPSigningAlgValuesSupported { get; init; }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
@@ -8,33 +8,36 @@ namespace Abblix.Oidc.Server.E2E.Tests.Model;
 /// <summary>
 /// Typed projection of the /.well-known/openid-configuration document.
 /// Only the members E2E tests actually read are declared; the rest of
-/// the response is ignored by the deserialiser.
+/// the response is ignored by the deserialiser. Every URL-bearing field
+/// surfaces as <see cref="Uri"/> so a malformed wire value fails at JSON
+/// parse time, not at the first <c>HttpClient.SendAsync</c> call, and so
+/// callers do not sprinkle <c>new Uri(...)</c> wraps over discovery reads.
 /// </summary>
 public sealed record DiscoveryDocument
 {
     [JsonPropertyName("issuer")]
-    public string Issuer { get; init; } = null!;
+    public Uri Issuer { get; init; } = null!;
 
     [JsonPropertyName("authorization_endpoint")]
-    public string AuthorizationEndpoint { get; init; } = null!;
+    public Uri AuthorizationEndpoint { get; init; } = null!;
 
     [JsonPropertyName("token_endpoint")]
-    public string TokenEndpoint { get; init; } = null!;
+    public Uri TokenEndpoint { get; init; } = null!;
 
     [JsonPropertyName("registration_endpoint")]
-    public string? RegistrationEndpoint { get; init; }
+    public Uri? RegistrationEndpoint { get; init; }
 
     [JsonPropertyName("pushed_authorization_request_endpoint")]
-    public string? PushedAuthorizationRequestEndpoint { get; init; }
+    public Uri? PushedAuthorizationRequestEndpoint { get; init; }
 
     [JsonPropertyName("introspection_endpoint")]
-    public string? IntrospectionEndpoint { get; init; }
+    public Uri? IntrospectionEndpoint { get; init; }
 
     [JsonPropertyName("userinfo_endpoint")]
-    public string? UserInfoEndpoint { get; init; }
+    public Uri? UserInfoEndpoint { get; init; }
 
     [JsonPropertyName("jwks_uri")]
-    public string JwksUri { get; init; } = null!;
+    public Uri JwksUri { get; init; } = null!;
 
     [JsonPropertyName("authorization_details_types_supported")]
     public string[]? AuthorizationDetailsTypesSupported { get; init; }

--- a/Abblix.Oidc.Server.E2E.Tests/QueryHelpers.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/QueryHelpers.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+// 
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+// 
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+// 
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+// 
+// For full licensing terms, please visit:
+// 
+// https://oidc.abblix.com/license
+// 
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.E2E.Tests;
+
+internal static class QueryHelpers
+{
+    public static Uri BuildUri(Uri baseUri, IEnumerable<KeyValuePair<string, string>> queryParams)
+    {
+        var builder = new UriBuilder(baseUri);
+        var query = string.Join('&', queryParams
+            .Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+        builder.Query = string.IsNullOrEmpty(builder.Query)
+            ? query
+            : builder.Query.TrimStart('?') + "&" + query;
+        return builder.Uri;
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
@@ -26,7 +26,9 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Abblix.Oidc.Server.Model;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
@@ -58,13 +60,13 @@ public class DPoPNonceTests
         var discovery = await FetchDiscoveryAsync(client);
 
         var (parResponse, verifier, _) = await PushParAsync(client, discovery);
-        var requestUri = (await ReadBodyAsync(parResponse))["request_uri"]!.GetValue<string>();
+        var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
         var code = await AuthorizeAsync(client, discovery, requestUri);
 
         // Real verifier matters — PKCE validation runs before the DPoP nonce check,
         // so a fake verifier short-circuits on invalid_grant and we never observe the
         // RFC 9449 §8 challenge we're actually testing for.
-        var proofWithoutNonce = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var proofWithoutNonce = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
         var tokenResponse = await SendTokenAsync(client, discovery, code, verifier, proofWithoutNonce);
 
         Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
@@ -79,6 +81,60 @@ public class DPoPNonceTests
         Assert.False(string.IsNullOrEmpty(nonceValues!.First()));
     }
 
+    // ───────────────────────────────────────────────────────────────────────
+    // Resource-server-side nonce challenge (RFC 9449 §9)
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UserInfo_with_dpop_proof_lacking_nonce_returns_use_dpop_nonce_challenge()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        // Navigate the token-endpoint nonce challenge first so we have a DPoP-bound
+        // access token to present at /userinfo.
+        var accessToken = await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey);
+
+        // First UserInfo call: no nonce on the proof — RS issues a fresh nonce challenge
+        // (RFC 9449 §9 + §7.1 SHOULD WWW-Authenticate: DPoP).
+        var firstProof = proofKey.BuildProof(
+            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+        var response = await SendUserInfoAsync(client, discovery, accessToken, firstProof);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(response.Headers.WwwAuthenticate,
+            h => h.Scheme == TokenTypes.DPoP && (h.Parameter ?? string.Empty).Contains(ErrorCodes.UseDPoPNonce));
+        Assert.True(response.Headers.TryGetValues(HttpRequestHeaders.DPoPNonce, out var nonceValues),
+            "UserInfo challenge response missing DPoP-Nonce header");
+        Assert.False(string.IsNullOrEmpty(nonceValues!.First()));
+    }
+
+    [Fact]
+    public async Task UserInfo_retry_with_nonce_from_challenge_succeeds()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var accessToken = await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey);
+
+        // Step 1: no nonce -> challenge carries fresh nonce.
+        var firstProof = proofKey.BuildProof(
+            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+        var challenge = await SendUserInfoAsync(client, discovery, accessToken, firstProof);
+        Assert.Equal(HttpStatusCode.Unauthorized, challenge.StatusCode);
+        var nonce = challenge.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
+
+        // Step 2: retry with the supplied nonce embedded in the proof.
+        var secondProof = proofKey.BuildProof(
+            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken, nonce: nonce);
+        var success = await SendUserInfoAsync(client, discovery, accessToken, secondProof);
+
+        var raw = await success.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(success.IsSuccessStatusCode,
+            $"/userinfo retry failed: {(int)success.StatusCode} {raw}");
+    }
+
     [Fact]
     public async Task Token_endpoint_retry_with_nonce_from_challenge_succeeds()
     {
@@ -87,23 +143,23 @@ public class DPoPNonceTests
         var discovery = await FetchDiscoveryAsync(client);
 
         var (parResponse, verifier, _) = await PushParAsync(client, discovery);
-        var requestUri = (await ReadBodyAsync(parResponse))["request_uri"]!.GetValue<string>();
+        var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
         var code = await AuthorizeAsync(client, discovery, requestUri);
 
         // Step 1: proof without nonce -> challenge carries fresh nonce on DPoP-Nonce header.
-        var firstProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var firstProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
         var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
         Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
         var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
 
         // Step 2: retry with the nonce embedded; same auth code (RFC 9449 §8 retry semantics).
-        var secondProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint), nonce: nonce);
+        var secondProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint), nonce: nonce);
         var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
 
         var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.True(secondResponse.IsSuccessStatusCode, $"/token retry failed: {(int)secondResponse.StatusCode} {raw}");
         var tokenBody = JsonNode.Parse(raw)!.AsObject();
-        Assert.Equal(TokenTypes.DPoP, tokenBody["token_type"]!.GetValue<string>());
+        Assert.Equal(TokenTypes.DPoP, tokenBody[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
     }
 
     // ───────────────────────────────────────────────────────────────────────
@@ -127,15 +183,15 @@ public class DPoPNonceTests
         var (verifier, challenge) = TestBase.GeneratePkcePair();
         var form = new Dictionary<string, string>
         {
-            ["client_id"] = TestConstants.DPoPRequiredClientId,
-            ["client_secret"] = TestConstants.ConfidentialClientSecret,
-            ["response_type"] = "code",
-            ["redirect_uri"] = TestConstants.RedirectUri,
-            ["scope"] = "openid",
-            ["state"] = Guid.NewGuid().ToString("N"),
-            ["nonce"] = Guid.NewGuid().ToString("N"),
-            ["code_challenge"] = challenge,
-            ["code_challenge_method"] = "S256",
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
         };
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
         {
@@ -150,14 +206,14 @@ public class DPoPNonceTests
     {
         var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, new Dictionary<string, string>
         {
-            ["client_id"] = TestConstants.DPoPRequiredClientId,
-            ["request_uri"] = requestUri,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
+            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
         var response = await client.GetAsync(uri);
         Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
             $"/authorize unexpected: {(int)response.StatusCode}");
         var location = response.Headers.Location!;
-        return System.Web.HttpUtility.ParseQueryString(location.Query)["code"]!;
+        return System.Web.HttpUtility.ParseQueryString(location.Query)[TokenRequest.Parameters.Code]!;
     }
 
     private static async Task<HttpResponseMessage> SendTokenAsync(
@@ -165,12 +221,12 @@ public class DPoPNonceTests
     {
         var form = new Dictionary<string, string>
         {
-            ["grant_type"] = "authorization_code",
-            ["code"] = code,
-            ["redirect_uri"] = TestConstants.RedirectUri,
-            ["code_verifier"] = verifier,
-            ["client_id"] = TestConstants.DPoPRequiredClientId,
-            ["client_secret"] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         };
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
         {
@@ -184,6 +240,54 @@ public class DPoPNonceTests
     {
         var raw = await response.Content.ReadAsStringAsync();
         return JsonNode.Parse(raw)!.AsObject();
+    }
+
+    /// <summary>
+    /// Drives the full token-endpoint nonce-challenge dance with <paramref name="proofKey"/>
+    /// and returns the resulting DPoP-bound access token. Used by /userinfo nonce tests
+    /// because <see cref="NonceEnabledTestFactory"/> also enables the token-endpoint
+    /// nonce, so a real access token cannot be obtained without first satisfying that
+    /// challenge.
+    /// </summary>
+    private static async Task<string> ObtainDPoPBoundTokenViaNonceFlowAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        DPoPProofGenerator proofKey)
+    {
+        var (parResponse, verifier, _) = await PushParAsync(client, discovery);
+        var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
+        var code = await AuthorizeAsync(client, discovery, requestUri);
+
+        var firstProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
+        var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
+        Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
+        var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
+
+        var secondProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint), nonce: nonce);
+        var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
+        var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(secondResponse.IsSuccessStatusCode,
+            $"Token request after nonce retry failed: {(int)secondResponse.StatusCode} {raw}");
+        var body = JsonNode.Parse(raw)!.AsObject();
+        return body[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
+    }
+
+    /// <summary>
+    /// Sends a GET to /userinfo presenting <paramref name="accessToken"/> under the DPoP
+    /// scheme together with the supplied proof. Returns the raw response so callers can
+    /// inspect status, WWW-Authenticate challenges, and DPoP-Nonce headers.
+    /// </summary>
+    private static async Task<HttpResponseMessage> SendUserInfoAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string accessToken,
+        string proofJwt)
+    {
+        Assert.NotNull(discovery.UserInfoEndpoint);
+        using var request = new HttpRequestMessage(HttpMethod.Get, discovery.UserInfoEndpoint);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenTypes.DPoP, accessToken);
+        request.WithDPoPHeader(proofJwt);
+        return await client.SendAsync(request);
     }
 }
 

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
@@ -21,37 +21,29 @@
 // info@abblix.com
 
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Abblix.Oidc.Server.Model;
+using Microsoft.AspNetCore.Http;
 using Xunit;
+using HttpRequestHeaders = Abblix.Oidc.Server.Common.Constants.HttpRequestHeaders;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 
 /// <summary>
-/// RFC 9449 §8 DPoP-Nonce challenge-response tests. The default <see cref="TestFactory"/>
-/// ships with nonce enforcement OFF; these tests run against <see cref="NonceEnabledTestFactory"/>
-/// (RequireAtTokenEndpoint = true) under a dedicated xunit collection so the singleton
-/// factory state never leaks to the rest of the DPoP suite.
+/// RFC 9449 §8 (AS) and §9 (RS) DPoP-Nonce challenge-response tests. The default
+/// <see cref="TestFactory"/> ships with nonce enforcement OFF; these tests run against
+/// <see cref="NonceEnabledTestFactory"/> (RequireAtTokenEndpoint and
+/// RequireAtUserInfoEndpoint both = true) under a dedicated xunit collection so the
+/// singleton factory state never leaks to the rest of the DPoP suite.
 /// </summary>
 [Collection(DPoPNonceTestCollection.Name)]
-public class DPoPNonceTests
+public class DPoPNonceTests(NonceEnabledTestFactory factory) : TestBase(factory)
 {
-    private readonly NonceEnabledTestFactory _factory;
-
-    public DPoPNonceTests(NonceEnabledTestFactory factory) => _factory = factory;
-
-    private HttpClient CreateClient() => _factory.CreateClient(new WebApplicationFactoryClientOptions
-    {
-        AllowAutoRedirect = false,
-        BaseAddress = new Uri("https://localhost"),
-    });
-
     [Fact]
     public async Task Token_endpoint_with_proof_lacking_nonce_returns_use_dpop_nonce_challenge_with_header()
     {
@@ -59,26 +51,25 @@ public class DPoPNonceTests
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var (parResponse, verifier, _) = await PushParAsync(client, discovery);
-        var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
-        var code = await AuthorizeAsync(client, discovery, requestUri);
+        var (_, _, nonce, challengeBody, challengeResponse) =
+            await NavigateTokenNonceChallengeAsync(client, discovery, proofKey);
 
-        // Real verifier matters — PKCE validation runs before the DPoP nonce check,
-        // so a fake verifier short-circuits on invalid_grant and we never observe the
-        // RFC 9449 §8 challenge we're actually testing for.
-        var proofWithoutNonce = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
-        var tokenResponse = await SendTokenAsync(client, discovery, code, verifier, proofWithoutNonce);
+        Assert.Equal(HttpStatusCode.BadRequest, challengeResponse.StatusCode);
+        Assert.Equal(ErrorCodes.UseDPoPNonce, challengeBody["error"]!.GetValue<string>());
+        Assert.False(string.IsNullOrEmpty(nonce));
+    }
 
-        Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
-        var body = await ReadBodyAsync(tokenResponse);
-        Assert.Equal(ErrorCodes.UseDPoPNonce, body["error"]!.GetValue<string>());
+    [Fact]
+    public async Task Token_endpoint_retry_with_nonce_from_challenge_succeeds()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
 
-        // RFC 9449 §8: the challenge response carries the fresh nonce in a header so
-        // the client knows what value to embed in the next proof.
-        Assert.True(tokenResponse.Headers.TryGetValues(HttpRequestHeaders.DPoPNonce, out var nonceValues),
-            "Response missing DPoP-Nonce header");
-        Assert.Single(nonceValues!);
-        Assert.False(string.IsNullOrEmpty(nonceValues!.First()));
+        var tokenBody = await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey);
+
+        Assert.Equal(TokenTypes.DPoP,
+            tokenBody[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
     }
 
     // ───────────────────────────────────────────────────────────────────────
@@ -91,23 +82,21 @@ public class DPoPNonceTests
         using var proofKey = new DPoPProofGenerator();
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
-
-        // Navigate the token-endpoint nonce challenge first so we have a DPoP-bound
-        // access token to present at /userinfo.
-        var accessToken = await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey);
+        var accessToken = (await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey))
+            [UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
 
         // First UserInfo call: no nonce on the proof — RS issues a fresh nonce challenge
         // (RFC 9449 §9 + §7.1 SHOULD WWW-Authenticate: DPoP).
-        var firstProof = proofKey.BuildProof(
+        var proofWithoutNonce = proofKey.BuildProof(
             HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken);
-        var response = await SendUserInfoAsync(client, discovery, accessToken, firstProof);
+        var response = await SendUserInfoAsync(client, discovery, accessToken, proofWithoutNonce);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.Contains(response.Headers.WwwAuthenticate,
             h => h.Scheme == TokenTypes.DPoP && (h.Parameter ?? string.Empty).Contains(ErrorCodes.UseDPoPNonce));
         Assert.True(response.Headers.TryGetValues(HttpRequestHeaders.DPoPNonce, out var nonceValues),
             "UserInfo challenge response missing DPoP-Nonce header");
-        Assert.False(string.IsNullOrEmpty(nonceValues!.First()));
+        Assert.False(string.IsNullOrEmpty(nonceValues.First()));
     }
 
     [Fact]
@@ -116,9 +105,10 @@ public class DPoPNonceTests
         using var proofKey = new DPoPProofGenerator();
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
-        var accessToken = await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey);
+        var accessToken = (await ObtainDPoPBoundTokenViaNonceFlowAsync(client, discovery, proofKey))
+            [UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
 
-        // Step 1: no nonce -> challenge carries fresh nonce.
+        // Step 1: no nonce → challenge carries fresh nonce.
         var firstProof = proofKey.BuildProof(
             HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken);
         var challenge = await SendUserInfoAsync(client, discovery, accessToken, firstProof);
@@ -135,86 +125,75 @@ public class DPoPNonceTests
             $"/userinfo retry failed: {(int)success.StatusCode} {raw}");
     }
 
-    [Fact]
-    public async Task Token_endpoint_retry_with_nonce_from_challenge_succeeds()
-    {
-        using var proofKey = new DPoPProofGenerator();
-        var client = CreateClient();
-        var discovery = await FetchDiscoveryAsync(client);
-
-        var (parResponse, verifier, _) = await PushParAsync(client, discovery);
-        var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
-        var code = await AuthorizeAsync(client, discovery, requestUri);
-
-        // Step 1: proof without nonce -> challenge carries fresh nonce on DPoP-Nonce header.
-        var firstProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
-        var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
-        Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
-        var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
-
-        // Step 2: retry with the nonce embedded; same auth code (RFC 9449 §8 retry semantics).
-        var secondProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint, nonce: nonce);
-        var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
-
-        var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        Assert.True(secondResponse.IsSuccessStatusCode, $"/token retry failed: {(int)secondResponse.StatusCode} {raw}");
-        var tokenBody = JsonNode.Parse(raw)!.AsObject();
-        Assert.Equal(TokenTypes.DPoP, tokenBody[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
-    }
-
     // ───────────────────────────────────────────────────────────────────────
-    // Per-test helpers — slim copies of TestBase pieces that are static there
-    // but get a different fixture in this collection. Hidden in private methods
-    // so the [Fact] bodies stay flow-step readable.
+    // Helpers — DPoP-aware flow primitives. Non-DPoP boilerplate (discovery,
+    // /authorize redirect parsing) is inherited from TestBase.
     // ───────────────────────────────────────────────────────────────────────
 
-    private static async Task<DiscoveryDocument> FetchDiscoveryAsync(HttpClient client)
+    /// <summary>
+    /// Bootstraps PAR + /authorize, then makes the first /token call with a proof that
+    /// carries no nonce — the AS issues a 400 + <c>use_dpop_nonce</c> + a fresh
+    /// <c>DPoP-Nonce</c> response header (RFC 9449 §8). Returns the PKCE verifier, the
+    /// auth code (still spendable per §8 retry semantics), the fresh nonce, the parsed
+    /// error body, and the raw response so callers can pin extra assertions.
+    /// </summary>
+    private static async Task<(string Verifier, string Code, string Nonce, JsonObject Body, HttpResponseMessage Response)>
+        NavigateTokenNonceChallengeAsync(
+            HttpClient client,
+            DiscoveryDocument discovery,
+            DPoPProofGenerator proofKey)
     {
-        var response = await client.GetAsync("/.well-known/openid-configuration");
-        response.EnsureSuccessStatusCode();
-        var doc = await System.Net.Http.Json.HttpContentJsonExtensions
-            .ReadFromJsonAsync<DiscoveryDocument>(response.Content);
-        return doc!;
-    }
-
-    private static async Task<(HttpResponseMessage, string Verifier, string Challenge)> PushParAsync(
-        HttpClient client, DiscoveryDocument discovery)
-    {
-        var (verifier, challenge) = TestBase.GeneratePkcePair();
-        var form = new Dictionary<string, string>
-        {
-            [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
-            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
-            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
-            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
-            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
-            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
-            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
-            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
-        };
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        var response = await client.SendAsync(request);
-        Assert.True(response.IsSuccessStatusCode, $"PAR failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()}");
-        return (response, verifier, challenge);
-    }
-
-    private static async Task<string> AuthorizeAsync(HttpClient client, DiscoveryDocument discovery, string requestUri)
-    {
-        var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, new Dictionary<string, string>
+        var (verifier, challenge) = GeneratePkcePair();
+        var parResponse = await PushAuthorizationRequestAsync(client, discovery, BuildParForm(challenge));
+        var requestUri = parResponse[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
         {
             [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
             [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
-        var response = await client.GetAsync(uri);
-        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
-            $"/authorize unexpected: {(int)response.StatusCode}");
-        var location = response.Headers.Location!;
-        return System.Web.HttpUtility.ParseQueryString(location.Query)[TokenRequest.Parameters.Code]!;
+
+        var proofWithoutNonce = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var response = await SendTokenAsync(client, discovery, code, verifier, proofWithoutNonce);
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var body = JsonNode.Parse(raw)!.AsObject();
+        var nonce = response.Headers.TryGetValues(HttpRequestHeaders.DPoPNonce, out var values)
+            ? values.First()
+            : string.Empty;
+        return (verifier, code, nonce, body, response);
     }
+
+    /// <summary>
+    /// Walks the full token-endpoint nonce dance — first request gets a challenge, second
+    /// embeds the issued nonce and succeeds — and returns the parsed success-body. Used
+    /// directly by the retry-success test and as bootstrap for the §9 UserInfo nonce tests.
+    /// </summary>
+    private static async Task<JsonObject> ObtainDPoPBoundTokenViaNonceFlowAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        DPoPProofGenerator proofKey)
+    {
+        var (verifier, code, nonce, _, _) = await NavigateTokenNonceChallengeAsync(client, discovery, proofKey);
+
+        var proofWithNonce = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint, nonce: nonce);
+        var response = await SendTokenAsync(client, discovery, code, verifier, proofWithNonce);
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(response.IsSuccessStatusCode,
+            $"/token retry failed: {(int)response.StatusCode} {raw}");
+        return JsonNode.Parse(raw)!.AsObject();
+    }
+
+    private static Dictionary<string, string> BuildParForm(string challenge) => new()
+    {
+        [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
+        [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+        [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+        [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+        [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+        [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+        [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+        [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+    };
 
     private static async Task<HttpResponseMessage> SendTokenAsync(
         HttpClient client, DiscoveryDocument discovery, string code, string verifier, string proofJwt)
@@ -228,48 +207,10 @@ public class DPoPNonceTests
             [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
             [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         };
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint);
+        request.Content = new FormUrlEncodedContent(form);
         request.WithDPoPHeader(proofJwt);
         return await client.SendAsync(request);
-    }
-
-    private static async Task<JsonObject> ReadBodyAsync(HttpResponseMessage response)
-    {
-        var raw = await response.Content.ReadAsStringAsync();
-        return JsonNode.Parse(raw)!.AsObject();
-    }
-
-    /// <summary>
-    /// Drives the full token-endpoint nonce-challenge dance with <paramref name="proofKey"/>
-    /// and returns the resulting DPoP-bound access token. Used by /userinfo nonce tests
-    /// because <see cref="NonceEnabledTestFactory"/> also enables the token-endpoint
-    /// nonce, so a real access token cannot be obtained without first satisfying that
-    /// challenge.
-    /// </summary>
-    private static async Task<string> ObtainDPoPBoundTokenViaNonceFlowAsync(
-        HttpClient client,
-        DiscoveryDocument discovery,
-        DPoPProofGenerator proofKey)
-    {
-        var (parResponse, verifier, _) = await PushParAsync(client, discovery);
-        var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
-        var code = await AuthorizeAsync(client, discovery, requestUri);
-
-        var firstProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
-        var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
-        Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
-        var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
-
-        var secondProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint, nonce: nonce);
-        var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
-        var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        Assert.True(secondResponse.IsSuccessStatusCode,
-            $"Token request after nonce retry failed: {(int)secondResponse.StatusCode} {raw}");
-        var body = JsonNode.Parse(raw)!.AsObject();
-        return body[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
     }
 
     /// <summary>
@@ -278,14 +219,11 @@ public class DPoPNonceTests
     /// inspect status, WWW-Authenticate challenges, and DPoP-Nonce headers.
     /// </summary>
     private static async Task<HttpResponseMessage> SendUserInfoAsync(
-        HttpClient client,
-        DiscoveryDocument discovery,
-        string accessToken,
-        string proofJwt)
+        HttpClient client, DiscoveryDocument discovery, string accessToken, string proofJwt)
     {
         Assert.NotNull(discovery.UserInfoEndpoint);
         using var request = new HttpRequestMessage(HttpMethod.Get, discovery.UserInfoEndpoint);
-        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenTypes.DPoP, accessToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue(TokenTypes.DPoP, accessToken);
         request.WithDPoPHeader(proofJwt);
         return await client.SendAsync(request);
     }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
@@ -1,0 +1,199 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/Oidc.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// RFC 9449 §8 DPoP-Nonce challenge-response tests. The default <see cref="TestFactory"/>
+/// ships with nonce enforcement OFF; these tests run against <see cref="NonceEnabledTestFactory"/>
+/// (RequireAtTokenEndpoint = true) under a dedicated xunit collection so the singleton
+/// factory state never leaks to the rest of the DPoP suite.
+/// </summary>
+[Collection(DPoPNonceTestCollection.Name)]
+public class DPoPNonceTests
+{
+    private readonly NonceEnabledTestFactory _factory;
+
+    public DPoPNonceTests(NonceEnabledTestFactory factory) => _factory = factory;
+
+    private HttpClient CreateClient() => _factory.CreateClient(new WebApplicationFactoryClientOptions
+    {
+        AllowAutoRedirect = false,
+        BaseAddress = new Uri("https://localhost"),
+    });
+
+    [Fact]
+    public async Task Token_endpoint_with_proof_lacking_nonce_returns_use_dpop_nonce_challenge_with_header()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var (parResponse, verifier, _) = await PushParAsync(client, discovery);
+        var requestUri = (await ReadBodyAsync(parResponse))["request_uri"]!.GetValue<string>();
+        var code = await AuthorizeAsync(client, discovery, requestUri);
+
+        // Real verifier matters — PKCE validation runs before the DPoP nonce check,
+        // so a fake verifier short-circuits on invalid_grant and we never observe the
+        // RFC 9449 §8 challenge we're actually testing for.
+        var proofWithoutNonce = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var tokenResponse = await SendTokenAsync(client, discovery, code, verifier, proofWithoutNonce);
+
+        Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
+        var body = await ReadBodyAsync(tokenResponse);
+        Assert.Equal(ErrorCodes.UseDPoPNonce, body["error"]!.GetValue<string>());
+
+        // RFC 9449 §8: the challenge response carries the fresh nonce in a header so
+        // the client knows what value to embed in the next proof.
+        Assert.True(tokenResponse.Headers.TryGetValues(HttpRequestHeaders.DPoPNonce, out var nonceValues),
+            "Response missing DPoP-Nonce header");
+        Assert.Single(nonceValues!);
+        Assert.False(string.IsNullOrEmpty(nonceValues!.First()));
+    }
+
+    [Fact]
+    public async Task Token_endpoint_retry_with_nonce_from_challenge_succeeds()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var (parResponse, verifier, _) = await PushParAsync(client, discovery);
+        var requestUri = (await ReadBodyAsync(parResponse))["request_uri"]!.GetValue<string>();
+        var code = await AuthorizeAsync(client, discovery, requestUri);
+
+        // Step 1: proof without nonce -> challenge carries fresh nonce on DPoP-Nonce header.
+        var firstProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
+        Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
+        var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
+
+        // Step 2: retry with the nonce embedded; same auth code (RFC 9449 §8 retry semantics).
+        var secondProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint), nonce: nonce);
+        var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
+
+        var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(secondResponse.IsSuccessStatusCode, $"/token retry failed: {(int)secondResponse.StatusCode} {raw}");
+        var tokenBody = JsonNode.Parse(raw)!.AsObject();
+        Assert.Equal(TokenTypes.DPoP, tokenBody["token_type"]!.GetValue<string>());
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Per-test helpers — slim copies of TestBase pieces that are static there
+    // but get a different fixture in this collection. Hidden in private methods
+    // so the [Fact] bodies stay flow-step readable.
+    // ───────────────────────────────────────────────────────────────────────
+
+    private static async Task<DiscoveryDocument> FetchDiscoveryAsync(HttpClient client)
+    {
+        var response = await client.GetAsync("/.well-known/openid-configuration");
+        response.EnsureSuccessStatusCode();
+        var doc = await System.Net.Http.Json.HttpContentJsonExtensions
+            .ReadFromJsonAsync<DiscoveryDocument>(response.Content);
+        return doc!;
+    }
+
+    private static async Task<(HttpResponseMessage, string Verifier, string Challenge)> PushParAsync(
+        HttpClient client, DiscoveryDocument discovery)
+    {
+        var (verifier, challenge) = TestBase.GeneratePkcePair();
+        var form = new Dictionary<string, string>
+        {
+            ["client_id"] = TestConstants.DPoPRequiredClientId,
+            ["client_secret"] = TestConstants.ConfidentialClientSecret,
+            ["response_type"] = "code",
+            ["redirect_uri"] = TestConstants.RedirectUri,
+            ["scope"] = "openid",
+            ["state"] = Guid.NewGuid().ToString("N"),
+            ["nonce"] = Guid.NewGuid().ToString("N"),
+            ["code_challenge"] = challenge,
+            ["code_challenge_method"] = "S256",
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        var response = await client.SendAsync(request);
+        Assert.True(response.IsSuccessStatusCode, $"PAR failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()}");
+        return (response, verifier, challenge);
+    }
+
+    private static async Task<string> AuthorizeAsync(HttpClient client, DiscoveryDocument discovery, string requestUri)
+    {
+        var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, new Dictionary<string, string>
+        {
+            ["client_id"] = TestConstants.DPoPRequiredClientId,
+            ["request_uri"] = requestUri,
+        });
+        var response = await client.GetAsync(uri);
+        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+            $"/authorize unexpected: {(int)response.StatusCode}");
+        var location = response.Headers.Location!;
+        return System.Web.HttpUtility.ParseQueryString(location.Query)["code"]!;
+    }
+
+    private static async Task<HttpResponseMessage> SendTokenAsync(
+        HttpClient client, DiscoveryDocument discovery, string code, string verifier, string proofJwt)
+    {
+        var form = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = TestConstants.RedirectUri,
+            ["code_verifier"] = verifier,
+            ["client_id"] = TestConstants.DPoPRequiredClientId,
+            ["client_secret"] = TestConstants.ConfidentialClientSecret,
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        request.WithDPoPHeader(proofJwt);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<JsonObject> ReadBodyAsync(HttpResponseMessage response)
+    {
+        var raw = await response.Content.ReadAsStringAsync();
+        return JsonNode.Parse(raw)!.AsObject();
+    }
+}
+
+/// <summary>
+/// Dedicated xunit collection for nonce-enabled scenarios — separate from
+/// <c>TestCollection</c> so the singleton <see cref="NonceEnabledTestFactory"/>
+/// fixture's per-host options never leak into the default-flow DPoP tests.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class DPoPNonceTestCollection : ICollectionFixture<NonceEnabledTestFactory>
+{
+    public const string Name = "DPoPNonce";
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
@@ -66,7 +66,7 @@ public class DPoPNonceTests
         // Real verifier matters — PKCE validation runs before the DPoP nonce check,
         // so a fake verifier short-circuits on invalid_grant and we never observe the
         // RFC 9449 §8 challenge we're actually testing for.
-        var proofWithoutNonce = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
+        var proofWithoutNonce = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var tokenResponse = await SendTokenAsync(client, discovery, code, verifier, proofWithoutNonce);
 
         Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
@@ -99,7 +99,7 @@ public class DPoPNonceTests
         // First UserInfo call: no nonce on the proof — RS issues a fresh nonce challenge
         // (RFC 9449 §9 + §7.1 SHOULD WWW-Authenticate: DPoP).
         var firstProof = proofKey.BuildProof(
-            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+            HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken);
         var response = await SendUserInfoAsync(client, discovery, accessToken, firstProof);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -120,14 +120,14 @@ public class DPoPNonceTests
 
         // Step 1: no nonce -> challenge carries fresh nonce.
         var firstProof = proofKey.BuildProof(
-            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+            HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken);
         var challenge = await SendUserInfoAsync(client, discovery, accessToken, firstProof);
         Assert.Equal(HttpStatusCode.Unauthorized, challenge.StatusCode);
         var nonce = challenge.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
 
         // Step 2: retry with the supplied nonce embedded in the proof.
         var secondProof = proofKey.BuildProof(
-            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken, nonce: nonce);
+            HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken, nonce: nonce);
         var success = await SendUserInfoAsync(client, discovery, accessToken, secondProof);
 
         var raw = await success.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -147,13 +147,13 @@ public class DPoPNonceTests
         var code = await AuthorizeAsync(client, discovery, requestUri);
 
         // Step 1: proof without nonce -> challenge carries fresh nonce on DPoP-Nonce header.
-        var firstProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
+        var firstProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
         Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
         var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
 
         // Step 2: retry with the nonce embedded; same auth code (RFC 9449 §8 retry semantics).
-        var secondProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint), nonce: nonce);
+        var secondProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint, nonce: nonce);
         var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
 
         var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -258,12 +258,12 @@ public class DPoPNonceTests
         var requestUri = (await ReadBodyAsync(parResponse))[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
         var code = await AuthorizeAsync(client, discovery, requestUri);
 
-        var firstProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
+        var firstProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var firstResponse = await SendTokenAsync(client, discovery, code, verifier, firstProof);
         Assert.Equal(HttpStatusCode.BadRequest, firstResponse.StatusCode);
         var nonce = firstResponse.Headers.GetValues(HttpRequestHeaders.DPoPNonce).First();
 
-        var secondProof = proofKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint), nonce: nonce);
+        var secondProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint, nonce: nonce);
         var secondResponse = await SendTokenAsync(client, discovery, code, verifier, secondProof);
         var raw = await secondResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.True(secondResponse.IsSuccessStatusCode,

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
@@ -207,10 +207,7 @@ public class DPoPNonceTests(NonceEnabledTestFactory factory) : TestBase(factory)
             [AuthorizationRequest.Parameters.ClientId] = TestConstants.DPoPRequiredClientId,
             [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         };
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint);
-        request.Content = new FormUrlEncodedContent(form);
-        request.WithDPoPHeader(proofJwt);
-        return await client.SendAsync(request);
+        return await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, form, proofJwt);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPNonceTests.cs
@@ -72,10 +72,6 @@ public class DPoPNonceTests(NonceEnabledTestFactory factory) : TestBase(factory)
             tokenBody[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // Resource-server-side nonce challenge (RFC 9449 §9)
-    // ───────────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task UserInfo_with_dpop_proof_lacking_nonce_returns_use_dpop_nonce_challenge()
     {
@@ -124,11 +120,6 @@ public class DPoPNonceTests(NonceEnabledTestFactory factory) : TestBase(factory)
         Assert.True(success.IsSuccessStatusCode,
             $"/userinfo retry failed: {(int)success.StatusCode} {raw}");
     }
-
-    // ───────────────────────────────────────────────────────────────────────
-    // Helpers — DPoP-aware flow primitives. Non-DPoP boilerplate (discovery,
-    // /authorize redirect parsing) is inherited from TestBase.
-    // ───────────────────────────────────────────────────────────────────────
 
     /// <summary>
     /// Bootstraps PAR + /authorize, then makes the first /token call with a proof that

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -648,19 +648,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         string scope = Scopes.OpenId,
         string? clientSecret = TestConstants.ConfidentialClientSecret)
     {
-        var (verifier, challenge) = GeneratePkcePair();
-
-        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof, scope, clientSecret);
-        Assert.True(parResponse.IsSuccessStatusCode,
-            $"PAR failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
-        var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
-        var requestUri = parBody[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
-
-        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
-        {
-            [AuthorizationRequest.Parameters.ClientId] = clientId,
-            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
-        });
+        var (verifier, code) = await PerformParAndAuthorizeAsync(
+            client, discovery, clientId, parProof, scope, clientSecret);
 
         var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof, clientSecret);
         Assert.True(tokenResponse.IsSuccessStatusCode,
@@ -681,11 +670,37 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         string? parProof,
         string? tokenProof)
     {
+        var (verifier, code) = await PerformParAndAuthorizeAsync(
+            client, discovery, clientId, parProof, Scopes.OpenId, TestConstants.ConfidentialClientSecret);
+
+        var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
+        Assert.False(tokenResponse.IsSuccessStatusCode,
+            $"/token unexpectedly succeeded: {await tokenResponse.Content.ReadAsStringAsync()}");
+        Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
+        var body = JsonNode.Parse(await tokenResponse.Content.ReadAsStringAsync())!.AsObject();
+        return body["error"]!.GetValue<string>();
+    }
+
+    /// <summary>
+    /// Pushes a PAR request, retrieves the resulting <c>request_uri</c>, drives /authorize
+    /// to consume it, and returns the issued auth code paired with the PKCE verifier so a
+    /// caller can complete the flow at /token. Shared bootstrap for the success and
+    /// expecting-error driver variants — keeps the PAR + /authorize choreography in one
+    /// place even though the two callers diverge on /token-stage expectations.
+    /// </summary>
+    private static async Task<(string Verifier, string Code)> PerformParAndAuthorizeAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string clientId,
+        string? parProof,
+        string scope,
+        string? clientSecret)
+    {
         var (verifier, challenge) = GeneratePkcePair();
 
-        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof);
+        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof, scope, clientSecret);
         Assert.True(parResponse.IsSuccessStatusCode,
-            $"PAR unexpectedly failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
+            $"PAR failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
         var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
         var requestUri = parBody[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
 
@@ -694,13 +709,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             [AuthorizationRequest.Parameters.ClientId] = clientId,
             [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
-
-        var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
-        Assert.False(tokenResponse.IsSuccessStatusCode,
-            $"/token unexpectedly succeeded: {await tokenResponse.Content.ReadAsStringAsync()}");
-        Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
-        var body = JsonNode.Parse(await tokenResponse.Content.ReadAsStringAsync())!.AsObject();
-        return body["error"]!.GetValue<string>();
+        return (verifier, code);
     }
 
     private static async Task<HttpResponseMessage> SendParAsync(

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -21,7 +21,9 @@
 // info@abblix.com
 
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json.Nodes;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
@@ -227,6 +229,122 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
     }
 
     // ───────────────────────────────────────────────────────────────────────
+    // UserInfo endpoint (RFC 9449 §7) — resource-server-side proof validation
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UserInfo_with_dpop_bound_token_and_matching_proof_succeeds()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var accessToken = await ObtainDPoPBoundAccessTokenAsync(client, discovery, proofKey);
+
+        // RFC 9449 §7.1: proof must carry ath = base64url(sha256(access_token)).
+        var userInfoProof = proofKey.BuildProof(
+            "GET", new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+
+        var response = await SendUserInfoAsync(
+            client, discovery, accessToken, userInfoProof, scheme: TokenTypes.DPoP);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(response.IsSuccessStatusCode, $"/userinfo failed: {(int)response.StatusCode} {body}");
+    }
+
+    [Fact]
+    public async Task UserInfo_dpop_bound_token_presented_as_bearer_is_rejected()
+    {
+        // RFC 9449 §7.2: "such a protected resource MUST reject a DPoP-bound access
+        // token received as a bearer token". The check exists to close the downgrade-
+        // to-Bearer attack surface. RFC 9449 §7.1 also asks the response to carry a
+        // WWW-Authenticate: DPoP challenge so the client knows which scheme to switch to.
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var accessToken = await ObtainDPoPBoundAccessTokenAsync(client, discovery, proofKey);
+
+        var response = await SendUserInfoAsync(
+            client, discovery, accessToken, proofJwt: null, scheme: TokenTypes.Bearer);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.DPoP);
+    }
+
+    [Fact]
+    public async Task UserInfo_unbound_token_presented_as_dpop_is_rejected()
+    {
+        // Abblix-side defensive posture: RFC 9449 §7.1's check list "the public key of
+        // the DPoP proof matches the public key to which the access token is bound"
+        // has no defined behaviour when the token carries no cnf.jkt at all (nothing
+        // to match against). Abblix chooses to reject so a Bearer-issued token cannot
+        // silently sneak through the DPoP scheme and bypass logging/policy gates that
+        // key off presentation mode. Not a spec MUST -- a deliberate posture.
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokenResponse = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null, tokenProof: null);
+        var unboundAccessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+
+        // Attach a syntactically valid proof to make sure the rejection is about the
+        // token's binding state, not about a missing proof header.
+        using var proofKey = new DPoPProofGenerator();
+        var proof = proofKey.BuildProof(
+            "GET", new Uri(discovery.UserInfoEndpoint!), accessToken: unboundAccessToken);
+
+        var response = await SendUserInfoAsync(
+            client, discovery, unboundAccessToken, proof, scheme: TokenTypes.DPoP);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.DPoP);
+    }
+
+    [Fact]
+    public async Task UserInfo_dpop_bound_token_with_proof_signed_by_different_key_is_rejected()
+    {
+        using var bindingKey = new DPoPProofGenerator();
+        using var attackerKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var accessToken = await ObtainDPoPBoundAccessTokenAsync(client, discovery, bindingKey);
+
+        // Proof signed with a different key — the attacker stole the token but lacks the
+        // private key the token was bound to. The AS computes the proof's jkt and finds
+        // it doesn't match the token's cnf.jkt. RFC 9449 §7.1: the resource server SHOULD
+        // accompany the 401 with a WWW-Authenticate: DPoP challenge so the client knows
+        // which scheme to use on retry.
+        var attackerProof = attackerKey.BuildProof(
+            "GET", new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+
+        var response = await SendUserInfoAsync(
+            client, discovery, accessToken, attackerProof, scheme: TokenTypes.DPoP);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.DPoP);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Discovery metadata (RFC 9449 §5.1)
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Discovery_exposes_dpop_signing_alg_values_supported()
+    {
+        var discovery = await FetchDiscoveryAsync(CreateClient());
+
+        Assert.NotNull(discovery.DPoPSigningAlgValuesSupported);
+        // RFC 9449 §4.2 alg whitelist (no HMAC, no none); the AS advertises an asymmetric
+        // subset. We pin a few canonical values; full enumeration is a unit-test concern.
+        Assert.Contains(SigningAlgorithms.ES256, discovery.DPoPSigningAlgValuesSupported!);
+        Assert.Contains(SigningAlgorithms.RS256, discovery.DPoPSigningAlgValuesSupported!);
+        Assert.Contains(SigningAlgorithms.PS256, discovery.DPoPSigningAlgValuesSupported!);
+        Assert.DoesNotContain("HS256", discovery.DPoPSigningAlgValuesSupported!);
+        Assert.DoesNotContain("none", discovery.DPoPSigningAlgValuesSupported!);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
     // Flow drivers
     // ───────────────────────────────────────────────────────────────────────
 
@@ -322,6 +440,45 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         {
             Content = new FormUrlEncodedContent(form),
         };
+        if (proofJwt is not null)
+            request.WithDPoPHeader(proofJwt);
+        return await client.SendAsync(request);
+    }
+
+    /// <summary>
+    /// Drives PAR -> /authorize -> /token with a token-endpoint DPoP proof signed by
+    /// <paramref name="proofKey"/>, asserts the resulting access token is DPoP-bound to
+    /// that key, and returns the raw access_token string. UserInfo scenarios start here.
+    /// </summary>
+    private static async Task<string> ObtainDPoPBoundAccessTokenAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        DPoPProofGenerator proofKey)
+    {
+        var tokenProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var tokenResponse = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null, tokenProof: tokenProof);
+        AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
+        return tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+    }
+
+    /// <summary>
+    /// Sends a GET to /userinfo with the given access token and optional DPoP proof,
+    /// presented under the supplied <paramref name="scheme"/> (DPoP or Bearer). Returns
+    /// the raw response so callers can inspect both status and headers.
+    /// </summary>
+    private static async Task<HttpResponseMessage> SendUserInfoAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string accessToken,
+        string? proofJwt,
+        string scheme)
+    {
+        Assert.NotNull(discovery.UserInfoEndpoint);
+        using var request = new HttpRequestMessage(HttpMethod.Get, discovery.UserInfoEndpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue(scheme, accessToken);
         if (proofJwt is not null)
             request.WithDPoPHeader(proofJwt);
         return await client.SendAsync(request);

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -28,6 +28,8 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Microsoft.AspNetCore.Http;
+using Abblix.Oidc.Server.Model;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
@@ -68,7 +70,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,
             parProof: null,
-            tokenProof: proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint)));
+            tokenProof: proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint)));
 
         AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
     }
@@ -105,7 +107,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             discovery,
             clientId: TestConstants.DPoPRequiredClientId,
             parProof: null,
-            tokenProof: proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint)));
+            tokenProof: proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint)));
 
         AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
     }
@@ -137,8 +139,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var parProof = proofKey.BuildProof("POST", new Uri(discovery.PushedAuthorizationRequestEndpoint!));
-        var tokenProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var parProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+        var tokenProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
 
         var tokenResponse = await DriveParAuthorizeTokenAsync(
             client,
@@ -160,8 +162,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var parProof = parKey.BuildProof("POST", new Uri(discovery.PushedAuthorizationRequestEndpoint!));
-        var tokenProof = tokenKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var parProof = parKey.BuildProof(HttpMethods.Post,new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+        var tokenProof = tokenKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
 
         var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
             client,
@@ -183,7 +185,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var parProof = parKey.BuildProof("POST", new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+        var parProof = parKey.BuildProof(HttpMethods.Post,new Uri(discovery.PushedAuthorizationRequestEndpoint!));
 
         var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
             client,
@@ -209,7 +211,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         // Mint ONE proof and reuse it across two independent flows. First flow succeeds
         // and the AS caches the proof's jti; second flow with the same proof string trips
         // the replay cache regardless of which other request parameters change.
-        var sharedProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var sharedProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
 
         var firstResponse = await DriveParAuthorizeTokenAsync(
             client,
@@ -229,6 +231,81 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
     }
 
     // ───────────────────────────────────────────────────────────────────────
+    // Refresh token rebinding (RFC 9449 §5)
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Refresh_with_same_dpop_key_yields_new_token_bound_to_same_jkt()
+    {
+        // RFC 9449 §5: when refreshing a DPoP-bound access token, the new token MUST be
+        // bound to the same key as the previous one. Abblix enforces this via the §10
+        // carry-over mechanism — the original grant's ProofKeyThumbprint is committed on
+        // the refresh token and DPoPTokenEndpointValidator rejects any proof key drift.
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint)),
+            scope: $"{Scopes.OpenId} {Scopes.OfflineAccess}");
+        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
+        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        // Fresh proof (new jti, current iat) signed by the SAME keypair.
+        var refreshProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
+        var refreshHttp = await SendRefreshAsync(
+            client, discovery, refreshToken, TestConstants.DPoPOpportunisticClientId, refreshProof);
+
+        var raw = await refreshHttp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(refreshHttp.IsSuccessStatusCode,
+            $"/token refresh failed: {(int)refreshHttp.StatusCode} {raw}");
+        var refreshBody = JsonNode.Parse(raw)!.AsObject();
+        AssertDPoPBound(refreshBody, expectedThumbprint: proofKey.Thumbprint);
+    }
+
+    [Fact]
+    public async Task Confidential_client_can_rebind_to_new_dpop_key_on_refresh()
+    {
+        // RFC 9449 §5 explicit carve-out: «Refresh tokens issued to confidential
+        // clients (those having established authentication credentials with the
+        // authorization server) are not bound to the DPoP proof public key because
+        // they are already sender-constrained with a different existing mechanism»
+        // (client authentication). The AS therefore accepts a fresh DPoP key on
+        // refresh and binds the new access token to it — a confidential client may
+        // rotate keys without re-running the auth-code dance. The strict
+        // same-key-MUST rule of §5 applies only to PUBLIC clients; a no-secret
+        // seeded client is out of scope for this slice.
+        using var originalKey = new DPoPProofGenerator();
+        using var rotatedKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: originalKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint)),
+            scope: Scopes.OpenId + " " + Scopes.OfflineAccess);
+        AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
+        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        // Refresh with a freshly rotated key — must succeed and the new access token
+        // must be bound to the rotated key (not the original one).
+        var rotatedProof = rotatedKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
+        var refreshHttp = await SendRefreshAsync(
+            client, discovery, refreshToken, TestConstants.DPoPOpportunisticClientId, rotatedProof);
+
+        var raw = await refreshHttp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(refreshHttp.IsSuccessStatusCode,
+            $"/token refresh failed: {(int)refreshHttp.StatusCode} {raw}");
+        var refreshBody = JsonNode.Parse(raw)!.AsObject();
+        AssertDPoPBound(refreshBody, expectedThumbprint: rotatedKey.Thumbprint);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
     // UserInfo endpoint (RFC 9449 §7) — resource-server-side proof validation
     // ───────────────────────────────────────────────────────────────────────
 
@@ -242,7 +319,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
 
         // RFC 9449 §7.1: proof must carry ath = base64url(sha256(access_token)).
         var userInfoProof = proofKey.BuildProof(
-            "GET", new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
 
         var response = await SendUserInfoAsync(
             client, discovery, accessToken, userInfoProof, scheme: TokenTypes.DPoP);
@@ -286,13 +363,13 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             client, discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,
             parProof: null, tokenProof: null);
-        var unboundAccessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        var unboundAccessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
 
         // Attach a syntactically valid proof to make sure the rejection is about the
         // token's binding state, not about a missing proof header.
         using var proofKey = new DPoPProofGenerator();
         var proof = proofKey.BuildProof(
-            "GET", new Uri(discovery.UserInfoEndpoint!), accessToken: unboundAccessToken);
+            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: unboundAccessToken);
 
         var response = await SendUserInfoAsync(
             client, discovery, unboundAccessToken, proof, scheme: TokenTypes.DPoP);
@@ -316,7 +393,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         // accompany the 401 with a WWW-Authenticate: DPoP challenge so the client knows
         // which scheme to use on retry.
         var attackerProof = attackerKey.BuildProof(
-            "GET", new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
 
         var response = await SendUserInfoAsync(
             client, discovery, accessToken, attackerProof, scheme: TokenTypes.DPoP);
@@ -359,20 +436,21 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         DiscoveryDocument discovery,
         string clientId,
         string? parProof,
-        string? tokenProof)
+        string? tokenProof,
+        string scope = Scopes.OpenId)
     {
         var (verifier, challenge) = GeneratePkcePair();
 
-        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof);
+        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof, scope);
         Assert.True(parResponse.IsSuccessStatusCode,
             $"PAR failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
         var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
-        var requestUri = parBody[WireParameters.RequestUri]!.GetValue<string>();
+        var requestUri = parBody[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
 
         var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.RequestUri] = requestUri,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
 
         var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
@@ -400,12 +478,12 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         Assert.True(parResponse.IsSuccessStatusCode,
             $"PAR unexpectedly failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
         var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
-        var requestUri = parBody[WireParameters.RequestUri]!.GetValue<string>();
+        var requestUri = parBody[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
 
         var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.RequestUri] = requestUri,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
 
         var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
@@ -413,7 +491,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             $"/token unexpectedly succeeded: {await tokenResponse.Content.ReadAsStringAsync()}");
         Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
         var body = JsonNode.Parse(await tokenResponse.Content.ReadAsStringAsync())!.AsObject();
-        return body[WireParameters.Error]!.GetValue<string>();
+        return body["error"]!.GetValue<string>();
     }
 
     private static async Task<HttpResponseMessage> SendParAsync(
@@ -421,19 +499,20 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         DiscoveryDocument discovery,
         string clientId,
         string challenge,
-        string? proofJwt)
+        string? proofJwt,
+        string scope = Scopes.OpenId)
     {
         var form = new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-            [WireParameters.ResponseType] = "code",
-            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
-            [WireParameters.Scope] = "openid",
-            [WireParameters.State] = Guid.NewGuid().ToString("N"),
-            [WireParameters.Nonce] = Guid.NewGuid().ToString("N"),
-            [WireParameters.CodeChallenge] = challenge,
-            [WireParameters.CodeChallengeMethod] = "S256",
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = scope,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
         };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
@@ -455,13 +534,13 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         DiscoveryDocument discovery,
         DPoPProofGenerator proofKey)
     {
-        var tokenProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+        var tokenProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
         var tokenResponse = await DriveParAuthorizeTokenAsync(
             client, discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,
             parProof: null, tokenProof: tokenProof);
         AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
-        return tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        return tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
     }
 
     /// <summary>
@@ -484,6 +563,33 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         return await client.SendAsync(request);
     }
 
+    /// <summary>
+    /// Sends a refresh_token grant request with a DPoP proof. The refresh token is
+    /// taken from the previous token response; the proof must be signed by the same
+    /// keypair the original access token was bound to (RFC 9449 §5 + §10 carry-over).
+    /// </summary>
+    private static async Task<HttpResponseMessage> SendRefreshAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string refreshToken,
+        string clientId,
+        string proofJwt)
+    {
+        var form = new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
+            [TokenRequest.Parameters.RefreshToken] = refreshToken,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        request.WithDPoPHeader(proofJwt);
+        return await client.SendAsync(request);
+    }
+
     private static async Task<HttpResponseMessage> SendTokenAsync(
         HttpClient client,
         DiscoveryDocument discovery,
@@ -494,12 +600,12 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
     {
         var form = new Dictionary<string, string>
         {
-            [WireParameters.GrantType] = "authorization_code",
-            [WireParameters.Code] = code,
-            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
-            [WireParameters.CodeVerifier] = verifier,
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
@@ -517,10 +623,10 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
 
     private static void AssertDPoPBound(JsonObject tokenResponse, string expectedThumbprint)
     {
-        Assert.Equal(TokenTypes.DPoP, tokenResponse["token_type"]!.GetValue<string>());
+        Assert.Equal(TokenTypes.DPoP, tokenResponse[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
 
         // RFC 9449 §6: the issued access token carries cnf.jkt = the proof key's JWK thumbprint.
-        var accessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var payload = DecodeJwtPayload(accessToken);
         var cnf = payload["cnf"]?.AsObject();
         Assert.NotNull(cnf);
@@ -530,8 +636,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
 
     private static void AssertBearer(JsonObject tokenResponse)
     {
-        Assert.Equal(TokenTypes.Bearer, tokenResponse["token_type"]!.GetValue<string>());
-        var accessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        Assert.Equal(TokenTypes.Bearer, tokenResponse[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
+        var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var payload = DecodeJwtPayload(accessToken);
         Assert.Null(payload["cnf"]);
     }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -54,10 +54,6 @@ namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 /// </remarks>
 public class DPoPTests(TestFactory factory) : TestBase(factory)
 {
-    // ───────────────────────────────────────────────────────────────────────
-    // Opportunistic binding (RFC 9449 §5.2)
-    // ───────────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task Opportunistic_client_with_proof_at_token_endpoint_gets_dpop_bound_access_token()
     {
@@ -91,10 +87,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         AssertBearer(tokenResponse);
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // Mandatory binding (RFC 9449 §5.2 + ClientInfo.RequireDPoP)
-    // ───────────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task Required_client_with_valid_proof_gets_dpop_bound_access_token()
     {
@@ -127,10 +119,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
 
         Assert.Equal(ErrorCodes.InvalidDPoPProof, tokenError);
     }
-
-    // ───────────────────────────────────────────────────────────────────────
-    // PAR carry-over (RFC 9449 §10): dpop_jkt commits at PAR, must match at /token
-    // ───────────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Proof_at_par_commits_dpop_jkt_and_matching_proof_at_token_succeeds()
@@ -197,10 +185,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         Assert.Equal(ErrorCodes.InvalidDPoPProof, tokenError);
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // Replay protection (RFC 9449 §11.1)
-    // ───────────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task Same_proof_jwt_presented_twice_is_rejected_on_the_second_attempt()
     {
@@ -229,14 +213,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             tokenProof: sharedProof);
         Assert.Equal(ErrorCodes.InvalidDPoPProof, secondError);
     }
-
-    // ───────────────────────────────────────────────────────────────────────
-    // Wire-level error contract — proof validator failures surface as
-    // 400 invalid_dpop_proof end-to-end. The validator's failure taxonomy is
-    // exhaustively covered by ProofValidatorTests at the unit level; the two
-    // tests here pin the contract that those failures actually reach the wire
-    // unchanged through DPoPTokenEndpointValidator and the response formatter.
-    // ───────────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Token_endpoint_rejects_proof_whose_htm_does_not_match_the_request_method()
@@ -297,10 +273,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         parts[2] = (firstChar == 'A' ? 'B' : 'A') + sig[1..];
         return string.Join('.', parts);
     }
-
-    // ───────────────────────────────────────────────────────────────────────
-    // Refresh token rebinding (RFC 9449 §5)
-    // ───────────────────────────────────────────────────────────────────────
 
     /// <summary>
     /// Drives an initial PAR -> /authorize -> /token round with <c>offline_access</c>
@@ -499,10 +471,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         Assert.Equal(ErrorCodes.InvalidDPoPProof, body["error"]!.GetValue<string>());
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // UserInfo endpoint (RFC 9449 §7) — resource-server-side proof validation
-    // ───────────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task UserInfo_with_dpop_bound_token_and_matching_proof_succeeds()
     {
@@ -596,10 +564,6 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.DPoP);
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // Discovery metadata (RFC 9449 §5.1)
-    // ───────────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task Discovery_exposes_dpop_signing_alg_values_supported()
     {
@@ -608,16 +572,12 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         Assert.NotNull(discovery.DPoPSigningAlgValuesSupported);
         // RFC 9449 §4.2 alg whitelist (no HMAC, no none); the AS advertises an asymmetric
         // subset. We pin a few canonical values; full enumeration is a unit-test concern.
-        Assert.Contains(SigningAlgorithms.ES256, discovery.DPoPSigningAlgValuesSupported!);
-        Assert.Contains(SigningAlgorithms.RS256, discovery.DPoPSigningAlgValuesSupported!);
-        Assert.Contains(SigningAlgorithms.PS256, discovery.DPoPSigningAlgValuesSupported!);
-        Assert.DoesNotContain("HS256", discovery.DPoPSigningAlgValuesSupported!);
-        Assert.DoesNotContain("none", discovery.DPoPSigningAlgValuesSupported!);
+        Assert.Contains(SigningAlgorithms.ES256, discovery.DPoPSigningAlgValuesSupported);
+        Assert.Contains(SigningAlgorithms.RS256, discovery.DPoPSigningAlgValuesSupported);
+        Assert.Contains(SigningAlgorithms.PS256, discovery.DPoPSigningAlgValuesSupported);
+        Assert.DoesNotContain(SigningAlgorithms.HS256, discovery.DPoPSigningAlgValuesSupported);
+        Assert.DoesNotContain(SigningAlgorithms.None, discovery.DPoPSigningAlgValuesSupported);
     }
-
-    // ───────────────────────────────────────────────────────────────────────
-    // Flow drivers
-    // ───────────────────────────────────────────────────────────────────────
 
     /// <summary>
     /// Drives PAR -> /authorize -> /token with optional DPoP proofs on PAR and token.
@@ -780,7 +740,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         {
             [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
             [TokenRequest.Parameters.RefreshToken] = refreshToken,
-            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientId] = clientId,
         };
         if (clientSecret is not null)
             form[ClientRequest.Parameters.ClientSecret] = clientSecret;
@@ -800,28 +760,27 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         {
             [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
             [TokenRequest.Parameters.Code] = code,
-            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
             [TokenRequest.Parameters.CodeVerifier] = verifier,
-            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientId] = clientId,
         };
         if (clientSecret is not null)
             form[ClientRequest.Parameters.ClientSecret] = clientSecret;
         return await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, form, proofJwt);
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // Assertions
-    // ───────────────────────────────────────────────────────────────────────
-
     private static void AssertDPoPBound(JsonObject tokenResponse, string expectedThumbprint)
     {
-        Assert.Equal(TokenTypes.DPoP, tokenResponse[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
+        var tokenType = tokenResponse[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>();
+        Assert.Equal(TokenTypes.DPoP, tokenType);
 
         // RFC 9449 §6: the issued access token carries cnf.jkt = the proof key's JWK thumbprint.
         var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var payload = DecodeJwtPayload(accessToken);
+
         var cnf = payload["cnf"]?.AsObject();
         Assert.NotNull(cnf);
+        
         var jkt = cnf["jkt"]?.GetValue<string>();
         Assert.Equal(expectedThumbprint, jkt);
     }
@@ -833,7 +792,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
 
         var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var payload = DecodeJwtPayload(accessToken);
-        
+
         Assert.Null(payload["cnf"]);
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -70,7 +70,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,
             parProof: null,
-            tokenProof: proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint)));
+            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint));
 
         AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
     }
@@ -107,7 +107,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             discovery,
             clientId: TestConstants.DPoPRequiredClientId,
             parProof: null,
-            tokenProof: proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint)));
+            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint));
 
         AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
     }
@@ -139,8 +139,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var parProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.PushedAuthorizationRequestEndpoint!));
-        var tokenProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
+        var parProof = proofKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
+        var tokenProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
 
         var tokenResponse = await DriveParAuthorizeTokenAsync(
             client,
@@ -162,8 +162,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var parProof = parKey.BuildProof(HttpMethods.Post,new Uri(discovery.PushedAuthorizationRequestEndpoint!));
-        var tokenProof = tokenKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
+        var parProof = parKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
+        var tokenProof = tokenKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
 
         var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
             client,
@@ -185,7 +185,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var parProof = parKey.BuildProof(HttpMethods.Post,new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+        var parProof = parKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
 
         var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
             client,
@@ -211,7 +211,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         // Mint ONE proof and reuse it across two independent flows. First flow succeeds
         // and the AS caches the proof's jti; second flow with the same proof string trips
         // the replay cache regardless of which other request parameters change.
-        var sharedProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
+        var sharedProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
 
         var firstResponse = await DriveParAuthorizeTokenAsync(
             client,
@@ -249,13 +249,13 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             client, discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,
             parProof: null,
-            tokenProof: proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint)),
+            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
             scope: $"{Scopes.OpenId} {Scopes.OfflineAccess}");
         AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
         var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
 
         // Fresh proof (new jti, current iat) signed by the SAME keypair.
-        var refreshProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
+        var refreshProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var refreshHttp = await SendRefreshAsync(
             client, discovery, refreshToken, TestConstants.DPoPOpportunisticClientId, refreshProof);
 
@@ -287,14 +287,14 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             client, discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,
             parProof: null,
-            tokenProof: originalKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint)),
+            tokenProof: originalKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
             scope: Scopes.OpenId + " " + Scopes.OfflineAccess);
         AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
         var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
 
         // Refresh with a freshly rotated key — must succeed and the new access token
         // must be bound to the rotated key (not the original one).
-        var rotatedProof = rotatedKey.BuildProof(HttpMethods.Post, new Uri(discovery.TokenEndpoint));
+        var rotatedProof = rotatedKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var refreshHttp = await SendRefreshAsync(
             client, discovery, refreshToken, TestConstants.DPoPOpportunisticClientId, rotatedProof);
 
@@ -319,7 +319,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
 
         // RFC 9449 §7.1: proof must carry ath = base64url(sha256(access_token)).
         var userInfoProof = proofKey.BuildProof(
-            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+            HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken);
 
         var response = await SendUserInfoAsync(
             client, discovery, accessToken, userInfoProof, scheme: TokenTypes.DPoP);
@@ -369,7 +369,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         // token's binding state, not about a missing proof header.
         using var proofKey = new DPoPProofGenerator();
         var proof = proofKey.BuildProof(
-            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: unboundAccessToken);
+            HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: unboundAccessToken);
 
         var response = await SendUserInfoAsync(
             client, discovery, unboundAccessToken, proof, scheme: TokenTypes.DPoP);
@@ -393,7 +393,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         // accompany the 401 with a WWW-Authenticate: DPoP challenge so the client knows
         // which scheme to use on retry.
         var attackerProof = attackerKey.BuildProof(
-            HttpMethods.Get, new Uri(discovery.UserInfoEndpoint!), accessToken: accessToken);
+            HttpMethods.Get, discovery.UserInfoEndpoint!, accessToken: accessToken);
 
         var response = await SendUserInfoAsync(
             client, discovery, accessToken, attackerProof, scheme: TokenTypes.DPoP);
@@ -534,7 +534,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         DiscoveryDocument discovery,
         DPoPProofGenerator proofKey)
     {
-        var tokenProof = proofKey.BuildProof(HttpMethods.Post,new Uri(discovery.TokenEndpoint));
+        var tokenProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var tokenResponse = await DriveParAuthorizeTokenAsync(
             client, discovery,
             clientId: TestConstants.DPoPOpportunisticClientId,

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -735,14 +735,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         // Public clients (TokenEndpointAuthMethod = none) supply no client_secret.
         if (clientSecret is not null)
             form[ClientRequest.Parameters.ClientSecret] = clientSecret;
-
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        if (proofJwt is not null)
-            request.WithDPoPHeader(proofJwt);
-        return await client.SendAsync(request);
+        return await FormPostHelpers.PostFormAsync(client, discovery.PushedAuthorizationRequestEndpoint!, form, proofJwt);
     }
 
     /// <summary>
@@ -805,12 +798,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         };
         if (clientSecret is not null)
             form[ClientRequest.Parameters.ClientSecret] = clientSecret;
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        request.WithDPoPHeader(proofJwt);
-        return await client.SendAsync(request);
+        return await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, form, proofJwt);
     }
 
     private static async Task<HttpResponseMessage> SendTokenAsync(
@@ -832,14 +820,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         };
         if (clientSecret is not null)
             form[ClientRequest.Parameters.ClientSecret] = clientSecret;
-
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        if (proofJwt is not null)
-            request.WithDPoPHeader(proofJwt);
-        return await client.SendAsync(request);
+        return await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, form, proofJwt);
     }
 
     // ───────────────────────────────────────────────────────────────────────

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -231,6 +231,74 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
     }
 
     // ───────────────────────────────────────────────────────────────────────
+    // Wire-level error contract — proof validator failures surface as
+    // 400 invalid_dpop_proof end-to-end. The validator's failure taxonomy is
+    // exhaustively covered by ProofValidatorTests at the unit level; the two
+    // tests here pin the contract that those failures actually reach the wire
+    // unchanged through DPoPTokenEndpointValidator and the response formatter.
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Token_endpoint_rejects_proof_whose_htm_does_not_match_the_request_method()
+    {
+        // RFC 9449 §4.3 step 8: htm MUST match the HTTP method byte-exact. Mint a
+        // proof claiming GET, then POST it to /token — the validator should reject
+        // and the wire response should carry error=invalid_dpop_proof at HTTP 400.
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var proofForWrongMethod = proofKey.BuildProof(HttpMethods.Get, discovery.TokenEndpoint);
+
+        var error = await DriveParAuthorizeTokenExpectingErrorAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: proofForWrongMethod);
+
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, error);
+    }
+
+    [Fact]
+    public async Task Token_endpoint_rejects_proof_with_corrupted_signature()
+    {
+        // RFC 9449 §4.3 step 6: signature MUST verify. Mint a valid proof then
+        // flip a byte in the signature segment; downstream signature verification
+        // fails and the validator returns invalid_dpop_proof — pin the wire shape.
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var validProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var corrupted = CorruptSignatureSegment(validProof);
+
+        var error = await DriveParAuthorizeTokenExpectingErrorAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: corrupted);
+
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, error);
+    }
+
+    /// <summary>
+    /// Tampers with the first character of a JWS's signature segment. The proof
+    /// otherwise remains structurally valid (3 dot-separated base64url parts);
+    /// only the bytes that signature verification reads change, so the failure
+    /// must come from the crypto check rather than from a structural pre-screen.
+    /// </summary>
+    private static string CorruptSignatureSegment(string proofJws)
+    {
+        var parts = proofJws.Split('.');
+        Assert.Equal(3, parts.Length);
+        var sig = parts[2];
+        var firstChar = sig[0];
+        // Swap with a different valid base64url character to keep the JWS parseable.
+        parts[2] = (firstChar == 'A' ? 'B' : 'A') + sig[1..];
+        return string.Join('.', parts);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
     // Refresh token rebinding (RFC 9449 §5)
     // ───────────────────────────────────────────────────────────────────────
 

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -1,0 +1,381 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// RFC 9449 Demonstrating Proof-of-Possession (DPoP) end-to-end against the test OIDC
+/// provider. Each test mints a proof with a per-instance ECDSA P-256 keypair, threads
+/// it through the real HTTP flow (PAR -> /authorize -> /token), and asserts on the
+/// wire-level outcome: the issued access token's <c>cnf.jkt</c> claim, the wire
+/// <c>token_type</c>, or the error code returned by the AS.
+/// </summary>
+/// <remarks>
+/// Two seeded clients drive the matrix:
+/// <see cref="TestConstants.DPoPRequiredClientId"/> -- <c>RequireDPoP = true</c>
+/// (mandatory binding; missing proof -> reject) and
+/// <see cref="TestConstants.DPoPOpportunisticClientId"/> -- <c>RequireDPoP = false</c>
+/// (proof optional; when present the AS still binds, RFC 9449 §5.2 opportunistic posture).
+/// Lower-level helpers from <see cref="TestBase"/> are used directly rather than
+/// <c>PerformParFlowAsync</c> because DPoP scenarios need different proofs on different
+/// endpoints (one per request) and a few exercise PAR-only or token-only deviations
+/// that the wrapper hides.
+/// </remarks>
+public class DPoPTests(TestFactory factory) : TestBase(factory)
+{
+    // ───────────────────────────────────────────────────────────────────────
+    // Opportunistic binding (RFC 9449 §5.2)
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Opportunistic_client_with_proof_at_token_endpoint_gets_dpop_bound_access_token()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokenResponse = await DriveParAuthorizeTokenAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint)));
+
+        AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
+    }
+
+    [Fact]
+    public async Task Opportunistic_client_without_proof_gets_bearer_access_token()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokenResponse = await DriveParAuthorizeTokenAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: null);
+
+        AssertBearer(tokenResponse);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Mandatory binding (RFC 9449 §5.2 + ClientInfo.RequireDPoP)
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Required_client_with_valid_proof_gets_dpop_bound_access_token()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokenResponse = await DriveParAuthorizeTokenAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPRequiredClientId,
+            parProof: null,
+            tokenProof: proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint)));
+
+        AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
+    }
+
+    [Fact]
+    public async Task Required_client_without_proof_is_rejected_with_invalid_dpop_proof()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPRequiredClientId,
+            parProof: null,
+            tokenProof: null);
+
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, tokenError);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // PAR carry-over (RFC 9449 §10): dpop_jkt commits at PAR, must match at /token
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Proof_at_par_commits_dpop_jkt_and_matching_proof_at_token_succeeds()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var parProof = proofKey.BuildProof("POST", new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+        var tokenProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+
+        var tokenResponse = await DriveParAuthorizeTokenAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: parProof,
+            tokenProof: tokenProof);
+
+        AssertDPoPBound(tokenResponse, expectedThumbprint: proofKey.Thumbprint);
+    }
+
+    [Fact]
+    public async Task Proof_at_par_followed_by_different_key_at_token_is_rejected()
+    {
+        // RFC 9449 §10: dpop_jkt committed at PAR pins which key the token endpoint
+        // must see; a different key proves the auth code was hijacked by another client.
+        using var parKey = new DPoPProofGenerator();
+        using var tokenKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var parProof = parKey.BuildProof("POST", new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+        var tokenProof = tokenKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+
+        var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: parProof,
+            tokenProof: tokenProof);
+
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, tokenError);
+    }
+
+    [Fact]
+    public async Task Carry_over_committed_at_par_but_no_proof_at_token_is_rejected()
+    {
+        // The canonical RFC 9449 §10 attack window: PAR pinned a key, but the redeemer
+        // shows up at /token without a proof. Even an opportunistic-binding client MUST
+        // reject -- the PAR-time commitment is unconditional.
+        using var parKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var parProof = parKey.BuildProof("POST", new Uri(discovery.PushedAuthorizationRequestEndpoint!));
+
+        var tokenError = await DriveParAuthorizeTokenExpectingErrorAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: parProof,
+            tokenProof: null);
+
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, tokenError);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Replay protection (RFC 9449 §11.1)
+    // ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Same_proof_jwt_presented_twice_is_rejected_on_the_second_attempt()
+    {
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        // Mint ONE proof and reuse it across two independent flows. First flow succeeds
+        // and the AS caches the proof's jti; second flow with the same proof string trips
+        // the replay cache regardless of which other request parameters change.
+        var sharedProof = proofKey.BuildProof("POST", new Uri(discovery.TokenEndpoint));
+
+        var firstResponse = await DriveParAuthorizeTokenAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: sharedProof);
+        AssertDPoPBound(firstResponse, expectedThumbprint: proofKey.Thumbprint);
+
+        var secondError = await DriveParAuthorizeTokenExpectingErrorAsync(
+            client,
+            discovery,
+            clientId: TestConstants.DPoPOpportunisticClientId,
+            parProof: null,
+            tokenProof: sharedProof);
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, secondError);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Flow drivers
+    // ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Drives PAR -> /authorize -> /token with optional DPoP proofs on PAR and token.
+    /// Returns the parsed token response on the success path; throws on any non-success
+    /// HTTP status -- callers expecting a token-endpoint error use the *ExpectingError*
+    /// variant.
+    /// </summary>
+    private static async Task<JsonObject> DriveParAuthorizeTokenAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string clientId,
+        string? parProof,
+        string? tokenProof)
+    {
+        var (verifier, challenge) = GeneratePkcePair();
+
+        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof);
+        Assert.True(parResponse.IsSuccessStatusCode,
+            $"PAR failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
+        var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
+        var requestUri = parBody[WireParameters.RequestUri]!.GetValue<string>();
+
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
+        {
+            [WireParameters.ClientId] = clientId,
+            [WireParameters.RequestUri] = requestUri,
+        });
+
+        var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
+        Assert.True(tokenResponse.IsSuccessStatusCode,
+            $"/token failed: {(int)tokenResponse.StatusCode} {await tokenResponse.Content.ReadAsStringAsync()}");
+        return JsonNode.Parse(await tokenResponse.Content.ReadAsStringAsync())!.AsObject();
+    }
+
+    /// <summary>
+    /// Same flow as <see cref="DriveParAuthorizeTokenAsync"/> but expects the /token
+    /// call to fail; returns the error code from the response body. PAR and /authorize
+    /// are still expected to succeed -- if they don't, the test fails loudly so the
+    /// scenario doesn't silently green-pass on a wrong-stage rejection.
+    /// </summary>
+    private static async Task<string> DriveParAuthorizeTokenExpectingErrorAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string clientId,
+        string? parProof,
+        string? tokenProof)
+    {
+        var (verifier, challenge) = GeneratePkcePair();
+
+        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof);
+        Assert.True(parResponse.IsSuccessStatusCode,
+            $"PAR unexpectedly failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
+        var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
+        var requestUri = parBody[WireParameters.RequestUri]!.GetValue<string>();
+
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
+        {
+            [WireParameters.ClientId] = clientId,
+            [WireParameters.RequestUri] = requestUri,
+        });
+
+        var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
+        Assert.False(tokenResponse.IsSuccessStatusCode,
+            $"/token unexpectedly succeeded: {await tokenResponse.Content.ReadAsStringAsync()}");
+        Assert.Equal(HttpStatusCode.BadRequest, tokenResponse.StatusCode);
+        var body = JsonNode.Parse(await tokenResponse.Content.ReadAsStringAsync())!.AsObject();
+        return body[WireParameters.Error]!.GetValue<string>();
+    }
+
+    private static async Task<HttpResponseMessage> SendParAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string clientId,
+        string challenge,
+        string? proofJwt)
+    {
+        var form = new Dictionary<string, string>
+        {
+            [WireParameters.ClientId] = clientId,
+            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [WireParameters.ResponseType] = "code",
+            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
+            [WireParameters.Scope] = "openid",
+            [WireParameters.State] = Guid.NewGuid().ToString("N"),
+            [WireParameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [WireParameters.CodeChallenge] = challenge,
+            [WireParameters.CodeChallengeMethod] = "S256",
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        if (proofJwt is not null)
+            request.WithDPoPHeader(proofJwt);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> SendTokenAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string clientId,
+        string code,
+        string verifier,
+        string? proofJwt)
+    {
+        var form = new Dictionary<string, string>
+        {
+            [WireParameters.GrantType] = "authorization_code",
+            [WireParameters.Code] = code,
+            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
+            [WireParameters.CodeVerifier] = verifier,
+            [WireParameters.ClientId] = clientId,
+            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        if (proofJwt is not null)
+            request.WithDPoPHeader(proofJwt);
+        return await client.SendAsync(request);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Assertions
+    // ───────────────────────────────────────────────────────────────────────
+
+    private static void AssertDPoPBound(JsonObject tokenResponse, string expectedThumbprint)
+    {
+        Assert.Equal(TokenTypes.DPoP, tokenResponse["token_type"]!.GetValue<string>());
+
+        // RFC 9449 §6: the issued access token carries cnf.jkt = the proof key's JWK thumbprint.
+        var accessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        var payload = DecodeJwtPayload(accessToken);
+        var cnf = payload["cnf"]?.AsObject();
+        Assert.NotNull(cnf);
+        var jkt = cnf!["jkt"]?.GetValue<string>();
+        Assert.Equal(expectedThumbprint, jkt);
+    }
+
+    private static void AssertBearer(JsonObject tokenResponse)
+    {
+        Assert.Equal(TokenTypes.Bearer, tokenResponse["token_type"]!.GetValue<string>());
+        var accessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        var payload = DecodeJwtPayload(accessToken);
+        Assert.Null(payload["cnf"]);
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -302,6 +302,32 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
     // Refresh token rebinding (RFC 9449 §5)
     // ───────────────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Drives an initial PAR -> /authorize -> /token round with <c>offline_access</c>
+    /// in scope, asserts the resulting access token is DPoP-bound to <paramref name="proofKey"/>,
+    /// and returns the issued refresh token. Common bootstrap for every refresh-rebinding
+    /// scenario — confidential vs public, PAR-anchored vs non-PAR.
+    /// </summary>
+    private static async Task<string> ObtainRefreshTokenBoundToAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        string clientId,
+        DPoPProofGenerator proofKey,
+        string? parProof = null,
+        string? clientSecret = TestConstants.ConfidentialClientSecret)
+    {
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: clientId,
+            parProof: parProof,
+            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
+            scope: $"{Scopes.OpenId} {Scopes.OfflineAccess}",
+            clientSecret: clientSecret);
+
+        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
+        return initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+    }
+
     [Fact]
     public async Task Refresh_with_same_dpop_key_yields_new_token_bound_to_same_jkt()
     {
@@ -313,14 +339,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var initial = await DriveParAuthorizeTokenAsync(
-            client, discovery,
-            clientId: TestConstants.DPoPOpportunisticClientId,
-            parProof: null,
-            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
-            scope: $"{Scopes.OpenId} {Scopes.OfflineAccess}");
-        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
-        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        var refreshToken = await ObtainRefreshTokenBoundToAsync(
+            client, discovery, TestConstants.DPoPOpportunisticClientId, proofKey);
 
         // Fresh proof (new jti, current iat) signed by the SAME keypair.
         var refreshProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
@@ -351,14 +371,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var initial = await DriveParAuthorizeTokenAsync(
-            client, discovery,
-            clientId: TestConstants.DPoPOpportunisticClientId,
-            parProof: null,
-            tokenProof: originalKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
-            scope: Scopes.OpenId + " " + Scopes.OfflineAccess);
-        AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
-        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        var refreshToken = await ObtainRefreshTokenBoundToAsync(
+            client, discovery, TestConstants.DPoPOpportunisticClientId, originalKey);
 
         // Refresh with a freshly rotated key — must succeed and the new access token
         // must be bound to the rotated key (not the original one).
@@ -387,16 +401,9 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var discovery = await FetchDiscoveryAsync(client);
 
         var parProof = proofKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
-        var tokenProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
-        var initial = await DriveParAuthorizeTokenAsync(
-            client, discovery,
-            clientId: TestConstants.DPoPPublicClientId,
-            parProof: parProof,
-            tokenProof: tokenProof,
-            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
-            clientSecret: null);
-        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
-        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        var refreshToken = await ObtainRefreshTokenBoundToAsync(
+            client, discovery, TestConstants.DPoPPublicClientId, proofKey,
+            parProof: parProof, clientSecret: null);
 
         var refreshProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var refreshHttp = await SendRefreshAsync(
@@ -422,15 +429,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var initial = await DriveParAuthorizeTokenAsync(
-            client, discovery,
-            clientId: TestConstants.DPoPPublicClientId,
-            parProof: null,
-            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
-            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
-            clientSecret: null);
-        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
-        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        var refreshToken = await ObtainRefreshTokenBoundToAsync(
+            client, discovery, TestConstants.DPoPPublicClientId, proofKey, clientSecret: null);
 
         var refreshProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var refreshHttp = await SendRefreshAsync(
@@ -457,15 +457,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        var initial = await DriveParAuthorizeTokenAsync(
-            client, discovery,
-            clientId: TestConstants.DPoPPublicClientId,
-            parProof: null,
-            tokenProof: originalKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
-            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
-            clientSecret: null);
-        AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
-        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        var refreshToken = await ObtainRefreshTokenBoundToAsync(
+            client, discovery, TestConstants.DPoPPublicClientId, originalKey, clientSecret: null);
 
         var attackerProof = attackerKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var refreshHttp = await SendRefreshAsync(
@@ -493,16 +486,9 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var discovery = await FetchDiscoveryAsync(client);
 
         var parProof = originalKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
-        var tokenProof = originalKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
-        var initial = await DriveParAuthorizeTokenAsync(
-            client, discovery,
-            clientId: TestConstants.DPoPPublicClientId,
-            parProof: parProof,
-            tokenProof: tokenProof,
-            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
-            clientSecret: null);
-        AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
-        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        var refreshToken = await ObtainRefreshTokenBoundToAsync(
+            client, discovery, TestConstants.DPoPPublicClientId, originalKey,
+            parProof: parProof, clientSecret: null);
 
         var attackerProof = attackerKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
         var refreshHttp = await SendRefreshAsync(
@@ -836,15 +822,18 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         var payload = DecodeJwtPayload(accessToken);
         var cnf = payload["cnf"]?.AsObject();
         Assert.NotNull(cnf);
-        var jkt = cnf!["jkt"]?.GetValue<string>();
+        var jkt = cnf["jkt"]?.GetValue<string>();
         Assert.Equal(expectedThumbprint, jkt);
     }
 
     private static void AssertBearer(JsonObject tokenResponse)
     {
-        Assert.Equal(TokenTypes.Bearer, tokenResponse[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>());
+        var tokenType = tokenResponse[BackChannelTokenPushRequest.Parameters.TokenType]!.GetValue<string>();
+        Assert.Equal(TokenTypes.Bearer, tokenType);
+
         var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var payload = DecodeJwtPayload(accessToken);
+        
         Assert.Null(payload["cnf"]);
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -305,6 +305,79 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         AssertDPoPBound(refreshBody, expectedThumbprint: rotatedKey.Thumbprint);
     }
 
+    [Fact]
+    public async Task Public_client_refresh_with_same_dpop_key_yields_new_token_bound_to_same_jkt()
+    {
+        // RFC 9449 §5: public clients (token_endpoint_auth_method = none) lack a shared
+        // secret, so DPoP is the sole sender-constraint. Same-key MUST therefore be
+        // enforced on refresh. Abblix carries the thumbprint forward via the §10
+        // PAR-time commitment path; a proof on the PAR request commits dpop_jkt into
+        // the stored authorization request, the auth code restores it, and refresh
+        // tokens for public clients keep it (vs. confidential clients which strip).
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var parProof = proofKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
+        var tokenProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPPublicClientId,
+            parProof: parProof,
+            tokenProof: tokenProof,
+            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
+            clientSecret: null);
+        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
+        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        var refreshProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var refreshHttp = await SendRefreshAsync(
+            client, discovery, refreshToken, TestConstants.DPoPPublicClientId, refreshProof, clientSecret: null);
+
+        var raw = await refreshHttp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(refreshHttp.IsSuccessStatusCode,
+            $"/token refresh failed: {(int)refreshHttp.StatusCode} {raw}");
+        var refreshBody = JsonNode.Parse(raw)!.AsObject();
+        AssertDPoPBound(refreshBody, expectedThumbprint: proofKey.Thumbprint);
+    }
+
+    [Fact]
+    public async Task Public_client_refresh_with_different_dpop_key_is_rejected_per_rfc9449_section5()
+    {
+        // RFC 9449 §5 MUST for public clients: «such a client MUST present a DPoP proof
+        // for the same key that was used to obtain the refresh token each time that
+        // refresh token is used». A rotated key on refresh is the canonical theft
+        // scenario the constraint exists to close — without a shared secret, the proof
+        // key is the only thing tying the holder to the original grant. Commitment is
+        // anchored at PAR (Abblix §10 carry-over path); a proof on PAR makes the AS
+        // pin dpop_jkt onto the stored authorization request, and the public-client
+        // refresh path preserves the binding through to subsequent token requests.
+        using var originalKey = new DPoPProofGenerator();
+        using var attackerKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var parProof = originalKey.BuildProof(HttpMethods.Post, discovery.PushedAuthorizationRequestEndpoint!);
+        var tokenProof = originalKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPPublicClientId,
+            parProof: parProof,
+            tokenProof: tokenProof,
+            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
+            clientSecret: null);
+        AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
+        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        var attackerProof = attackerKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var refreshHttp = await SendRefreshAsync(
+            client, discovery, refreshToken, TestConstants.DPoPPublicClientId, attackerProof, clientSecret: null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, refreshHttp.StatusCode);
+        var body = JsonNode.Parse(await refreshHttp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, body["error"]!.GetValue<string>());
+    }
+
     // ───────────────────────────────────────────────────────────────────────
     // UserInfo endpoint (RFC 9449 §7) — resource-server-side proof validation
     // ───────────────────────────────────────────────────────────────────────
@@ -437,11 +510,12 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         string clientId,
         string? parProof,
         string? tokenProof,
-        string scope = Scopes.OpenId)
+        string scope = Scopes.OpenId,
+        string? clientSecret = TestConstants.ConfidentialClientSecret)
     {
         var (verifier, challenge) = GeneratePkcePair();
 
-        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof, scope);
+        var parResponse = await SendParAsync(client, discovery, clientId, challenge, parProof, scope, clientSecret);
         Assert.True(parResponse.IsSuccessStatusCode,
             $"PAR failed: {(int)parResponse.StatusCode} {await parResponse.Content.ReadAsStringAsync()}");
         var parBody = JsonNode.Parse(await parResponse.Content.ReadAsStringAsync())!.AsObject();
@@ -453,7 +527,7 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
 
-        var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof);
+        var tokenResponse = await SendTokenAsync(client, discovery, clientId, code, verifier, tokenProof, clientSecret);
         Assert.True(tokenResponse.IsSuccessStatusCode,
             $"/token failed: {(int)tokenResponse.StatusCode} {await tokenResponse.Content.ReadAsStringAsync()}");
         return JsonNode.Parse(await tokenResponse.Content.ReadAsStringAsync())!.AsObject();
@@ -500,12 +574,12 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         string clientId,
         string challenge,
         string? proofJwt,
-        string scope = Scopes.OpenId)
+        string scope = Scopes.OpenId,
+        string? clientSecret = TestConstants.ConfidentialClientSecret)
     {
         var form = new Dictionary<string, string>
         {
             [AuthorizationRequest.Parameters.ClientId] = clientId,
-            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
             [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
             [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
             [AuthorizationRequest.Parameters.Scope] = scope,
@@ -514,6 +588,9 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
             [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
         };
+        // Public clients (TokenEndpointAuthMethod = none) supply no client_secret.
+        if (clientSecret is not null)
+            form[ClientRequest.Parameters.ClientSecret] = clientSecret;
 
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
         {
@@ -573,15 +650,17 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         DiscoveryDocument discovery,
         string refreshToken,
         string clientId,
-        string proofJwt)
+        string proofJwt,
+        string? clientSecret = TestConstants.ConfidentialClientSecret)
     {
         var form = new Dictionary<string, string>
         {
             [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
             [TokenRequest.Parameters.RefreshToken] = refreshToken,
             [AuthorizationRequest.Parameters.ClientId] = clientId,
-            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         };
+        if (clientSecret is not null)
+            form[ClientRequest.Parameters.ClientSecret] = clientSecret;
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
         {
             Content = new FormUrlEncodedContent(form),
@@ -596,7 +675,8 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
         string clientId,
         string code,
         string verifier,
-        string? proofJwt)
+        string? proofJwt,
+        string? clientSecret = TestConstants.ConfidentialClientSecret)
     {
         var form = new Dictionary<string, string>
         {
@@ -605,8 +685,9 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
             [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
             [TokenRequest.Parameters.CodeVerifier] = verifier,
             [AuthorizationRequest.Parameters.ClientId] = clientId,
-            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         };
+        if (clientSecret is not null)
+            form[ClientRequest.Parameters.ClientSecret] = clientSecret;
 
         using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
         {

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTests.cs
@@ -342,6 +342,73 @@ public class DPoPTests(TestFactory factory) : TestBase(factory)
     }
 
     [Fact]
+    public async Task Public_client_non_par_refresh_with_same_dpop_key_yields_new_token_bound_to_same_jkt()
+    {
+        // RFC 9449 §5 applies regardless of how the initial token was obtained — a
+        // proof at /token alone (no PAR commitment) is enough to bind the access
+        // token, and the binding MUST flow through to the refresh token. Pins the
+        // TokenRequestProcessor fix: public-flow refreshContext sources its thumbprint
+        // from authContext (live proof) rather than from the un-evaluated grant
+        // context (which is null without PAR).
+        using var proofKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPPublicClientId,
+            parProof: null,
+            tokenProof: proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
+            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
+            clientSecret: null);
+        AssertDPoPBound(initial, expectedThumbprint: proofKey.Thumbprint);
+        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        var refreshProof = proofKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var refreshHttp = await SendRefreshAsync(
+            client, discovery, refreshToken, TestConstants.DPoPPublicClientId, refreshProof, clientSecret: null);
+
+        var raw = await refreshHttp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(refreshHttp.IsSuccessStatusCode,
+            $"/token refresh failed: {(int)refreshHttp.StatusCode} {raw}");
+        AssertDPoPBound(JsonNode.Parse(raw)!.AsObject(), expectedThumbprint: proofKey.Thumbprint);
+    }
+
+    [Fact]
+    public async Task Public_client_non_par_refresh_with_different_dpop_key_is_rejected_per_rfc9449_section5()
+    {
+        // Regression pin for the TokenRequestProcessor fix. Before the fix the public
+        // refresh path sourced refreshContext from request.AuthorizedGrant.Context,
+        // which carried no ProofKeyThumbprint for non-PAR flows; the validator's
+        // committed-vs-presented compare then short-circuited (committed = null) and
+        // a rotated key was silently accepted — a §5 MUST violation. Post-fix the
+        // refresh JWT carries cnf.jkt from authContext (live proof's thumbprint), so
+        // the next refresh's mismatched proof is caught.
+        using var originalKey = new DPoPProofGenerator();
+        using var attackerKey = new DPoPProofGenerator();
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var initial = await DriveParAuthorizeTokenAsync(
+            client, discovery,
+            clientId: TestConstants.DPoPPublicClientId,
+            parProof: null,
+            tokenProof: originalKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint),
+            scope: Scopes.OpenId + " " + Scopes.OfflineAccess,
+            clientSecret: null);
+        AssertDPoPBound(initial, expectedThumbprint: originalKey.Thumbprint);
+        var refreshToken = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        var attackerProof = attackerKey.BuildProof(HttpMethods.Post, discovery.TokenEndpoint);
+        var refreshHttp = await SendRefreshAsync(
+            client, discovery, refreshToken, TestConstants.DPoPPublicClientId, attackerProof, clientSecret: null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, refreshHttp.StatusCode);
+        var body = JsonNode.Parse(await refreshHttp.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+        Assert.Equal(ErrorCodes.InvalidDPoPProof, body["error"]!.GetValue<string>());
+    }
+
+    [Fact]
     public async Task Public_client_refresh_with_different_dpop_key_is_rejected_per_rfc9449_section5()
     {
         // RFC 9449 §5 MUST for public clients: «such a client MUST present a DPoP proof

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
@@ -6,6 +6,8 @@ using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Common.Constants;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
@@ -53,15 +55,15 @@ public class JarRichAuthorizationRequestsTests(TestFactory factory) : TestBase(f
         var dcrBody = new JsonObject
         {
             ["redirect_uris"] = new JsonArray { TestConstants.RedirectUri },
-            ["grant_types"] = new JsonArray { "authorization_code" },
+            ["grant_types"] = new JsonArray { GrantTypes.AuthorizationCode },
             ["response_types"] = new JsonArray { "code" },
             ["token_endpoint_auth_method"] = "client_secret_post",
             ["jwks"] = JsonSerializer.SerializeToNode(PublicJwksFor(clientKey)),
             ["authorization_details_types"] = new JsonArray { TestConstants.PaymentInitiationType },
         };
         var registered = await RegisterClientAsync(httpClient, discovery, dcrBody);
-        var clientId = registered["client_id"]!.GetValue<string>();
-        var clientSecret = registered["client_secret"]!.GetValue<string>();
+        var clientId = registered[AuthorizationRequest.Parameters.ClientId]!.GetValue<string>();
+        var clientSecret = registered[ClientRequest.Parameters.ClientSecret]!.GetValue<string>();
 
         // 3. Build the request JWT containing every authorize parameter -- including the wire-shape
         // authorization_details JSON array attached as a custom claim. RFC 9101 §6: iss = client_id,
@@ -78,15 +80,15 @@ public class JarRichAuthorizationRequestsTests(TestFactory factory) : TestBase(f
                 ExpiresAt = now.AddMinutes(5),
             },
         };
-        requestJwt.Payload.Json["response_type"] = "code";
-        requestJwt.Payload.Json["client_id"] = clientId;
-        requestJwt.Payload.Json["redirect_uri"] = TestConstants.RedirectUri;
-        requestJwt.Payload.Json["scope"] = "openid";
-        requestJwt.Payload.Json["state"] = Guid.NewGuid().ToString("N");
-        requestJwt.Payload.Json["nonce"] = Guid.NewGuid().ToString("N");
-        requestJwt.Payload.Json["code_challenge"] = challenge;
-        requestJwt.Payload.Json["code_challenge_method"] = "S256";
-        requestJwt.Payload.Json[WireParameters.AuthorizationDetails] = JsonNode.Parse(PaymentInitiationWireJson);
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.ResponseType] = "code";
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.ClientId] = clientId;
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri;
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.Scope] = Scopes.OpenId;
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N");
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N");
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.CodeChallenge] = challenge;
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256;
+        requestJwt.Payload.Json[AuthorizationRequest.Parameters.AuthorizationDetails] = JsonNode.Parse(PaymentInitiationWireJson);
 
         var creator = JwtServices.GetRequiredService<IJsonWebTokenCreator>();
         var signedRequest = await creator.IssueAsync(requestJwt, clientKey);
@@ -96,27 +98,27 @@ public class JarRichAuthorizationRequestsTests(TestFactory factory) : TestBase(f
         // verifying the signature).
         var code = await AuthorizeAndExtractCodeAsync(httpClient, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
             ["request"] = signedRequest,
         });
 
         // 5. /token exchange.
         var tokenResponse = await ExchangeCodeForTokensAsync(httpClient, discovery, new Dictionary<string, string>
         {
-            [WireParameters.GrantType] = "authorization_code",
-            [WireParameters.Code] = code,
-            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
-            [WireParameters.CodeVerifier] = verifier,
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.ClientSecret] = clientSecret,
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = clientSecret,
         });
 
         // 6. The access token must carry the same authorization_details the request JWT carried,
         // byte-exact. This is the JAR + RAR invariant: signed request object preserves nested
         // claims through every layer (JWT validation -> request-object fetcher -> standard
         // authorize pipeline -> RAR per-type validator -> consent -> token emission).
-        var payload = DecodeJwtPayload(tokenResponse[WireParameters.AccessToken]!.GetValue<string>());
-        var claim = (payload[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var payload = DecodeJwtPayload(tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var claim = (payload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.NotNull(claim);
         Assert.Equal(PaymentInitiationWireJson, claim.ToJsonString());
     }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
@@ -75,7 +75,7 @@ public class JarRichAuthorizationRequestsTests(TestFactory factory) : TestBase(f
             Payload =
             {
                 Issuer = clientId,
-                Audiences = [discovery.Issuer],
+                Audiences = [discovery.Issuer.AbsoluteUri],
                 IssuedAt = now,
                 ExpiresAt = now.AddMinutes(5),
             },

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
@@ -201,15 +201,6 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
         Assert.Equal(PaymentInitiationWireJson, echoed.ToJsonString());
     }
 
-    // ───────────────────────────────────────────────────────────────────────
-    // RFC 9396 consent capture (#142). The configurable AutoConsentsProvider
-    // models the three canonical Granted.AuthorizationDetails values:
-    //   - non-empty array  -> user consented to a (possibly narrowed) set
-    //   - empty JsonArray  -> user denied every entry
-    //   - null (no override) -> legacy provider, pipeline passes the request
-    //                           through unchanged (PR #135 baseline)
-    // ───────────────────────────────────────────────────────────────────────
-
     /// <summary>
     /// Drives PAR / authorize / token with a consent-side override and asserts the issued
     /// access token's <c>authorization_details</c> claim equals the override byte-exact.

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
@@ -143,8 +143,8 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
 
         var echoed = registered["authorization_details_types"] as JsonArray;
         Assert.NotNull(echoed);
-        Assert.Single(echoed!);
-        Assert.Equal(TestConstants.PaymentInitiationType, echoed![0]!.GetValue<string>());
+        Assert.Single(echoed);
+        Assert.Equal(TestConstants.PaymentInitiationType, echoed[0]!.GetValue<string>());
     }
 
     [Fact]
@@ -192,10 +192,11 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
 
         var body = JsonNode.Parse(raw)?.AsObject();
         Assert.NotNull(body);
-        Assert.Equal("true", body!["active"]?.GetValue<string>());
+        Assert.Equal("true", body["active"]?.GetValue<string>());
+
         var echoed = body[WireParameters.AuthorizationDetails] as JsonArray;
         Assert.NotNull(echoed);
-        Assert.Equal(PaymentInitiationWireJson, echoed!.ToJsonString());
+        Assert.Equal(PaymentInitiationWireJson, echoed.ToJsonString());
     }
 
     // ───────────────────────────────────────────────────────────────────────

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
@@ -5,6 +5,8 @@ using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Abblix.Oidc.Server.Features.Licensing;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Common.Constants;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
@@ -37,12 +39,12 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
             TestConstants.RedirectUri, PaymentInitiationWireJson);
 
         // RFC 9396 §7: authorization_details echoed byte-exact in the token response
-        var echoed = (tokenResponse[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var echoed = (tokenResponse[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(PaymentInitiationWireJson, echoed.ToJsonString());
 
         // Access token carries the claim byte-exact
-        var payload = DecodeJwtPayload(tokenResponse[WireParameters.AccessToken]!.GetValue<string>());
-        var claim = (payload[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var payload = DecodeJwtPayload(tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var claim = (payload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(PaymentInitiationWireJson, claim.ToJsonString());
     }
 
@@ -53,7 +55,7 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, MultiEntryWireJson);
 
-        var echoed = (tokenResponse[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var echoed = (tokenResponse[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(MultiEntryWireJson, echoed.ToJsonString());
         Assert.Equal(2, echoed.Count);
     }
@@ -65,8 +67,8 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
             TestConstants.IdTokenRarClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
 
-        var idTokenPayload = DecodeJwtPayload(tokenResponse["id_token"]!.GetValue<string>());
-        var claim = (idTokenPayload[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var idTokenPayload = DecodeJwtPayload(tokenResponse[BackChannelTokenPushRequest.Parameters.IdToken]!.GetValue<string>());
+        var claim = (idTokenPayload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(PaymentInitiationWireJson, claim.ToJsonString());
     }
 
@@ -77,8 +79,8 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
 
-        var idTokenPayload = DecodeJwtPayload(tokenResponse["id_token"]!.GetValue<string>());
-        Assert.Null(idTokenPayload[WireParameters.AuthorizationDetails]);
+        var idTokenPayload = DecodeJwtPayload(tokenResponse[BackChannelTokenPushRequest.Parameters.IdToken]!.GetValue<string>());
+        Assert.Null(idTokenPayload[AuthorizationRequest.Parameters.AuthorizationDetails]);
     }
 
     [Fact]
@@ -134,7 +136,7 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
         var requested = new JsonObject
         {
             ["redirect_uris"] = new JsonArray { TestConstants.RedirectUri },
-            ["grant_types"] = new JsonArray { "authorization_code" },
+            ["grant_types"] = new JsonArray { GrantTypes.AuthorizationCode },
             ["response_types"] = new JsonArray { "code" },
             ["token_endpoint_auth_method"] = "client_secret_post",
             ["authorization_details_types"] = new JsonArray { TestConstants.PaymentInitiationType },
@@ -172,7 +174,7 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
         var tokenResponse = await PerformParFlowAsync(
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
-        var accessToken = tokenResponse[WireParameters.AccessToken]!.GetValue<string>();
+        var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
 
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
@@ -181,10 +183,10 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
         using var introspectRequest = new HttpRequestMessage(HttpMethod.Post, discovery.IntrospectionEndpoint);
         introspectRequest.Content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = TestConstants.ConfidentialClientId,
-            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
             ["token"] = accessToken,
-            ["token_type_hint"] = WireParameters.AccessToken,
+            ["token_type_hint"] = UserInfoRequest.Parameters.AccessToken,
         });
         var response = await client.SendAsync(introspectRequest, TestContext.Current.CancellationToken);
         var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -194,7 +196,7 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
         Assert.NotNull(body);
         Assert.Equal("true", body["active"]?.GetValue<string>());
 
-        var echoed = body[WireParameters.AuthorizationDetails] as JsonArray;
+        var echoed = body[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray;
         Assert.NotNull(echoed);
         Assert.Equal(PaymentInitiationWireJson, echoed.ToJsonString());
     }
@@ -224,8 +226,8 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, requestedWireJson, client: client);
 
-        var payload = DecodeJwtPayload(tokenResponse[WireParameters.AccessToken]!.GetValue<string>());
-        var claim = (payload[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var payload = DecodeJwtPayload(tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var claim = (payload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(grantedWireJson, claim.ToJsonString());
         return claim;
     }
@@ -253,21 +255,21 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
 
         var parResponse = await PushAuthorizationRequestAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = TestConstants.ConfidentialClientId,
-            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-            [WireParameters.ResponseType] = "code",
-            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
-            [WireParameters.Scope] = "openid",
-            [WireParameters.CodeChallenge] = challenge,
-            [WireParameters.CodeChallengeMethod] = "S256",
-            [WireParameters.AuthorizationDetails] = PaymentInitiationWireJson,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ResponseType] = "code",
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+            [AuthorizationRequest.Parameters.AuthorizationDetails] = PaymentInitiationWireJson,
         });
-        var requestUri = parResponse[WireParameters.RequestUri]!.GetValue<string>();
+        var requestUri = parResponse[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
 
         var error = await AuthorizeAndExtractErrorAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = TestConstants.ConfidentialClientId,
-            [WireParameters.RequestUri] = requestUri,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
 
         Assert.Equal("access_denied", error);
@@ -318,8 +320,8 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
 
-        var payload = DecodeJwtPayload(tokenResponse[WireParameters.AccessToken]!.GetValue<string>());
-        var claim = (payload[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var payload = DecodeJwtPayload(tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var claim = (payload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(PaymentInitiationWireJson, claim.ToJsonString());
     }
 
@@ -329,22 +331,22 @@ public class RichAuthorizationRequestsTests(TestFactory factory) : TestBase(fact
         var initial = await PerformParFlowAsync(
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson,
-            scope: "openid offline_access");
-        var refreshToken = initial["refresh_token"]?.GetValue<string>()
+            scope: Scopes.OpenId + " " + Scopes.OfflineAccess);
+        var refreshToken = initial[GrantTypes.RefreshToken]?.GetValue<string>()
             ?? throw new InvalidOperationException("Initial token response missing refresh_token");
 
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
         var refreshed = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
         {
-            ["grant_type"] = "refresh_token",
-            ["refresh_token"] = refreshToken,
-            ["client_id"] = TestConstants.ConfidentialClientId,
-            ["client_secret"] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
+            [GrantTypes.RefreshToken] = refreshToken,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         });
 
-        var payload = DecodeJwtPayload(refreshed[WireParameters.AccessToken]!.GetValue<string>());
-        var claim = (payload[WireParameters.AuthorizationDetails] as JsonArray)!;
+        var payload = DecodeJwtPayload(refreshed[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var claim = (payload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray)!;
         Assert.Equal(PaymentInitiationWireJson, claim.ToJsonString());
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenExchangeTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenExchangeTests.cs
@@ -3,6 +3,8 @@
 
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Common.Constants;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
@@ -27,23 +29,23 @@ public class TokenExchangeTests(TestFactory factory) : TestBase(factory)
         var initial = await PerformParFlowAsync(
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
-        var subjectToken = initial[WireParameters.AccessToken]!.GetValue<string>();
+        var subjectToken = initial[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var originalSubject = DecodeJwtPayload(subjectToken)["sub"]!.GetValue<string>();
 
         // 2. Exchange it via grant_type=token-exchange.
         var exchanged = await PerformTokenExchangeAsync(new Dictionary<string, string>
         {
-            ["grant_type"] = TokenExchangeGrantType,
+            [TokenRequest.Parameters.GrantType] = TokenExchangeGrantType,
             ["subject_token"] = subjectToken,
             ["subject_token_type"] = AccessTokenType,
-            ["client_id"] = TestConstants.ConfidentialClientId,
-            ["client_secret"] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         });
 
         // 3. Issued access token: same sub, AD forwarded byte-exact, no act claim.
-        var newPayload = DecodeJwtPayload(exchanged[WireParameters.AccessToken]!.GetValue<string>());
+        var newPayload = DecodeJwtPayload(exchanged[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
         Assert.Equal(originalSubject, newPayload["sub"]!.GetValue<string>());
-        var ad = newPayload[WireParameters.AuthorizationDetails] as JsonArray;
+        var ad = newPayload[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray;
         Assert.NotNull(ad);
         Assert.Equal(PaymentInitiationWireJson, ad!.ToJsonString());
         Assert.Null(newPayload["act"]);
@@ -56,7 +58,7 @@ public class TokenExchangeTests(TestFactory factory) : TestBase(factory)
         var subject = await PerformParFlowAsync(
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
-        var subjectToken = subject[WireParameters.AccessToken]!.GetValue<string>();
+        var subjectToken = subject[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var subjectSub = DecodeJwtPayload(subjectToken)["sub"]!.GetValue<string>();
 
         // 2. Mint the actor_token. Same client + flow stands in for a distinct service identity
@@ -65,23 +67,23 @@ public class TokenExchangeTests(TestFactory factory) : TestBase(factory)
         var actor = await PerformParFlowAsync(
             TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret,
             TestConstants.RedirectUri, PaymentInitiationWireJson);
-        var actorToken = actor[WireParameters.AccessToken]!.GetValue<string>();
+        var actorToken = actor[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
         var actorSub = DecodeJwtPayload(actorToken)["sub"]!.GetValue<string>();
 
         // 3. Exchange with both subject_token and actor_token.
         var exchanged = await PerformTokenExchangeAsync(new Dictionary<string, string>
         {
-            ["grant_type"] = TokenExchangeGrantType,
+            [TokenRequest.Parameters.GrantType] = TokenExchangeGrantType,
             ["subject_token"] = subjectToken,
             ["subject_token_type"] = AccessTokenType,
             ["actor_token"] = actorToken,
             ["actor_token_type"] = AccessTokenType,
-            ["client_id"] = TestConstants.ConfidentialClientId,
-            ["client_secret"] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
         });
 
         // 4. Issued token: sub = subject, act = { sub: actor }.
-        var newPayload = DecodeJwtPayload(exchanged[WireParameters.AccessToken]!.GetValue<string>());
+        var newPayload = DecodeJwtPayload(exchanged[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
         Assert.Equal(subjectSub, newPayload["sub"]!.GetValue<string>());
         var act = newPayload["act"] as JsonObject;
         Assert.NotNull(act);
@@ -101,7 +103,7 @@ public class TokenExchangeTests(TestFactory factory) : TestBase(factory)
         var requested = new JsonObject
         {
             ["redirect_uris"] = new JsonArray { TestConstants.RedirectUri },
-            ["grant_types"] = new JsonArray { "authorization_code" },
+            ["grant_types"] = new JsonArray { GrantTypes.AuthorizationCode },
             ["response_types"] = new JsonArray { "code" },
             ["token_endpoint_auth_method"] = "client_secret_post",
             ["token_exchange_subject_token_types"] = new JsonArray

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -268,7 +268,7 @@ public abstract class TestBase(TestFactory factory)
 
 internal static class QueryHelpers
 {
-    public static Uri BuildUri(string baseUri, IEnumerable<KeyValuePair<string, string>> queryParams)
+    public static Uri BuildUri(Uri baseUri, IEnumerable<KeyValuePair<string, string>> queryParams)
     {
         var builder = new UriBuilder(baseUri);
         var query = string.Join('&', queryParams

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -1,7 +1,6 @@
 // Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
@@ -11,6 +10,7 @@ using Abblix.Oidc.Server.E2E.Tests.Model;
 using Abblix.Oidc.Server.Model;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests;
@@ -24,14 +24,12 @@ namespace Abblix.Oidc.Server.E2E.Tests;
 [Collection(TestCollection.Name)]
 public abstract class TestBase(TestFactory factory)
 {
-    [SuppressMessage("Minor Code Smell", "S1075",
-        Justification = "TestServer in-memory base address; not a deployment URL.")]
     protected HttpClient CreateClient()
     {
         var client = factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false,
-            BaseAddress = new Uri("https://localhost"),
+            BaseAddress = TestServerAddress.BaseAddress,
         });
         return client;
     }
@@ -80,20 +78,9 @@ public abstract class TestBase(TestFactory factory)
     protected static async Task<string> AuthorizeAndExtractCodeAsync(
         HttpClient client,
         DiscoveryDocument discovery,
-        Dictionary<string, string> queryParams)
-    {
-        var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, queryParams);
-        var response = await client.GetAsync(uri);
-        // Auto-redirect is disabled — the success terminal is a 302 back to redirect_uri
-        // with code in the query string.
-        Assert.True(
-            response.StatusCode is System.Net.HttpStatusCode.Redirect or System.Net.HttpStatusCode.Found,
-            $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: {await response.Content.ReadAsStringAsync()}");
-        var location = response.Headers.Location ?? throw new InvalidOperationException("/authorize did not set Location header");
-        var query = System.Web.HttpUtility.ParseQueryString(location.Query);
-        var code = query[TokenRequest.Parameters.Code] ?? throw new InvalidOperationException($"No code in callback URI: {location}");
-        return code;
-    }
+        Dictionary<string, string> queryParams) =>
+        await AuthorizeAndExtractFromCallbackAsync(
+            client, discovery, queryParams, TokenRequest.Parameters.Code);
 
     /// <summary>
     /// Drives /authorize and asserts the AS redirected back to <c>redirect_uri</c> with an
@@ -103,7 +90,19 @@ public abstract class TestBase(TestFactory factory)
     protected static async Task<string> AuthorizeAndExtractErrorAsync(
         HttpClient client,
         DiscoveryDocument discovery,
-        Dictionary<string, string> queryParams)
+        Dictionary<string, string> queryParams) =>
+        await AuthorizeAndExtractFromCallbackAsync(client, discovery, queryParams, "error");
+
+    /// <summary>
+    /// Drives /authorize, asserts the AS responded with a 302/303 back to <c>redirect_uri</c>,
+    /// and returns the value of the requested callback-URI query parameter. Shared body of
+    /// <see cref="AuthorizeAndExtractCodeAsync"/> and <see cref="AuthorizeAndExtractErrorAsync"/>.
+    /// </summary>
+    private static async Task<string> AuthorizeAndExtractFromCallbackAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        Dictionary<string, string> queryParams,
+        string paramName)
     {
         var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, queryParams);
         var response = await client.GetAsync(uri);
@@ -112,7 +111,7 @@ public abstract class TestBase(TestFactory factory)
             $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: {await response.Content.ReadAsStringAsync()}");
         var location = response.Headers.Location ?? throw new InvalidOperationException("/authorize did not set Location header");
         var query = System.Web.HttpUtility.ParseQueryString(location.Query);
-        return query["error"] ?? throw new InvalidOperationException($"No error in callback URI: {location}");
+        return query[paramName] ?? throw new InvalidOperationException($"No '{paramName}' in callback URI: {location}");
     }
 
     protected static async Task<JsonObject> ExchangeCodeForTokensAsync(

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -63,11 +63,7 @@ public abstract class TestBase(TestFactory factory)
         IEnumerable<KeyValuePair<string, string>> form)
     {
         Assert.NotNull(discovery.PushedAuthorizationRequestEndpoint);
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        var response = await client.SendAsync(request);
+        var response = await FormPostHelpers.PostFormAsync(client, discovery.PushedAuthorizationRequestEndpoint!, form);
         var raw = await response.Content.ReadAsStringAsync();
         Assert.True(response.IsSuccessStatusCode, $"PAR failed: {(int)response.StatusCode} {raw}");
         var parsed = JsonNode.Parse(raw)?.AsObject();
@@ -119,11 +115,7 @@ public abstract class TestBase(TestFactory factory)
         DiscoveryDocument discovery,
         IEnumerable<KeyValuePair<string, string>> form)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        var response = await client.SendAsync(request);
+        var response = await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, form);
         var raw = await response.Content.ReadAsStringAsync();
         Assert.True(response.IsSuccessStatusCode, $"/token failed: {(int)response.StatusCode} {raw}");
         var parsed = JsonNode.Parse(raw)?.AsObject();
@@ -202,11 +194,7 @@ public abstract class TestBase(TestFactory factory)
     {
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
-        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.PushedAuthorizationRequestEndpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        return await client.SendAsync(request);
+        return await FormPostHelpers.PostFormAsync(client, discovery.PushedAuthorizationRequestEndpoint!, form);
     }
 
     /// <summary>
@@ -276,5 +264,31 @@ internal static class QueryHelpers
             ? query
             : builder.Query.TrimStart('?') + "&" + query;
         return builder.Uri;
+    }
+}
+
+internal static class FormPostHelpers
+{
+    /// <summary>
+    /// Posts <paramref name="form"/> as <c>application/x-www-form-urlencoded</c> to
+    /// <paramref name="endpoint"/>, optionally attaching a DPoP proof header. Returns
+    /// the raw response so callers can inspect status, body, and headers. Used by every
+    /// E2E helper that hits /par, /token, /refresh, or other form-based OAuth endpoints
+    /// — keeps the HttpRequestMessage + FormUrlEncodedContent + WithDPoPHeader plumbing
+    /// in one place.
+    /// </summary>
+    public static async Task<HttpResponseMessage> PostFormAsync(
+        HttpClient client,
+        Uri endpoint,
+        IEnumerable<KeyValuePair<string, string>> form,
+        string? dpopProof = null)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        if (dpopProof is not null)
+            request.WithDPoPHeader(dpopProof);
+        return await client.SendAsync(request);
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -128,9 +128,11 @@ public abstract class TestBase(TestFactory factory)
     {
         var parts = jwt.Split('.');
         Assert.True(parts.Length == 3, "JWT must have 3 segments");
+
         var payload = Base64UrlDecode(parts[1]);
         var parsed = JsonNode.Parse(payload)?.AsObject();
         Assert.NotNull(parsed);
+
         return parsed;
     }
 

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -1,6 +1,7 @@
 // Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 
+using System.Net;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
@@ -40,7 +41,7 @@ public abstract class TestBase(TestFactory factory)
         response.EnsureSuccessStatusCode();
         var doc = await response.Content.ReadFromJsonAsync<DiscoveryDocument>();
         Assert.NotNull(doc);
-        return doc!;
+        return doc;
     }
 
     protected static async Task<JsonObject> RegisterClientAsync(
@@ -54,7 +55,7 @@ public abstract class TestBase(TestFactory factory)
         Assert.True(response.IsSuccessStatusCode, $"DCR failed: {(int)response.StatusCode} {raw}");
         var parsed = JsonNode.Parse(raw)?.AsObject();
         Assert.NotNull(parsed);
-        return parsed!;
+        return parsed;
     }
 
     protected static async Task<JsonObject> PushAuthorizationRequestAsync(
@@ -68,7 +69,7 @@ public abstract class TestBase(TestFactory factory)
         Assert.True(response.IsSuccessStatusCode, $"PAR failed: {(int)response.StatusCode} {raw}");
         var parsed = JsonNode.Parse(raw)?.AsObject();
         Assert.NotNull(parsed);
-        return parsed!;
+        return parsed;
     }
 
     protected static async Task<string> AuthorizeAndExtractCodeAsync(
@@ -103,7 +104,7 @@ public abstract class TestBase(TestFactory factory)
         var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, queryParams);
         var response = await client.GetAsync(uri);
         Assert.True(
-            response.StatusCode is System.Net.HttpStatusCode.Redirect or System.Net.HttpStatusCode.Found,
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
             $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: {await response.Content.ReadAsStringAsync()}");
         var location = response.Headers.Location ?? throw new InvalidOperationException("/authorize did not set Location header");
         var query = System.Web.HttpUtility.ParseQueryString(location.Query);
@@ -120,7 +121,7 @@ public abstract class TestBase(TestFactory factory)
         Assert.True(response.IsSuccessStatusCode, $"/token failed: {(int)response.StatusCode} {raw}");
         var parsed = JsonNode.Parse(raw)?.AsObject();
         Assert.NotNull(parsed);
-        return parsed!;
+        return parsed;
     }
 
     protected static JsonObject DecodeJwtPayload(string jwt)
@@ -130,7 +131,7 @@ public abstract class TestBase(TestFactory factory)
         var payload = Base64UrlDecode(parts[1]);
         var parsed = JsonNode.Parse(payload)?.AsObject();
         Assert.NotNull(parsed);
-        return parsed!;
+        return parsed;
     }
 
     /// <summary>
@@ -189,7 +190,7 @@ public abstract class TestBase(TestFactory factory)
     /// asserting success). Use when a negative test expects PAR itself
     /// to fail (e.g. allowlist enforcement).
     /// </summary>
-    protected async Task<HttpResponseMessage> PushAuthorizationRequestRawAsync(
+    private async Task<HttpResponseMessage> PushAuthorizationRequestRawAsync(
         IEnumerable<KeyValuePair<string, string>> form)
     {
         var client = CreateClient();
@@ -250,45 +251,5 @@ public abstract class TestBase(TestFactory factory)
             case 3: padded += "="; break;
         }
         return Convert.FromBase64String(padded);
-    }
-}
-
-internal static class QueryHelpers
-{
-    public static Uri BuildUri(Uri baseUri, IEnumerable<KeyValuePair<string, string>> queryParams)
-    {
-        var builder = new UriBuilder(baseUri);
-        var query = string.Join('&', queryParams
-            .Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
-        builder.Query = string.IsNullOrEmpty(builder.Query)
-            ? query
-            : builder.Query.TrimStart('?') + "&" + query;
-        return builder.Uri;
-    }
-}
-
-internal static class FormPostHelpers
-{
-    /// <summary>
-    /// Posts <paramref name="form"/> as <c>application/x-www-form-urlencoded</c> to
-    /// <paramref name="endpoint"/>, optionally attaching a DPoP proof header. Returns
-    /// the raw response so callers can inspect status, body, and headers. Used by every
-    /// E2E helper that hits /par, /token, /refresh, or other form-based OAuth endpoints
-    /// — keeps the HttpRequestMessage + FormUrlEncodedContent + WithDPoPHeader plumbing
-    /// in one place.
-    /// </summary>
-    public static async Task<HttpResponseMessage> PostFormAsync(
-        HttpClient client,
-        Uri endpoint,
-        IEnumerable<KeyValuePair<string, string>> form,
-        string? dpopProof = null)
-    {
-        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
-        {
-            Content = new FormUrlEncodedContent(form),
-        };
-        if (dpopProof is not null)
-            request.WithDPoPHeader(dpopProof);
-        return await client.SendAsync(request);
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -8,7 +8,9 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.Model;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Abblix.Oidc.Server.Common.Constants;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests;
@@ -22,32 +24,6 @@ namespace Abblix.Oidc.Server.E2E.Tests;
 [Collection(TestCollection.Name)]
 public abstract class TestBase(TestFactory factory)
 {
-    /// <summary>
-    /// OAuth 2.0 / OIDC / RAR wire parameter names. Centralised so scenarios and
-    /// helpers don't sprinkle literal strings (Sonar S1192) and a rename surfaces
-    /// in one place.
-    /// </summary>
-    protected static class WireParameters
-    {
-        public const string ClientId = "client_id";
-        public const string ClientSecret = "client_secret";
-        public const string ResponseType = "response_type";
-        public const string RedirectUri = "redirect_uri";
-        public const string Scope = "scope";
-        public const string State = "state";
-        public const string Nonce = "nonce";
-        public const string CodeChallenge = "code_challenge";
-        public const string CodeChallengeMethod = "code_challenge_method";
-        public const string CodeVerifier = "code_verifier";
-        public const string GrantType = "grant_type";
-        public const string Code = "code";
-        public const string RequestUri = "request_uri";
-        public const string RefreshToken = "refresh_token";
-        public const string Error = "error";
-        public const string AuthorizationDetails = "authorization_details";
-        public const string AccessToken = "access_token";
-    }
-
     [SuppressMessage("Minor Code Smell", "S1075",
         Justification = "TestServer in-memory base address; not a deployment URL.")]
     protected HttpClient CreateClient()
@@ -115,7 +91,7 @@ public abstract class TestBase(TestFactory factory)
             $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: {await response.Content.ReadAsStringAsync()}");
         var location = response.Headers.Location ?? throw new InvalidOperationException("/authorize did not set Location header");
         var query = System.Web.HttpUtility.ParseQueryString(location.Query);
-        var code = query[WireParameters.Code] ?? throw new InvalidOperationException($"No code in callback URI: {location}");
+        var code = query[TokenRequest.Parameters.Code] ?? throw new InvalidOperationException($"No code in callback URI: {location}");
         return code;
     }
 
@@ -136,7 +112,7 @@ public abstract class TestBase(TestFactory factory)
             $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: {await response.Content.ReadAsStringAsync()}");
         var location = response.Headers.Location ?? throw new InvalidOperationException("/authorize did not set Location header");
         var query = System.Web.HttpUtility.ParseQueryString(location.Query);
-        return query[WireParameters.Error] ?? throw new InvalidOperationException($"No error in callback URI: {location}");
+        return query["error"] ?? throw new InvalidOperationException($"No error in callback URI: {location}");
     }
 
     protected static async Task<JsonObject> ExchangeCodeForTokensAsync(
@@ -177,7 +153,7 @@ public abstract class TestBase(TestFactory factory)
         string clientSecret,
         string redirectUri,
         string authorizationDetailsWireJson,
-        string scope = "openid",
+        string scope = Scopes.OpenId,
         HttpClient? client = null)
     {
         client ??= CreateClient();
@@ -186,34 +162,34 @@ public abstract class TestBase(TestFactory factory)
 
         var parResponse = await PushAuthorizationRequestAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.ClientSecret] = clientSecret,
-            [WireParameters.ResponseType] = "code",
-            [WireParameters.RedirectUri] = redirectUri,
-            [WireParameters.Scope] = scope,
-            [WireParameters.State] = Guid.NewGuid().ToString("N"),
-            [WireParameters.Nonce] = Guid.NewGuid().ToString("N"),
-            [WireParameters.CodeChallenge] = challenge,
-            [WireParameters.CodeChallengeMethod] = "S256",
-            [WireParameters.AuthorizationDetails] = authorizationDetailsWireJson,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = clientSecret,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = redirectUri,
+            [AuthorizationRequest.Parameters.Scope] = scope,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+            [AuthorizationRequest.Parameters.AuthorizationDetails] = authorizationDetailsWireJson,
         });
-        var requestUri = parResponse[WireParameters.RequestUri]?.GetValue<string>()
+        var requestUri = parResponse[AuthorizationRequest.Parameters.RequestUri]?.GetValue<string>()
             ?? throw new InvalidOperationException("PAR did not return request_uri");
 
         var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.RequestUri] = requestUri,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
         });
 
         return await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
         {
-            [WireParameters.GrantType] = "authorization_code",
-            [WireParameters.Code] = code,
-            [WireParameters.RedirectUri] = redirectUri,
-            [WireParameters.CodeVerifier] = verifier,
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.ClientSecret] = clientSecret,
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = redirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = clientSecret,
         });
     }
 
@@ -248,22 +224,22 @@ public abstract class TestBase(TestFactory factory)
         var (_, challenge) = GeneratePkcePair();
         var response = await PushAuthorizationRequestRawAsync(new Dictionary<string, string>
         {
-            [WireParameters.ClientId] = clientId,
-            [WireParameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-            [WireParameters.ResponseType] = "code",
-            [WireParameters.RedirectUri] = TestConstants.RedirectUri,
-            [WireParameters.Scope] = "openid",
-            [WireParameters.CodeChallenge] = challenge,
-            [WireParameters.CodeChallengeMethod] = "S256",
-            [WireParameters.AuthorizationDetails] = authorizationDetailsWireJson,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+            [AuthorizationRequest.Parameters.AuthorizationDetails] = authorizationDetailsWireJson,
         });
 
         var raw = await response.Content.ReadAsStringAsync();
         Assert.False(response.IsSuccessStatusCode,
             $"Expected error response but got {(int)response.StatusCode}: {raw}");
         var body = JsonNode.Parse(raw)?.AsObject();
-        var errorCode = body?[WireParameters.Error]?.GetValue<string>();
-        Assert.Equal("invalid_authorization_details", errorCode);
+        var errorCode = body?["error"]?.GetValue<string>();
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, errorCode);
     }
 
     internal static (string Verifier, string Challenge) GeneratePkcePair()

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -266,7 +266,7 @@ public abstract class TestBase(TestFactory factory)
         Assert.Equal("invalid_authorization_details", errorCode);
     }
 
-    protected static (string Verifier, string Challenge) GeneratePkcePair()
+    internal static (string Verifier, string Challenge) GeneratePkcePair()
     {
         var verifierBytes = RandomNumberGenerator.GetBytes(32);
         var verifier = Base64UrlEncode(verifierBytes);

--- a/Abblix.Oidc.Server.E2E.Tests/TestFactory.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestFactory.cs
@@ -1,8 +1,8 @@
 // Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -32,12 +32,10 @@ public class TestFactory : WebApplicationFactory<Program>
         });
     }
 
-    [SuppressMessage("Minor Code Smell", "S1075",
-        Justification = "TestServer in-memory base address; not a deployment URL.")]
     protected override void ConfigureClient(HttpClient client)
     {
         // OIDC MVC controllers carry [RequireHttps]; force the in-memory
         // TestServer client to https://localhost so Request.IsHttps == true.
-        client.BaseAddress = new Uri("https://localhost");
+        client.BaseAddress = TestServerAddress.BaseAddress;
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/DPoPProofGenerator.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/DPoPProofGenerator.cs
@@ -1,0 +1,138 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+
+namespace Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+
+/// <summary>
+/// Mints signed DPoP proof JWS values for E2E flows. One generator instance owns one
+/// ECDSA P-256 keypair (the proof-of-possession key the access token will be bound to);
+/// it produces a fresh proof per call, each carrying its own <c>jti</c> and current-time
+/// <c>iat</c> so the replay cache lets it through. The same instance is reused across
+/// PAR + /token + /userinfo in a single flow so every step proves possession of the
+/// same key — that's the whole RFC 9449 invariant.
+/// </summary>
+/// <remarks>
+/// Mirrors the unit-test <c>DPoPProofBuilder</c> in shape (the validator's view of a
+/// proof is identical regardless of who built it), but lives in the E2E test assembly
+/// so scenario files can mint proofs directly without crossing assembly boundaries.
+/// The unit-side builder offers fine-grained mutation knobs (CorruptSignature,
+/// IncludePrivateInJwk, …) for negative validation tests; this generator stays on the
+/// success path because E2E scenarios drive negatives via "wrong key" / "no header" /
+/// "wrong URI" — different keypairs and method/URI inputs, not crafted bad proofs.
+/// </remarks>
+public sealed class DPoPProofGenerator : IDisposable
+{
+    private readonly ECDsa _ecdsa;
+    private readonly TimeProvider _timeProvider;
+
+    public DPoPProofGenerator(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var publicParams = _ecdsa.ExportParameters(includePrivateParameters: false);
+        PublicJwk = new EllipticCurveJsonWebKey
+        {
+            Algorithm = SigningAlgorithms.ES256,
+            Usage = PublicKeyUsages.Signature,
+        }.Apply(publicParams);
+    }
+
+    /// <summary>Public half of the proof-of-possession key — what the AS sees in the
+    /// proof's <c>jwk</c> header and what the issued access token's <c>cnf.jkt</c>
+    /// binds to.</summary>
+    public EllipticCurveJsonWebKey PublicJwk { get; }
+
+    /// <summary>RFC 7638 JWK thumbprint of <see cref="PublicJwk"/>, base64url-encoded —
+    /// the value the AS commits to as <c>dpop_jkt</c> on PAR and emits as <c>cnf.jkt</c>
+    /// on the access token. Tests assert against this verbatim.</summary>
+    public string Thumbprint => PublicJwk.ComputeJwkThumbprintBase64Url();
+
+    /// <summary>
+    /// Builds a DPoP proof for the given request, signed with this generator's keypair.
+    /// Each call mints a fresh <c>jti</c> and uses the current wall-clock <c>iat</c>;
+    /// presenting the same returned string twice trips the AS replay cache on the second
+    /// attempt (the canonical E2E replay scenario).
+    /// </summary>
+    /// <param name="httpMethod">HTTP method byte-exact (RFC 9449 §4.2 <c>htm</c>).
+    /// Uppercase per IETF convention.</param>
+    /// <param name="requestUri">Absolute URI of the request after RFC 3986 §6.2
+    /// canonicalisation. Pass exactly what the client will send on the wire; the
+    /// validator canonicalises both sides before comparing.</param>
+    /// <param name="accessToken">When the proof accompanies an access token at a
+    /// protected resource, the proof MUST carry <c>ath = base64url(sha256(token))</c>
+    /// per RFC 9449 §4.2. Pass the raw access token here and the generator embeds the
+    /// hash. Leave null at the /token endpoint and elsewhere proof-only.</param>
+    /// <param name="nonce">RFC 9449 §8 server-supplied freshness nonce. Pass the value
+    /// from the previous response's <c>DPoP-Nonce</c> header when the AS challenged for
+    /// one; leave null for nonce-disabled deployments (the E2E default).</param>
+    public string BuildProof(
+        string httpMethod,
+        Uri requestUri,
+        string? accessToken = null,
+        string? nonce = null)
+    {
+        var header = new JsonObject
+        {
+            ["typ"] = JwtTypes.DPoPProof,
+            ["alg"] = SigningAlgorithms.ES256,
+            [JwtClaimTypes.JsonWebKeyHeader] = JsonSerializer.SerializeToNode(PublicJwk),
+        };
+
+        var payload = new JsonObject
+        {
+            [JwtClaimTypes.DPoPHttpMethod] = httpMethod,
+            [JwtClaimTypes.DPoPHttpUri] = requestUri.AbsoluteUri,
+            [JwtClaimTypes.JwtId] = Guid.NewGuid().ToString("N"),
+            [JwtClaimTypes.IssuedAt] = _timeProvider.GetUtcNow().ToUnixTimeSeconds(),
+        };
+
+        if (accessToken is not null)
+        {
+            payload[JwtClaimTypes.DPoPAccessTokenHash] =
+                Base64Url.EncodeToString(SHA256.HashData(Encoding.ASCII.GetBytes(accessToken)));
+        }
+
+        if (nonce is not null)
+            payload["nonce"] = nonce;
+
+        var headerB64 = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(header.ToJsonString()));
+        var payloadB64 = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload.ToJsonString()));
+        var signingInput = $"{headerB64}.{payloadB64}";
+
+        var signature = _ecdsa.SignData(
+            Encoding.UTF8.GetBytes(signingInput),
+            HashAlgorithmName.SHA256,
+            DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+
+        return $"{signingInput}.{Base64Url.EncodeToString(signature)}";
+    }
+
+    public void Dispose() => _ecdsa.Dispose();
+}

--- a/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/HttpClientDPoPExtensions.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/HttpClientDPoPExtensions.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Constants;
+
+namespace Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+
+/// <summary>
+/// Per-request DPoP header attachment for E2E scenarios. The proof is request-bound
+/// (htm + htu carve out the exact endpoint), so DPoP is NOT a default-header
+/// candidate the way Authorization is — every request needs its own proof minted
+/// against its own method + URI. These helpers wrap that wiring so test code reads
+/// at flow-step granularity.
+/// </summary>
+internal static class HttpClientDPoPExtensions
+{
+    /// <summary>
+    /// Attaches the supplied proof JWT to <paramref name="request"/> in the RFC 9449
+    /// <c>DPoP</c> header. The caller is responsible for having minted the proof against
+    /// the same method + URI the request will hit — there is no AS leniency on either.
+    /// </summary>
+    public static HttpRequestMessage WithDPoPHeader(this HttpRequestMessage request, string proofJwt)
+    {
+        request.Headers.Add(HttpRequestHeaders.DPoP, proofJwt);
+        return request;
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/NonceEnabledTestFactory.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/NonceEnabledTestFactory.cs
@@ -1,0 +1,57 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/Oidc.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+
+/// <summary>
+/// Variant of <see cref="Tests.TestFactory"/> that flips on the RFC 9449 §8 nonce
+/// requirement at both the token endpoint and the UserInfo endpoint. Hosted under a
+/// separate xunit collection so the singleton <see cref="WebApplicationFactory{TEntryPoint}"/>
+/// inside this factory never shares state with the default flow tests — toggling
+/// <c>OidcOptions.DPoP.Nonce.RequireAtTokenEndpoint</c> globally would otherwise
+/// cascade unrelated tests into the nonce challenge loop.
+/// </summary>
+public sealed class NonceEnabledTestFactory : TestFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
+                new PostConfigureOptions<OidcOptions>(
+                    Options.DefaultName,
+                    options =>
+                    {
+                        options.DPoP.Nonce.RequireAtTokenEndpoint = true;
+                        options.DPoP.Nonce.RequireAtUserInfoEndpoint = true;
+                    }));
+        });
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/TestServerAddress.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/TestServerAddress.cs
@@ -1,0 +1,21 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+
+/// <summary>
+/// Single source for the in-memory TestServer's base address. Centralised so the
+/// Sonar S1075 hardcoded-URI suppression lives in one spot rather than spreading
+/// across every factory/test that instantiates an HttpClient. The TestServer is
+/// not a deployment surface — its base URL is host-anchored on
+/// <c>https://localhost</c> only because the OIDC MVC controllers carry
+/// <c>[RequireHttps]</c> and need <c>Request.IsHttps == true</c>.
+/// </summary>
+public static class TestServerAddress
+{
+    [SuppressMessage("Minor Code Smell", "S1075",
+        Justification = "In-memory TestServer base address; not a deployment URL.")]
+    public static readonly Uri BaseAddress = new("https://localhost");
+}

--- a/Abblix.Oidc.Server/Common/Configuration/ClientJwksConfigurationExtensions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ClientJwksConfigurationExtensions.cs
@@ -109,7 +109,7 @@ public static class ClientJwksConfigurationExtensions
             // polymorphic JsonWebKey entries), so a plain "Jwks is not null" guard
             // skips clients whose JWKs the host actually does want bound from config,
             // leaving signature verification at runtime with zero keys for the issuer.
-            if (client.Jwks is { Keys: { Length: > 0 } })
+            if (client.Jwks is { Keys.Length: > 0 })
                 continue;
 
             if (jwksSection.Get<JsonWebKeySetSettings>() is {} jwks)

--- a/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
@@ -93,21 +93,36 @@ public class TokenRequestProcessor(
 
 		if (authContext.Scope.HasFlag(Scopes.OfflineAccess))
 		{
-			// RFC 9449 §5: confidential clients' refresh tokens are not separately
-			// DPoP-bound — client authentication already sender-constrains them. Stripping
-			// the committed jkt from the persisted refresh-token context lets the next
-			// refresh call skip the committed-vs-presented compare in
-			// DPoPTokenEndpointValidator. The new access token's cnf.jkt is independently
-			// re-derived from the live proof in TokenAuthorizationContextEvaluator.
-			var refreshContext = clientInfo.ClientType == ClientType.Confidential
-				? request.AuthorizedGrant.Context with { ProofKeyThumbprint = null }
-				: request.AuthorizedGrant.Context;
+			var refreshContext = request.AuthorizedGrant.Context with
+			{
+				// RFC 9449 §5 confidential-vs-public split:
+				ProofKeyThumbprint = clientInfo.ClientType switch
+				{
+					//   * Confidential clients: refresh tokens are not separately DPoP-bound,
+					//     client authentication already sender-constrains them. Stripping the
+					//     committed jkt from the persisted refresh-token context lets a follow-up
+					//     refresh call skip the committed-vs-presented compare in
+					//     DPoPTokenEndpointValidator, allowing key rotation per §5's carve-out.
+					ClientType.Confidential => null,
+
+					//   * Public clients: DPoP is the SOLE sender-constraint, so §5 mandates
+					//     same-key MUST on every refresh. Source the binding from authContext
+					//     (the evaluator stamps the live proof's thumbprint) rather than from
+					//     the original grant context, otherwise a non-PAR initial flow loses
+					//     the binding and the next refresh would accept any key — a §5 violation.
+					//     authContext.ProofKeyThumbprint is null when the request carried no proof,
+					//     which keeps Bearer-only public flows unchanged.
+					_ => authContext.ProofKeyThumbprint,
+				},
+			};
 
 			response.RefreshToken = await refreshTokenService.CreateRefreshTokenAsync(
 				request.AuthorizedGrant.AuthSession,
 				refreshContext,
 				clientInfo,
-				request.AuthorizedGrant is RefreshTokenAuthorizedGrant { RefreshToken: var refreshToken } ? refreshToken : null);
+				request.AuthorizedGrant is RefreshTokenAuthorizedGrant { RefreshToken: var refreshToken }
+					? refreshToken
+					: null);
 		}
 
 		if (authContext.Scope.HasFlag(Scopes.OpenId))


### PR DESCRIPTION
## Summary

- **25 new DPoP E2E scenarios** covering RFC 9449 §4-11 end-to-end against the test OIDC provider
- **Production fix** in `TokenRequestProcessor`: public-client refresh now preserves the DPoP binding even without a PAR commitment (RFC §5 MUST was silently bypassed before)
- **New E2E test infrastructure**: `DPoPProofGenerator`, `WithDPoPHeader` extension, `NonceEnabledTestFactory` + dedicated xunit collection
- **TestHost**: 3 new seeded clients — `e2e-dpop-required`, `e2e-dpop-opportunistic`, `e2e-dpop-public`
- **`DiscoveryDocument`** model: URL fields now `Uri` (fail at JSON parse, not first HTTP call); + `userinfo_endpoint`, + `dpop_signing_alg_values_supported`
- **Magic-string sweep**: 109 callsites moved off the test-local `WireParameters` static class onto library `Common.Constants.*` and `Model.XxxRequest.Parameters.*` directly; `WireParameters` deleted
- **Carry-over chore commit**: small linter cleanup left uncommitted on develop from PR #135

## RFC 9449 compliance matrix

| RFC § | Scenarios | Type |
|---|---|---|
| §4 (proof structure) | unit + via §5/§7/§10 paths |  |
| §5 token issuance + `token_type=DPoP` + `cnf.jkt` binding | 4 (opp + req variants) | MUST |
| §5 confidential refresh rebind allowed | 1 (`Confidential_client_can_rebind_…`) | MUST carve-out |
| §5 public refresh same-key MUST (PAR-anchored) | 2 (same-key + rotated-key reject) | MUST |
| §5 public refresh same-key MUST (non-PAR) | 2 (same-key + rotated-key reject) | MUST — **pins production fix** |
| §5.1 `dpop_signing_alg_values_supported` discovery | 1 | SHOULD |
| §6 `cnf.jkt` claim in access token | covered by every binding test | MUST |
| §7.1 UserInfo access + ath + WWW-Authenticate | 4 (success + scheme/key mismatches) | MUST + SHOULD |
| §7.2 Bearer↔DPoP downgrade reject | 1 | MUST |
| §8 AS-side nonce challenge | 2 (challenge + retry) | MUST |
| §9 RS-side nonce challenge | 2 (challenge + retry) | MUST |
| §10 PAR `dpop_jkt` carry-over | 3 (match + mismatch + missing-proof) | MUST |
| §11.1 replay protection | 1 | implementation MUST |
| §11.1 / §4.3 wire-level error contract for proof-validator failures | 2 (htm mismatch + corrupt signature) | wire contract |
| §11.3/4/5 alg/sig/thumbprint failures | unit (`ProofValidatorTests`) |  |
| §11.6/7 privacy/DoS | non-functional |  |

Every assertion traces to a spec MUST/SHOULD or an explicit Abblix-side defensive posture (one such — `UserInfo_unbound_token_presented_as_dpop_is_rejected` — marked in the test's comment).

## Production-side fix

`TokenRequestProcessor.cs`: for public clients, the refresh-token context now sources `ProofKeyThumbprint` from `authContext` (where `TokenAuthorizationContextEvaluator` stamps the live proof's thumbprint) rather than from the un-evaluated `request.AuthorizedGrant.Context`. Before the fix, a public client running a non-PAR initial flow (authorize + DPoP proof at /token only, no `request_uri`) lost the proof-of-possession binding through the refresh token, and a follow-up refresh with a rotated key was silently accepted — a §5 MUST violation. Confidential semantics unchanged: the §5 carve-out continues to strip the jkt because client authentication already sender-constrains.

The `Public_client_non_par_refresh_with_different_dpop_key_is_rejected_…` regression test would fail before the fix; together with the PAR-anchored variants, the four §5 public-client tests now pin both binding paths.

## Verification

- E2E: 23 → 48 (+25)
- UnitTests: 2014 (unchanged)
- WWW-Authenticate: DPoP challenge asserted on every UserInfo 401 (RFC §7.1 SHOULD)