### PR TITLE
refactor(jwt): align crit handler extension point with keyed-name DI

### DIFF
--- a/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
+++ b/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
@@ -192,16 +192,15 @@ public class CriticalHeaderTests
     }
 
     /// <summary>
-    /// When the host registers a handler whose <see cref="ICriticalHeaderHandler.UnderstoodNames"/>
-    /// covers the 'crit' name and the matching header is present, validation succeeds. This is
-    /// the happy path that lets a future RFC 7797 / RFC 8225 / custom extension plug in without
-    /// further library changes.
+    /// When the host registers a handler under the 'crit' name and the matching header is
+    /// present, validation succeeds. This is the happy path that lets a future RFC 7797 /
+    /// RFC 8225 / custom extension plug in without further library changes.
     /// </summary>
     [Fact]
     public async Task TokenWithRegisteredHandlerInCrit_Validates()
     {
         var sp = CreateServiceProvider(services =>
-            services.AddCriticalHeaderHandler<NoopB64Handler>());
+            services.AddCriticalHeaderHandler<NoopB64Handler>(ExtensionName));
         var jwt = await IssueTokenWithHeader(
             sp,
             criticalNode: new JsonArray((JsonNode)ExtensionName),
@@ -222,7 +221,7 @@ public class CriticalHeaderTests
     public async Task HandlerReturningError_PropagatesAsValidationFailure()
     {
         var sp = CreateServiceProvider(services =>
-            services.AddCriticalHeaderHandler<RejectingB64Handler>());
+            services.AddCriticalHeaderHandler<RejectingB64Handler>(ExtensionName));
         var jwt = await IssueTokenWithHeader(
             sp,
             criticalNode: new JsonArray((JsonNode)ExtensionName),
@@ -236,24 +235,25 @@ public class CriticalHeaderTests
     }
 
     /// <summary>
-    /// Two handlers claiming the same JWS 'crit' header name is a host-misconfiguration. The
-    /// validator surfaces it at construction time so the host fails to boot, not on the first
-    /// validating request — boot-time failures are far easier to diagnose than per-request
-    /// rejection cascades.
+    /// Routing is keyed on the DI registration name, not the handler type. A handler registered
+    /// under a different name does not make the 'crit' name in the token routable, so the JWS is
+    /// still rejected as «unknown critical header parameter».
     /// </summary>
     [Fact]
-    public void TwoHandlersClaimingSameName_ThrowsAtValidatorConstruction()
+    public async Task HandlerRegisteredUnderDifferentName_DoesNotRouteCritName()
     {
+        const string otherName = "ppt";
         var sp = CreateServiceProvider(services =>
-        {
-            services.AddCriticalHeaderHandler<NoopB64Handler>();
-            services.AddCriticalHeaderHandler<RejectingB64Handler>();
-        });
+            services.AddCriticalHeaderHandler<NoopB64Handler>(otherName));
+        var jwt = await IssueTokenWithHeader(
+            sp,
+            criticalNode: new JsonArray((JsonNode)ExtensionName),
+            extensionValue: false);
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => sp.GetRequiredService<IJsonWebTokenValidator>());
-        Assert.Contains("'b64'", ex.Message);
-        Assert.Contains(nameof(ICriticalHeaderHandler), ex.Message);
+        var result = await Validate(sp, jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
     }
 
     private static IServiceProvider CreateServiceProvider(Action<IServiceCollection>? configure = null)
@@ -267,32 +267,26 @@ public class CriticalHeaderTests
     }
 
     /// <summary>
-    /// Test-double handler that declares understanding of <c>"b64"</c> (RFC 7797 name reused
-    /// here for convenience; this handler does not implement RFC 7797's signature-input
-    /// transformation — the JWS we sign carries a bare boolean header field). Always
-    /// short-circuits to success, matching the «signature-affecting extension whose work lives
-    /// in the signing pipeline» mode.
+    /// Test-double handler for <c>"b64"</c> (RFC 7797 name reused here for convenience; this
+    /// handler does not implement RFC 7797's signature-input transformation — the JWS we sign
+    /// carries a bare boolean header field). Always short-circuits to success, matching the
+    /// «signature-affecting extension whose work lives in the signing pipeline» mode. The name
+    /// it answers to is the DI key it is registered under, not a property.
     /// </summary>
     private sealed class NoopB64Handler : ICriticalHeaderHandler
     {
-        public IReadOnlySet<string> UnderstoodNames { get; } =
-            new HashSet<string>(StringComparer.Ordinal) { ExtensionName };
-
         public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context)
             => Task.FromResult<JwtValidationError?>(null);
     }
 
     /// <summary>
-    /// Test-double handler that declares understanding of <c>"b64"</c> and rejects every
-    /// JWS — used to verify that handler rejection actually propagates through the validator
-    /// (and that no earlier guard short-circuits past the handler invocation).
+    /// Test-double handler that rejects every JWS — used to verify that handler rejection
+    /// actually propagates through the validator (and that no earlier guard short-circuits
+    /// past the handler invocation).
     /// </summary>
     private sealed class RejectingB64Handler : ICriticalHeaderHandler
     {
         public const string RejectionReason = "test-double handler rejection";
-
-        public IReadOnlySet<string> UnderstoodNames { get; } =
-            new HashSet<string>(StringComparer.Ordinal) { ExtensionName };
 
         public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context)
             => Task.FromResult<JwtValidationError?>(

--- a/Abblix.Jwt/ICriticalHeaderHandler.cs
+++ b/Abblix.Jwt/ICriticalHeaderHandler.cs
@@ -24,9 +24,11 @@ namespace Abblix.Jwt;
 
 /// <summary>
 /// Recipient-side handler for one JWS 'crit' header extension spec (RFC 7515 §4.1.11).
-/// Covers «understood AND processed»: the implementation declares which JOSE header
-/// parameter name(s) the extension introduces via <see cref="UnderstoodNames"/>, and
-/// applies the extension's recipient-side semantics via <see cref="HandleAsync"/>.
+/// Covers «understood AND processed»: the handler applies the extension's recipient-side
+/// semantics via <see cref="HandleAsync"/>. The JOSE header parameter name the handler
+/// implements is the DI key it is registered under — see
+/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/> — so name
+/// and behaviour are inseparable: a name cannot be registered without a handler behind it.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -62,27 +64,19 @@ namespace Abblix.Jwt;
 /// need a pre-signature hook that transforms the JWS Signing Input bytes, which
 /// MUST run before signature verification. That hook is a separate sibling
 /// contract on the signing pipeline (out of scope for this interface). A b64
-/// implementation of THIS interface is a thin shim that declares understanding
-/// of "b64" and short-circuits to success — successful signature verification
-/// already proves the directive was honoured.
+/// implementation of THIS interface is a thin shim registered under "b64" that
+/// short-circuits to success — successful signature verification already proves
+/// the directive was honoured.
 /// </para>
 /// <para>
 /// Register with
-/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>.
-/// Two handlers claiming the same name fail loud at validator construction —
-/// each crit name MUST have exactly one handler.
+/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>,
+/// passing the JOSE header parameter name as the DI key. One handler owns one name;
+/// a handler covering a family of related names registers under each.
 /// </para>
 /// </remarks>
 public interface ICriticalHeaderHandler
 {
-    /// <summary>
-    /// JOSE header parameter names this handler implements. Byte-exact match
-    /// per RFC 7515 §5.3. MUST be non-empty. Multi-name is allowed for specs
-    /// that introduce a family of related parameters (rare); most extensions
-    /// declare a single name.
-    /// </summary>
-    IReadOnlySet<string> UnderstoodNames { get; }
-
     /// <summary>
     /// Apply the extension's recipient-side semantics. May read the parsed
     /// token (header and payload), consult external state via the context's

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -25,6 +25,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 using System.Buffers.Text;
 
@@ -37,59 +38,20 @@ namespace Abblix.Jwt;
 /// <param name="encryptor">The JWE encryptor for decrypting encrypted tokens.</param>
 /// <param name="signer">The JWS signer for validating signatures.</param>
 /// <param name="signingAlgorithmsProvider">The provider for supported signing algorithms.</param>
-/// <param name="critHandlers">Registered handlers for JWS 'crit' header extensions
-/// (RFC 7515 §4.1.11). Each handler self-declares its understood header parameter names
-/// via <see cref="ICriticalHeaderHandler.UnderstoodNames"/>; the validator routes a
-/// 'crit' name to its single owning handler at validation time. An empty enumerable is
-/// the default — the library currently understands no crit extensions and rejects every
-/// well-formed 'crit' header until a host registers a handler via
-/// <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>.</param>
+/// <param name="serviceProvider">Resolves registered <see cref="ICriticalHeaderHandler"/>
+/// instances by JWS 'crit' header name (RFC 7515 §4.1.11). Handlers are registered as keyed
+/// singletons via <see cref="ServiceCollectionExtensions.AddCriticalHeaderHandler{THandler}"/>;
+/// the validator routes a 'crit' name to its handler with
+/// <c>GetKeyedService&lt;ICriticalHeaderHandler&gt;(name)</c> at validation time. With no
+/// handler registered (the default) the library understands no crit extensions and rejects
+/// every well-formed 'crit' header.</param>
 internal class JsonWebTokenValidator(
     TimeProvider timeProvider,
     IJsonWebTokenEncryptor encryptor,
     IJsonWebTokenSigner signer,
     SigningAlgorithmsProvider signingAlgorithmsProvider,
-    IEnumerable<ICriticalHeaderHandler> critHandlers) : IJsonWebTokenValidator
+    IServiceProvider serviceProvider) : IJsonWebTokenValidator
 {
-    /// <summary>
-    /// Name → owning handler lookup built once at construction. Building here surfaces
-    /// host-misconfiguration (two handlers claiming the same name, empty UnderstoodNames)
-    /// at first <see cref="IJsonWebTokenValidator"/> resolution rather than at the first
-    /// validating request — boot-time failures are easier to diagnose than per-request
-    /// rejection cascades.
-    /// </summary>
-    private readonly IReadOnlyDictionary<string, ICriticalHeaderHandler> _critHandlersByName =
-        BuildCritHandlerLookup(critHandlers);
-
-    private static IReadOnlyDictionary<string, ICriticalHeaderHandler> BuildCritHandlerLookup(
-        IEnumerable<ICriticalHeaderHandler> handlers)
-    {
-        var lookup = new Dictionary<string, ICriticalHeaderHandler>(StringComparer.Ordinal);
-        foreach (var handler in handlers)
-        {
-            if (handler.UnderstoodNames.Count == 0)
-            {
-                throw new InvalidOperationException(
-                    $"{handler.GetType().FullName} declared an empty " +
-                    $"{nameof(ICriticalHeaderHandler.UnderstoodNames)} set — at least one JWS 'crit' " +
-                    "header name is required for a handler to ever be routed to.");
-            }
-
-            foreach (var name in handler.UnderstoodNames)
-            {
-                if (lookup.TryGetValue(name, out var existing))
-                {
-                    throw new InvalidOperationException(
-                        $"Two {nameof(ICriticalHeaderHandler)} registrations claim the same JWS 'crit' " +
-                        $"header name '{name}': {existing.GetType().FullName} and " +
-                        $"{handler.GetType().FullName}. Each crit name MUST have exactly one handler.");
-                }
-                lookup[name] = handler;
-            }
-        }
-        return lookup;
-    }
-
     /// <summary>
     /// Header parameter names defined by RFC 7515 §4.1 (and 'crit' itself). Per RFC 7515 §4.1.11
     /// a producer MUST NOT list any of these in 'crit'; we reject as recipient-MAY because
@@ -379,8 +341,7 @@ internal class JsonWebTokenValidator(
     /// <see cref="ICriticalHeaderHandler"/>. An unrouted name is rejected as «unknown
     /// critical header parameter» per RFC 7515 §4.1.11 ("If any of the listed extension
     /// Header Parameters are not understood and supported by the recipient, then the JWS
-    /// is invalid"). Each handler whose understood-names overlap 'crit' runs exactly once
-    /// and may reject the JWS by returning an error.
+    /// is invalid").
     /// </summary>
     private async Task<Result<JsonWebToken, JwtValidationError>> ValidateCriticalHeadersAsync(
         JsonWebToken token,
@@ -411,13 +372,13 @@ internal class JsonWebTokenValidator(
 
     /// <summary>
     /// Runs the structural guards from RFC 7515 §4.1.11 (empty array, duplicates, reserved
-    /// standard names, dangling references) plus the registry-routing precondition (every
-    /// surviving name MUST have a registered <see cref="ICriticalHeaderHandler"/>). Returns
-    /// <see langword="null"/> when every name in <paramref name="crit"/> is well-formed and
-    /// routable; otherwise the first rejection in declaration order so the diagnostic
-    /// pinpoints the specific violating name.
+    /// standard names, dangling references), all independent of the handler registry. Returns
+    /// <see langword="null"/> when every name in <paramref name="crit"/> is well-formed;
+    /// otherwise the first rejection in declaration order so the diagnostic pinpoints the
+    /// specific violating name. Routability (whether a handler is registered for a surviving
+    /// name) is decided in <see cref="DispatchCritHandlersAsync"/>.
     /// </summary>
-    private JwtValidationError? ValidateCritStructure(IReadOnlyList<string> crit, JsonWebTokenHeader header)
+    private static JwtValidationError? ValidateCritStructure(IReadOnlyList<string> crit, JsonWebTokenHeader header)
     {
         if (crit.Count == 0)
         {
@@ -445,31 +406,36 @@ internal class JsonWebTokenValidator(
                     JwtError.InvalidToken,
                     $"'crit' lists header name '{name}' that is not present in the JOSE header");
             }
-
-            if (!_critHandlersByName.ContainsKey(name))
-            {
-                return new JwtValidationError(
-                    JwtError.InvalidToken,
-                    $"Unknown critical header parameter: {name}");
-            }
         }
 
         return null;
     }
 
     /// <summary>
-    /// Dispatches each crit-listed name to its registered handler. Assumes
-    /// <see cref="ValidateCritStructure"/> has already passed — every name in
-    /// <paramref name="crit"/> is guaranteed routable. Order = appearance in 'crit'; each
-    /// handler runs at most once even when it claims multiple names that all appear in
-    /// 'crit'. <see cref="ReferenceEqualityComparer"/> because handlers are singletons —
-    /// instance identity is the dedup key.
+    /// Resolves the registered handler for each crit-listed name (keyed by name in DI) and
+    /// runs them in declaration order. Every name is resolved BEFORE any handler runs: per
+    /// RFC 7515 §4.1.11 an unknown name invalidates the whole JWS, so an earlier extension's
+    /// side effects must never apply only to reject on a later unknown name. An unresolved
+    /// name is rejected as «unknown critical header parameter».
     /// </summary>
     private async Task<Result<JsonWebToken, JwtValidationError>> DispatchCritHandlersAsync(
         JsonWebToken token,
         ValidationParameters parameters,
         IReadOnlyList<string> crit)
     {
+        var handlers = new ICriticalHeaderHandler[crit.Count];
+        for (var i = 0; i < crit.Count; i++)
+        {
+            if (serviceProvider.GetKeyedService<ICriticalHeaderHandler>(crit[i]) is not { } handler)
+            {
+                return new JwtValidationError(
+                    JwtError.InvalidToken,
+                    $"Unknown critical header parameter: {crit[i]}");
+            }
+
+            handlers[i] = handler;
+        }
+
         var context = new CriticalHeaderContext
         {
             Token = token,
@@ -477,13 +443,8 @@ internal class JsonWebTokenValidator(
             TimeProvider = timeProvider,
         };
 
-        var ran = new HashSet<ICriticalHeaderHandler>(ReferenceEqualityComparer.Instance);
-        foreach (var name in crit)
-        {
-            var handler = _critHandlersByName[name];
-            if (ran.Add(handler) && await handler.HandleAsync(context) is { } error)
-                return error;
-        }
+        if (await handlers.FirstOrDefaultAsync(handler => handler.HandleAsync(context)) is { } error)
+            return error;
 
         return token;
     }

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -113,24 +113,31 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers an <see cref="ICriticalHeaderHandler"/> that handles one or more JOSE
-    /// header extension parameters listed in a JWS 'crit' array (RFC 7515 §4.1.11). The
-    /// handler itself declares its understood header names via
-    /// <see cref="ICriticalHeaderHandler.UnderstoodNames"/>, so the registration cannot
-    /// claim a name without backing its value-handling — name and behaviour are inseparable.
+    /// Registers an <see cref="ICriticalHeaderHandler"/> for a single JOSE header extension
+    /// parameter listed in a JWS 'crit' array (RFC 7515 §4.1.11). The parameter name is the
+    /// DI key, so the registration cannot claim a name without a handler behind it — name and
+    /// behaviour are inseparable.
     /// </summary>
     /// <typeparam name="THandler">Concrete handler type.</typeparam>
+    /// <param name="services">The service collection to register the handler in.</param>
+    /// <param name="headerName">The JOSE header parameter name the handler implements
+    /// (byte-exact per RFC 7515 §5.3); used as the DI key the validator routes a 'crit' name
+    /// to. A handler covering a family of related names registers under each.</param>
+    /// <returns>The service collection for method chaining.</returns>
     /// <remarks>
-    /// Uses <see cref="ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection,ServiceDescriptor)"/>
-    /// so multiple crit extensions coexist; the validator builds a name → handler lookup
-    /// at construction and rejects any registration whose understood-names overlap an already
-    /// registered handler (each crit name MUST have exactly one handler).
+    /// Keyed-name DI mirrors the signer/encryptor registrations in this assembly
+    /// (<see cref="AddDataSigner{TKey,TSigner}"/> by 'alg'): one keyed registration serves
+    /// O(1) request-time dispatch (<c>GetKeyedService&lt;ICriticalHeaderHandler&gt;(name)</c>).
+    /// <see cref="ServiceCollectionDescriptorExtensions.TryAddKeyedSingleton{TService,TImplementation}(IServiceCollection,object)"/>
+    /// dedups by (service, key) first-wins, so a host pre-registration for a name wins over a
+    /// later default.
     /// </remarks>
-    public static IServiceCollection AddCriticalHeaderHandler<THandler>(this IServiceCollection services)
+    public static IServiceCollection AddCriticalHeaderHandler<THandler>(
+        this IServiceCollection services,
+        string headerName)
         where THandler : class, ICriticalHeaderHandler
     {
-        services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<ICriticalHeaderHandler, THandler>());
+        services.TryAddKeyedSingleton<ICriticalHeaderHandler, THandler>(headerName);
         return services;
     }
 


### PR DESCRIPTION
Realigns the JWS `crit` handler extension point (#134) with the keyed-name DI convention used across the codebase — `IDataSigner` by `alg`, `IAuthorizationDetailValidator` by `type`, `ISubjectTokenResolver` by token type.

## Change

- `ICriticalHeaderHandler` drops `UnderstoodNames`; the crit parameter name is the DI key, and the handler keeps only `HandleAsync`.
- `AddCriticalHeaderHandler<THandler>(string headerName)` registers via `TryAddKeyedSingleton` instead of `TryAddEnumerable`.
- The validator injects `IServiceProvider` and resolves `GetKeyedService<ICriticalHeaderHandler>(name)` per crit name. The constructed lookup dictionary, the construction-time conflict / empty-set throws, and the per-instance dedup pass are all gone.
- RFC 7515 §4.1.11 ordering preserved: every crit name is resolved before any handler runs, so an unknown name never lets an earlier extension's side effects apply. Dispatch uses `Abblix.Utils.FirstOrDefaultAsync`, matching the validator-composite idiom.

Name and behaviour stay inseparable — a key cannot be registered without a concrete handler — so the empty-marker failure mode that motivated #134 stays closed. Crit validation semantics are unchanged; this is an extension-API shape alignment within the unreleased v2.3 cycle. Net −44 lines.

Closes #147
