### PR TITLE
refactor(jwt): replace ICriticalHeaderHandler marker with self-declaring contract (#134)

### DIFF
--- a/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
+++ b/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
@@ -28,9 +28,12 @@ using Xunit;
 namespace Abblix.Jwt.UnitTests;
 
 /// <summary>
-/// Unit tests for the JWS 'crit' header parameter validation per RFC 7515 §4.1.11.
-/// Tokens are signed with a real RSA key so the signature step passes; the focus is on the
-/// post-signature 'crit' validation pass that decides whether the JOSE header itself is acceptable.
+/// Unit tests for the JWS 'crit' header parameter validation per RFC 7515 §4.1.11. Tokens are
+/// signed with a real RSA key so the signature step passes; the focus is on the post-signature
+/// 'crit' validation pass that decides whether the JOSE header itself is acceptable. Library
+/// ships with zero <see cref="ICriticalHeaderHandler"/> implementations by default — the
+/// «no handler registered» tests exercise the rejection branch, the handler-backed tests
+/// register a test-double handler for <c>"b64"</c> to walk the happy and side-effect paths.
 /// </summary>
 public class CriticalHeaderTests
 {
@@ -115,12 +118,13 @@ public class CriticalHeaderTests
 
     /// <summary>
     /// Every name in 'crit' MUST also appear as a header parameter in the JOSE header.
-    /// A name in 'crit' but absent from the header is a "dangling" reference.
+    /// A name in 'crit' but absent from the header is a "dangling" reference — the validator
+    /// rejects on this earlier guard before reaching the "unknown extension" fallthrough.
     /// </summary>
     [Fact]
     public async Task TokenWithCritNameNotPresentInHeader_FailsValidation()
     {
-        var sp = CreateServiceProvider(ExtensionName);
+        var sp = CreateServiceProvider();
         var jwt = await IssueTokenWithHeader(
             sp,
             criticalNode: new JsonArray((JsonNode)ExtensionName),
@@ -133,9 +137,11 @@ public class CriticalHeaderTests
     }
 
     /// <summary>
-    /// A 'crit' name that names an extension the host has not registered MUST be rejected
+    /// A 'crit' name that names an extension this library does not understand MUST be rejected
     /// (RFC 7515 §4.1.11: "If any of the listed extension Header Parameters are not understood
-    /// and supported by the recipient, then the JWS is invalid").
+    /// and supported by the recipient, then the JWS is invalid"). The library currently
+    /// understands no extensions, so any well-formed 'crit' that survives the malformation
+    /// guards lands here.
     /// </summary>
     [Fact]
     public async Task TokenWithUnknownExtensionInCrit_FailsValidation()
@@ -150,25 +156,6 @@ public class CriticalHeaderTests
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(JwtError.InvalidToken, error.Error);
-    }
-
-    /// <summary>
-    /// When the host has registered a handler for the 'crit' name and the named header is
-    /// present in the JOSE header, validation succeeds. This is the happy path that lets a
-    /// future RFC 7797 / DPoP-style extension be wired into the validator without library changes.
-    /// </summary>
-    [Fact]
-    public async Task TokenWithRegisteredExtensionInCrit_Validates()
-    {
-        var sp = CreateServiceProvider(ExtensionName);
-        var jwt = await IssueTokenWithHeader(
-            sp,
-            criticalNode: new JsonArray((JsonNode)ExtensionName),
-            extensionValue: false);
-
-        var result = await Validate(sp, jwt);
-
-        Assert.True(result.TryGetSuccess(out _));
     }
 
     /// <summary>
@@ -204,22 +191,113 @@ public class CriticalHeaderTests
         Assert.Equal(JwtError.InvalidToken, error.Error);
     }
 
-    private static IServiceProvider CreateServiceProvider(params string[] understoodHeaderNames)
+    /// <summary>
+    /// When the host registers a handler whose <see cref="ICriticalHeaderHandler.UnderstoodNames"/>
+    /// covers the 'crit' name and the matching header is present, validation succeeds. This is
+    /// the happy path that lets a future RFC 7797 / RFC 8225 / custom extension plug in without
+    /// further library changes.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithRegisteredHandlerInCrit_Validates()
+    {
+        var sp = CreateServiceProvider(services =>
+            services.AddCriticalHeaderHandler<NoopB64Handler>());
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName),
+            extensionValue: false);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// When a registered handler rejects the JWS, the validator surfaces the handler's
+    /// <see cref="JwtValidationError"/> verbatim — confirming that the handler is actually
+    /// invoked (not bypassed by an earlier guard) and that its decision is the validator's
+    /// decision.
+    /// </summary>
+    [Fact]
+    public async Task HandlerReturningError_PropagatesAsValidationFailure()
+    {
+        var sp = CreateServiceProvider(services =>
+            services.AddCriticalHeaderHandler<RejectingB64Handler>());
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName),
+            extensionValue: false);
+
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Equal(RejectingB64Handler.RejectionReason, error.ErrorDescription);
+    }
+
+    /// <summary>
+    /// Two handlers claiming the same JWS 'crit' header name is a host-misconfiguration. The
+    /// validator surfaces it at construction time so the host fails to boot, not on the first
+    /// validating request — boot-time failures are far easier to diagnose than per-request
+    /// rejection cascades.
+    /// </summary>
+    [Fact]
+    public void TwoHandlersClaimingSameName_ThrowsAtValidatorConstruction()
+    {
+        var sp = CreateServiceProvider(services =>
+        {
+            services.AddCriticalHeaderHandler<NoopB64Handler>();
+            services.AddCriticalHeaderHandler<RejectingB64Handler>();
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => sp.GetRequiredService<IJsonWebTokenValidator>());
+        Assert.Contains("'b64'", ex.Message);
+        Assert.Contains(nameof(ICriticalHeaderHandler), ex.Message);
+    }
+
+    private static IServiceProvider CreateServiceProvider(Action<IServiceCollection>? configure = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton(TimeProvider.System);
         services.AddLogging();
         services.AddJsonWebTokens();
-        foreach (var name in understoodHeaderNames)
-            services.AddCriticalHeaderHandler<UnderstoodHandler>(name);
+        configure?.Invoke(services);
         return services.BuildServiceProvider();
     }
 
     /// <summary>
-    /// Empty marker implementation used to fill keyed <see cref="ICriticalHeaderHandler"/>
-    /// registrations in tests; the validator only checks for presence by header name.
+    /// Test-double handler that declares understanding of <c>"b64"</c> (RFC 7797 name reused
+    /// here for convenience; this handler does not implement RFC 7797's signature-input
+    /// transformation — the JWS we sign carries a bare boolean header field). Always
+    /// short-circuits to success, matching the «signature-affecting extension whose work lives
+    /// in the signing pipeline» mode.
     /// </summary>
-    private sealed class UnderstoodHandler : ICriticalHeaderHandler;
+    private sealed class NoopB64Handler : ICriticalHeaderHandler
+    {
+        public IReadOnlySet<string> UnderstoodNames { get; } =
+            new HashSet<string>(StringComparer.Ordinal) { ExtensionName };
+
+        public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context)
+            => Task.FromResult<JwtValidationError?>(null);
+    }
+
+    /// <summary>
+    /// Test-double handler that declares understanding of <c>"b64"</c> and rejects every
+    /// JWS — used to verify that handler rejection actually propagates through the validator
+    /// (and that no earlier guard short-circuits past the handler invocation).
+    /// </summary>
+    private sealed class RejectingB64Handler : ICriticalHeaderHandler
+    {
+        public const string RejectionReason = "test-double handler rejection";
+
+        public IReadOnlySet<string> UnderstoodNames { get; } =
+            new HashSet<string>(StringComparer.Ordinal) { ExtensionName };
+
+        public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context)
+            => Task.FromResult<JwtValidationError?>(
+                new JwtValidationError(JwtError.InvalidToken, RejectionReason));
+    }
 
     private static async Task<string> IssueTokenWithHeader(
         IServiceProvider sp,

--- a/Abblix.Jwt/CriticalHeaderContext.cs
+++ b/Abblix.Jwt/CriticalHeaderContext.cs
@@ -1,0 +1,29 @@
+namespace Abblix.Jwt;
+
+/// <summary>
+/// Per-call context passed to <see cref="ICriticalHeaderHandler.HandleAsync"/>.
+/// Reference type with init-only properties so adding a future field is a
+/// non-breaking change for handler implementations.
+/// </summary>
+public sealed class CriticalHeaderContext
+{
+    /// <summary>The parsed JWS being validated. Handlers typically read
+    /// <c>Token.Header.Json[name]</c> for their declared name; payload access
+    /// is available when the extension's semantics span both halves
+    /// (e.g. RFC 8225 PASSporT profile rules).</summary>
+    public required JsonWebToken Token { get; init; }
+
+    /// <summary>The host-supplied validation parameters in force for this
+    /// call. Handlers consult these to honour caller policy (algorithm
+    /// allowlists, time skew, audience/issuer hooks).</summary>
+    public required ValidationParameters Parameters { get; init; }
+
+    /// <summary>The validator's <see cref="TimeProvider"/>. Handlers read the
+    /// current instant from this so freshness checks honour the host's
+    /// fake-clock configuration in tests.</summary>
+    public required TimeProvider TimeProvider { get; init; }
+
+    /// <summary>Caller cancellation propagation for I/O-bound handlers
+    /// (replay-store lookups, audit emitters).</summary>
+    public CancellationToken CancellationToken { get; init; }
+}

--- a/Abblix.Jwt/ICriticalHeaderHandler.cs
+++ b/Abblix.Jwt/ICriticalHeaderHandler.cs
@@ -7,7 +7,7 @@
 //
 // LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
 // in any form outside of the official GitHub repository at:
-// https://github.com/Abblix/OIDC.Server. All development and modifications
+// https://github.com/Abblix/Oidc.Server. All development and modifications
 // must occur within the official repository and are managed solely by Abblix LLP.
 //
 // Unauthorized use, modification, or distribution of this software is strictly
@@ -23,19 +23,74 @@
 namespace Abblix.Jwt;
 
 /// <summary>
-/// Marker that declares the host implementation understands a specific JOSE header parameter
-/// listed in a JWS 'crit' header (RFC 7515 §4.1.11). Handlers are registered as keyed services
-/// where the DI key is the header parameter name (for example "b64", or "iat" for DPoP) — the
-/// key is the source of truth for the name, so this contract does not need to expose it.
+/// Recipient-side handler for one JWS 'crit' header extension spec (RFC 7515 §4.1.11).
+/// Covers «understood AND processed»: the implementation declares which JOSE header
+/// parameter name(s) the extension introduces via <see cref="UnderstoodNames"/>, and
+/// applies the extension's recipient-side semantics via <see cref="HandleAsync"/>.
 /// </summary>
 /// <remarks>
-/// RFC 7515 §4.1.11 requires verifiers to reject any JWS whose 'crit' header lists a parameter
-/// the verifier does not understand. Hosts implementing JOSE extensions register a handler
-/// keyed by each supported extension name via
-/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>; the validator
-/// rejects any JWS whose 'crit' lists a name that has no matching keyed registration. The
-/// contract is intentionally empty for now: when a concrete extension lands and needs
-/// value-level processing, methods will be added here and existing keyed registrations remain
-/// valid.
+/// <para>
+/// One method, <see cref="HandleAsync"/>, intentionally collapses «validate» and
+/// «handle». Every realistic crit extension reads the header, optionally performs
+/// side effects (consume a replay nonce, emit an audit event), and returns
+/// success or a typed error. Splitting into validate+handle methods would tear
+/// related code apart — nonce extraction, freshness check, and consumption are
+/// one logical step.
+/// </para>
+/// <para>
+/// Two realistic processing modes share this shape:
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <b>Validate-only</b> — read the header value, compare against local
+///       policy, accept or reject. Pure function over the JWT. Examples:
+///       RFC 8225 'ppt' (PASSporT Type), enterprise-policy headers.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Stateful handler</b> — read the header value, mutate external state
+///       (replay-cache, audit log, counters), accept or reject. Example:
+///       ACME-style 'nonce' (RFC 8555 §6.5.2) consumption with atomic
+///       single-use semantics.
+///     </description>
+///   </item>
+/// </list>
+/// </para>
+/// <para>
+/// Signature-affecting crit extensions (RFC 7797 'b64' — Unencoded Payload Option)
+/// need a pre-signature hook that transforms the JWS Signing Input bytes, which
+/// MUST run before signature verification. That hook is a separate sibling
+/// contract on the signing pipeline (out of scope for this interface). A b64
+/// implementation of THIS interface is a thin shim that declares understanding
+/// of "b64" and short-circuits to success — successful signature verification
+/// already proves the directive was honoured.
+/// </para>
+/// <para>
+/// Register with
+/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>.
+/// Two handlers claiming the same name fail loud at validator construction —
+/// each crit name MUST have exactly one handler.
+/// </para>
 /// </remarks>
-public interface ICriticalHeaderHandler;
+public interface ICriticalHeaderHandler
+{
+    /// <summary>
+    /// JOSE header parameter names this handler implements. Byte-exact match
+    /// per RFC 7515 §5.3. MUST be non-empty. Multi-name is allowed for specs
+    /// that introduce a family of related parameters (rare); most extensions
+    /// declare a single name.
+    /// </summary>
+    IReadOnlySet<string> UnderstoodNames { get; }
+
+    /// <summary>
+    /// Apply the extension's recipient-side semantics. May read the parsed
+    /// token (header and payload), consult external state via the context's
+    /// time provider or DI-injected dependencies, perform side effects, and
+    /// reject the JWS by returning a non-null <see cref="JwtValidationError"/>.
+    /// Return <see langword="null"/> on success.
+    /// </summary>
+    /// <param name="context">Per-call inputs (parsed token, validation
+    /// parameters, time provider, cancellation token).</param>
+    Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context);
+}

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -25,7 +25,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Utils;
-using Microsoft.Extensions.DependencyInjection;
 
 using System.Buffers.Text;
 
@@ -38,17 +37,59 @@ namespace Abblix.Jwt;
 /// <param name="encryptor">The JWE encryptor for decrypting encrypted tokens.</param>
 /// <param name="signer">The JWS signer for validating signatures.</param>
 /// <param name="signingAlgorithmsProvider">The provider for supported signing algorithms.</param>
-/// <param name="serviceProvider">Resolves keyed <see cref="ICriticalHeaderHandler"/> registrations
-/// when validating a JWS 'crit' header (RFC 7515 §4.1.11). Hosts register a handler keyed by each
-/// understood JOSE header parameter name via
+/// <param name="critHandlers">Registered handlers for JWS 'crit' header extensions
+/// (RFC 7515 §4.1.11). Each handler self-declares its understood header parameter names
+/// via <see cref="ICriticalHeaderHandler.UnderstoodNames"/>; the validator routes a
+/// 'crit' name to its single owning handler at validation time. An empty enumerable is
+/// the default — the library currently understands no crit extensions and rejects every
+/// well-formed 'crit' header until a host registers a handler via
 /// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>.</param>
 internal class JsonWebTokenValidator(
     TimeProvider timeProvider,
     IJsonWebTokenEncryptor encryptor,
     IJsonWebTokenSigner signer,
     SigningAlgorithmsProvider signingAlgorithmsProvider,
-    IServiceProvider serviceProvider) : IJsonWebTokenValidator
+    IEnumerable<ICriticalHeaderHandler> critHandlers) : IJsonWebTokenValidator
 {
+    /// <summary>
+    /// Name → owning handler lookup built once at construction. Building here surfaces
+    /// host-misconfiguration (two handlers claiming the same name, empty UnderstoodNames)
+    /// at first <see cref="IJsonWebTokenValidator"/> resolution rather than at the first
+    /// validating request — boot-time failures are easier to diagnose than per-request
+    /// rejection cascades.
+    /// </summary>
+    private readonly IReadOnlyDictionary<string, ICriticalHeaderHandler> _critHandlersByName =
+        BuildCritHandlerLookup(critHandlers);
+
+    private static IReadOnlyDictionary<string, ICriticalHeaderHandler> BuildCritHandlerLookup(
+        IEnumerable<ICriticalHeaderHandler> handlers)
+    {
+        var lookup = new Dictionary<string, ICriticalHeaderHandler>(StringComparer.Ordinal);
+        foreach (var handler in handlers)
+        {
+            if (handler.UnderstoodNames.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"{handler.GetType().FullName} declared an empty " +
+                    $"{nameof(ICriticalHeaderHandler.UnderstoodNames)} set — at least one JWS 'crit' " +
+                    "header name is required for a handler to ever be routed to.");
+            }
+
+            foreach (var name in handler.UnderstoodNames)
+            {
+                if (lookup.TryGetValue(name, out var existing))
+                {
+                    throw new InvalidOperationException(
+                        $"Two {nameof(ICriticalHeaderHandler)} registrations claim the same JWS 'crit' " +
+                        $"header name '{name}': {existing.GetType().FullName} and " +
+                        $"{handler.GetType().FullName}. Each crit name MUST have exactly one handler.");
+                }
+                lookup[name] = handler;
+            }
+        }
+        return lookup;
+    }
+
     /// <summary>
     /// Header parameter names defined by RFC 7515 §4.1 (and 'crit' itself). Per RFC 7515 §4.1.11
     /// a producer MUST NOT list any of these in 'crit'; we reject as recipient-MAY because
@@ -102,26 +143,20 @@ internal class JsonWebTokenValidator(
     }
 
     /// <summary>
-    /// Validates a JWS token from string parts.
-    /// Creates JsonWebToken only after successful validation.
+    /// Validates a JWS token from string parts. Each stage in the Bind chain either passes
+    /// the token through unchanged (success) or short-circuits the rest of the chain with
+    /// its <see cref="JwtValidationError"/>. Stages are ordered cheapest-and-most-categorical
+    /// first (signature, then header-level checks, then payload-level checks) so a malformed
+    /// or attacker-supplied token is rejected before any host-supplied callback is invoked.
     /// </summary>
-    private async Task<Result<JsonWebToken, JwtValidationError>> ValidateJwsAsync(
-        string[] jwtParts,
-        ValidationParameters parameters)
-    {
-        return await ParseJws(jwtParts).BindAsync<JsonWebToken>(async token =>
-        {
-            var error =
-                await ValidateSignatureAsync(token, jwtParts, parameters) ??
-                ValidateCriticalHeaders(token.Header) ??
-                ValidateTokenType(token.Header, parameters) ??
-                await ValidateIssuerAsync(token.Payload.Issuer, parameters) ??
-                await ValidateAudienceAsync(token.Payload.Audiences, parameters) ??
-                ValidateLifetime(token.Payload, parameters);
-
-            return error != null ? error : token;
-        });
-    }
+    private Task<Result<JsonWebToken, JwtValidationError>> ValidateJwsAsync(string[] jwtParts, ValidationParameters parameters)
+        => ParseJws(jwtParts)
+            .BindAsync(token => ValidateSignatureAsync(token, jwtParts, parameters))
+            .BindAsync(token => ValidateCriticalHeadersAsync(token, parameters))
+            .Bind(token => ValidateTokenType(token, parameters))
+            .BindAsync(token => ValidateIssuerAsync(token, parameters))
+            .BindAsync(token => ValidateAudienceAsync(token, parameters))
+            .Bind(token => ValidateLifetime(token, parameters));
 
     /// <summary>
     /// Parses JWS string parts into header, payload, and signature.
@@ -136,14 +171,24 @@ internal class JsonWebTokenValidator(
         }
         catch
         {
-            return new JwtValidationError(JwtError.MalformedToken, "Invalid JWT format: base64url decoding failed");
+            return new JwtValidationError(
+                JwtError.MalformedToken,
+                "Invalid JWT format: base64url decoding failed");
         }
 
         if (!TryParseJsonObject(headerPart, out var headerObject))
-            return new JwtValidationError(JwtError.MalformedToken, "Invalid JWS header: must be a JSON object");
+        {
+            return new JwtValidationError(
+                JwtError.MalformedToken,
+                "Invalid JWS header: must be a JSON object");
+        }
 
         if (!TryParseJsonObject(payloadPart, out var payloadObject))
-            return new JwtValidationError(JwtError.MalformedToken, "Invalid JWS payload: must be a JSON object");
+        {
+            return new JwtValidationError(
+                JwtError.MalformedToken,
+                "Invalid JWS payload: must be a JSON object");
+        }
 
         var token = new JsonWebToken
         {
@@ -169,9 +214,11 @@ internal class JsonWebTokenValidator(
     }
 
     /// <summary>
-    /// Validates the JWS signature according to validation parameters.
+    /// Validates the JWS signature according to validation parameters. Returns the token
+    /// unchanged on success — the chain stage adds nothing to the token, only gates the
+    /// rest of the pipeline behind a successful integrity proof.
     /// </summary>
-    private async Task<JwtValidationError?> ValidateSignatureAsync(
+    private async Task<Result<JsonWebToken, JwtValidationError>> ValidateSignatureAsync(
         JsonWebToken token,
         string[] jwtParts,
         ValidationParameters parameters)
@@ -216,12 +263,12 @@ internal class JsonWebTokenValidator(
                 return new JwtValidationError(
                     JwtError.MalformedToken, "Unsigned token must have empty signature");
 
-            case not SigningAlgorithms.None
-                when parameters.Options.HasAnyFlag(ValidationOptions.RequireSignedTokens | ValidationOptions.ValidateIssuerSigningKey):
+            case not SigningAlgorithms.None when parameters.Options.HasAnyFlag(
+                    ValidationOptions.RequireSignedTokens | ValidationOptions.ValidateIssuerSigningKey):
                 break;
 
             default:
-                return null;
+                return token;
         }
 
         // Two trust-model branches selected by the caller via UseEmbeddedVerificationKey:
@@ -246,11 +293,12 @@ internal class JsonWebTokenValidator(
     /// supplies the candidate key.</param>
     /// <param name="jwtParts">The three compact-serialization segments
     /// (<c>header.payload.signature</c>) needed to recompute and compare the signature.</param>
-    /// <returns><c>null</c> on success, or a <see cref="JwtValidationError"/> with
+    /// <returns>The token unchanged on success; a <see cref="JwtValidationError"/> with
     /// <see cref="JwtError.InvalidHeader"/> when the <c>jwk</c> header is malformed or
-    /// absent, or whatever category <see cref="IJsonWebTokenSigner.ValidateAsync"/> raises
+    /// absent; or whatever category <see cref="IJsonWebTokenSigner.ValidateAsync"/> raises
     /// when the cryptographic check fails.</returns>
-    private async Task<JwtValidationError?> ValidateEmbeddedKeyAsync(JsonWebToken token, string[] jwtParts)
+    private async Task<Result<JsonWebToken, JwtValidationError>> ValidateEmbeddedKeyAsync(
+        JsonWebToken token, string[] jwtParts)
     {
         JsonWebKey? embeddedJwk;
         try
@@ -271,7 +319,8 @@ internal class JsonWebTokenValidator(
                 $"Header '{JwtClaimTypes.JsonWebKeyHeader}' is required when {nameof(ValidationOptions.UseEmbeddedVerificationKey)} is set");
         }
 
-        return await signer.ValidateAsync(jwtParts, token.Header, embeddedJwk.ToAsync());
+        var error = await signer.ValidateAsync(jwtParts, token.Header, embeddedJwk.ToAsync());
+        return error is null ? token : error;
     }
 
     /// <summary>
@@ -290,11 +339,11 @@ internal class JsonWebTokenValidator(
     /// must be configured for this branch and is dereferenced via
     /// <see cref="ObjectExtensions.NotNull{T}(T?, string)"/> so a missing resolver fails
     /// loud rather than silently accepting an unverifiable token.</param>
-    /// <returns><c>null</c> on success, or a <see cref="JwtValidationError"/> with
-    /// <see cref="JwtError.InvalidToken"/> when <c>iss</c> is missing, or whatever category
+    /// <returns>The token unchanged on success; a <see cref="JwtValidationError"/> with
+    /// <see cref="JwtError.InvalidToken"/> when <c>iss</c> is missing; or whatever category
     /// <see cref="IJsonWebTokenSigner.ValidateAsync"/> raises (typically
     /// <see cref="JwtError.InvalidSignature"/>) when no resolved key verifies.</returns>
-    private async Task<JwtValidationError?> ValidateIssuerSignatureAsync(
+    private async Task<Result<JsonWebToken, JwtValidationError>> ValidateIssuerSignatureAsync(
         JsonWebToken token,
         string[] jwtParts,
         ValidationParameters parameters)
@@ -319,18 +368,26 @@ internal class JsonWebTokenValidator(
                 "No signing-key resolver configured: this validation path expected to look up signing keys by 'iss' but the host did not provide ResolveIssuerSigningKeys.");
         }
 
-        return await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
+        var error = await signer.ValidateAsync(jwtParts, token.Header, resolveIssuerSigningKeys(issuer));
+        return error is null ? token : error;
     }
 
     /// <summary>
-    /// Validates the JWS 'crit' header parameter (RFC 7515 §4.1.11). When present, every name in
-    /// the array MUST be a non-standard JOSE header parameter name that is also present in the
-    /// JOSE header and that the host has registered an <see cref="ICriticalHeaderHandler"/> for.
-    /// Empty 'crit', duplicates, standard header names, dangling references, and unknown
-    /// extension names all cause rejection.
+    /// Validates the JWS 'crit' header parameter (RFC 7515 §4.1.11). Runs the spec-required
+    /// malformation guards (empty array, duplicates, reserved names, dangling references)
+    /// independent of any registry, then routes each crit name to its registered
+    /// <see cref="ICriticalHeaderHandler"/>. An unrouted name is rejected as «unknown
+    /// critical header parameter» per RFC 7515 §4.1.11 ("If any of the listed extension
+    /// Header Parameters are not understood and supported by the recipient, then the JWS
+    /// is invalid"). Each handler whose understood-names overlap 'crit' runs exactly once
+    /// and may reject the JWS by returning an error.
     /// </summary>
-    private JwtValidationError? ValidateCriticalHeaders(JsonWebTokenHeader header)
+    private async Task<Result<JsonWebToken, JwtValidationError>> ValidateCriticalHeadersAsync(
+        JsonWebToken token,
+        ValidationParameters parameters)
     {
+        var header = token.Header;
+
         IReadOnlyList<string>? crit;
         try
         {
@@ -344,8 +401,24 @@ internal class JsonWebTokenValidator(
         }
 
         if (crit is null)
-            return null;
+            return token;
 
+        if (ValidateCritStructure(crit, header) is { } structuralError)
+            return structuralError;
+
+        return await DispatchCritHandlersAsync(token, parameters, crit);
+    }
+
+    /// <summary>
+    /// Runs the structural guards from RFC 7515 §4.1.11 (empty array, duplicates, reserved
+    /// standard names, dangling references) plus the registry-routing precondition (every
+    /// surviving name MUST have a registered <see cref="ICriticalHeaderHandler"/>). Returns
+    /// <see langword="null"/> when every name in <paramref name="crit"/> is well-formed and
+    /// routable; otherwise the first rejection in declaration order so the diagnostic
+    /// pinpoints the specific violating name.
+    /// </summary>
+    private JwtValidationError? ValidateCritStructure(IReadOnlyList<string> crit, JsonWebTokenHeader header)
+    {
         if (crit.Count == 0)
         {
             return new JwtValidationError(
@@ -373,8 +446,7 @@ internal class JsonWebTokenValidator(
                     $"'crit' lists header name '{name}' that is not present in the JOSE header");
             }
 
-            var handler = serviceProvider.GetKeyedService<ICriticalHeaderHandler>(name);
-            if (handler is null)
+            if (!_critHandlersByName.ContainsKey(name))
             {
                 return new JwtValidationError(
                     JwtError.InvalidToken,
@@ -383,6 +455,37 @@ internal class JsonWebTokenValidator(
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Dispatches each crit-listed name to its registered handler. Assumes
+    /// <see cref="ValidateCritStructure"/> has already passed — every name in
+    /// <paramref name="crit"/> is guaranteed routable. Order = appearance in 'crit'; each
+    /// handler runs at most once even when it claims multiple names that all appear in
+    /// 'crit'. <see cref="ReferenceEqualityComparer"/> because handlers are singletons —
+    /// instance identity is the dedup key.
+    /// </summary>
+    private async Task<Result<JsonWebToken, JwtValidationError>> DispatchCritHandlersAsync(
+        JsonWebToken token,
+        ValidationParameters parameters,
+        IReadOnlyList<string> crit)
+    {
+        var context = new CriticalHeaderContext
+        {
+            Token = token,
+            Parameters = parameters,
+            TimeProvider = timeProvider,
+        };
+
+        var ran = new HashSet<ICriticalHeaderHandler>(ReferenceEqualityComparer.Instance);
+        foreach (var name in crit)
+        {
+            var handler = _critHandlersByName[name];
+            if (ran.Add(handler) && await handler.HandleAsync(context) is { } error)
+                return error;
+        }
+
+        return token;
     }
 
     /// <summary>
@@ -421,12 +524,13 @@ internal class JsonWebTokenValidator(
     /// before lookup per the §4.1.9 convention so <c>typ=at+jwt</c> and
     /// <c>typ=application/at+jwt</c> both match a registered <c>at+jwt</c> expectation.
     /// </summary>
-    private static JwtValidationError? ValidateTokenType(JsonWebTokenHeader header, ValidationParameters parameters)
+    private static Result<JsonWebToken, JwtValidationError> ValidateTokenType(
+        JsonWebToken token, ValidationParameters parameters)
     {
         if (parameters is not { ExpectedTokenTypes: { Count: > 0 } expected})
-            return null;
+            return token;
 
-        var typ = header.Type;
+        var typ = token.Header.Type;
         if (typ is null)
         {
             return new JwtValidationError(
@@ -442,8 +546,7 @@ internal class JsonWebTokenValidator(
                 $"JWT 'typ' header '{typ}' does not match expected token type(s): {string.Join(", ", expected)}");
         }
 
-        return null;
-
+        return token;
     }
 
     /// <summary>
@@ -460,8 +563,10 @@ internal class JsonWebTokenValidator(
     /// <summary>
     /// Validates the issuer claim according to validation parameters.
     /// </summary>
-    private static async Task<JwtValidationError?> ValidateIssuerAsync(string? issuer, ValidationParameters parameters)
+    private static async Task<Result<JsonWebToken, JwtValidationError>> ValidateIssuerAsync(
+        JsonWebToken token, ValidationParameters parameters)
     {
+        var issuer = token.Payload.Issuer;
         if (issuer != null)
         {
             if (parameters.Options.HasAnyFlag(ValidationOptions.RequireIssuer | ValidationOptions.ValidateIssuer))
@@ -477,17 +582,16 @@ internal class JsonWebTokenValidator(
             return new JwtValidationError(JwtError.InvalidToken, "Missing issuer in JWT payload");
         }
 
-        return null;
+        return token;
     }
 
     /// <summary>
     /// Validates the audience claim according to validation parameters.
     /// </summary>
-    private static async Task<JwtValidationError?> ValidateAudienceAsync(
-        IEnumerable<string> audiences,
-        ValidationParameters parameters)
+    private static async Task<Result<JsonWebToken, JwtValidationError>> ValidateAudienceAsync(
+        JsonWebToken token, ValidationParameters parameters)
     {
-        var audiencesList = audiences.ToList();
+        var audiencesList = token.Payload.Audiences.ToList();
 
         if (parameters.Options.HasFlag(ValidationOptions.RequireAudience) && audiencesList.Count == 0)
             return new JwtValidationError(JwtError.InvalidToken, "Missing audience in JWT payload");
@@ -502,21 +606,22 @@ internal class JsonWebTokenValidator(
             }
         }
 
-        return null;
+        return token;
     }
 
     /// <summary>
     /// Validates the lifetime claims (nbf and exp) according to validation parameters.
     /// </summary>
-    private JwtValidationError? ValidateLifetime(JsonWebTokenPayload payload, ValidationParameters parameters)
+    private Result<JsonWebToken, JwtValidationError> ValidateLifetime(
+        JsonWebToken token, ValidationParameters parameters)
     {
         if (!parameters.Options.HasFlag(ValidationOptions.ValidateLifetime))
-            return null;
+            return token;
 
-        var notBefore = payload.NotBefore;
-        var expiresAt = payload.ExpiresAt;
+        var notBefore = token.Payload.NotBefore;
+        var expiresAt = token.Payload.ExpiresAt;
         if (!notBefore.HasValue && !expiresAt.HasValue)
-            return null;
+            return token;
 
         var utcNow = timeProvider.GetUtcNow();
 
@@ -534,7 +639,7 @@ internal class JsonWebTokenValidator(
                 return new JwtValidationError(JwtError.InvalidToken, "Token has expired");
         }
 
-        return null;
+        return token;
     }
 
 }

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -113,27 +113,24 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers an <see cref="ICriticalHeaderHandler"/> keyed by the JOSE header parameter
-    /// name the host understands when it appears in a JWS 'crit' array (RFC 7515 §4.1.11).
-    /// The validator looks up handlers by header name; a token whose 'crit' lists a name that
-    /// has no matching keyed registration is rejected.
+    /// Registers an <see cref="ICriticalHeaderHandler"/> that handles one or more JOSE
+    /// header extension parameters listed in a JWS 'crit' array (RFC 7515 §4.1.11). The
+    /// handler itself declares its understood header names via
+    /// <see cref="ICriticalHeaderHandler.UnderstoodNames"/>, so the registration cannot
+    /// claim a name without backing its value-handling — name and behaviour are inseparable.
     /// </summary>
-    /// <typeparam name="THandler">The handler implementation type.</typeparam>
-    /// <param name="services">The service collection to register the handler in.</param>
-    /// <param name="headerName">The JOSE header parameter name this handler declares
-    /// understanding of. Used as the DI key, byte-exact match with the 'crit' entry.</param>
-    /// <returns>The service collection for method chaining.</returns>
+    /// <typeparam name="THandler">Concrete handler type.</typeparam>
     /// <remarks>
-    /// Uses <see cref="ServiceCollectionServiceExtensions.AddKeyedSingleton(IServiceCollection,Type,object,Type)"/>
-    /// (via <see cref="ServiceCollectionDescriptorExtensions.TryAdd(IServiceCollection,ServiceDescriptor)"/>)
-    /// so the validator's keyed lookup by header name resolves the handler in O(1).
+    /// Uses <see cref="ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection,ServiceDescriptor)"/>
+    /// so multiple crit extensions coexist; the validator builds a name → handler lookup
+    /// at construction and rejects any registration whose understood-names overlap an already
+    /// registered handler (each crit name MUST have exactly one handler).
     /// </remarks>
-    public static IServiceCollection AddCriticalHeaderHandler<THandler>(
-        this IServiceCollection services,
-        string headerName)
+    public static IServiceCollection AddCriticalHeaderHandler<THandler>(this IServiceCollection services)
         where THandler : class, ICriticalHeaderHandler
     {
-        services.TryAddKeyedSingleton<ICriticalHeaderHandler, THandler>(headerName);
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ICriticalHeaderHandler, THandler>());
         return services;
     }
 


### PR DESCRIPTION
## Summary
- `ICriticalHeaderHandler` was an **empty marker interface** with zero production implementations and no backing JWS pipeline. Registering it under e.g. `"b64"` advertised RFC 7797 support that the signature path could not actually deliver — best case the signature would mismatch with a misleading error, worst case the payload happens to be valid base64url and the signature verifies against semantics different from what the client signed (silent integrity break).
- Same name retained for continuity, but the interface now carries the real contract: the implementation supplies both `UnderstoodNames` (one or many JOSE header parameter names) AND value-handling (`HandleAsync(CriticalHeaderContext) → Task<JwtValidationError?>`). A registration cannot claim a name without backing its semantics.
- Registration via `services.AddCriticalHeaderHandler<THandler>()` (`TryAddEnumerable` under the hood); two handlers claiming the same name throw at validator construction with a structured diagnostic so misconfigurations fail boot rather than per-request.

## Why a real contract, not just deletion
Realistic crit-extensions land in three processing modes:

| Mode | Example | Pipeline hook |
|---|---|---|
| Validate-only | RFC 8225 `ppt` (PASSporT Type), enterprise policy headers | post-signature |
| Stateful handler | ACME-style `nonce` (RFC 8555 §6.5.2), audit emitters | post-signature + side effect |
| Signature-affecting | RFC 7797 `b64` (Unencoded Payload Option) | **pre-signature**, in signing pipeline |

`ICriticalHeaderHandler` cleanly covers modes 1 & 2 with a single `HandleAsync(CriticalHeaderContext)` returning `JwtValidationError?`. Mode 3 (only `b64` realistically) needs a sibling pre-signature contract on the signing pipeline that is out of scope for this PR — when RFC 7797 actually lands it brings its own pre-signature `IJwsSigningInputTransformer` (or similar) plus a thin `ICriticalHeaderHandler` shim that declares understanding and short-circuits, because the integrity proof already fired.

## Validator changes
- `IServiceProvider` ctor parameter replaced with `IEnumerable<ICriticalHeaderHandler>` (the registry).
- Name → handler lookup built **once at construction**; empty `UnderstoodNames` or two handlers claiming the same name throws `InvalidOperationException`.
- `ValidateCriticalHeaders` → async `ValidateCriticalHeadersAsync`. Spec-required malformation guards (empty array, duplicates, reserved names, dangling references) remain independent of the registry. Surviving names route through `handler.HandleAsync`; each handler runs at most once per request even when it claims multiple names that all appear in `crit`.
- Library default = zero registered handlers → every well-formed `crit` is rejected as «unknown critical header parameter» (RFC 7515 §4.1.11 conformant — verifier MUST reject what it does not understand).

## Verification
- `dotnet build` clean on `Abblix.Jwt`, `Abblix.Jwt.UnitTests`, `Abblix.Oidc.Server.UnitTests`, `Abblix.Oidc.Server.E2E.Tests` — 0 errors, 0 new warnings.
- `dotnet test`:
  - `Abblix.Jwt.UnitTests`: **285 passed** (+3 over baseline: happy-path with registered handler, side-effect propagation, conflict-throws-at-construction)
  - `Abblix.Oidc.Server.UnitTests`: 2014 passed
  - `Abblix.Oidc.Server.E2E.Tests`: 48 passed

## Why now (and not v3.0)
The marker shipped during v2.3 development on `develop` but `v2.3` has not yet been cut — there is no `release/v2.3` branch and no tag past `v2.2`. This is a scope adjustment within the still-open v2.3 cycle, not a SemVer-breaking removal of a published public API.

Closes #134
