### PR TITLE
fix(ciba+mtls): close spec-conformance gaps found in code review

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
@@ -1,0 +1,80 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
+using Abblix.Oidc.Server.Features.UserInfo;
+using Abblix.Oidc.Server.Mvc;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.BackChannelAuthentication.Validation;
+
+/// <summary>
+/// Pins that <see cref="PushModeValidator"/> participates in the CIBA backchannel
+/// authentication validation pipeline that <c>AddOidcServices</c> wires up. Without the
+/// registration the validator is dead code and push-mode requests are never checked for
+/// the mandatory notification endpoint at request time. The pipeline is resolved through
+/// DI and the composed validator set is inspected directly, so the test reflects the real
+/// pipeline a host runs (the individual validators are captured inside the composite by
+/// <c>Compose()</c>, not left as service descriptors). <see cref="PingModeValidator"/> is
+/// asserted alongside as a methodology anchor — it is registered, so the test distinguishes
+/// "validator missing" from "inspection technique broken".
+/// </summary>
+public class PushModeValidatorRegistrationTests
+{
+    [Fact]
+    public void AddOidcServices_WiresBothPingAndPushModeValidatorsIntoTheBackChannelPipeline()
+    {
+        var provider = BuildProvider();
+
+        var composite = provider.GetRequiredService<IBackChannelAuthenticationContextValidator>();
+        var validators = ExtractComposedValidators(composite);
+
+        Assert.Contains(validators, v => v is PingModeValidator);
+        Assert.Contains(validators, v => v is PushModeValidator);
+    }
+
+    private static IBackChannelAuthenticationContextValidator[] ExtractComposedValidators(
+        IBackChannelAuthenticationContextValidator composite)
+    {
+        // Compose() removes the individual IBackChannelAuthenticationContextValidator
+        // descriptors and captures them inside the composite's constructor-injected array,
+        // so the only way to observe the real pipeline is to read that array back. Locate it
+        // by field type rather than by the compiler-generated capture-field name.
+        var field = composite.GetType()
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Single(f => f.FieldType == typeof(IBackChannelAuthenticationContextValidator[]));
+
+        return (IBackChannelAuthenticationContextValidator[])field.GetValue(composite)!;
+    }
+
+    private static IServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+
+        // Host-level prerequisites every real ASP.NET host registers (the DI analog of
+        // AddLogging): memory-backed caches for Storages, and stubbed host-supplied services
+        // the CIBA validator pipeline transitively touches.
+        services.AddDistributedMemoryCache();
+        services.AddMemoryCache();
+        services.AddSingleton(Mock.Of<IUserCredentialsAuthenticator>());
+        services.AddSingleton(Mock.Of<IUserInfoProvider>());
+
+        services.AddOidcServices(options =>
+        {
+            options.Issuer = TestConstants.DefaultIssuer;
+            options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)];
+            options.RequireInitialAccessToken = false;
+        });
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidatorTests.cs
@@ -206,18 +206,19 @@ public class UserIdentityValidatorTests
         // Act
         var result = await _validator.ValidateAsync(context);
 
-        // Assert
+        // Assert — pin the error code (the stable contract), not the description wording.
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Equal("LoginHintToken validation failed.", result.ErrorDescription);
     }
 
     /// <summary>
-    /// Verifies validation succeeds when login_hint_token has InvalidToken error.
-    /// InvalidToken error is treated as non-JWT and skipped.
+    /// Verifies error when login_hint_token fails JWT validation with an InvalidToken error
+    /// while the client opted into JWT parsing (ParseLoginHintTokenAsJwt = true). A token the
+    /// client declared as a JWT but that fails validation (malformed, bad signature, forged)
+    /// must be rejected, not silently accepted as if no usable hint were present.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_LoginHintTokenWithInvalidTokenError_ShouldReturnNull()
+    public async Task ValidateAsync_LoginHintTokenWithInvalidTokenError_ShouldReturnInvalidRequest()
     {
         // Arrange
         var validationError = new JwtValidationError(JwtError.InvalidToken, "Not a JWT");
@@ -233,8 +234,9 @@ public class UserIdentityValidatorTests
         // Act
         var result = await _validator.ValidateAsync(context);
 
-        // Assert
-        Assert.Null(result);
+        // Assert — pin the error code (the stable contract), not the description wording.
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
@@ -140,11 +140,11 @@ public class BackChannelAuthenticationValidatorTests
     }
 
     /// <summary>
-    /// Verifies error when ping mode with endpoint specified.
-    /// Implementation currently only supports poll mode.
+    /// Verifies validation succeeds with ping mode and a notification endpoint.
+    /// Per OIDC CIBA §4, ping mode is a valid delivery mode and requires the endpoint.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_PingModeWithEndpoint_ShouldReturnError()
+    public async Task ValidateAsync_PingModeWithEndpoint_ShouldReturnNull()
     {
         // Arrange
         var context = CreateContext(
@@ -155,9 +155,7 @@ public class BackChannelAuthenticationValidatorTests
         var result = await _validator.ValidateAsync(context);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("not supported", result.ErrorDescription);
+        Assert.Null(result);
     }
 
     /// <summary>
@@ -181,11 +179,11 @@ public class BackChannelAuthenticationValidatorTests
     }
 
     /// <summary>
-    /// Verifies error when push mode with endpoint specified.
-    /// Implementation currently only supports poll mode.
+    /// Verifies validation succeeds with push mode and a notification endpoint.
+    /// Per OIDC CIBA §4, push mode is a valid delivery mode and requires the endpoint.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_PushModeWithEndpoint_ShouldReturnError()
+    public async Task ValidateAsync_PushModeWithEndpoint_ShouldReturnNull()
     {
         // Arrange
         var context = CreateContext(
@@ -196,9 +194,7 @@ public class BackChannelAuthenticationValidatorTests
         var result = await _validator.ValidateAsync(context);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("not supported", result.ErrorDescription);
+        Assert.Null(result);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TlsClientAuthValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TlsClientAuthValidatorTests.cs
@@ -79,9 +79,34 @@ public class TlsClientAuthValidatorTests
         // Act
         var result = await _validator.ValidateAsync(context);
 
+        // Assert — pin the error code (the stable contract), not the description wording.
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+    }
+
+    /// <summary>
+    /// Verifies validation fails when more than one subject identifier is specified.
+    /// RFC 8705 §2.1.2 requires a tls_client_auth client to register exactly one of the
+    /// subject-identifier parameters; supplying both a Subject DN and a SAN must be rejected.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithMultipleSubjectIdentifiers_ShouldReturnError()
+    {
+        // Arrange
+        var context = CreateContext(new ClientRegistrationRequest
+        {
+            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
+            TlsClientAuthSubjectDn = "CN=client.example.com,O=Example Corp,C=US",
+            TlsClientAuthSanDns = ["client.example.com"],
+        });
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
         // Assert
         Assert.NotNull(result);
-        Assert.Contains("at least one", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
     }
 
     /// <summary>
@@ -356,11 +381,12 @@ public class TlsClientAuthValidatorTests
     }
 
     /// <summary>
-    /// Verifies validation succeeds with multiple metadata types.
-    /// Combination of DN, DNS, URI, IP, and email should all be validated.
+    /// Verifies validation fails when several subject-identifier metadata types are combined.
+    /// RFC 8705 §2.1.2 requires exactly one; a request mixing DN, DNS, URI, IP and email must
+    /// be rejected rather than accepted.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_WithMultipleValidMetadata_ShouldReturnNull()
+    public async Task ValidateAsync_WithMultipleMetadataTypes_ShouldReturnError()
     {
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
@@ -378,7 +404,8 @@ public class TlsClientAuthValidatorTests
         var result = await _validator.ValidateAsync(context);
 
         // Assert
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -273,8 +273,9 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
+        // slow_down (polled too fast, CIBA Core §11) is the stable wire contract; the human-readable
+        // description is free to change, so the test pins the error code only.
         Assert.Equal(ErrorCodes.SlowDown, error.Error);
-        Assert.Contains("pending", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenAuthorizationContextEvaluatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenAuthorizationContextEvaluatorTests.cs
@@ -1,0 +1,120 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System;
+using System.Buffers.Text;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Token;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token;
+
+/// <summary>
+/// Verifies the RFC 8705 certificate-binding rules in
+/// <see cref="TokenAuthorizationContextEvaluator"/>: a refreshed token stays bound to the
+/// certificate the original token was bound to (RFC 8705 §4 — the AS SHOULD bind the refresh
+/// token to the certificate and check that binding), and an initial token binds to the
+/// certificate presented at issuance (§3). The invariant the refresh tests pin is that a
+/// refresh neither drops the binding (when no certificate is re-presented) nor silently
+/// rebinds to a different certificate.
+/// </summary>
+public class TokenAuthorizationContextEvaluatorTests
+{
+    private const string OriginalThumbprint = "original-cert-thumbprint";
+
+    private static readonly TokenAuthorizationContextEvaluator Evaluator = new();
+
+    [Fact]
+    public void Refresh_WithoutClientCertificate_PreservesOriginalCertificateBinding()
+    {
+        // A DPoP/mTLS-style bound grant is refreshed on a connection that does not re-present
+        // the client certificate. RFC 8705 §4 says the refreshed token should remain bound
+        // to the original certificate — the binding must not be wiped to null.
+        var request = CreateRefreshRequest(
+            boundThumbprint: OriginalThumbprint,
+            clientCertificate: null);
+
+        var result = Evaluator.EvaluateAuthorizationContext(request);
+
+        Assert.Equal(OriginalThumbprint, result.CertificateSha256Thumbprint);
+    }
+
+    [Fact]
+    public void Refresh_WithDifferentClientCertificate_DoesNotRebindToNewCertificate()
+    {
+        // A rotated certificate is presented on refresh. The token must stay bound to the
+        // ORIGINAL certificate (RFC 8705 §4) rather than silently rebinding to the new one.
+        using var rotatedCertificate = CreateCertificate();
+        var request = CreateRefreshRequest(
+            boundThumbprint: OriginalThumbprint,
+            clientCertificate: rotatedCertificate);
+
+        var result = Evaluator.EvaluateAuthorizationContext(request);
+
+        Assert.Equal(OriginalThumbprint, result.CertificateSha256Thumbprint);
+    }
+
+    [Fact]
+    public void InitialIssuance_WithClientCertificate_BindsToPresentedCertificate()
+    {
+        // Initial issuance: the grant carries no prior binding, the client authenticated via
+        // mTLS, so the issued token binds to the presented certificate's SHA-256 thumbprint.
+        using var certificate = CreateCertificate();
+        var expectedThumbprint = Base64Url.EncodeToString(SHA256.HashData(certificate.RawData));
+        var request = CreateRefreshRequest(
+            boundThumbprint: null,
+            clientCertificate: certificate);
+
+        var result = Evaluator.EvaluateAuthorizationContext(request);
+
+        Assert.Equal(expectedThumbprint, result.CertificateSha256Thumbprint);
+    }
+
+    private static ValidTokenRequest CreateRefreshRequest(
+        string? boundThumbprint,
+        X509Certificate2? clientCertificate)
+    {
+        var fixedTime = DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        var session = new AuthSession("user-123", "session-456", fixedTime, "local");
+        var context = new AuthorizationContext("test-client", [TestConstants.DefaultScope], null)
+        {
+            CertificateSha256Thumbprint = boundThumbprint,
+        };
+        var grant = new AuthorizedGrant(session, context);
+        var clientInfo = new ClientInfo("test-client")
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
+        };
+
+        return new ValidTokenRequest(
+            new TokenRequest(),
+            grant,
+            clientInfo,
+            [],
+            [],
+            clientCertificate);
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Test Client",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        var notBefore = DateTimeOffset.Parse("2025-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        var notAfter = DateTimeOffset.Parse("2027-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        return request.CreateSelfSigned(notBefore, notAfter);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/Storages/Proto/MappersTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Storages/Proto/MappersTests.cs
@@ -695,4 +695,50 @@ public class MappersTests
         var result = proto.FromProto();
         Assert.Null(result.NextPollAt);
     }
+
+    [Fact]
+    public void BackChannelAuthenticationRequestMapper_RoundTrips_ClientNotificationFields()
+    {
+        // Ping/push delivery depends on these two fields surviving storage: the client
+        // notification endpoint that receives the callback, and the bearer token the
+        // callback authenticates with. Dropping either through the protobuf round-trip
+        // silently breaks ping/push (the notification goes nowhere or carries no secret).
+        var fixedTime = DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        var session = new AuthSession("user-123", "session-456", fixedTime, "local");
+        var context = new AuthorizationContext("client-123", [TestConstants.DefaultScope], null);
+        var grant = new AuthorizedGrant(session, context);
+        var request = new BackChannelAuthenticationRequest(grant, fixedTime.AddMinutes(5))
+        {
+            ClientNotificationEndpoint = new Uri("https://client.example/ciba-callback"),
+            ClientNotificationToken = "notif-token-abc123",
+        };
+
+        // Act
+        var proto = request.ToProto();
+        var result = proto.FromProto();
+
+        // Assert
+        Assert.Equal(request.ClientNotificationEndpoint, result.ClientNotificationEndpoint);
+        Assert.Equal(request.ClientNotificationToken, result.ClientNotificationToken);
+    }
+
+    [Fact]
+    public void BackChannelAuthenticationRequestMapper_RoundTrips_NullClientNotificationFields()
+    {
+        // Poll-mode requests carry no notification endpoint/token; the absence must survive
+        // the round-trip as null rather than being coerced into an empty string.
+        var fixedTime = DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        var session = new AuthSession("user-123", "session-456", fixedTime, "local");
+        var context = new AuthorizationContext("client-123", [TestConstants.DefaultScope], null);
+        var grant = new AuthorizedGrant(session, context);
+        var request = new BackChannelAuthenticationRequest(grant, fixedTime.AddMinutes(5));
+
+        // Act
+        var proto = request.ToProto();
+        var result = proto.FromProto();
+
+        // Assert
+        Assert.Null(result.ClientNotificationEndpoint);
+        Assert.Null(result.ClientNotificationToken);
+    }
 }

--- a/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserCodeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserCodeValidator.cs
@@ -32,6 +32,12 @@ namespace Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
 /// and provider configuration. This validator ensures that if the client or provider requires the
 /// UserCode parameter for backchannel authentication, it is included in the request.
 /// </summary>
+/// <remarks>
+/// This validator checks <em>presence</em> only. Verifying the code's <em>value</em> against the
+/// user's actual code is the host's responsibility and happens during the device interaction — see
+/// the security contract on
+/// <see cref="Features.BackChannelAuthentication.Interfaces.IUserDeviceAuthenticationHandler"/>.
+/// </remarks>
 /// <param name="options">
 /// The OIDC options used to configure the behavior of the backchannel authentication process.</param>
 public class UserCodeValidator(IOptions<OidcOptions> options) : IBackChannelAuthenticationContextValidator

--- a/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidator.cs
@@ -99,14 +99,12 @@ public class UserIdentityValidator(
             }
             else
             {
-                var error = loginHintTokenResult.GetFailure();
-                if (error.Error != JwtError.InvalidToken)
-                {
-                    // If JWT validation fails, return an error
-                    return new OidcError(
-                        ErrorCodes.InvalidRequest,
-                        "LoginHintToken validation failed.");
-                }
+                // The client opted into JWT parsing (ParseLoginHintTokenAsJwt), so any
+                // validation failure — including a malformed / forged token surfacing as
+                // InvalidToken — is rejected rather than silently treated as "no usable hint".
+                return new OidcError(
+                    ErrorCodes.InvalidRequest,
+                    "LoginHintToken validation failed.");
             }
         }
 

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -34,7 +34,8 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 /// <c>backchannel_authentication_request_signing_alg</c> is on the server's supported list.
 /// </summary>
 /// <param name="jwtValidator">Source of supported JWT signing algorithms.</param>
-public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValidator) : IClientRegistrationContextValidator
+public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValidator)
+    : IClientRegistrationContextValidator
 {
     /// <inheritdoc />
     public Task<OidcError?> ValidateAsync(ClientRegistrationValidationContext context)
@@ -61,18 +62,21 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
                     "Notification endpoint is invalid if the token delivery mode is set to poll");
 
             case {
-                BackChannelTokenDeliveryMode: BackchannelTokenDeliveryModes.Ping or BackchannelTokenDeliveryModes.Push,
+                BackChannelTokenDeliveryMode:
+                    BackchannelTokenDeliveryModes.Ping or
+                    BackchannelTokenDeliveryModes.Push,
                 BackChannelClientNotificationEndpoint: null,
             }:
                 return new OidcError(
                     ErrorCodes.InvalidRequest,
                     "Notification endpoint is required if the token delivery mode is set to ping or push");
 
-            case { BackChannelTokenDeliveryMode: BackchannelTokenDeliveryModes.Poll }:
-            //case { BackChannelTokenDeliveryMode: BackchannelTokenDeliveryModes.Ping or BackchannelTokenDeliveryModes.Push }:
-                break;
-
-            default:
+            case {
+                BackChannelTokenDeliveryMode: not (
+                    BackchannelTokenDeliveryModes.Poll or
+                    BackchannelTokenDeliveryModes.Ping or
+                    BackchannelTokenDeliveryModes.Push),
+            }:
                 return new OidcError(
                     ErrorCodes.InvalidRequest,
                     "The specified token delivery mode is not supported");

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/TlsClientAuthValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/TlsClientAuthValidator.cs
@@ -49,12 +49,21 @@ public class TlsClientAuthValidator : SyncClientRegistrationContextValidator
         if (!IsTlsClientAuth(request))
             return null;
 
-        if (!HasAnyTlsMetadata(request))
+        // RFC 8705 §2.1.2: a tls_client_auth client registers EXACTLY ONE subject identifier.
+        switch (CountSubjectIdentifiers(request))
         {
-            return ErrorFactory.InvalidClientMetadata(
-                "When using tls_client_auth, at least one of the following must be specified: " +
-                "tls_client_auth_subject_dn, tls_client_auth_san_dns, tls_client_auth_san_uri, " +
-                "tls_client_auth_san_ip, or tls_client_auth_san_email");
+            case 0:
+                return ErrorFactory.InvalidClientMetadata(
+                    "When using tls_client_auth, exactly one of the following must be specified: " +
+                    "tls_client_auth_subject_dn, tls_client_auth_san_dns, tls_client_auth_san_uri, " +
+                    "tls_client_auth_san_ip, or tls_client_auth_san_email");
+
+            case > 1:
+                return ErrorFactory.InvalidClientMetadata(
+                    "When using tls_client_auth, exactly one subject identifier may be specified " +
+                    "(RFC 8705 §2.1.2): choose a single one of tls_client_auth_subject_dn, " +
+                    "tls_client_auth_san_dns, tls_client_auth_san_uri, tls_client_auth_san_ip, or " +
+                    "tls_client_auth_san_email");
         }
 
         return ValidateSubjectDn(request)
@@ -73,17 +82,22 @@ public class TlsClientAuthValidator : SyncClientRegistrationContextValidator
         request.TokenEndpointAuthMethod == ClientAuthenticationMethods.TlsClientAuth;
 
     /// <summary>
-    /// Checks whether any TLS client authentication metadata is provided in the request.
-    /// At least one of Subject DN or SAN fields must be specified for tls_client_auth.
+    /// Counts how many of the five RFC 8705 §2.1.2 subject-identifier metadata parameters are
+    /// present. A SAN array with several entries still counts as a single parameter — the spec
+    /// constrains which parameter is registered, not how many values it carries.
     /// </summary>
-    /// <param name="request">The client registration request to check.</param>
-    /// <returns>True if any TLS metadata is provided; otherwise, false.</returns>
-    private static bool HasAnyTlsMetadata(ClientRegistrationRequest request) =>
-        !string.IsNullOrWhiteSpace(request.TlsClientAuthSubjectDn) ||
-        request.TlsClientAuthSanDns is { Length: > 0 } ||
-        request.TlsClientAuthSanUri is { Length: > 0 } ||
-        request.TlsClientAuthSanIp is { Length: > 0 } ||
-        request.TlsClientAuthSanEmail is { Length: > 0 };
+    /// <param name="request">The client registration request to inspect.</param>
+    /// <returns>The number of populated subject-identifier parameters (0–5).</returns>
+    private static int CountSubjectIdentifiers(ClientRegistrationRequest request)
+    {
+        var count = 0;
+        if (!string.IsNullOrWhiteSpace(request.TlsClientAuthSubjectDn)) count++;
+        if (request.TlsClientAuthSanDns is { Length: > 0 }) count++;
+        if (request.TlsClientAuthSanUri is { Length: > 0 }) count++;
+        if (request.TlsClientAuthSanIp is { Length: > 0 }) count++;
+        if (request.TlsClientAuthSanEmail is { Length: > 0 }) count++;
+        return count;
+    }
 
     /// <summary>
     /// Validates the Subject Distinguished Name field if provided.

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -648,6 +648,7 @@ public static class ServiceCollectionExtensions
             ServiceDescriptor.Singleton<IBackChannelAuthenticationContextValidator, RequestedExpiryValidator>(),
             ServiceDescriptor.Singleton<IBackChannelAuthenticationContextValidator, UserCodeValidator>(),
             ServiceDescriptor.Singleton<IBackChannelAuthenticationContextValidator, PingModeValidator>(),
+            ServiceDescriptor.Singleton<IBackChannelAuthenticationContextValidator, PushModeValidator>(),
             // RFC 9396 §3 authorization_details on CIBA backchannel auth requests.
             ServiceDescriptor.Singleton<IBackChannelAuthenticationContextValidator, BackChannelAuthorizationDetailsValidator>(),
         ]);

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -135,7 +135,7 @@ public class BackChannelAuthenticationGrantHandler(
             // If the request is still pending and not yet time to poll again
             { Status: BackChannelAuthenticationStatus.Pending, NextPollAt: { } nextPollAt }
                 when timeProvider.GetUtcNow() < nextPollAt
-                => new OidcError(ErrorCodes.SlowDown, "The authorization request is still pending as the user hasn't been authenticated"),
+                => new OidcError(ErrorCodes.SlowDown, "The token endpoint was polled before the minimum interval elapsed; reduce the polling rate."),
 
             // If the user has not yet been authenticated and the request is still pending,
             // either wait for status change (long-polling) or return immediately (short-polling)

--- a/Abblix.Oidc.Server/Endpoints/Token/TokenAuthorizationContextEvaluator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/TokenAuthorizationContextEvaluator.cs
@@ -61,9 +61,14 @@ public class TokenAuthorizationContextEvaluator : ITokenAuthorizationContextEval
         }
 
         // Return a new authorization context updated with the determined scopes and resources.
-        // Compute certificate-bound confirmation thumbprint if applicable
-        string? thumbprint = null;
-        if (request.ClientCertificate != null)
+        // Certificate-bound confirmation thumbprint (RFC 8705 §3): preserve the binding the
+        // grant already carries. RFC 8705 §4 says the AS SHOULD keep a refreshed token bound to
+        // the original certificate and check that binding, so an existing thumbprint is never
+        // overwritten — neither dropped when no certificate is re-presented on refresh, nor
+        // rebound to a rotated certificate. A fresh thumbprint is computed only at initial
+        // issuance (no prior binding) when the client authenticated via mTLS.
+        var thumbprint = authContext.CertificateSha256Thumbprint;
+        if (thumbprint == null && request.ClientCertificate != null)
         {
             var authMethod = request.ClientInfo.TokenEndpointAuthMethod;
             if (authMethod == ClientAuthenticationMethods.SelfSignedTlsClientAuth

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -136,6 +136,19 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///   <item><strong>User Code:</strong> If request.Model.UserCode is present, require user to confirm it</item>
 ///   <item><strong>Authentication:</strong> All notifications use Bearer token from <c>client_notification_token</c></item>
 /// </list>
+///
+/// <para><strong>Security contract — user_code verification (CIBA Core 1.0 §7.1):</strong></para>
+/// <para>
+/// The library validates only the <em>presence</em> of <c>user_code</c> when the provider and client
+/// require it (see <see cref="Endpoints.BackChannelAuthentication.Validation.UserCodeValidator"/>); it
+/// deliberately does not — and cannot — verify the code's <em>value</em>, because the secret is known
+/// only to the end-user and the user's authentication device, which this handler owns. Your
+/// implementation therefore <strong>MUST</strong> verify <c>request.Model.UserCode</c> against the
+/// user's actual code as part of the device interaction, and <strong>MUST NOT</strong> return a
+/// successful <see cref="AuthSession"/> unless that check passed. A wrong or absent code MUST resolve
+/// to a failed <see cref="Result{TValue,TError}"/> (typically <c>access_denied</c>).
+/// Treating presence-validation as sufficient leaves the code unenforced and defeats its purpose.
+/// </para>
 /// </remarks>
 public interface IUserDeviceAuthenticationHandler
 {

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/TlsMetadataClientAuthenticator.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/TlsMetadataClientAuthenticator.cs
@@ -3,6 +3,7 @@
 
 using System.Formats.Asn1;
 using System.Net;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Abblix.Oidc.Server.Common.Constants;
@@ -105,20 +106,23 @@ public partial class TlsMetadataClientAuthenticator(
         if (string.IsNullOrWhiteSpace(requiredDn))
             return true; // no requirement
 
+        // A case-insensitive string compare is deliberately NOT used as a fallback: DN string
+        // equality is sensitive to attribute ordering, RDN spacing and encoding, so it both
+        // false-negatives and (on case) matches too loosely — a security-weakening path. The
+        // required DN is validated at registration time (TlsClientAuthValidator), so a parse
+        // failure here can only mean a misconfigured client; authentication fails closed.
+        X500DistinguishedName requiredX500Dn;
         try
         {
-            // Use X500DistinguishedName for proper RFC 4514 parsing and normalization
-            var certDn = cert.SubjectName;
-            var requiredX500Dn = new X500DistinguishedName(requiredDn);
-
-            // Compare binary representation for exact match
-            return certDn.RawData.AsSpan().SequenceEqual(requiredX500Dn.RawData);
+            requiredX500Dn = new X500DistinguishedName(requiredDn);
         }
-        catch
+        catch (CryptographicException)
         {
-            // Fallback to string comparison if parsing fails
-            return string.Equals(cert.Subject, requiredDn, StringComparison.OrdinalIgnoreCase);
+            return false;
         }
+
+        // Compare the binary RFC 4514 representation for an exact match.
+        return cert.SubjectName.RawData.AsSpan().SequenceEqual(requiredX500Dn.RawData);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Features/Storages/Proto/BackChannelAuthenticationRequest.proto
+++ b/Abblix.Oidc.Server/Features/Storages/Proto/BackChannelAuthenticationRequest.proto
@@ -30,4 +30,12 @@ message BackChannelAuthenticationRequest {
 
   // Absolute expiration time for this authentication request
   google.protobuf.Timestamp expires_at = 4;
+
+  // Client notification endpoint (ping/push delivery): the URL that receives the
+  // CIBA callback. Absent for poll mode.
+  optional string client_notification_endpoint = 5;
+
+  // Client notification token (ping/push delivery): the bearer secret the callback
+  // authenticates with. Absent for poll mode.
+  optional string client_notification_token = 6;
 }

--- a/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/BackChannelAuthenticationRequestMapper.cs
+++ b/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/BackChannelAuthenticationRequestMapper.cs
@@ -44,6 +44,14 @@ internal static class BackChannelAuthenticationRequestMapper
         if (source.NextPollAt.HasValue)
             proto.NextPollAt = source.NextPollAt.Value.ToTimestamp();
 
+        // Ping/push delivery fields — absent for poll mode, kept null-distinct via the
+        // proto3 optional accessors so the round-trip never coerces null into "".
+        if (source.ClientNotificationEndpoint is not null)
+            proto.ClientNotificationEndpoint = source.ClientNotificationEndpoint.ToString();
+
+        if (source.ClientNotificationToken is not null)
+            proto.ClientNotificationToken = source.ClientNotificationToken;
+
         return proto;
     }
 
@@ -58,6 +66,12 @@ internal static class BackChannelAuthenticationRequestMapper
         {
             NextPollAt = source.NextPollAt?.ToDateTimeOffset(),
             Status = source.Status.FromProtoStatus(),
+            ClientNotificationEndpoint = source.HasClientNotificationEndpoint
+                ? new Uri(source.ClientNotificationEndpoint)
+                : null,
+            ClientNotificationToken = source.HasClientNotificationToken
+                ? source.ClientNotificationToken
+                : null,
         };
     }
 


### PR DESCRIPTION
Closes the conformance gaps surfaced by a review of the CIBA (OpenID Connect CIBA Core 1.0) and mTLS (RFC 8705) implementations. Each fix landed test-first; in several cases an existing test had frozen the buggy behaviour as expected and was inverted to assert the spec-correct outcome.

## CIBA (OpenID Connect CIBA Core 1.0)

- **DCR rejected every valid ping/push client.** The valid-mode branch was commented out, so a `ping`/`push` registration with a notification endpoint fell through to "delivery mode not supported". Restructured to reject only modes outside the §4 set; the two tests that asserted the rejection were inverted.
- **Protobuf storage dropped `client_notification_endpoint` / `client_notification_token`.** Both were lost on every round-trip, silently breaking ping/push delivery (the callback URL and its bearer secret never survived). Added both fields to the proto and mapper.
- **`PushModeValidator` was never registered**, so push requests skipped the mandatory notification-endpoint check at request time. Registered it alongside `PingModeValidator`.
- **`UserIdentityValidator` silently accepted an invalid `login_hint_token`** (an `InvalidToken` failure was treated as "no usable hint") when the client opted into JWT parsing. Now any validation failure is rejected (CIBA §7.2 SHOULD return an error; aligns with the no-silent-swallow rule).
- **`slow_down` carried an `authorization_pending` description.** Reworded to the polling-cadence meaning (CIBA §11); the error code was already correct.
- **Documented the `user_code` security contract** on `IUserDeviceAuthenticationHandler`: the library validates presence only; the host MUST verify the code's value during the device interaction.

## mTLS (RFC 8705)

- **Certificate binding was lost or silently rebound on refresh.** `TokenAuthorizationContextEvaluator` recomputed `cnf.x5t#S256` from whatever certificate was on the current connection, so a refresh without a certificate dropped the binding to null and a rotated certificate rebound to it. RFC 8705 §4 says the AS SHOULD keep the refreshed token bound to the original certificate; the binding is now preserved and a fresh thumbprint is computed only at initial issuance.
- **`tls_client_auth` accepted more than one subject identifier.** RFC 8705 §2.1.2 requires exactly one; the DCR validator now rejects multiple, and the test that froze the multi-field acceptance was inverted.
- **`MatchSubjectDn` fell back to a case-insensitive string comparison** when DN parsing threw — a security-weakening path sensitive to attribute ordering and case. Removed: the required DN is validated at registration time, so a parse failure now fails closed.

## Deferred to a follow-up

RFC 8705 §3 certificate-bound-token verification at the protected resource (UserInfo / Introspection) and the `tls_client_certificate_bound_access_tokens` discovery flag are tracked separately — they are a larger change (new resource-side validator wired into two endpoints plus discovery metadata) and land in a follow-up PR.

No production behaviour outside these paths is affected; full unit suite green (2021 tests).