### PR TITLE
fix(device): harden Device Authorization Grant per RFC 8628

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Common/Configuration/DeviceAuthorizationOptionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/Configuration/DeviceAuthorizationOptionsTests.cs
@@ -1,0 +1,63 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Common.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Verifies the configuration-time guards on <see cref="DeviceAuthorizationOptions"/>. RFC 8628
+/// Section 5.2 requires a very high entropy device code; since the device code carries no usability
+/// constraint (it is never shown to the user), the option rejects byte lengths below the 128-bit
+/// cryptographic floor rather than silently emitting a weak, guessable code.
+/// </summary>
+public class DeviceAuthorizationOptionsTests
+{
+    [Theory]
+    [InlineData(8)]   // 64 bits
+    [InlineData(15)]  // 120 bits — just below the floor
+    public void DeviceCodeLength_BelowEntropyFloor_Throws(int lengthInBytes)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateOptions(lengthInBytes));
+    }
+
+    [Theory]
+    [InlineData(16)]  // 128 bits — the floor
+    [InlineData(32)]  // 256 bits — the documented default
+    public void DeviceCodeLength_AtOrAboveEntropyFloor_IsAccepted(int lengthInBytes)
+    {
+        var options = CreateOptions(lengthInBytes);
+
+        Assert.Equal(lengthInBytes, options.DeviceCodeLength);
+    }
+
+    private static DeviceAuthorizationOptions CreateOptions(int deviceCodeLength) => new()
+    {
+        CodeLifetime = TimeSpan.FromMinutes(5),
+        PollingInterval = TimeSpan.FromSeconds(5),
+        DeviceCodeLength = deviceCodeLength,
+        UserCodeLength = 8,
+        VerificationUri = new Uri("https://auth.example.com/device"),
+    };
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeNormalizerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeNormalizerTests.cs
@@ -1,0 +1,83 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.DeviceAuthorization;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.DeviceAuthorization;
+
+/// <summary>
+/// Verifies user code canonicalization per the input-processing guidance in RFC 8628 Section 6.1:
+/// readability punctuation and out-of-alphabet characters are stripped, and case is folded only
+/// when the configured alphabet is single-case.
+/// </summary>
+public class UserCodeNormalizerTests
+{
+    private const string Consonants = "BCDFGHJKLMNPQRSTVWXZ";
+    private const string Digits = "0123456789";
+
+    [Theory]
+    // Consonant (upper-only) alphabet: lowercase folds up, dashes and spaces are dropped.
+    [InlineData(Consonants, "wdjb-mjht", "WDJBMJHT")]
+    [InlineData(Consonants, "WDJB-MJHT", "WDJBMJHT")]
+    [InlineData(Consonants, " wdjb mjht ", "WDJBMJHT")]
+    // Numeric alphabet is caseless: only dashes/spaces are dropped, digits preserved.
+    [InlineData(Digits, "019-450-730", "019450730")]
+    [InlineData(Digits, "019 450 730", "019450730")]
+    public void Normalize_StripsPunctuationAndFoldsCaseForSingleCaseAlphabets(
+        string alphabet, string input, string expected)
+    {
+        var normalizer = CreateNormalizer(alphabet);
+
+        Assert.Equal(expected, normalizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_DoesNotFoldCase_ForMixedCaseAlphabet()
+    {
+        // A mixed-case alphabet distinguishes 'a' from 'A'; folding would collapse them, so the
+        // normalizer must preserve case and only drop characters outside the set.
+        var normalizer = CreateNormalizer("aB");
+
+        // 'a' and 'B' are in the set and kept; the dash is dropped.
+        Assert.Equal("aB", normalizer.Normalize("a-B"));
+        // 'A' and 'b' are NOT in the set (no case folding) and are dropped; 'a' survives.
+        Assert.Equal("a", normalizer.Normalize("A-a-b"));
+    }
+
+    private static UserCodeNormalizer CreateNormalizer(string alphabet) => new(
+        Options.Create(new OidcOptions
+        {
+            DeviceAuthorization = new DeviceAuthorizationOptions
+            {
+                CodeLifetime = TimeSpan.FromMinutes(5),
+                PollingInterval = TimeSpan.FromSeconds(5),
+                DeviceCodeLength = 32,
+                UserCodeLength = 8,
+                VerificationUri = new Uri("https://auth.example.com/device"),
+                UserCodeAlphabet = alphabet,
+            },
+        }));
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeRateLimiterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeRateLimiterTests.cs
@@ -1,0 +1,100 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.DeviceAuthorization;
+using Abblix.Oidc.Server.Features.Storages;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.DeviceAuthorization;
+
+/// <summary>
+/// Verifies the per-IP rate-limiting invariant in <see cref="UserCodeRateLimiter"/> (RFC 8628
+/// Section 5.2). The per-user-code counter and the per-IP counter protect against different
+/// attacks: the per-user-code backoff slows guessing of a single code, while the per-IP counter
+/// caps how many failures a single source may accumulate across many distinct codes. A successful
+/// verification legitimately clears the per-user-code backoff, but it must NOT clear the per-IP
+/// counter — otherwise an attacker who occasionally lands a valid code can reset the cross-code
+/// brute-force budget at will.
+/// </summary>
+public class UserCodeRateLimiterTests
+{
+    private const string UserCode = "WDJB-MJHT";
+    private const string ClientIdentifier = "203.0.113.7";
+    private const string UserCodeKey = "rate-limit:user-code:WDJB-MJHT";
+    private const string IpKey = "rate-limit:ip:203.0.113.7";
+
+    private readonly Mock<IEntityStorage> _storage;
+    private readonly UserCodeRateLimiter _rateLimiter;
+
+    public UserCodeRateLimiterTests()
+    {
+        _storage = new Mock<IEntityStorage>(MockBehavior.Loose);
+
+        var keyFactory = new Mock<IEntityStorageKeyFactory>(MockBehavior.Loose);
+        keyFactory.Setup(f => f.UserCodeRateLimitKey(UserCode)).Returns(UserCodeKey);
+        keyFactory.Setup(f => f.IpRateLimitKey(ClientIdentifier)).Returns(IpKey);
+
+        _rateLimiter = new UserCodeRateLimiter(
+            NullLogger<UserCodeRateLimiter>.Instance,
+            _storage.Object,
+            keyFactory.Object,
+            TimeProvider.System,
+            Options.Create(new OidcOptions { DeviceAuthorization = CreateDeviceAuthorizationOptions() }));
+    }
+
+    private static DeviceAuthorizationOptions CreateDeviceAuthorizationOptions() => new()
+    {
+        CodeLifetime = TimeSpan.FromMinutes(5),
+        PollingInterval = TimeSpan.FromSeconds(5),
+        DeviceCodeLength = 32,
+        UserCodeLength = 8,
+        VerificationUri = new Uri("https://auth.example.com/device"),
+    };
+
+    [Fact]
+    public async Task RecordSuccess_ClearsPerUserCodeBackoff()
+    {
+        await _rateLimiter.RecordSuccessAsync(UserCode, ClientIdentifier);
+
+        _storage.Verify(
+            s => s.RemoveAsync(UserCodeKey, It.IsAny<CancellationToken?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordSuccess_DoesNotClearPerIpCounter()
+    {
+        // A successful verification must not wipe the cross-code per-IP brute-force budget.
+        await _rateLimiter.RecordSuccessAsync(UserCode, ClientIdentifier);
+
+        _storage.Verify(
+            s => s.RemoveAsync(IpKey, It.IsAny<CancellationToken?>()),
+            Times.Never);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -1,0 +1,97 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.DeviceAuthorization;
+using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
+using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.DeviceAuthorization;
+
+/// <summary>
+/// Verifies that <see cref="UserCodeVerificationService"/> canonicalizes the user-entered code
+/// before lookup (RFC 8628 Section 6.1), so the readability variants a user may type — a different
+/// case or copied-in dashes — resolve to the same stored device authorization request rather than
+/// being rejected as invalid.
+/// </summary>
+public class UserCodeVerificationServiceTests
+{
+    private const string CanonicalUserCode = "WDJBMJHT";
+    private const string DeviceCode = "device-code-123";
+    private const string ClientId = "test-client";
+
+    private readonly UserCodeVerificationService _service;
+
+    public UserCodeVerificationServiceTests()
+    {
+        var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode);
+
+        var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
+        storage
+            .Setup(s => s.TryGetByUserCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) =>
+                code == CanonicalUserCode ? (DeviceCode, request) : null);
+
+        var rateLimiter = new Mock<IUserCodeRateLimiter>(MockBehavior.Loose);
+        rateLimiter
+            .Setup(r => r.CheckAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((Result<bool, TimeSpan>)true);
+
+        var normalizer = new UserCodeNormalizer(Options.Create(new OidcOptions
+        {
+            DeviceAuthorization = new DeviceAuthorizationOptions
+            {
+                CodeLifetime = TimeSpan.FromMinutes(5),
+                PollingInterval = TimeSpan.FromSeconds(5),
+                DeviceCodeLength = 32,
+                UserCodeLength = 8,
+                VerificationUri = new Uri("https://auth.example.com/device"),
+                UserCodeAlphabet = "BCDFGHJKLMNPQRSTVWXZ",
+            },
+        }));
+
+        _service = new UserCodeVerificationService(
+            storage.Object,
+            rateLimiter.Object,
+            normalizer,
+            Mock.Of<IHttpContextAccessor>());
+    }
+
+    [Theory]
+    [InlineData("WDJBMJHT")]
+    [InlineData("wdjbmjht")]
+    [InlineData("WDJB-MJHT")]
+    [InlineData(" wdjb-mjht ")]
+    public async Task Verify_AcceptsReadabilityVariantsOfStoredCode(string entered)
+    {
+        var result = await _service.VerifyAsync(entered);
+
+        var valid = Assert.IsType<ValidUserCode>(result);
+        Assert.Equal(ClientId, valid.ClientId);
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/DeviceAuthorizationOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/DeviceAuthorizationOptions.cs
@@ -39,10 +39,35 @@ public record DeviceAuthorizationOptions
     public required TimeSpan PollingInterval { get; set; }
 
     /// <summary>
-    /// The length in bytes of the device code. The device code is a high-entropy string
-    /// used by the client to poll the token endpoint.
+    /// The minimum device code length in bytes (128 bits). The device code is never displayed to
+    /// the user, so it carries no usability constraint and RFC 8628 Section 5.2 requires very high
+    /// entropy; 128 bits is the conventional cryptographic floor for a non-guessable random value.
     /// </summary>
-    public required int DeviceCodeLength { get; set; }
+    private const int MinDeviceCodeLengthBytes = 16;
+
+    private int _deviceCodeLength;
+
+    /// <summary>
+    /// The length in bytes of the device code. The device code is a high-entropy string
+    /// used by the client to poll the token endpoint. Must be at least 128 bits (16 bytes)
+    /// of entropy per RFC 8628 Section 5.2.
+    /// </summary>
+    public required int DeviceCodeLength
+    {
+        get => _deviceCodeLength;
+        set
+        {
+            if (value < MinDeviceCodeLengthBytes)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(DeviceCodeLength),
+                    value,
+                    $"The device_code MUST contain very high entropy per RFC 8628 Section 5.2; " +
+                    $"the length must be at least {MinDeviceCodeLengthBytes} bytes (128 bits).");
+            }
+            _deviceCodeLength = value;
+        }
+    }
 
     /// <summary>
     /// The length of the user code (number of characters).

--- a/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeNormalizer.cs
+++ b/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeNormalizer.cs
@@ -1,0 +1,41 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
+
+/// <summary>
+/// Canonicalizes a user-entered user code before it is matched against a stored code in the
+/// Device Authorization Grant (RFC 8628). RFC 8628 Section 6.1 recommends that the server strip
+/// readability punctuation the user may have copied (dashes, spaces), case-fold input for
+/// single-case character sets, and drop any characters outside the configured alphabet, so that
+/// equivalent user input is not rejected as invalid.
+/// </summary>
+public interface IUserCodeNormalizer
+{
+    /// <summary>
+    /// Produces the canonical form of a user code for comparison: characters outside the
+    /// configured alphabet are removed, and case is folded when the alphabet is single-case.
+    /// </summary>
+    /// <param name="userCode">The raw user code as entered by the end-user.</param>
+    /// <returns>The canonical user code used for storage lookup and rate limiting.</returns>
+    string Normalize(string userCode);
+}

--- a/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeNormalizer.cs
+++ b/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeNormalizer.cs
@@ -1,0 +1,71 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
+using Abblix.Utils;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
+
+/// <summary>
+/// Canonicalizes user-entered user codes for the Device Authorization Grant (RFC 8628) following
+/// the input-processing guidance in Section 6.1: punctuation added for readability (dashes,
+/// spaces) and any other characters outside the configured alphabet are dropped, and case is
+/// folded when the alphabet is single-case so that a user typing the equivalent lowercase (or
+/// uppercase) form is not rejected.
+/// </summary>
+/// <param name="options">Configuration options carrying the user code alphabet.</param>
+public class UserCodeNormalizer(IOptions<OidcOptions> options) : IUserCodeNormalizer
+{
+    /// <inheritdoc />
+    public string Normalize(string userCode)
+    {
+        var alphabet = options.Value.DeviceAuthorization
+            .NotNull(nameof(OidcOptions.DeviceAuthorization))
+            .UserCodeAlphabet;
+
+        // Case-fold only when the alphabet is unambiguously single-case: folding a mixed-case
+        // alphabet would collapse distinct code points, and folding a caseless (e.g. numeric)
+        // alphabet is a no-op anyway.
+        var hasUpper = alphabet.Any(char.IsUpper);
+        var hasLower = alphabet.Any(char.IsLower);
+        var fold = (hasUpper, hasLower) switch
+        {
+            (true, false) => (Func<char, char>)char.ToUpperInvariant,
+            (false, true) => char.ToLowerInvariant,
+            _ => static c => c,
+        };
+
+        var allowed = alphabet.ToHashSet();
+        var builder = new StringBuilder(userCode.Length);
+        foreach (var character in userCode)
+        {
+            var folded = fold(character);
+            if (allowed.Contains(folded))
+                builder.Append(folded);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeRateLimiter.cs
+++ b/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeRateLimiter.cs
@@ -155,12 +155,12 @@ public partial class UserCodeRateLimiter(
     /// <inheritdoc />
     public async Task RecordSuccessAsync(string userCode, string clientIdentifier)
     {
-        // Clear rate limiting state on successful verification
+        // Clear the per-user-code backoff: this code has now been verified, so its own attempt
+        // history is no longer relevant. The per-IP counter is deliberately left intact — it caps
+        // brute-force attempts spanning many distinct codes from one source (RFC 8628 Section 5.2),
+        // and an occasional successful verification must not reset that cross-code budget.
         var userCodeKey = keyFactory.UserCodeRateLimitKey(userCode);
         await storage.RemoveAsync(userCodeKey);
-
-        var ipKey = keyFactory.IpRateLimitKey(clientIdentifier);
-        await storage.RemoveAsync(ipKey);
 
         LogUserCodeVerified(userCode, clientIdentifier);
     }

--- a/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -33,15 +33,22 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// </summary>
 /// <param name="storage">The storage service for device authorization requests.</param>
 /// <param name="rateLimiter">The rate limiter for preventing brute force attacks.</param>
+/// <param name="normalizer">Canonicalizes user-entered codes before lookup (RFC 8628 Section 6.1).</param>
 /// <param name="httpContextAccessor">Accessor for the current HTTP context to retrieve client IP.</param>
 public class UserCodeVerificationService(
     IDeviceAuthorizationStorage storage,
     IUserCodeRateLimiter rateLimiter,
+    IUserCodeNormalizer normalizer,
     IHttpContextAccessor httpContextAccessor) : IUserCodeVerificationService
 {
     /// <inheritdoc />
     public async Task<UserCodeVerificationResult> VerifyAsync(string userCode)
     {
+        // Canonicalize before both rate limiting and lookup: this accepts the readability variants
+        // the user may have typed and keeps a single rate-limit bucket per logical code, so case or
+        // dash variations cannot be used to multiply the per-code brute-force budget.
+        userCode = normalizer.Normalize(userCode);
+
         var clientIp = httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 
         // Check rate limiting before attempting verification
@@ -77,6 +84,7 @@ public class UserCodeVerificationService(
     /// <inheritdoc />
     public async Task<bool> ApproveAsync(string userCode, AuthorizedGrant authorizedGrant)
     {
+        userCode = normalizer.Normalize(userCode);
         var result = await storage.TryGetByUserCodeAsync(userCode);
         if (result == null)
             return false;
@@ -96,6 +104,7 @@ public class UserCodeVerificationService(
     /// <inheritdoc />
     public async Task<bool> DenyAsync(string userCode)
     {
+        userCode = normalizer.Normalize(userCode);
         var result = await storage.TryGetByUserCodeAsync(userCode);
         if (result == null)
             return false;

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -526,6 +526,7 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddSingleton<IDeviceCodeGenerator, DeviceCodeGenerator>();
         services.TryAddSingleton<IUserCodeGenerator, UserCodeGenerator>();
+        services.TryAddSingleton<IUserCodeNormalizer, UserCodeNormalizer>();
         services.TryAddSingleton<IDeviceAuthorizationStorage, DeviceAuthorizationStorage>();
         services.TryAddSingleton<IUserCodeRateLimiter, UserCodeRateLimiter>();
         services.TryAddSingleton<IUserCodeVerificationService, UserCodeVerificationService>();


### PR DESCRIPTION
## Summary

A review of `Features/DeviceAuthorization` surfaced three hardening gaps in the Device Authorization Grant (RFC 8628). Each is fixed with a reproducing test.

**Per-IP rate-limit reset (RFC 8628 §5.2).** `UserCodeRateLimiter.RecordSuccessAsync` cleared *both* the per-user-code backoff and the per-IP brute-force counter on success. The per-IP counter caps failures spanning many distinct codes from one source; wiping it on an occasional successful verification let an attacker reset that cross-code budget at will. Only the per-user-code backoff is cleared now.

**user_code normalization (RFC 8628 §6.1).** The entered code was used verbatim as the storage key, so a user typing a different case or copied-in readability dashes (`WDJB-MJHT`, `wdjbmjht`) was rejected as `invalid_user_code`. A new alphabet-aware `IUserCodeNormalizer` strips out-of-alphabet characters and case-folds single-case alphabets, applied before both rate limiting and lookup — which also collapses case/dash variants into one rate-limit bucket. §6.1 is non-normative usability guidance; this is a robustness/UX fix, not a compliance gap.

**device_code entropy floor (RFC 8628 §5.2).** `DeviceCodeLength` (bytes of randomness) was unvalidated, so a host could configure a guessable code. The setter now enforces a 128-bit (16-byte) floor — the device code is never shown to the user, so §5.2 mandates very high entropy with no usability counterweight. `UserCodeLength` is deliberately left to host discretion per §5.1.
