### PR TITLE
fix: enforce client scope set, require JWT-bearer exp, validate resource config

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -108,7 +108,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("assertion", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -133,7 +132,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("assertion", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -184,7 +182,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("invalid", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -212,7 +209,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("sub", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -730,7 +726,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("algorithm", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -776,7 +771,7 @@ public class JwtBearerGrantHandlerTests
 		SetupValidJwtValidation(mocks.JwtValidator, jwt);
 		SetupTrustedIssuer(mocks.IssuerProvider, Issuer);
 		mocks.IssuerProvider
-			.Setup(p => p.IsReplayedAsync("unique-jti-12345"))
+			.Setup(p => p.IsReplayedAsync("unique-jti-12345", It.IsAny<DateTimeOffset?>()))
 			.ReturnsAsync(true);
 		var clientInfo = new ClientInfo(ClientId);
 		var tokenRequest = new TokenRequest
@@ -791,7 +786,35 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("already been used", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// Verifies that an assertion without an 'exp' claim is rejected.
+	/// RFC 7523 Section 3 requires the JWT to contain an 'exp' claim limiting its usable window;
+	/// without it the assertion would otherwise be accepted as never-expiring.
+	/// </summary>
+	[Fact]
+	public async Task MissingExpirationClaim_ShouldReject()
+	{
+		// Arrange
+		var (handler, mocks) = CreateHandler();
+		var jwt = CreateValidJwt();
+		jwt.Payload.ExpiresAt = null;
+		SetupValidJwtValidation(mocks.JwtValidator, jwt);
+		SetupTrustedIssuer(mocks.IssuerProvider, Issuer);
+		var clientInfo = new ClientInfo(ClientId);
+		var tokenRequest = new TokenRequest
+		{
+			GrantType = GrantTypes.JwtBearer,
+			Assertion = Assertion
+		};
+
+		// Act
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+
+		// Assert
+		Assert.True(result.TryGetFailure(out var error));
+		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
 	}
 
 	/// <summary>
@@ -820,7 +843,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("jti", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -846,7 +868,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("size", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -933,7 +954,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("too old", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -995,7 +1015,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("iat", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -1027,7 +1046,6 @@ public class JwtBearerGrantHandlerTests
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
-		Assert.Contains("token type", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -1111,11 +1129,7 @@ public class JwtBearerGrantHandlerTests
 			.ReturnsAsync(trustedIssuer);
 
 		issuerProvider
-			.Setup(p => p.IsReplayedAsync(It.IsAny<string>()))
+			.Setup(p => p.IsReplayedAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>()))
 			.ReturnsAsync(false);
-
-		issuerProvider
-			.Setup(p => p.MarkAsUsedAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>()))
-			.Returns(Task.CompletedTask);
 	}
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ScopeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ScopeValidatorTests.cs
@@ -23,6 +23,7 @@
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Token.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.ScopeManagement;
 using Abblix.Oidc.Server.Model;
 using Moq;
@@ -55,7 +56,10 @@ public class ScopeValidatorTests
             Scope = scope,
         };
         var clientRequest = new ClientRequest();
-        var context = new TokenValidationContext(tokenRequest, clientRequest);
+        var context = new TokenValidationContext(tokenRequest, clientRequest)
+        {
+            ClientInfo = new ClientInfo("test-client"),
+        };
         if (resources != null)
         {
             context.Resources = resources;

--- a/Abblix.Oidc.Server.UnitTests/Features/ResourceIndicators/ResourceManagerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ResourceIndicators/ResourceManagerTests.cs
@@ -354,4 +354,37 @@ public class ResourceManagerTests
         Assert.Single(writeScope.ClaimTypes);
         Assert.Contains("write_claim1", writeScope.ClaimTypes);
     }
+
+    /// <summary>
+    /// Verifies that a non-absolute configured resource URI is rejected at construction, rather than
+    /// becoming a silent dead entry that can never match a request (RFC 8707 Section 2).
+    /// </summary>
+    [Fact]
+    public void Construction_WithNonAbsoluteResourceUri_Throws()
+    {
+        var resource = new ResourceDefinition(new Uri("/relative/api", UriKind.Relative), new ScopeDefinition("read"));
+        var options = Options.Create(new OidcOptions { Resources = [resource] });
+
+        Assert.Throws<ArgumentException>(() => new ResourceManager(options));
+    }
+
+    /// <summary>
+    /// Verifies that two configured resource definitions sharing a URI fail fast at construction with
+    /// a clear error rather than an opaque dictionary exception.
+    /// </summary>
+    [Fact]
+    public void Construction_WithDuplicateResourceUris_Throws()
+    {
+        var uri = new Uri("https://api.example.com");
+        var options = Options.Create(new OidcOptions
+        {
+            Resources =
+            [
+                new ResourceDefinition(uri, new ScopeDefinition("read")),
+                new ResourceDefinition(uri, new ScopeDefinition("write")),
+            ],
+        });
+
+        Assert.Throws<ArgumentException>(() => new ResourceManager(options));
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/ScopeManagement/ScopeManagerExtensionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ScopeManagement/ScopeManagerExtensionsTests.cs
@@ -62,7 +62,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { Scopes.OpenId, Scopes.Profile, Scopes.Email };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -85,7 +85,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { "custom:read", "custom:write" };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -107,7 +107,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { Scopes.OpenId, "unknown-scope" };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.False(result);
@@ -133,7 +133,7 @@ public class ScopeManagerExtensionsTests
         };
 
         // Act
-        var result = _scopeManager.Validate(scopes, resources, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, resources, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -159,7 +159,7 @@ public class ScopeManagerExtensionsTests
         };
 
         // Act
-        var result = _scopeManager.Validate(scopes, resources, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, resources, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -181,7 +181,7 @@ public class ScopeManagerExtensionsTests
         var scopes = Enumerable.Empty<string>();
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -201,7 +201,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { Scopes.OpenId, "custom:read" };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -222,7 +222,7 @@ public class ScopeManagerExtensionsTests
         var resources = Array.Empty<ResourceDefinition>();
 
         // Act
-        var result = _scopeManager.Validate(scopes, resources, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, resources, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -247,7 +247,7 @@ public class ScopeManagerExtensionsTests
         };
 
         // Act
-        var result = _scopeManager.Validate(scopes, resources, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, resources, null, out var definitions, out var error);
 
         // Assert
         Assert.False(result);
@@ -267,7 +267,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { "custom:read" };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out _);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out _);
 
         // Assert
         Assert.True(result);
@@ -289,7 +289,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { "OPENID" }; // Wrong case
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.False(result);
@@ -308,7 +308,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { Scopes.OpenId, Scopes.OpenId }; // Duplicate
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out _);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out _);
 
         // Assert
         Assert.True(result);
@@ -335,7 +335,7 @@ public class ScopeManagerExtensionsTests
         };
 
         // Act
-        var result = _scopeManager.Validate(scopes, resources, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, resources, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -362,7 +362,7 @@ public class ScopeManagerExtensionsTests
         };
 
         // Act
-        var result = _scopeManager.Validate(scopes, resources, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, resources, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -382,7 +382,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { "invalid", Scopes.OpenId };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.False(result);
@@ -402,7 +402,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { Scopes.OpenId, Scopes.OfflineAccess };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -427,7 +427,7 @@ public class ScopeManagerExtensionsTests
         };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out var error);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out var error);
 
         // Assert
         Assert.True(result);
@@ -447,7 +447,7 @@ public class ScopeManagerExtensionsTests
         var scopes = new[] { Scopes.Email, Scopes.Profile, Scopes.OpenId };
 
         // Act
-        var result = _scopeManager.Validate(scopes, null, out var definitions, out _);
+        var result = _scopeManager.Validate(scopes, null, null, out var definitions, out _);
 
         // Assert
         Assert.True(result);
@@ -456,5 +456,61 @@ public class ScopeManagerExtensionsTests
         Assert.Equal(Scopes.Email, definitions[0].Scope);
         Assert.Equal(Scopes.Profile, definitions[1].Scope);
         Assert.Equal(Scopes.OpenId, definitions[2].Scope);
+    }
+
+    /// <summary>
+    /// Verifies a requested scope outside the client's allowed (registered) scope set is rejected.
+    /// RFC 6749 §3.3: the authorization server restricts scope by policy — a client must not obtain
+    /// a scope it was never registered for, even if that scope is registered server-wide.
+    /// </summary>
+    [Fact]
+    public void Validate_RequestedScopeNotInClientAllowedScopes_ShouldReject()
+    {
+        // Arrange — the scope is registered globally, but not in the client's allowed set.
+        var scopes = new[] { Scopes.OpenId, Scopes.Profile };
+        var allowedClientScopes = new[] { Scopes.OpenId };
+
+        // Act
+        var result = _scopeManager.Validate(scopes, null, allowedClientScopes, out var definitions, out _);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(definitions);
+    }
+
+    /// <summary>
+    /// Verifies a request confined to the client's allowed scope set succeeds.
+    /// </summary>
+    [Fact]
+    public void Validate_RequestedScopesWithinClientAllowedScopes_ShouldSucceed()
+    {
+        // Arrange
+        var scopes = new[] { Scopes.OpenId };
+        var allowedClientScopes = new[] { Scopes.OpenId, Scopes.Profile };
+
+        // Act
+        var result = _scopeManager.Validate(scopes, null, allowedClientScopes, out var definitions, out _);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(definitions);
+    }
+
+    /// <summary>
+    /// Verifies an empty client allow-list imposes no per-client restriction (backward compatible),
+    /// mirroring the per-issuer allow-list semantics of the JWT bearer grant.
+    /// </summary>
+    [Fact]
+    public void Validate_EmptyClientAllowedScopes_ShouldNotRestrict()
+    {
+        // Arrange
+        var scopes = new[] { Scopes.OpenId, Scopes.Profile };
+
+        // Act
+        var result = _scopeManager.Validate(scopes, null, [], out var definitions, out _);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(definitions);
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ScopeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ScopeValidator.cs
@@ -59,6 +59,7 @@ public class ScopeValidator(IScopeManager scopeManager) : SyncAuthorizationConte
 		if (!scopeManager.Validate(
 			    context.Request.Scope,
 			    context.Resources,
+			    context.ClientInfo.AllowedScopes,
 			    out var scopeDefinitions,
 			    out var errorDescription))
 		{

--- a/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/ScopeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/ScopeValidator.cs
@@ -76,6 +76,7 @@ public class ScopeValidator(IScopeManager scopeManager) : IBackChannelAuthentica
 		if (!scopeManager.Validate(
 			    context.Request.Scope,
 			    context.Resources,
+			    context.ClientInfo.AllowedScopes,
 			    out var scopeDefinitions,
 			    out var errorDescription))
 		{

--- a/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/ScopeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/ScopeValidator.cs
@@ -51,6 +51,7 @@ public class ScopeValidator(IScopeManager scopeManager) : IDeviceAuthorizationCo
         if (!scopeManager.Validate(
                 scopes,
                 context.Resources,
+                context.ClientInfo.AllowedScopes,
                 out var scopeDefinitions,
                 out var errorDescription))
         {

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -241,13 +241,15 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTokenContextValidators(this IServiceCollection services)
     {
         // Register individual validators that will participate in a composite pattern.
-        // Order is load-bearing: ClientValidator must precede DPoPTokenEndpointValidator
-        // because the latter reads ClientInfo.RequireDPoP to decide whether DPoP
-        // is mandatory or opportunistic.
+        // Order is load-bearing:
+        // - ClientValidator must precede DPoPTokenEndpointValidator because the latter reads
+        //   ClientInfo.RequireDPoP to decide whether DPoP is mandatory or opportunistic.
+        // - ClientValidator must also precede ScopeValidator: ScopeValidator enforces the client's
+        //   registered scope set and therefore reads ClientInfo, which ClientValidator populates.
         services.TryAddEnumerable([
             ServiceDescriptor.Singleton<ITokenContextValidator, Token.Validation.ResourceValidator>(),
-            ServiceDescriptor.Singleton<ITokenContextValidator, Token.Validation.ScopeValidator>(),
             ServiceDescriptor.Singleton<ITokenContextValidator, Token.Validation.ClientValidator>(),
+            ServiceDescriptor.Singleton<ITokenContextValidator, Token.Validation.ScopeValidator>(),
             ServiceDescriptor.Singleton<ITokenContextValidator, AuthorizationGrantValidator>(),
             ServiceDescriptor.Singleton<ITokenContextValidator, DPoPTokenEndpointValidator>()
         ]);

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.Logging.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.Logging.cs
@@ -53,6 +53,12 @@ partial class JwtBearerGrantHandler
 	private partial void LogMissingSubject(string ClientId);
 
 	[LoggerMessage(
+		EventId = LogEvents.Endpoints.JwtBearer.MissingExpiration,
+		Level = LogLevel.Warning,
+		Message = "JWT assertion missing required 'exp' claim for issuer {Issuer}, client {ClientId}")]
+	private partial void LogMissingExpiration(string ClientId, string Issuer);
+
+	[LoggerMessage(
 		EventId = LogEvents.Endpoints.JwtBearer.AlgorithmNotAllowed,
 		Level = LogLevel.Warning,
 		Message = "JWT assertion rejected: algorithm {Algorithm} not allowed for issuer {Issuer}, client {ClientId}")]

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -116,6 +116,7 @@ public partial class JwtBearerGrantHandler(
 		return ValidateAssertionParameter(request, clientInfo)
 			.BindAsync(assertion => ValidateJwtAsync(assertion, clientInfo))
 			.BindAsync(jwt => ValidateSubjectAsync(jwt, clientInfo))
+			.Bind(ctx => ValidateExpiration(ctx, clientInfo))
 			.Bind(ctx => ValidateAlgorithm(ctx, clientInfo))
 			.Bind(ctx => ValidateTokenType(ctx, clientInfo))
 			.Bind(ctx => ValidateJwtAge(ctx, clientInfo))
@@ -199,6 +200,23 @@ public partial class JwtBearerGrantHandler(
 	}
 
 	/// <summary>
+	/// Validates that the JWT assertion carries an 'exp' (expiration) claim. RFC 7523 Section 3
+	/// requires the assertion to contain an 'exp' claim that limits the window during which it can
+	/// be used; the generic lifetime check treats a token with neither 'nbf' nor 'exp' as valid, so
+	/// this enforces the grant-specific MUST and is also what bounds the replay-cache entry's TTL.
+	/// </summary>
+	private Result<ValidationContext, OidcError> ValidateExpiration(ValidationContext ctx, ClientInfo clientInfo)
+	{
+		if (ctx.Jwt.Payload.ExpiresAt.HasValue)
+			return ctx;
+
+		LogMissingExpiration(clientInfo.ClientId, ctx.Issuer);
+
+		return new OidcError(ErrorCodes.InvalidGrant,
+			"The JWT assertion must contain an 'exp' (expiration) claim");
+	}
+
+	/// <summary>
 	/// Validates that the JWT signing algorithm is in the allowed list.
 	/// </summary>
 	private Result<ValidationContext, OidcError> ValidateAlgorithm(ValidationContext ctx, ClientInfo clientInfo)
@@ -279,13 +297,15 @@ public partial class JwtBearerGrantHandler(
 				"The JWT assertion must contain a 'jti' (JWT ID) claim for replay protection");
 		}
 
-		if (await issuerProvider.IsReplayedAsync(jti))
+		// Single atomic reserve-and-check: record the jti keyed to the assertion's own 'exp' (which
+		// ValidateExpiration guarantees is present) and treat "already present" as a replay. One call
+		// avoids both the lost-TTL bug of a separate mark step and the read-then-write race.
+		if (await issuerProvider.IsReplayedAsync(jti, ctx.Jwt.Payload.ExpiresAt))
 		{
 			LogReplayDetected(jti, clientInfo.ClientId, ctx.Issuer, ctx.Jwt.Header.KeyId ?? "none", requestInfoProvider.RemoteIpAddress);
 			return new OidcError(ErrorCodes.InvalidGrant, "The JWT assertion has already been used");
 		}
 
-		await issuerProvider.MarkAsUsedAsync(jti, ctx.Jwt.Payload.ExpiresAt);
 		return ctx;
 	}
 

--- a/Abblix.Oidc.Server/Endpoints/Token/Validation/ScopeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Validation/ScopeValidator.cs
@@ -50,6 +50,7 @@ public class ScopeValidator(IScopeManager scopeManager): SyncTokenContextValidat
         if (!scopeManager.Validate(
                 context.Request.Scope,
                 context.Resources,
+                context.ClientInfo.AllowedScopes,
                 out var scopeDefinitions,
                 out var errorDescription))
         {

--- a/Abblix.Oidc.Server/Features/JwtBearer/IJwtBearerIssuerProvider.cs
+++ b/Abblix.Oidc.Server/Features/JwtBearer/IJwtBearerIssuerProvider.cs
@@ -73,16 +73,12 @@ public interface IJwtBearerIssuerProvider
 	IAsyncEnumerable<JsonWebKey> GetSigningKeysAsync(string issuer);
 
 	/// <summary>
-	/// Checks if a JWT with the specified JTI has already been used (replay protection).
+	/// Atomically records the JWT's JTI for replay protection and reports whether it had already
+	/// been recorded. The entry is kept until the assertion's own expiration, so a JWT cannot be
+	/// replayed for any part of its validity window.
 	/// </summary>
-	/// <param name="jti">The JWT ID (jti claim) to check.</param>
-	/// <returns>True if the JWT has already been used; false otherwise.</returns>
-	Task<bool> IsReplayedAsync(string jti);
-
-	/// <summary>
-	/// Marks a JWT as used by storing its JTI until the specified expiration time.
-	/// </summary>
-	/// <param name="jti">The JWT ID (jti claim) to mark as used.</param>
-	/// <param name="expiresAt">The time at which the JWT expires.</param>
-	Task MarkAsUsedAsync(string jti, DateTimeOffset? expiresAt);
+	/// <param name="jti">The JWT ID (jti claim) to reserve.</param>
+	/// <param name="expiresAt">The assertion's expiration; bounds how long the JTI is remembered.</param>
+	/// <returns>True if this JTI was already recorded (a replay); false if it was recorded just now.</returns>
+	Task<bool> IsReplayedAsync(string jti, DateTimeOffset? expiresAt);
 }

--- a/Abblix.Oidc.Server/Features/JwtBearer/JwtBearerIssuerProvider.cs
+++ b/Abblix.Oidc.Server/Features/JwtBearer/JwtBearerIssuerProvider.cs
@@ -134,19 +134,6 @@ public partial class JwtBearerIssuerProvider(
 	}
 
 	/// <inheritdoc />
-	/// <remarks>
-	/// Probes the replay cache by issuing a recording <c>TryAddAsync</c> call and
-	/// inverting the result: a fresh jti is recorded with a default TTL on this
-	/// probe, so the follow-up <see cref="MarkAsUsedAsync"/> call observes a
-	/// duplicate and is a no-op. Net behaviour matches the legacy two-step contract
-	/// for sequential callers; the entry's TTL is the canonical default rather than
-	/// the assertion's actual expiry. New code should adopt the canonical
-	/// <c>TryAddAsync</c> contract directly to avoid this asymmetry.
-	/// </remarks>
-	public async Task<bool> IsReplayedAsync(string jti)
-		=> !await replayCache.TryAddAsync(jti, expiresAt: null);
-
-	/// <inheritdoc />
-	public Task MarkAsUsedAsync(string jti, DateTimeOffset? expiresAt)
-		=> replayCache.TryAddAsync(jti, expiresAt);
+	public async Task<bool> IsReplayedAsync(string jti, DateTimeOffset? expiresAt)
+		=> !await replayCache.TryAddAsync(jti, expiresAt);
 }

--- a/Abblix.Oidc.Server/Features/ResourceIndicators/ResourceManager.cs
+++ b/Abblix.Oidc.Server/Features/ResourceIndicators/ResourceManager.cs
@@ -44,8 +44,25 @@ public class ResourceManager(IOptions<OidcOptions> options) : IResourceManager
     private static Dictionary<Uri, ResourceDefinition> InitializeResources(IOptions<OidcOptions> options)
     {
         var resources = new Dictionary<Uri, ResourceDefinition>();
-        if (options.Value.Resources != null)
-            Array.ForEach(options.Value.Resources, resource => resources.Add(resource.Resource, resource));
+        if (options.Value.Resources == null)
+            return resources;
+
+        foreach (var resource in options.Value.Resources)
+        {
+            // A non-absolute resource URI can never match a request (requests are rejected unless
+            // absolute per RFC 8707 Section 2), so it would sit as a silent dead entry. Fail fast
+            // with a clear message instead.
+            if (!resource.Resource.IsAbsoluteUri)
+                throw new ArgumentException(
+                    $"The configured resource '{resource.Resource}' must be an absolute URI (RFC 8707 Section 2).",
+                    nameof(OidcOptions.Resources));
+
+            if (!resources.TryAdd(resource.Resource, resource))
+                throw new ArgumentException(
+                    $"Duplicate resource definition for '{resource.Resource}'. Each configured resource URI must be unique.",
+                    nameof(OidcOptions.Resources));
+        }
+
         return resources;
     }
 

--- a/Abblix.Oidc.Server/Features/ScopeManagement/ScopeManagerExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ScopeManagement/ScopeManagerExtensions.cs
@@ -41,6 +41,9 @@ public static class ScopeManagerExtensions
     /// <param name="scopes">A collection of scope identifiers to be validated.</param>
     /// <param name="resources">An optional array of <see cref="ResourceDefinition"/> objects to validate scopes
     /// against.</param>
+    /// <param name="allowedClientScopes">The scopes the requesting client is allowed to request (its registered
+    /// scope set). When non-empty, any requested scope outside this set is rejected. When null or empty, no
+    /// per-client restriction is applied. Mirrors the per-issuer allow-list used by the JWT bearer grant.</param>
     /// <param name="scopeDefinitions">Outputs an array of <see cref="ScopeDefinition"/> objects if
     /// the validation is successful, otherwise null.</param>
     /// <param name="errorDescription">Outputs a string describing the reason for validation failure,
@@ -50,6 +53,7 @@ public static class ScopeManagerExtensions
         this IScopeManager scopeManager,
         IEnumerable<string> scopes,
         ResourceDefinition[]? resources,
+        string[]? allowedClientScopes,
         [MaybeNullWhen(false)] out ScopeDefinition[] scopeDefinitions,
         [MaybeNullWhen(true)] out string errorDescription)
     {
@@ -67,6 +71,16 @@ public static class ScopeManagerExtensions
 
         foreach (var scope in scopes)
         {
+            // Enforce the client's registered scope set: a client must not obtain a scope it was
+            // never registered for (RFC 6749 §3.3 — the AS restricts scope by policy). Empty/null
+            // means no restriction, matching the per-issuer allow-list of the JWT bearer grant.
+            if (allowedClientScopes is { Length: > 0 } &&
+                !allowedClientScopes.Contains(scope, StringComparer.Ordinal))
+            {
+                errorDescription = "The scope is not allowed for this client";
+                return false;
+            }
+
             // Check if the scope is recognized by the scope manager
             if (scopeManager.TryGet(scope, out var scopeDefinition))
             {

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -61,6 +61,7 @@ internal static class LogEvents
             public const int IssuerNotTrusted = Base + 13;
             public const int AudienceFailedStrict = Base + 14;
             public const int AudienceFailedPermissive = Base + 15;
+            public const int MissingExpiration = Base + 16;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Three findings from reviewing `Features/ScopeManagement`, `Features/JwtBearer`, and `Features/ResourceIndicators`, each fixed with reproducing tests.

### ScopeManagement — enforce the client's registered scope set (commit 1)

`ClientInfo.AllowedScopes` was recorded at registration and documented as the scopes the client is allowed to request, but **no scope validator consulted it** — the only gate was whether a scope was registered server-wide. A client could request any registered scope (for `client_credentials` there is no consent step to catch it). `ScopeManagerExtensions.Validate` now takes the client's allowed set and rejects requested scopes outside it, wired through all four runtime scope validators. An empty/null set imposes no restriction (mirrors the JWT-bearer per-issuer allow-list), so clients without an explicit registered scope set are unaffected.

### JwtBearer — require `exp`, bind replay to it (commit 2)

RFC 7523 §3 requires the assertion to carry `exp`, but the generic lifetime check accepts a token with neither `nbf` nor `exp`, so a no-`exp` assertion was accepted as never-expiring. A dedicated stage now rejects it with `invalid_grant`. With `exp` guaranteed present, replay protection collapses to a single atomic step — the `jti` is recorded keyed to the assertion's own `exp` and a duplicate is a replay. This replaces the previous two-call shape (a probing `IsReplayed` that recorded under a default 1-hour TTL, then a `MarkAsUsed` that no-opped), which let a longer-lived assertion be replayed after an hour and carried a read-then-write race.

### ResourceIndicators — validate configured resource URIs at startup (commit 3)

`ResourceManager` indexed entries with `Dictionary.Add` and no checks: a duplicate URI surfaced as an opaque exception, and a non-absolute URI became a silent dead entry that can never match a request (RFC 8707 §2). Construction now rejects non-absolute URIs and reports duplicates with a clear message.
