### PR TITLE
chore(jwt): use operator form for clock-skew arithmetic

### DIFF
--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -590,14 +590,14 @@ internal class JsonWebTokenValidator(
         if (notBefore.HasValue)
         {
             var notBeforeUtc = notBefore.Value.ToUniversalTime();
-            if (utcNow.Add(parameters.ClockSkew) < notBeforeUtc)
+            if (utcNow + parameters.ClockSkew < notBeforeUtc)
                 return new JwtValidationError(JwtError.InvalidToken, "Token not yet valid");
         }
 
         if (expiresAt.HasValue)
         {
             var expiresUtc = expiresAt.Value.ToUniversalTime();
-            if (expiresUtc <= utcNow.Subtract(parameters.ClockSkew))
+            if (expiresUtc <= utcNow - parameters.ClockSkew)
                 return new JwtValidationError(JwtError.InvalidToken, "Token has expired");
         }
 


### PR DESCRIPTION
Cosmetic, behaviour-identical: replace `DateTimeOffset.Add`/`Subtract` with the `+`/`-` operators in JsonWebTokenValidator's not-before and expiry comparisons. The operator form reads closer to the arithmetic it expresses; no behaviour change.