### PR TITLE
test: fix flaky CI failures from parallelised suites (licensing static state + shared host race)

### DIFF
--- a/Abblix.Oidc.Server.E2E.Tests/TestFactory.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests;
 
@@ -17,8 +18,23 @@ namespace Abblix.Oidc.Server.E2E.Tests;
 /// (no Initial Access Token) — are applied here; everything else is
 /// what a real consumer of Abblix.Oidc.Server gets.
 /// </summary>
-public class TestFactory : WebApplicationFactory<Program>
+public class TestFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
+    /// <summary>
+    /// Eagerly builds the single shared host once, before the parallel test classes touch it.
+    /// WebApplicationFactory builds its host lazily on first access and its EnsureServer step is
+    /// not thread-safe; under the assembly-fixture + parallel-collection model, concurrent
+    /// first-access would otherwise build the host more than once — each build mints a fresh
+    /// signing key and gets its own isolated in-memory stores, so a token issued through one
+    /// build fails signature validation (or grant lookup) against another. Forcing the build here,
+    /// single-threaded, removes that race. This is test-infrastructure correctness, not behaviour.
+    /// </summary>
+    public ValueTask InitializeAsync()
+    {
+        _ = Server;
+        return ValueTask.CompletedTask;
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Test");

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/AggregationExtensionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/AggregationExtensionsTests.cs
@@ -32,6 +32,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 /// <summary>
 /// Tests for AggregationExtensions methods used in license merging and comparison operations.
 /// </summary>
+[Collection("License")]
 public class AggregationExtensionsTests
 {
     #region Greater<T> Tests

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
@@ -43,6 +43,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 /// This approach tests the underlying license aggregation and enforcement logic
 /// that LicenseChecker relies on, but in a fully isolated manner.
 /// </remarks>
+[Collection("License")]
 public class LicenseEnforcementTests
 {
     #region Client Limit Enforcement

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoaderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoaderTests.cs
@@ -45,6 +45,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 ///
 /// Successful license loading is tested through integration tests with actual licenses.
 /// </remarks>
+[Collection("License")]
 public class LicenseLoaderTests
 {
     #region Invalid JWT Tests

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
@@ -52,6 +52,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 ///
 /// Full integration testing with valid licenses requires actual Abblix license JWTs.
 /// </remarks>
+[Collection("License")]
 public class LicenseLoadingServiceTests
 {
     #region Helper Classes

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
@@ -47,6 +47,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 /// - Concurrent access safety
 /// - Cleanup timer functionality
 /// </remarks>
+[Collection("License")]
 public class LicenseLoggerTests
 {
     #region Basic Throttling Tests

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -32,6 +32,7 @@ using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 
+[Collection("License")]
 public class LicenseManagerTests
 {
     private static License CreateLicense(int? notBefore, int? expiresAt, int? gracePeriod = null)

--- a/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseProvidersTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseProvidersTests.cs
@@ -35,6 +35,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 /// <summary>
 /// Tests for license JWT provider implementations.
 /// </summary>
+[Collection("License")]
 public class LicenseProvidersTests
 {
     #region StaticLicenseJwtProvider Tests

--- a/Abblix.Oidc.Server.UnitTests/TestInfrastructure/LicenseCollection.cs
+++ b/Abblix.Oidc.Server.UnitTests/TestInfrastructure/LicenseCollection.cs
@@ -3,8 +3,18 @@ using Xunit;
 namespace Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 
 /// <summary>
-/// xUnit collection definition for tests that require license configuration.
-/// Use [Collection("License")] attribute on test classes to ensure license is set up.
+/// xUnit collection definition for tests that touch the global static licensing state
+/// (<c>LicenseChecker</c>, <c>LicenseLogger.Instance</c>) — whether they mutate it (loading
+/// licenses, exercising the checker) or read it through the permissive <see cref="LicenseFixture"/>.
+/// Use <c>[Collection("License")]</c> on such test classes.
 /// </summary>
-[CollectionDefinition("License")]
+/// <remarks>
+/// <see cref="DisableParallelization"/> is intentionally <c>true</c>: the licensing state is a
+/// process-wide static with no reset hook (a deliberate anti-tamper design), so a test mutating it
+/// must never overlap any other test reading or writing it. This collection therefore runs in
+/// xUnit's non-parallel phase, isolated from the rest of the suite. Without this, a license-loading
+/// test racing the parallel suite leaves the static checker in an unexpected state and produces
+/// flaky, CI-only failures.
+/// </remarks>
+[CollectionDefinition("License", DisableParallelization = true)]
 public class LicenseCollection : ICollectionFixture<LicenseFixture>;


### PR DESCRIPTION
Fixes the flaky, CI-only test failures that surfaced after the test suites were parallelised (#157). Two independent root causes, both confirmed from the CI TRX (the failures do not reproduce locally, even in Release under stress):

## Licensing tests racing the parallel suite

`LicenseLoadingServiceTests.StartAsync_WithCancellation` failed with a half-applied-license error instead of the expected cancellation. The licensing tests exercise the process-wide static `LicenseChecker` / `LicenseLogger.Instance`, which have no reset hook (a deliberate anti-tamper design), yet only `LicenseCheckerTests` was in the `License` collection and that collection allowed parallel execution with other collections.

- Mark the `License` collection `DisableParallelization = true` and place every `Features/Licensing` test class into it, so they run as one isolated, non-parallel block that never overlaps a test reading or writing the static licensing state.

## E2E shared-host concurrent-creation race

`RarConsentTests.Refresh_token_grant_preserves_authorization_details_byte_exact` and `TokenExchangeTests.Impersonation_...` failed with `invalid_grant "No signing key matched ... none usable"` and an invalid `subject_token`. After the E2E suite was parallelised across classes over a single assembly-fixture host, `WebApplicationFactory`'s lazy `EnsureServer` (not thread-safe) could build the host more than once under concurrent first-access — each build minting a fresh signing key and isolated in-memory stores, so a token issued through one build failed validation/lookup against another.

- Implement `IAsyncLifetime` on `TestFactory` and force the host build once in `InitializeAsync` (awaited by xUnit before any test runs), establishing the single shared host and its signing key before parallel access.

Diagnosed from the `test-results` artifact of the failed run on #158; root causes are in develop (introduced by #157), so this lands as a standalone fix that unblocks the open PRs. Test-infrastructure only — no production code changes. Full unit suite (2014) and E2E suite (48) green locally.