### PR TITLE
fix(client-auth): constant-time secret compare; require jti on client assertions

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
@@ -363,11 +363,12 @@ public class ClientSecretJwtAuthenticatorTests
     }
 
     /// <summary>
-    /// Verifies authentication succeeds when JWT has no JTI.
-    /// Per OIDC Core, JTI is recommended but not required.
+    /// Verifies authentication is rejected when the assertion has no jti. OpenID Connect Core §9
+    /// makes jti REQUIRED ("A unique identifier for the token, which can be used to prevent reuse
+    /// of the token"); without it the assertion is replayable within its expiry window.
     /// </summary>
     [Fact]
-    public async Task TryAuthenticateClientAsync_WithoutJti_ShouldAuthenticate()
+    public async Task TryAuthenticateClientAsync_WithoutJti_ShouldReturnNull()
     {
         // Arrange
         var jwt = "valid.jwt.token";
@@ -412,10 +413,9 @@ public class ClientSecretJwtAuthenticatorTests
         var result = await _authenticator.TryAuthenticateClientAsync(request);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ClientId, result.ClientId);
+        Assert.Null(result);
 
-        // JWT registry should not be called without JTI
+        // A rejected assertion is never recorded in the replay registry.
         _tokenRegistry.Verify(r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()), Times.Never);
     }
 

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
@@ -66,7 +66,10 @@ public class PrivateKeyJwtAuthenticatorTests
         var (authenticator, mocks) = CreateAuthenticator();
 
         var clientInfo = CreateClientInfo(ClientId);
-        var validToken = CreateValidJwtToken(ClientId, ClientId);
+        // A spec-valid client assertion carries a jti (OIDC Core §9 REQUIRED).
+        var validToken = CreateValidJwtTokenWithJtiAndExp(
+            ClientId, ClientId, "valid-jti-assertion",
+            DateTimeOffset.Parse("2027-01-01T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture));
 
         mocks.ClientJwtValidator
             .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
@@ -339,21 +342,23 @@ public class PrivateKeyJwtAuthenticatorTests
     }
 
     /// <summary>
-    /// Verifies that authentication succeeds even when jti claim is missing.
-    /// While jti is recommended for preventing replay attacks, it's not strictly required.
+    /// Verifies that an assertion without a jti claim is rejected. OpenID Connect Core §9 makes
+    /// jti REQUIRED ("A unique identifier for the token, which can be used to prevent reuse of the
+    /// token"); accepting a jti-less assertion would leave it replayable within its expiry window,
+    /// since single-use enforcement keys off jti.
     /// </summary>
     [Fact]
-    public async Task ValidJwtWithoutJti_ShouldAuthenticate()
+    public async Task AssertionWithoutJti_ShouldReturnNull()
     {
         // Arrange
         var (authenticator, mocks) = CreateAuthenticator();
 
         var clientInfo = CreateClientInfo(ClientId);
-        var validToken = CreateValidJwtToken(ClientId, ClientId);
+        var tokenWithoutJti = CreateValidJwtToken(ClientId, ClientId);
 
         mocks.ClientJwtValidator
             .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
-            .ReturnsAsync(new ValidJsonWebToken(validToken, clientInfo));
+            .ReturnsAsync(new ValidJsonWebToken(tokenWithoutJti, clientInfo));
 
         var request = new ClientRequest
         {
@@ -365,9 +370,8 @@ public class PrivateKeyJwtAuthenticatorTests
         var result = await authenticator.TryAuthenticateClientAsync(request);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ClientId, result.ClientId);
-        // Verify no token registry interaction when jti is missing
+        Assert.Null(result);
+        // A rejected assertion is never recorded in the replay registry.
         mocks.TokenRegistry.Verify(
             r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()),
             Times.Never);

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretAuthenticator.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretAuthenticator.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using CryptographicOperations = System.Security.Cryptography.CryptographicOperations;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Hashing;
 using Abblix.Oidc.Server.Features.Licensing;
@@ -148,7 +149,9 @@ public abstract partial class ClientSecretAuthenticator(
 		{
 			hash ??= hashService.Sha(hashAlgorithm, secretValue);
 
-			if (validSecretHash.SequenceEqual(hash))
+			// Constant-time compare of the secret hashes (both are fixed-length digests of the
+			// same algorithm) so the token endpoint does not leak a timing oracle on the hash.
+			if (CryptographicOperations.FixedTimeEquals(validSecretHash, hash))
 				yield return clientSecret;
 		}
 	}

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
@@ -62,4 +62,10 @@ partial class JwtAssertionAuthenticatorBase
         Level = LogLevel.Warning,
         Message = "The error during authentication: iss is '{Issuer}', but sub is {Subject}")]
     private partial void LogIssuerSubjectMismatch(string? Issuer, string? Subject);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.MissingJti,
+        Level = LogLevel.Warning,
+        Message = "The client assertion for {@ClientId} has no jti claim, which OIDC Core §9 requires for single-use replay protection")]
+    private partial void LogMissingJti(string ClientId);
 }

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -108,7 +108,18 @@ public abstract partial class JwtAssertionAuthenticatorBase(
             return null;
         }
 
-        if (token is { Payload: { JwtId: { } jwtId, ExpiresAt: { } expiresAt } })
+        // OIDC Core §9: the client-authentication assertion's jti is REQUIRED — "A unique
+        // identifier for the token, which can be used to prevent reuse of the token". Reject an
+        // assertion without it: single-use replay protection is impossible without a unique id,
+        // and accepting it would leave the assertion replayable within its expiry window (the
+        // replay registry below, and the validation decorator, both key off jti).
+        if (token.Payload.JwtId is not { } jwtId)
+        {
+            LogMissingJti(clientInfo.ClientId);
+            return null;
+        }
+
+        if (token.Payload.ExpiresAt is { } expiresAt)
         {
             await tokenRegistry.SetStatusAsync(jwtId, JsonWebTokenStatus.Used, expiresAt);
         }

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -201,6 +201,7 @@ internal static class LogEvents
             public const int AuthMethodNotAllowed = Base + 4;
             public const int SubjectExtractionFailed = Base + 5;
             public const int IssuerSubjectMismatch = Base + 6;
+            public const int MissingJti = Base + 7;
         }
 
         /// <summary>


### PR DESCRIPTION
Two findings from a security review of `Features/ClientAuthentication`.

**Constant-time secret comparison (High).** `ClientSecretAuthenticator` compared the presented secret's hash to the stored hash with the short-circuiting `Enumerable.SequenceEqual` on the token-endpoint authentication hot path. Replaced with `CryptographicOperations.FixedTimeEquals`. The comparison is over fixed-length SHA-256/512 digests (so the real-world timing signal was already attenuated), but a fixed-time primitive is the correct bar.

**Require jti on client assertions (Medium, OIDC Core §9).** `JwtAssertionAuthenticatorBase` recorded and checked the replay marker only when the assertion carried a `jti`, so an assertion omitting `jti` bypassed single-use protection and was replayable within its expiry window. OpenID Connect Core §9 makes `jti` REQUIRED for the `private_key_jwt` / `client_secret_jwt` assertion ("A unique identifier for the token, which can be used to prevent reuse of the token"). The assertion is now rejected when `jti` is absent. The two tests that had frozen the jti-optional acceptance (private_key_jwt, client_secret_jwt) were inverted to assert rejection.

Unit tests reproduce the jti gap (red→green via the inverted tests); the constant-time change is behaviour-preserving (timing isn't unit-testable). Full suite green (2027). No E2E (assertion replay needs cert/JWT-signing infra disproportionate to the fix).

Lower-priority review items deferred: registry check-and-set is read-then-write (TOCTOU under concurrency); client_secret_jwt requires plaintext-secret-at-rest (inherent, undocumented); SAN-URI parse-drop is silent; HashService uses ASCII for secret bytes.