### PR TITLE
chore: add issue templates and discussion routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report a defect in Abblix OIDC Server
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. For usage and how-to questions, please use
+        [Discussions → Q&A](https://github.com/Abblix/Oidc.Server/discussions/categories/q-a) instead.
+  - type: input
+    id: version
+    attributes:
+      label: Abblix OIDC Server version
+      placeholder: e.g. 2.2.0
+    validations:
+      required: true
+  - type: input
+    id: dotnet
+    attributes:
+      label: .NET / ASP.NET Core version
+      placeholder: e.g. .NET 9
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: Describe the bug, including the relevant OAuth/OIDC flow or RFC if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior (cite the spec section if relevant)
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or token (redact all secrets)
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / how-to (OIDC, OAuth 2.0, .NET integration)
+    url: https://github.com/Abblix/Oidc.Server/discussions/categories/q-a
+    about: Ask usage and integration questions in Discussions — maintainers and the community answer there.
+  - name: Ideas & feedback
+    url: https://github.com/Abblix/Oidc.Server/discussions/categories/ideas
+    about: Share an idea or vote on what to build next.
+  - name: Licensing & commercial inquiries
+    url: mailto:info@abblix.com
+    about: Pricing, licensing, redistribution, and commercial support.
+  - name: Security vulnerability (do not open a public issue)
+    url: mailto:info@abblix.com
+    about: Report security issues privately by email.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a capability or standard for Abblix OIDC Server
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea but not a concrete request yet? Start in
+        [Discussions → Ideas](https://github.com/Abblix/Oidc.Server/discussions/categories/ideas).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that you can't today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: input
+    id: spec
+    attributes:
+      label: Related RFC / OpenID specification (if any)
+      placeholder: e.g. RFC 9396, OpenID4VCI, FAPI 2.0


### PR DESCRIPTION
Adds GitHub issue forms and contact-link routing:

- `bug_report.yml` — version, .NET version, repro, spec reference, logs (redacted).
- `feature_request.yml` — problem/use-case, proposal, related RFC/spec.
- `config.yml` — disables blank issues; routes questions → Discussions Q&A, ideas → Discussions Ideas, licensing/security → email.

Lowers friction for first issues and keeps how-to questions in Discussions. Targets `develop` (the default branch, so templates take effect on merge).