### PR TITLE
feat(mtls): RFC 8705 §3 certificate-bound access token verification + discovery flag

### DIFF
--- a/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
@@ -108,6 +108,7 @@ public class ConfigurationResponseFormatter(
 
 			TokenEndpointAuthMethodsSupported = response.TokenEndpointAuthMethodsSupported,
 			TokenEndpointAuthSigningAlgValuesSupported = response.TokenEndpointAuthSigningAlgValuesSupported,
+			TlsClientCertificateBoundAccessTokens = response.TlsClientCertificateBoundAccessTokens,
 
 			IdTokenSigningAlgValuesSupported = response.IdTokenSigningAlgValuesSupported,
 			SubjectTypesSupported = response.SubjectTypesSupported,

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
@@ -50,6 +50,7 @@ public class UserInfoRequestValidatorTests
     private readonly Mock<IAccessTokenService> _accessTokenService;
     private readonly Mock<IClientInfoProvider> _clientInfoProvider;
     private readonly Mock<IDPoPUserInfoValidator> _dpopValidator;
+    private readonly Mock<IMtlsUserInfoValidator> _mtlsValidator;
     private readonly UserInfoRequestValidator _validator;
 
     public UserInfoRequestValidatorTests(TestInfrastructure.LicenseFixture fixture)
@@ -61,12 +62,17 @@ public class UserInfoRequestValidatorTests
         _dpopValidator
             .Setup(v => v.ValidateAsync(It.IsAny<ClientRequest>(), It.IsAny<JsonWebToken>(), It.IsAny<string>()))
             .ReturnsAsync((OidcError?)null);
+        _mtlsValidator = new Mock<IMtlsUserInfoValidator>(MockBehavior.Strict);
+        _mtlsValidator
+            .Setup(v => v.Validate(It.IsAny<ClientRequest>(), It.IsAny<JsonWebToken>()))
+            .Returns((OidcError?)null);
 
         _validator = new UserInfoRequestValidator(
             _jwtValidator.Object,
             _accessTokenService.Object,
             _clientInfoProvider.Object,
-            _dpopValidator.Object);
+            _dpopValidator.Object,
+            _mtlsValidator.Object);
     }
 
     private static UserInfoRequest CreateUserInfoRequest(string? accessToken = null)

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/Validation/MtlsUserInfoValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/Validation/MtlsUserInfoValidatorTests.cs
@@ -1,0 +1,107 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System;
+using System.Buffers.Text;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.UserInfo.Validation;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.UserInfo.Validation;
+
+/// <summary>
+/// Verifies RFC 8705 §3 resource-side enforcement of certificate-bound access tokens in
+/// <see cref="MtlsUserInfoValidator"/>: a token carrying <c>cnf.x5t#S256</c> is accepted only
+/// when the certificate presented on the mutual-TLS connection hashes to the bound value, and
+/// rejected with <c>invalid_token</c> otherwise. Tokens without the binding pass through.
+/// </summary>
+public class MtlsUserInfoValidatorTests
+{
+    private readonly MtlsUserInfoValidator _validator = new();
+
+    [Fact]
+    public void UnboundToken_WithoutCertificate_IsAccepted()
+    {
+        // No cnf.x5t#S256 — a plain Bearer/DPoP token. The mTLS validator has nothing to
+        // enforce and must not reject it even when no certificate is presented.
+        var token = new JsonWebToken();
+        var request = new ClientRequest();
+
+        var result = _validator.Validate(request, token);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void BoundToken_WithMatchingCertificate_IsAccepted()
+    {
+        using var certificate = CreateCertificate();
+        var token = CreateBoundToken(ThumbprintOf(certificate));
+        var request = new ClientRequest { ClientCertificate = certificate };
+
+        var result = _validator.Validate(request, token);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void BoundToken_WithoutCertificate_IsRejected()
+    {
+        // RFC 8705 §3: a certificate-bound token presented over a connection that carries no
+        // client certificate must be rejected — the token is replayable otherwise.
+        var token = CreateBoundToken("some-committed-thumbprint");
+        var request = new ClientRequest();
+
+        var result = _validator.Validate(request, token);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidToken, result.Error);
+    }
+
+    [Fact]
+    public void BoundToken_WithDifferentCertificate_IsRejected()
+    {
+        // The presented certificate is not the one the token was bound to (stolen-token replay
+        // by a holder of a different certificate). RFC 8705 §3 requires rejection.
+        using var boundCertificate = CreateCertificate();
+        using var otherCertificate = CreateCertificate();
+        var token = CreateBoundToken(ThumbprintOf(boundCertificate));
+        var request = new ClientRequest { ClientCertificate = otherCertificate };
+
+        var result = _validator.Validate(request, token);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidToken, result.Error);
+    }
+
+    private static string ThumbprintOf(X509Certificate2 certificate) =>
+        Base64Url.EncodeToString(SHA256.HashData(certificate.RawData));
+
+    private static JsonWebToken CreateBoundToken(string thumbprint) =>
+        new()
+        {
+            Payload =
+            {
+                Confirmation = new JsonWebTokenConfirmation { CertificateSha256Thumbprint = thumbprint },
+            },
+        };
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Test Client",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        var notBefore = DateTimeOffset.Parse("2025-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        var notAfter = DateTimeOffset.Parse("2027-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        return request.CreateSelfSigned(notBefore, notAfter);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
@@ -278,6 +278,42 @@ public class DiscoveryControllerMtlsTests
         Assert.Equal(new Uri("https://mtls.example.com/userinfo"), result.Value.MtlsEndpointAliases.UserInfoEndpoint);
     }
 
+    /// <summary>
+    /// Verifies the RFC 8705 §3.3 tls_client_certificate_bound_access_tokens flag surfaces in the
+    /// formatted discovery document when the handler advertised support.
+    /// </summary>
+    [Fact]
+    public async Task ConfigurationAsync_WithCertificateBoundTokensSupported_ShouldSurfaceFlag()
+    {
+        // Arrange
+        var baseResponse = new ConfigurationResponse { TlsClientCertificateBoundAccessTokens = true };
+
+        // Act
+        var result = await _formatter.FormatResponseAsync(baseResponse);
+
+        // Assert
+        Assert.NotNull(result.Value);
+        Assert.True(result.Value.TlsClientCertificateBoundAccessTokens);
+    }
+
+    /// <summary>
+    /// Verifies the flag is omitted (null) when the provider does not advertise certificate-bound
+    /// token support, so the discovery document carries no misleading "false".
+    /// </summary>
+    [Fact]
+    public async Task ConfigurationAsync_WithoutCertificateBoundTokens_ShouldOmitFlag()
+    {
+        // Arrange
+        var baseResponse = new ConfigurationResponse();
+
+        // Act
+        var result = await _formatter.FormatResponseAsync(baseResponse);
+
+        // Assert
+        Assert.NotNull(result.Value);
+        Assert.Null(result.Value.TlsClientCertificateBoundAccessTokens);
+    }
+
     private void SetupEndpointResolver()
     {
         // Setup endpoint resolver to return predictable URIs

--- a/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
@@ -22,6 +22,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
@@ -85,6 +86,16 @@ public sealed class ConfigurationHandler(
 		RequireSignedRequestObject = options.Value.RequireSignedRequestObject,
 
 		TokenEndpointAuthMethodsSupported = clientAuthenticator.ClientAuthenticationMethodsSupported,
+
+		// RFC 8705 §3.3: advertise certificate-bound access tokens only when a mutual-TLS client
+		// authentication method is available — the server then both issues bound tokens and
+		// enforces the binding at its protected resources (MtlsUserInfoValidator).
+		TlsClientCertificateBoundAccessTokens = clientAuthenticator.ClientAuthenticationMethodsSupported.Any(
+			method => method is ClientAuthenticationMethods.TlsClientAuth
+				or ClientAuthenticationMethods.SelfSignedTlsClientAuth)
+			? true
+			: null,
+
 		TokenEndpointAuthSigningAlgValuesSupported = jwtAlgorithms.SigningAlgorithmsSupported,
 		IdTokenSigningAlgValuesSupported = jwtAlgorithms.SignedResponseAlgorithmsSupported,
 		UserInfoSigningAlgValuesSupported = jwtAlgorithms.SignedResponseAlgorithmsSupported,

--- a/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
@@ -133,6 +133,14 @@ public record ConfigurationResponse
 	public IEnumerable<string>? DpopSigningAlgValuesSupported { init; get; }
 
 	/// <summary>
+	/// Indicates support for mutual-TLS client certificate-bound access tokens
+	/// (<c>tls_client_certificate_bound_access_tokens</c>, RFC 8705 §3.3). <c>true</c> when
+	/// the provider both issues such tokens and enforces the binding at its protected
+	/// resources; <c>null</c> (omitted) otherwise.
+	/// </summary>
+	public bool? TlsClientCertificateBoundAccessTokens { init; get; }
+
+	/// <summary>
 	/// Specifies the signing algorithms supported for request objects.
 	/// </summary>
 	public IEnumerable<string>? RequestObjectSigningAlgValuesSupported { init; get; }

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -492,6 +492,7 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IUserInfoRequestValidator, UserInfoRequestValidator>();
         services.TryAddScoped<IUserInfoRequestProcessor, UserInfoRequestProcessor>();
         services.TryAddSingleton<IDPoPUserInfoValidator, UserInfo.Validation.DPoPUserInfoValidator>();
+        services.TryAddSingleton<IMtlsUserInfoValidator, UserInfo.Validation.MtlsUserInfoValidator>();
         return services;
     }
 

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/Interfaces/IMtlsUserInfoValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/Interfaces/IMtlsUserInfoValidator.cs
@@ -1,0 +1,52 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/Oidc.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Model;
+
+namespace Abblix.Oidc.Server.Endpoints.UserInfo.Interfaces;
+
+/// <summary>
+/// Validates the mutual-TLS certificate-binding contract on a UserInfo request per
+/// RFC 8705 §3: when the inbound access token is certificate-bound (carries
+/// <c>cnf.x5t#S256</c>), the protected resource MUST obtain the client certificate used for
+/// mutual TLS and verify that its SHA-256 thumbprint matches the bound value, rejecting the
+/// request otherwise. Unbound access tokens bypass the check. Sibling of
+/// <see cref="IDPoPUserInfoValidator"/>: the two proof-of-possession mechanisms (DPoP
+/// <c>cnf.jkt</c> and mTLS <c>cnf.x5t#S256</c>) are independent and a token carrying both
+/// must satisfy each.
+/// </summary>
+public interface IMtlsUserInfoValidator
+{
+    /// <summary>
+    /// Returns <c>null</c> when the binding holds (or the token is not certificate-bound),
+    /// and an <see cref="OidcError"/> with <c>invalid_token</c> when the token is bound but
+    /// the presented certificate is absent or its thumbprint does not match
+    /// <c>cnf.x5t#S256</c> (RFC 8705 §3 — HTTP 401, per RFC 6750).
+    /// </summary>
+    /// <param name="clientRequest">Carries the client certificate presented on the mutual-TLS
+    /// connection (when any).</param>
+    /// <param name="accessToken">The parsed access-token JWT whose <c>cnf.x5t#S256</c>
+    /// (when present) the presented certificate must match.</param>
+    OidcError? Validate(ClientRequest clientRequest, JsonWebToken accessToken);
+}

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
@@ -48,11 +48,14 @@ namespace Abblix.Oidc.Server.Endpoints.UserInfo;
 /// <param name="clientInfoProvider">Loads the <see cref="ClientInfo"/> for the token's client.</param>
 /// <param name="dpopValidator">RFC 9449 §7 DPoP resource-server-side validator that enforces the
 /// proof-of-possession binding when the access token carries a <c>cnf.jkt</c> confirmation.</param>
+/// <param name="mtlsValidator">RFC 8705 §3 mutual-TLS resource-server-side validator that enforces
+/// the certificate binding when the access token carries a <c>cnf.x5t#S256</c> confirmation.</param>
 public class UserInfoRequestValidator(
 	IAuthServiceJwtValidator jwtValidator,
 	IAccessTokenService accessTokenService,
 	IClientInfoProvider clientInfoProvider,
-	IDPoPUserInfoValidator dpopValidator) : IUserInfoRequestValidator
+	IDPoPUserInfoValidator dpopValidator,
+	IMtlsUserInfoValidator mtlsValidator) : IUserInfoRequestValidator
 {
 	/// <summary>
 	/// Asynchronously validates a user information request and determines its validity based on
@@ -132,6 +135,13 @@ public class UserInfoRequestValidator(
 		var dpopError = await dpopValidator.ValidateAsync(clientRequest, token, jwtAccessToken);
 		if (dpopError is not null)
 			return dpopError;
+
+		// RFC 8705 §3 RS-side enforcement: when the access token carries cnf.x5t#S256 the
+		// certificate presented on the mutual-TLS connection MUST hash to the bound value.
+		// Independent of the DPoP binding above — a token carrying both must satisfy each.
+		var mtlsError = mtlsValidator.Validate(clientRequest, token);
+		if (mtlsError is not null)
+			return mtlsError;
 
 		var (authSession, authContext) = await accessTokenService.AuthenticateByAccessTokenAsync(token);
 

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/Validation/MtlsUserInfoValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/Validation/MtlsUserInfoValidator.cs
@@ -1,0 +1,73 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/Oidc.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.UserInfo.Interfaces;
+using Abblix.Oidc.Server.Model;
+
+namespace Abblix.Oidc.Server.Endpoints.UserInfo.Validation;
+
+/// <summary>
+/// Resource-server-side enforcement of RFC 8705 §3 mutual-TLS certificate-bound access tokens
+/// at the UserInfo endpoint. Mirrors the role of <see cref="DPoPUserInfoValidator"/> for the
+/// <c>cnf.x5t#S256</c> binding: when the access token is certificate-bound, the SHA-256
+/// thumbprint of the certificate presented on the mutual-TLS connection MUST match the bound
+/// value, otherwise the request is rejected with <c>invalid_token</c> (HTTP 401, per RFC 6750).
+/// </summary>
+public class MtlsUserInfoValidator : IMtlsUserInfoValidator
+{
+    /// <inheritdoc/>
+    public OidcError? Validate(ClientRequest clientRequest, JsonWebToken accessToken)
+    {
+        if (accessToken.Payload.Confirmation?.CertificateSha256Thumbprint is not { } committed)
+        {
+            // Not certificate-bound (no cnf.x5t#S256). Bearer / DPoP-only tokens are handled
+            // by their own paths; nothing to enforce here.
+            return null;
+        }
+
+        if (clientRequest.ClientCertificate is not { } certificate)
+        {
+            return new OidcError(
+                ErrorCodes.InvalidToken,
+                "The access token is certificate-bound (cnf.x5t#S256) but no client certificate " +
+                "was presented on the mutual-TLS connection.");
+        }
+
+        // RFC 8705 §3.1: cnf.x5t#S256 is the base64url-encoded SHA-256 digest of the DER
+        // encoding of the certificate, with trailing '=' padding removed.
+        var presented = Base64Url.EncodeToString(SHA256.HashData(certificate.RawData));
+        if (!string.Equals(presented, committed, StringComparison.Ordinal))
+        {
+            return new OidcError(
+                ErrorCodes.InvalidToken,
+                "The presented client certificate does not match the access token's " +
+                "cnf.x5t#S256 binding.");
+        }
+
+        return null;
+    }
+}

--- a/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
@@ -204,6 +204,11 @@ public record ConfigurationResponse
         /// endpoint URLs (RFC 8705 §5).</summary>
         public const string MtlsEndpointAliases = "mtls_endpoint_aliases";
 
+        /// <summary>The <c>tls_client_certificate_bound_access_tokens</c> metadata flag advertising
+        /// that the provider supports mutual-TLS client certificate-bound access tokens
+        /// (RFC 8705 §3.3).</summary>
+        public const string TlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens";
+
         /// <summary>The <c>acr_values_supported</c> metadata field listing Authentication Context Class
         /// Reference values the provider can satisfy.</summary>
         public const string AcrValuesSupported = "acr_values_supported";
@@ -485,6 +490,14 @@ public record ConfigurationResponse
     /// </summary>
     [JsonPropertyName(Parameters.MtlsEndpointAliases)]
     public MtlsAliases? MtlsEndpointAliases { get; init; }
+
+    /// <summary>
+    /// RFC 8705 §3.3: indicates that the provider supports mutual-TLS client certificate-bound
+    /// access tokens. Emitted as <c>true</c> when the provider both issues such tokens and
+    /// enforces the binding at its protected resources; omitted otherwise.
+    /// </summary>
+    [JsonPropertyName(Parameters.TlsClientCertificateBoundAccessTokens)]
+    public bool? TlsClientCertificateBoundAccessTokens { get; init; }
 
     /// <summary>
     /// Lists the ACR (Authentication Context Class Reference) values supported by the OpenID Provider.


### PR DESCRIPTION
Follow-up to #158. Closes the deferred RFC 8705 §3 gap: the server issued certificate-bound access tokens (writing `cnf.x5t#S256`) but never verified the binding at its protected resource, and never advertised the capability.

## Resource-side verification (RFC 8705 §3)

§3 requires a protected resource to obtain the client certificate from the mutual-TLS connection and verify it matches the access token's `cnf.x5t#S256`, rejecting with `invalid_token` (HTTP 401) otherwise. UserInfo accepted certificate-bound tokens as plain bearer tokens, so a bound token was replayable by any holder without the certificate — defeating the sender-constraint.

- New `MtlsUserInfoValidator` (sibling of `DPoPUserInfoValidator`): when the token carries `cnf.x5t#S256`, recomputes `base64url(SHA-256(DER))` from the presented certificate and rejects on a missing or mismatched certificate. Wired into `UserInfoRequestValidator` alongside the DPoP check — the two proof-of-possession bindings are independent and a token carrying both must satisfy each.
- **Introspection** needs no change: the response already echoes the full token payload (including `cnf`), satisfying §3.2 — the binding is conveyed to the calling resource server, which performs its own §3 check.

## Discovery metadata (RFC 8705 §3.3)

- Threads `tls_client_certificate_bound_access_tokens` (IANA OAuth Authorization Server Metadata, RFC 8705 §3.3) through the discovery DTO chain. Emitted `true` only when a mutual-TLS client authentication method is supported — i.e. when the server both issues bound tokens and now enforces the binding; omitted otherwise.

## Notes

- The verification design uses a sibling validator rather than a shared base with `DPoPUserInfoValidator`: the substantive logic is disjoint (proof-JWT machinery vs certificate-hash recompute) and the only common skeleton is already served by the typed `JsonWebTokenConfirmation` accessor.
- Standards docs (`implemented-standards.md`) update for RFC 8705 §3 certificate-bound tokens is a separate Docs-repo change.

Full unit suite green (2020 tests).