### PR TITLE
refactor(jwt): slim CriticalHeaderContext to per-call data only

### DIFF
--- a/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
+++ b/Abblix.Jwt.UnitTests/CriticalHeaderTests.cs
@@ -275,7 +275,7 @@ public class CriticalHeaderTests
     /// </summary>
     private sealed class NoopB64Handler : ICriticalHeaderHandler
     {
-        public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context)
+        public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context, CancellationToken cancellationToken)
             => Task.FromResult<JwtValidationError?>(null);
     }
 
@@ -288,7 +288,7 @@ public class CriticalHeaderTests
     {
         public const string RejectionReason = "test-double handler rejection";
 
-        public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context)
+        public Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context, CancellationToken cancellationToken)
             => Task.FromResult<JwtValidationError?>(
                 new JwtValidationError(JwtError.InvalidToken, RejectionReason));
     }

--- a/Abblix.Jwt/CriticalHeaderContext.cs
+++ b/Abblix.Jwt/CriticalHeaderContext.cs
@@ -17,13 +17,4 @@ public sealed class CriticalHeaderContext
     /// call. Handlers consult these to honour caller policy (algorithm
     /// allowlists, time skew, audience/issuer hooks).</summary>
     public required ValidationParameters Parameters { get; init; }
-
-    /// <summary>The validator's <see cref="TimeProvider"/>. Handlers read the
-    /// current instant from this so freshness checks honour the host's
-    /// fake-clock configuration in tests.</summary>
-    public required TimeProvider TimeProvider { get; init; }
-
-    /// <summary>Caller cancellation propagation for I/O-bound handlers
-    /// (replay-store lookups, audit emitters).</summary>
-    public CancellationToken CancellationToken { get; init; }
 }

--- a/Abblix.Jwt/ICriticalHeaderHandler.cs
+++ b/Abblix.Jwt/ICriticalHeaderHandler.cs
@@ -79,12 +79,15 @@ public interface ICriticalHeaderHandler
 {
     /// <summary>
     /// Apply the extension's recipient-side semantics. May read the parsed
-    /// token (header and payload), consult external state via the context's
-    /// time provider or DI-injected dependencies, perform side effects, and
-    /// reject the JWS by returning a non-null <see cref="JwtValidationError"/>.
-    /// Return <see langword="null"/> on success.
+    /// token (header and payload), consult external state via DI-injected
+    /// dependencies (inject <see cref="TimeProvider"/> if the extension needs
+    /// the clock), perform side effects, and reject the JWS by returning a
+    /// non-null <see cref="JwtValidationError"/>. Return <see langword="null"/>
+    /// on success.
     /// </summary>
-    /// <param name="context">Per-call inputs (parsed token, validation
-    /// parameters, time provider, cancellation token).</param>
-    Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context);
+    /// <param name="context">Per-call inputs: the parsed token and the
+    /// validation parameters in force.</param>
+    /// <param name="cancellationToken">Propagates cancellation to I/O-bound
+    /// handlers (replay-store lookups, audit emitters).</param>
+    Task<JwtValidationError?> HandleAsync(CriticalHeaderContext context, CancellationToken cancellationToken);
 }

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -440,10 +440,11 @@ internal class JsonWebTokenValidator(
         {
             Token = token,
             Parameters = parameters,
-            TimeProvider = timeProvider,
         };
 
-        if (await handlers.FirstOrDefaultAsync(handler => handler.HandleAsync(context)) is { } error)
+        // The JWS validation pipeline does not thread a CancellationToken (see
+        // IJsonWebTokenValidator.ValidateAsync), so none is available to propagate here.
+        if (await handlers.FirstOrDefaultAsync(handler => handler.HandleAsync(context, CancellationToken.None)) is { } error)
             return error;
 
         return token;


### PR DESCRIPTION
Removes `TimeProvider` and `CancellationToken` from `CriticalHeaderContext`:

- **`TimeProvider`** is a DI singleton — a handler that needs the clock injects it via its constructor (handlers are keyed-singleton registrations), consistent with the rest of the codebase. It is not per-call data.
- **`CancellationToken`** moves to a dedicated last parameter on `ICriticalHeaderHandler.HandleAsync`, per the .NET convention (do not bundle a token into a context/options object). The JWS validation pipeline does not thread a token today (`IJsonWebTokenValidator.ValidateAsync` has no `CancellationToken`), so the validator passes `CancellationToken.None`; threading a real token from the top is a separate optional improvement.

`CriticalHeaderContext` now carries only `Token` + `Parameters`. Pre-release contract with no shipped handlers, so no external impact. Jwt 285 / build clean.

Targets `develop`.