### PR TITLE
fix(dcr): preserve AllowedScopes on RFC 7592 client update

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
@@ -1,0 +1,76 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Model;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement;
+
+/// <summary>
+/// Verifies that an RFC 7592 client update (a full replacement) re-persists the per-client scope
+/// set. Dropping AllowedScopes on update would revert the client to "any scope" (null = unrestricted),
+/// defeating the scope enforcement applied at the authorization and token endpoints.
+/// </summary>
+public class UpdateClientRequestProcessorTests
+{
+    [Fact]
+    public async Task Update_PreservesAllowedScopes()
+    {
+        // Arrange
+        ClientInfo? saved = null;
+        var clientInfoManager = new Mock<IClientInfoManager>(MockBehavior.Strict);
+        clientInfoManager
+            .Setup(m => m.UpdateClientAsync(It.IsAny<ClientInfo>()))
+            .Callback<ClientInfo>(c => saved = c)
+            .Returns(Task.CompletedTask);
+
+        var tokenService = new Mock<IRegistrationAccessTokenService>(MockBehavior.Loose);
+        tokenService
+            .Setup(s => s.IssueTokenAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<TimeSpan?>()))
+            .ReturnsAsync("registration-access-token");
+
+        var processor = new UpdateClientRequestProcessor(
+            clientInfoManager.Object, tokenService.Object, TimeProvider.System);
+
+        var model = new ClientRegistrationRequest
+        {
+            RedirectUris = [new Uri("https://client.example.com/cb")],
+            Scope = ["openid", "profile"],
+        };
+        var existing = new ClientInfo("client-1");
+        var request = new ValidUpdateClientRequest(
+            new UpdateClientRequest(new ClientRequest(), model), existing, model);
+
+        // Act
+        await processor.ProcessAsync(request);
+
+        // Assert
+        Assert.NotNull(saved);
+        Assert.Equal(model.Scope, saved.AllowedScopes);
+    }
+}

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -103,6 +103,12 @@ public class UpdateClientRequestProcessor(
             RequestObjectEncryptionMethod = model.RequestObjectEncryptionEnc,
             TokenEndpointAuthSigningAlgorithm = model.TokenEndpointAuthSigningAlg,
             RequestUris = model.RequestUris ?? [],
+            // RFC 7592 update is a full replacement: these must be re-applied or the update silently
+            // drops them. Omitting AllowedScopes in particular reverted the client to "any scope"
+            // (null = unrestricted), defeating the per-client scope enforcement on the update path.
+            AllowedScopes = model.Scope,
+            SoftwareId = model.SoftwareId,
+            SoftwareVersion = model.SoftwareVersion,
         };
 
         // Update logout configuration using wrapper objects


### PR DESCRIPTION
## Summary

RFC 7592 client update is a full replacement — `UpdateClientRequestProcessor` rebuilds `ClientInfo` from the request. It omitted `AllowedScopes`, `SoftwareId`, and `SoftwareVersion`, which registration sets. Dropping `AllowedScopes` reverted the client to `null` (= "any scope, unrestricted") after **any** update, which silently defeats the per-client scope enforcement added for the authorization and token endpoints — a privilege-escalation-on-update variant of that gap. The update now re-applies all three fields.

Found while auditing for other DCR-populated-but-unenforced `ClientInfo` fields (the same class as the original `AllowedScopes` gap). Reproducing test asserts an update preserves `AllowedScopes`.
