### PR TITLE
docs(client-auth): record why authentication stays a try-each composite, not keyed-DI

### DIFF
--- a/Abblix.Oidc.Server/Features/ClientAuthentication/CompositeClientAuthenticator.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/CompositeClientAuthenticator.cs
@@ -30,6 +30,13 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// This class allows for attempting client authentication through a sequence of different
 /// authentication methods, providing flexibility in supporting multiple authentication protocols.
 /// </summary>
+/// <remarks>
+/// This is intentionally a try-each composite rather than keyed-name DI by
+/// <c>token_endpoint_auth_method</c>: that method is not a discriminator present in the token
+/// request (it is the client's registered metadata), so it cannot be keyed on directly — each
+/// authenticator instead self-selects by recognising its own credential form. See the rationale
+/// at <see cref="ServiceCollectionExtensions.AddClientAuthentication"/>.
+/// </remarks>
 internal class CompositeClientAuthenticator(params IClientAuthenticator[] clientAuthenticators)
 	: IClientAuthenticator
 {

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -80,6 +80,18 @@ public static class ServiceCollectionExtensions
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddClientAuthentication(this IServiceCollection services)
     {
+        // Deliberate design: client authentication is a try-each composite, NOT keyed-name DI
+        // by token_endpoint_auth_method. Unlike the keyed-DI extension points in this codebase
+        // (signers by alg, RAR validators by type, crit handlers by name), the auth method is
+        // NOT a discriminator carried in the incoming token request — it is the client's
+        // registered metadata. The request only presents credentials whose FORM implies the
+        // method (Basic header, body secret, mTLS certificate, client_assertion JWT), and
+        // client_id itself is extracted method-specifically (decoded from the Base64 Basic
+        // header vs read from the body vs taken from the assertion's sub). Keying on the method
+        // would require first detecting the credential form to derive it — which is exactly what
+        // each authenticator's TryAuthenticateClientAsync already does — so keyed dispatch would
+        // be circular and strictly more complex. Each authenticator self-selects by inspecting
+        // the request for its own credential shape; the composite returns the first match.
         services.TryAddEnumerable([
             ServiceDescriptor.Singleton<IClientAuthenticator, NoneClientAuthenticator>(),
             ServiceDescriptor.Singleton<IClientAuthenticator, ClientSecretPostAuthenticator>(),


### PR DESCRIPTION
Records the decision (from review discussion) NOT to migrate client authentication to keyed-name DI.

On close inspection of the authenticators, `token_endpoint_auth_method` is not a discriminator present in the token request — it is the client's registered metadata. The request only carries credentials whose *form* implies the method (Basic header, body secret, mTLS certificate, `client_assertion` JWT), and `client_id` is itself extracted method-specifically (decoded from the Base64 Basic header vs read from the body vs taken from the assertion's `sub`). Keying on the method would require first detecting the credential form to derive it — exactly what each authenticator's `TryAuthenticateClientAsync` already does — so keyed dispatch would be circular and strictly more complex. The try-each composite is the correct pattern here.

Comment-only: documents the rationale at `AddClientAuthentication` and on `CompositeClientAuthenticator` so the migration isn't proposed again. No behaviour change.