### PR TITLE
fix(ciba): single-use auth_req_id, push-delivery integrity, HTTPS endpoint + SSRF-harden client callbacks

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
@@ -115,8 +115,6 @@ public class BackChannelAuthenticationValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("poll", result.ErrorDescription);
-        Assert.Contains("Notification endpoint is invalid", result.ErrorDescription);
     }
 
     /// <summary>
@@ -135,8 +133,6 @@ public class BackChannelAuthenticationValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("ping or push", result.ErrorDescription);
-        Assert.Contains("required", result.ErrorDescription);
     }
 
     /// <summary>
@@ -159,6 +155,28 @@ public class BackChannelAuthenticationValidatorTests
     }
 
     /// <summary>
+    /// Verifies error when the notification endpoint is not an HTTPS URL.
+    /// CIBA Core 1.0 §4 states it MUST be an HTTPS URL and communication MUST use TLS.
+    /// </summary>
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Ping)]
+    [InlineData(BackchannelTokenDeliveryModes.Push)]
+    public async Task ValidateAsync_NotificationEndpointNotHttps_ShouldReturnError(string deliveryMode)
+    {
+        // Arrange
+        var context = CreateContext(
+            tokenDeliveryMode: deliveryMode,
+            notificationEndpoint: new Uri("http://client.example.com/notify"));
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+    }
+
+    /// <summary>
     /// Verifies error when push mode lacks notification endpoint.
     /// Per OIDC CIBA, push mode requires notification endpoint.
     /// </summary>
@@ -174,8 +192,6 @@ public class BackChannelAuthenticationValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("ping or push", result.ErrorDescription);
-        Assert.Contains("required", result.ErrorDescription);
     }
 
     /// <summary>
@@ -213,8 +229,6 @@ public class BackChannelAuthenticationValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("not supported", result.ErrorDescription);
-        Assert.Contains("token delivery mode", result.ErrorDescription);
     }
 
     /// <summary>
@@ -262,8 +276,6 @@ public class BackChannelAuthenticationValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("signing algorithm", result.ErrorDescription);
-        Assert.Contains("not supported", result.ErrorDescription);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -92,7 +92,7 @@ public class BackChannelAuthenticationGrantHandlerTests
     private class TestServiceProvider(IBackChannelRequestStorage storage) : IKeyedServiceProvider
     {
         private readonly IBackChannelGrantProcessor _pollProcessor = new PollModeGrantProcessor(storage);
-        private readonly IBackChannelGrantProcessor _pingProcessor = new PingModeGrantProcessor();
+        private readonly IBackChannelGrantProcessor _pingProcessor = new PingModeGrantProcessor(storage);
         private readonly IBackChannelGrantProcessor _pushProcessor = new PushModeGrantProcessor();
 
         public object? GetKeyedService(Type serviceType, object? serviceKey)
@@ -601,12 +601,12 @@ public class BackChannelAuthenticationGrantHandlerTests
     }
 
     /// <summary>
-    /// Verifies that in ping mode, authenticated requests are NOT removed from storage
-    /// after token retrieval. This allows clients to retrieve tokens after receiving the ping notification,
-    /// and supports potential retry scenarios.
+    /// Verifies that in ping mode, the authenticated request is removed from storage on retrieval.
+    /// The auth_req_id is single-use (CIBA Core 1.0 Section 7.3), so a notified client cannot replay
+    /// it to mint fresh tokens; ping consumes the entry exactly like poll.
     /// </summary>
     [Fact]
-    public async Task AuthenticatedRequest_PingMode_DoesNotRemoveFromStorage()
+    public async Task AuthenticatedRequest_PingMode_RemovesFromStorage()
     {
         // Arrange
         var clientInfo = new ClientInfo(ClientId)
@@ -622,12 +622,13 @@ public class BackChannelAuthenticationGrantHandlerTests
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
 
-        var authRequest = new BackChannelAuthenticationRequest(expectedGrant, DateTimeOffset.UtcNow.AddMinutes(5))
+        var authRequest = new BackChannelAuthenticationRequest(expectedGrant, _currentTime.AddMinutes(5))
         {
             Status = BackChannelAuthenticationStatus.Authenticated
         };
 
         _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync(authRequest);
+        _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
         var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
@@ -635,7 +636,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.NotNull(grant);
-        _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
+        _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
     }
 
     /// <summary>
@@ -673,7 +674,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Assert
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-        Assert.Contains("push", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
         _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
     }
 

--- a/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -96,7 +96,7 @@ public class AuthenticationCompletionHandlerTests
 
         _notificationService.Setup(n => n.SendAsync(_notificationEndpoint, NotificationToken, It.IsAny<IBackChannelNotificationRequest>(), BackchannelTokenDeliveryModes.Ping))
             .Callback(() => callOrder.Add("notify"))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         var handler = CreatePingModeHandler();
 
@@ -280,7 +280,7 @@ public class AuthenticationCompletionHandlerTests
             .Returns(Task.CompletedTask);
 
         _notificationService.Setup(n => n.SendAsync(_notificationEndpoint, NotificationToken, It.IsAny<IBackChannelNotificationRequest>(), BackchannelTokenDeliveryModes.Ping))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         var handler = CreatePingModeHandler();
 
@@ -330,7 +330,7 @@ public class AuthenticationCompletionHandlerTests
                 NotificationToken,
                 It.IsAny<IBackChannelNotificationRequest>(),
                 BackchannelTokenDeliveryModes.Push))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId))
             .ReturnsAsync((BackChannelAuthenticationRequest?)null);
@@ -347,6 +347,59 @@ public class AuthenticationCompletionHandlerTests
             Times.Once);
         _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
         _storage.Verify(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that when push delivery fails, the authenticated request is retained in storage
+    /// rather than removed. Push clients cannot poll, so discarding the grant on a failed delivery
+    /// would silently lose tokens the client never received; the request is kept until it expires.
+    /// </summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_PushMode_DeliveryFails_RetainsRequest()
+    {
+        // Arrange
+        var fixedTime = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var authSession = new AuthSession(UserId, "session_123", fixedTime, "backchannel");
+        var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
+        var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), fixedTime.AddMinutes(5))
+        {
+            Status = BackChannelAuthenticationStatus.Authenticated,
+            ClientNotificationEndpoint = _notificationEndpoint,
+            ClientNotificationToken = NotificationToken,
+        };
+
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Push,
+        };
+
+        var jwt = new Jwt.JsonWebToken();
+        var tokenIssued = new TokenIssued(
+            new EncodedJsonWebToken(jwt, "access_token_jwt"),
+            TokenTypes.Bearer,
+            TimeSpan.FromHours(1),
+            new Uri("urn:ietf:params:oauth:token-type:access_token"));
+
+        _tokenRequestProcessor.Setup(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()))
+            .ReturnsAsync(Result<TokenIssued, OidcError>.Success(tokenIssued));
+
+        _notificationService.Setup(s => s.SendAsync(
+                _notificationEndpoint,
+                NotificationToken,
+                It.IsAny<IBackChannelNotificationRequest>(),
+                BackchannelTokenDeliveryModes.Push))
+            .ReturnsAsync(false);
+
+        var handler = CreatePushModeHandler();
+
+        // Act
+        await handler.CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
+
+        // Assert
+        _notificationService.Verify(
+            s => s.SendAsync(_notificationEndpoint, NotificationToken, It.IsAny<IBackChannelNotificationRequest>(), BackchannelTokenDeliveryModes.Push),
+            Times.Once);
+        _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessorTests.cs
@@ -1,0 +1,93 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication.GrantProcessors;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
+using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.BackChannelAuthentication.GrantProcessors;
+
+/// <summary>
+/// Verifies that CIBA ping mode consumes the <c>auth_req_id</c> on token retrieval. CIBA Core 1.0
+/// Section 7.3 states the <c>auth_req_id</c> can be used only once; Section 10.1.1 defines the
+/// token response identically for poll and ping. Ping therefore must remove the grant from storage
+/// on first successful retrieval, exactly like poll, so a notified client cannot replay the same
+/// <c>auth_req_id</c> to mint fresh tokens until expiry.
+/// </summary>
+public class PingModeGrantProcessorTests
+{
+    private const string AuthRequestId = "auth-req-id-123";
+
+    private readonly Mock<IBackChannelRequestStorage> _storage;
+    private readonly PingModeGrantProcessor _processor;
+    private readonly BackChannelAuthenticationRequest _request;
+
+    public PingModeGrantProcessorTests()
+    {
+        var fixedTime = DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture);
+        var session = new AuthSession("user-1", "session-1", fixedTime, "local");
+        var context = new AuthorizationContext("client-1", [TestConstants.DefaultScope], null);
+        _request = new BackChannelAuthenticationRequest(new AuthorizedGrant(session, context), fixedTime.AddMinutes(5));
+
+        _storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
+        _processor = new PingModeGrantProcessor(_storage.Object);
+    }
+
+    [Fact]
+    public async Task Process_ConsumesAuthReqIdFromStorage()
+    {
+        _storage.Setup(s => s.TryRemoveAsync(AuthRequestId)).ReturnsAsync(_request);
+
+        var result = await _processor.ProcessAuthenticatedRequestAsync(AuthRequestId, _request);
+
+        Assert.True(result.TryGetSuccess(out var grant));
+        Assert.Equal(_request.AuthorizedGrant, grant);
+        _storage.Verify(s => s.TryRemoveAsync(AuthRequestId), Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_SecondRetrieval_ReturnsInvalidGrant()
+    {
+        // First retrieval consumes the entry; the second sees nothing in storage and must fail
+        // rather than re-issue tokens for the same single-use auth_req_id.
+        _storage.SetupSequence(s => s.TryRemoveAsync(AuthRequestId))
+            .ReturnsAsync(_request)
+            .ReturnsAsync((BackChannelAuthenticationRequest?)null);
+
+        var first = await _processor.ProcessAuthenticatedRequestAsync(AuthRequestId, _request);
+        var second = await _processor.ProcessAuthenticatedRequestAsync(AuthRequestId, _request);
+
+        Assert.True(first.TryGetSuccess(out _));
+        Assert.True(second.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/HttpNotificationDeliveryServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/HttpNotificationDeliveryServiceTests.cs
@@ -120,9 +120,10 @@ public class HttpNotificationDeliveryServiceTests
 
         // Act
         var payload = new BackChannelPingNotificationRequest { AuthenticationRequestId = AuthReqId };
-        await _service.SendAsync(_clientNotificationEndpoint, ClientNotificationToken, payload, "ping");
+        var delivered = await _service.SendAsync(_clientNotificationEndpoint, ClientNotificationToken, payload, "ping");
 
         // Assert
+        Assert.True(delivered);
         _logger.Verify(
             l => l.Log(
                 LogLevel.Information,
@@ -156,8 +157,9 @@ public class HttpNotificationDeliveryServiceTests
 
         // Act & Assert (should not throw)
         var payload = new BackChannelPingNotificationRequest { AuthenticationRequestId = AuthReqId };
-        await _service.SendAsync(_clientNotificationEndpoint, ClientNotificationToken, payload, "ping");
+        var delivered = await _service.SendAsync(_clientNotificationEndpoint, ClientNotificationToken, payload, "ping");
 
+        Assert.False(delivered);
         _logger.Verify(
             l => l.Log(
                 LogLevel.Warning,
@@ -192,8 +194,9 @@ public class HttpNotificationDeliveryServiceTests
 
         // Act & Assert (should not throw)
         var payload = new BackChannelPingNotificationRequest { AuthenticationRequestId = AuthReqId };
-        await _service.SendAsync(_clientNotificationEndpoint, ClientNotificationToken, payload, "ping");
+        var delivered = await _service.SendAsync(_clientNotificationEndpoint, ClientNotificationToken, payload, "ping");
 
+        Assert.False(delivered);
         _logger.Verify(
             l => l.Log(
                 LogLevel.Error,

--- a/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientSsrfWiringTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientSsrfWiringTests.cs
@@ -1,0 +1,72 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net.Http;
+using Abblix.Oidc.Server.Features;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication;
+using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.SecureHttpFetch;
+
+/// <summary>
+/// Regression guard: every HTTP client this library uses to POST to a client-supplied URL
+/// (the CIBA ping/push notification endpoint and the back-channel logout URI) must route through
+/// <see cref="SsrfValidatingHttpMessageHandler"/>. Without it, a client could register an internal
+/// URL (e.g. a cloud metadata service) and turn a server-initiated callback into an SSRF vector.
+/// </summary>
+public class OutboundHttpClientSsrfWiringTests
+{
+    [Theory]
+    [InlineData(nameof(HttpNotificationDeliveryService))]
+    [InlineData("ILogoutTokenSender")] // default logical name of the typed BackChannelLogoutTokenSender client
+    public void ClientCallbackHttpClients_RouteThroughSsrfValidatingHandler(string clientName)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+        services.AddBackChannelLogout();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var handlerFactory = serviceProvider.GetRequiredService<IHttpMessageHandlerFactory>();
+
+        using var handler = handlerFactory.CreateHandler(clientName);
+
+        Assert.True(
+            ChainContainsSsrfHandler(handler),
+            $"HTTP client '{clientName}' must include {nameof(SsrfValidatingHttpMessageHandler)} in its handler chain.");
+    }
+
+    private static bool ChainContainsSsrfHandler(HttpMessageHandler handler)
+    {
+        for (var current = handler; current is DelegatingHandler delegating; current = delegating.InnerHandler!)
+        {
+            if (current is SsrfValidatingHttpMessageHandler)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/BackChannelAuthenticationOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/BackChannelAuthenticationOptions.cs
@@ -120,4 +120,11 @@ public record BackChannelAuthenticationOptions
     /// but may impact performance. Longer lifetimes reduce overhead but may cause stale connections.
     /// </remarks>
     public TimeSpan NotificationHttpClientHandlerLifetime { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Bounds how long the server waits when POSTing a ping/push notification to a client's
+    /// notification endpoint. Caps the time a slow or unresponsive client-controlled endpoint can
+    /// tie up the authentication-completion path. Default is 30 seconds.
+    /// </summary>
+    public TimeSpan NotificationHttpClientTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -82,6 +82,17 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
                     "The specified token delivery mode is not supported");
         }
 
+        // CIBA Core 1.0 §4: the notification endpoint MUST be an HTTPS URL (communication with it
+        // MUST use TLS). Only ping/push reach here with an endpoint set — poll-with-endpoint and the
+        // missing-endpoint cases are already rejected above.
+        var notificationEndpoint = context.Request.BackChannelClientNotificationEndpoint;
+        if (notificationEndpoint != null && notificationEndpoint.Scheme != Uri.UriSchemeHttps)
+        {
+            return new OidcError(
+                ErrorCodes.InvalidRequest,
+                "The backchannel_client_notification_endpoint must use the HTTPS scheme");
+        }
+
         var signingAlgorithm = context.Request.BackChannelAuthenticationRequestSigningAlg;
         if (signingAlgorithm.HasValue() &&
             !jwtValidator.SigningAlgorithmsSupported.Contains(signingAlgorithm, StringComparer.Ordinal))

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
@@ -43,4 +43,10 @@ partial class PushModeCompletionHandler
         Level = LogLevel.Error,
         Message = "Failed to generate tokens for CIBA push mode, auth_req_id: {AuthReqId}, Error: {ErrorCode}")]
     private partial void LogTokenGenerationFailed(string AuthReqId, string ErrorCode);
+
+    [LoggerMessage(
+        EventId = LogEvents.Device.PushModeCompletionHandler.PushDeliveryFailed,
+        Level = LogLevel.Warning,
+        Message = "CIBA push delivery failed for auth_req_id: {AuthReqId}; the authenticated request is retained until it expires")]
+    private partial void LogPushDeliveryFailed(string AuthReqId);
 }

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -103,16 +103,25 @@ public partial class PushModeCompletionHandler(
                     RefreshToken = tokens.RefreshToken?.EncodedJwt,
                 };
 
-                await notificationService.SendAsync(
+                var delivered = await notificationService.SendAsync(
                     request.ClientNotificationEndpoint,
                     request.ClientNotificationToken,
                     payload,
                     BackchannelTokenDeliveryModes.Push);
 
-                // Per CIBA spec 10.3.1, remove after push delivery (unlike poll/ping modes)
-                await _storage.TryRemoveAsync(authenticationRequestId);
-
-                LogTokensDelivered(authenticationRequestId);
+                if (delivered)
+                {
+                    // Per CIBA spec 10.3.1, remove after push delivery (unlike poll/ping modes).
+                    await _storage.TryRemoveAsync(authenticationRequestId);
+                    LogTokensDelivered(authenticationRequestId);
+                }
+                else
+                {
+                    // Delivery failed: keep the request so the tokens are not silently lost. Push
+                    // clients cannot poll, so removing here would orphan an authenticated grant the
+                    // client never received; instead it is retained until it expires.
+                    LogPushDeliveryFailed(authenticationRequestId);
+                }
 
                 return null;
             },

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Abblix.Utils;
@@ -29,10 +30,13 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.GrantProcessors;
 
 /// <summary>
 /// Handles CIBA ping mode token retrieval at the token endpoint.
-/// In ping mode, the server sends a notification to the client, then the client retrieves tokens.
-/// Tokens remain in storage after retrieval (allows multiple retrievals after single notification).
+/// In ping mode, the server notifies the client, then the client makes a single token request.
+/// The auth_req_id is single-use (CIBA Core 1.0 Section 7.3), so the grant is removed from storage
+/// on retrieval — identically to poll mode (Section 10.1.1 defines their token responses the same).
 /// </summary>
-public class PingModeGrantProcessor : IBackChannelGrantProcessor
+/// <param name="storage">Storage for backchannel authentication requests.</param>
+public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
+    : IBackChannelGrantProcessor
 {
     /// <summary>
     /// Ping mode clients are allowed to call the token endpoint after the ping notification arrives,
@@ -41,14 +45,24 @@ public class PingModeGrantProcessor : IBackChannelGrantProcessor
     public OidcError? ValidateTokenEndpointAccess() => null;
 
     /// <summary>
-    /// Returns the authorized grant without removing it from storage; ping mode permits the client
-    /// to retrieve tokens once the ping notification arrives, while keeping the entry available
-    /// until it expires.
+    /// Atomically removes the authentication request from storage and returns its authorized grant.
+    /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 7.3), a second retrieval
+    /// — or a concurrent one that lost the race — finds nothing and is rejected with
+    /// <c>invalid_grant</c> rather than re-issuing tokens.
     /// </summary>
-    public Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
+    public async Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request)
     {
-        return Task.FromResult<Result<AuthorizedGrant, OidcError>>(request.AuthorizedGrant);
+        var removedRequest = await storage.TryRemoveAsync(authenticationRequestId);
+
+        if (removedRequest == null)
+        {
+            return new OidcError(
+                ErrorCodes.InvalidGrant,
+                "The authentication request has already been used");
+        }
+
+        return removedRequest.AuthorizedGrant;
     }
 }

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/HttpNotificationDeliveryService.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/HttpNotificationDeliveryService.cs
@@ -44,7 +44,8 @@ public partial class HttpNotificationDeliveryService(
     /// <param name="clientNotificationToken">Bearer token for authenticating the notification request.</param>
     /// <param name="payload">The notification payload to send.</param>
     /// <param name="mode">The CIBA mode (ping or push) for logging purposes.</param>
-    public async Task SendAsync(
+    /// <returns><c>true</c> if the endpoint returned a success status; otherwise <c>false</c>.</returns>
+    public async Task<bool> SendAsync(
         Uri clientNotificationEndpoint,
         string clientNotificationToken,
         IBackChannelNotificationRequest payload,
@@ -65,15 +66,16 @@ public partial class HttpNotificationDeliveryService(
             if (response.IsSuccessStatusCode)
             {
                 LogNotificationSucceeded(mode);
+                return true;
             }
-            else
-            {
-                LogNotificationFailed(mode, response.StatusCode);
-            }
+
+            LogNotificationFailed(mode, response.StatusCode);
+            return false;
         }
         catch (Exception ex)
         {
             LogNotificationError(ex, mode, clientNotificationEndpoint);
+            return false;
         }
     }
 }

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
@@ -56,8 +56,12 @@ public interface INotificationDeliveryService
     /// <param name="mode">
     /// The CIBA mode (e.g., "ping" or "push") for logging purposes.
     /// </param>
-    /// <returns>A task representing the asynchronous notification operation.</returns>
-    Task SendAsync(
+    /// <returns>
+    /// <c>true</c> if the client endpoint accepted the notification (2xx response); <c>false</c> if
+    /// delivery failed (non-success status or transport error). Push mode relies on this to avoid
+    /// discarding the grant when token delivery did not reach the client.
+    /// </returns>
+    Task<bool> SendAsync(
         Uri clientNotificationEndpoint,
         string clientNotificationToken,
         IBackChannelNotificationRequest payload,

--- a/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfHttpClientServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfHttpClientServiceCollectionExtensions.cs
@@ -1,0 +1,57 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+/// <summary>
+/// Registers HTTP clients that initiate requests to client-supplied URLs (CIBA notification
+/// endpoints, back-channel logout URIs, JWKS/issuer fetches). Every such client must route through
+/// <see cref="SsrfValidatingHttpMessageHandler"/>; bundling the handler with the client registration
+/// makes it impossible to add a new outbound client that silently skips SSRF protection.
+/// </summary>
+public static class SsrfHttpClientServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a typed HTTP client whose primary handler is the SSRF-validating handler.
+    /// </summary>
+    public static IHttpClientBuilder AddSsrfHttpClient<TClient, TImplementation>(
+        this IServiceCollection services,
+        Action<IServiceProvider, HttpClient> configureClient)
+        where TClient : class
+        where TImplementation : class, TClient
+        => services
+            .AddHttpClient<TClient, TImplementation>(configureClient)
+            .ConfigurePrimaryHttpMessageHandler<SsrfValidatingHttpMessageHandler>();
+
+    /// <summary>
+    /// Registers a named HTTP client whose primary handler is the SSRF-validating handler.
+    /// </summary>
+    public static IHttpClientBuilder AddSsrfHttpClient(
+        this IServiceCollection services,
+        string name,
+        Action<IServiceProvider, HttpClient> configureClient)
+        => services
+            .AddHttpClient(name, configureClient)
+            .ConfigurePrimaryHttpMessageHandler<SsrfValidatingHttpMessageHandler>();
+}

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -184,8 +184,15 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddEnumerable(ServiceDescriptor.Scoped<ILogoutNotifier, BackChannelLogoutNotifier>());
         services.TryAddSingleton<ILogoutTokenService, LogoutTokenService>();
+        // The back-channel logout URI is a client-supplied URL, so POSTing logout tokens to it must
+        // run through the SSRF-validating handler and carry a bounded timeout, like every other
+        // server-initiated outbound request in this library.
         return services
-            .AddHttpClient<ILogoutTokenSender, BackChannelLogoutTokenSender>()
+            .AddSsrfHttpClient<ILogoutTokenSender, BackChannelLogoutTokenSender>((serviceProvider, client) =>
+            {
+                client.Timeout = serviceProvider.GetRequiredService<IOptions<SecureHttpFetchOptions>>()
+                    .Value.RequestTimeout;
+            })
             .Services;
     }
 
@@ -508,7 +515,14 @@ public static class ServiceCollectionExtensions
                 httpOptions.HandlerLifetime = oidcOptions.Value.BackChannelAuthentication.NotificationHttpClientHandlerLifetime;
             });
 
-        services.AddHttpClient(nameof(HttpNotificationDeliveryService));
+        // The notification endpoint is a client-supplied URL, so server-initiated POSTs to it must
+        // run through the SSRF-validating handler (blocks internal hosts, private IPs, DNS rebinding)
+        // and carry a bounded timeout, exactly like every other outbound fetch in this library.
+        services.AddSsrfHttpClient(nameof(HttpNotificationDeliveryService), (serviceProvider, client) =>
+        {
+            client.Timeout = serviceProvider.GetRequiredService<IOptions<OidcOptions>>()
+                .Value.BackChannelAuthentication.NotificationHttpClientTimeout;
+        });
 
         // Register CIBA grant handler (dual: IAuthorizationGrantHandler + IGrantTypeInformer).
         services.AddAuthorizationGrant<BackChannelAuthenticationGrantHandler>();
@@ -574,13 +588,11 @@ public static class ServiceCollectionExtensions
 
         services.TryAddTransient<SsrfValidatingHttpMessageHandler>();
 
-        services
-            .AddHttpClient<ISecureHttpFetcher, SecureHttpFetcher>((serviceProvider, client) =>
-            {
-                var options = serviceProvider.GetRequiredService<IOptions<SecureHttpFetchOptions>>().Value;
-                client.Timeout = options.RequestTimeout;
-            })
-            .ConfigurePrimaryHttpMessageHandler<SsrfValidatingHttpMessageHandler>();
+        services.AddSsrfHttpClient<ISecureHttpFetcher, SecureHttpFetcher>((serviceProvider, client) =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<SecureHttpFetchOptions>>().Value;
+            client.Timeout = options.RequestTimeout;
+        });
 
         return services;
     }

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -505,6 +505,7 @@ internal static class LogEvents
             public const int GeneratingTokens = Base + 1;
             public const int TokensDelivered = Base + 2;
             public const int TokenGenerationFailed = Base + 3;
+            public const int PushDeliveryFailed = Base + 4;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Two related concerns from reviewing `Features/BackChannelAuthentication`, each fixed with reproducing tests.

### CIBA spec compliance (commit 2)

**Ping single-use (CIBA Core 1.0 §7.3 / §10.1.1).** `PingModeGrantProcessor` returned the grant *without* removing it from storage (xmldoc: "allows multiple retrievals"), so a notified client could replay the same `auth_req_id` to mint fresh tokens until expiry. §7.3: "The `auth_req_id` can be used only once." §10.1.1 defines the poll and ping token responses identically. Ping now consumes the grant atomically, exactly like poll. The frozen test asserting non-removal was inverted.

**Push delivery loss (§10.3.1).** `INotificationDeliveryService.SendAsync` swallowed every failure (non-2xx and exceptions) and the push completion handler removed the grant *unconditionally* — so a failed push silently lost the tokens, and push clients cannot poll to recover. `SendAsync` now returns whether delivery succeeded; on failure the authenticated request is retained until it expires (with a warning), and removed only on confirmed delivery.

**HTTPS notification endpoint (§4).** The DCR validator checked only the *presence* of `backchannel_client_notification_endpoint`, never the scheme. §4: "It MUST be an HTTPS URL and Communication with the Client Notification Endpoint MUST utilize TLS." Non-HTTPS registrations are now rejected with `invalid_request`.

### SSRF hardening of outbound client callbacks (commit 1)

Server-initiated POSTs to client-supplied URLs — the CIBA notification endpoint and the back-channel logout URI — ran on a plain `HttpClient` with no SSRF protection or timeout, unlike the JWKS fetch client. A new `AddSsrfHttpClient` helper bundles `SsrfValidatingHttpMessageHandler` with the client registration (so a future outbound client cannot silently skip it); the notification, logout, and JWKS clients all route through it, each with a bounded timeout.
