### PR TITLE
feat(jarm): JWT Secured Authorization Response Mode

### DIFF
--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtSecuredAuthorizationResponseTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtSecuredAuthorizationResponseTests.cs
@@ -1,0 +1,88 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// JWT Secured Authorization Response Mode (JARM). The client requests <c>response_mode=query.jwt</c>; the
+/// authorization server returns the authorization response parameters packed into a single signed
+/// <c>response</c> JWT carrying the JARM-mandated <c>iss</c>/<c>aud</c>/<c>exp</c> claims (JARM §2.1). The
+/// end-to-end invariant: the authorization code lives inside the response JWT, not as a bare query parameter,
+/// and that code is still redeemable at the token endpoint.
+/// </summary>
+public class JwtSecuredAuthorizationResponseTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task QueryJwt_packs_authorization_response_into_signed_jwt()
+    {
+        var httpClient = CreateClient();
+        var discovery = await FetchDiscoveryAsync(httpClient);
+        var (verifier, challenge) = GeneratePkcePair();
+
+        // Register a code-flow client. No JARM-specific registration is required: the response is signed with
+        // the server's default algorithm (RS256, JARM §3); the client opts in purely by the response mode.
+        var dcrBody = new JsonObject
+        {
+            ["redirect_uris"] = new JsonArray { TestConstants.RedirectUri },
+            ["grant_types"] = new JsonArray { GrantTypes.AuthorizationCode },
+            ["response_types"] = new JsonArray { ResponseTypes.Code },
+            ["token_endpoint_auth_method"] = "client_secret_post",
+        };
+        var registered = await RegisterClientAsync(httpClient, discovery, dcrBody);
+        var clientId = registered[AuthorizationRequest.Parameters.ClientId]!.GetValue<string>();
+        var clientSecret = registered[ClientRequest.Parameters.ClientSecret]!.GetValue<string>();
+
+        var state = Guid.NewGuid().ToString("N");
+
+        // Drive /authorize requesting the JARM query.jwt response mode.
+        var responseJwt = await AuthorizeAndExtractResponseJwtAsync(httpClient, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.State] = state,
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+            [AuthorizationRequest.Parameters.ResponseMode] = ResponseModes.QueryJwt,
+        });
+
+        // The callback carries a 3-segment JWS, not bare query parameters.
+        Assert.Equal(3, responseJwt.Split('.').Length);
+
+        var payload = DecodeJwtPayload(responseJwt);
+
+        // JARM §2.1 mandated claims. Compare the issuer ignoring a trailing slash (Uri.AbsoluteUri keeps one,
+        // the issuer identifier does not).
+        Assert.Equal(
+            discovery.Issuer.AbsoluteUri.TrimEnd('/'),
+            payload["iss"]!.GetValue<string>().TrimEnd('/'));
+        Assert.Equal(clientId, payload["aud"]!.GetValue<string>());
+        Assert.NotNull(payload["exp"]);
+
+        // The authorization response parameters are inside the JWT, not on the wire.
+        Assert.Equal(state, payload[AuthorizationRequest.Parameters.State]!.GetValue<string>());
+        var code = payload[TokenRequest.Parameters.Code]!.GetValue<string>();
+        Assert.False(string.IsNullOrEmpty(code));
+
+        // The code extracted from the response JWT is a real, redeemable authorization code.
+        var tokenResponse = await ExchangeCodeForTokensAsync(httpClient, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = clientSecret,
+        });
+
+        Assert.NotNull(tokenResponse[UserInfoRequest.Parameters.AccessToken]);
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -90,6 +90,16 @@ public abstract class TestBase(TestFactory factory)
         await AuthorizeAndExtractFromCallbackAsync(client, discovery, queryParams, "error");
 
     /// <summary>
+    /// Drives /authorize for a JARM (JWT Secured Authorization Response Mode) request and returns the value of
+    /// the single <c>response</c> callback parameter — the signed (and optionally encrypted) response JWT.
+    /// </summary>
+    protected static async Task<string> AuthorizeAndExtractResponseJwtAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        Dictionary<string, string> queryParams) =>
+        await AuthorizeAndExtractFromCallbackAsync(client, discovery, queryParams, "response");
+
+    /// <summary>
     /// Drives /authorize, asserts the AS responded with a 302/303 back to <c>redirect_uri</c>,
     /// and returns the value of the requested callback-URI query parameter. Shared body of
     /// <see cref="AuthorizeAndExtractCodeAsync"/> and <see cref="AuthorizeAndExtractErrorAsync"/>.

--- a/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationErrorFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationErrorFormatter.cs
@@ -24,6 +24,7 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Mvc.Binders;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
@@ -43,10 +44,12 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// included in error responses if applicable.</param>
 /// <param name="authorizationMetadata">Provider for the discovery metadata needed to map the requested
 /// response mode onto the corresponding redirect-handling strategy.</param>
+/// <param name="responseEncoder">Encodes the response as a JARM JWT when the requested response mode is a JWT variant.</param>
 public class AuthorizationErrorFormatter(
     IParametersProvider parametersProvider,
     IIssuerProvider issuerProvider,
-    IAuthorizationMetadataProvider authorizationMetadata) : IAuthorizationErrorFormatter
+    IAuthorizationMetadataProvider authorizationMetadata,
+    IAuthorizationResponseEncoder responseEncoder) : IAuthorizationErrorFormatter
 {
     /// <summary>
     /// Asynchronously formats an authorization error response into an HTTP action result,
@@ -70,7 +73,24 @@ public class AuthorizationErrorFormatter(
                     ErrorUri = error.ErrorUri,
                 };
 
-                return await FormatResponseAsync(response, error.ResponseMode, redirectUri);
+                // An error response is delivered through the requested response mode, including JARM (JWT)
+                // modes. The core encoder packs the error parameters into the `response` JWT; the `jwt` shortcut
+                // defaults to fragment for token-bearing flows and query otherwise.
+                var effectiveResponse = response;
+                var deliveryMode = error.ResponseMode;
+                if (ResponseModes.IsJwtMode(error.ResponseMode))
+                {
+                    var carriesTokens = request.ResponseType is { } responseType &&
+                        (responseType.Contains(ResponseTypes.Token) || responseType.Contains(ResponseTypes.IdToken));
+
+                    var parameters = parametersProvider.GetParameters(response).ToArray();
+                    var jarm = await responseEncoder.EncodeAsync(
+                        error.ResponseMode, request.ClientId, carriesTokens, parameters);
+                    effectiveResponse = new AuthorizationResponse { Response = jarm.ResponseJwt };
+                    deliveryMode = jarm.DeliveryMode;
+                }
+
+                return await FormatResponseAsync(effectiveResponse, deliveryMode, redirectUri);
 
             default:
                 return new BadRequestObjectResult(new ErrorResponse(error.Error, error.ErrorDescription));

--- a/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationResponseFormatter.cs
@@ -26,7 +26,9 @@ using Abblix.Oidc.Server.Common.Exceptions;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.SessionManagement;
+using Abblix.Oidc.Server.Mvc.Binders;
 using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Mvc.ActionResults;
@@ -50,6 +52,8 @@ public class AuthorizationResponseFormatter(
     IUriResolver uriResolver,
     IIssuerProvider issuerProvider,
     IAuthorizationMetadataProvider authorizationMetadata,
+    IParametersProvider parametersProvider,
+    IAuthorizationResponseEncoder responseEncoder,
     IAuthorizationErrorFormatter errorFormatter) : IAuthorizationResponseFormatter
 {
     /// <summary>
@@ -108,7 +112,21 @@ public class AuthorizationResponseFormatter(
                     SessionState = success.SessionState,
                 };
 
-                var actionResult = await errorFormatter.FormatResponseAsync(modelResponse, success.ResponseMode, redirectUri);
+                // JARM (JWT Secured Authorization Response Mode): when the client requested a *.jwt response
+                // mode, pack the response parameters into a signed/encrypted `response` JWT (built by the core
+                // encoder) and deliver it via the matching plaintext mode.
+                var effectiveResponse = modelResponse;
+                var deliveryMode = success.ResponseMode;
+                if (ResponseModes.IsJwtMode(success.ResponseMode))
+                {
+                    var parameters = parametersProvider.GetParameters(modelResponse).ToArray();
+                    var jarm = await responseEncoder.EncodeAsync(
+                        success.ResponseMode, response.Model.ClientId, carriesTokens, parameters);
+                    effectiveResponse = new AuthorizationResponse { Response = jarm.ResponseJwt };
+                    deliveryMode = jarm.DeliveryMode;
+                }
+
+                var actionResult = await errorFormatter.FormatResponseAsync(effectiveResponse, deliveryMode, redirectUri);
 
                 if (sessionManagementService.Enabled &&
                     success.SessionId.HasValue() &&

--- a/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
@@ -119,6 +119,9 @@ public class ConfigurationResponseFormatter(
 			RequestObjectSigningAlgValuesSupported = response.RequestObjectSigningAlgValuesSupported,
 			RequestObjectEncryptionAlgValuesSupported = response.RequestObjectEncryptionAlgValuesSupported,
 			RequestObjectEncryptionEncValuesSupported = response.RequestObjectEncryptionEncValuesSupported,
+			AuthorizationSigningAlgValuesSupported = response.AuthorizationSigningAlgValuesSupported,
+			AuthorizationEncryptionAlgValuesSupported = response.AuthorizationEncryptionAlgValuesSupported,
+			AuthorizationEncryptionEncValuesSupported = response.AuthorizationEncryptionEncValuesSupported,
 
 			RequirePushedAuthorizationRequests = response.RequirePushedAuthorizationRequests,
 			RequireSignedRequestObject = response.RequireSignedRequestObject,

--- a/Abblix.Oidc.Server.Mvc/Model/AuthorizationRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/AuthorizationRequest.cs
@@ -88,7 +88,9 @@ public record AuthorizationRequest
 	/// such as in the query string or fragment of the redirect URI.
 	/// </summary>
 	[BindProperty(SupportsGet = true, Name = Parameters.ResponseMode)]
-    [AllowedValues(ResponseModes.FormPost, ResponseModes.Fragment, ResponseModes.Query)]
+    [AllowedValues(
+        ResponseModes.FormPost, ResponseModes.Fragment, ResponseModes.Query,
+        ResponseModes.QueryJwt, ResponseModes.FragmentJwt, ResponseModes.FormPostJwt, ResponseModes.Jwt)]
     public string? ResponseMode { get; init; }
 
 	/// <summary>

--- a/Abblix.Oidc.Server.Mvc/Model/AuthorizationResponse.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/AuthorizationResponse.cs
@@ -52,6 +52,8 @@ public record AuthorizationResponse
 		public const string SessionState = "session_state";
 
 		public const string Issuer = "iss";
+
+		public const string Response = "response";
 	}
 
 	/// <summary>
@@ -137,4 +139,11 @@ public record AuthorizationResponse
 	/// </summary>
 	[JsonPropertyName(Parameters.Issuer)]
 	public string? Issuer { get; set; }
+
+	/// <summary>
+	/// The JARM (JWT Secured Authorization Response Mode) response JWT. When set, it is the sole wire
+	/// parameter — all other authorization response parameters are carried as claims inside this JWT.
+	/// </summary>
+	[JsonPropertyName(Parameters.Response)]
+	public string? Response { get; set; }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/ResponseModeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/ResponseModeValidatorTests.cs
@@ -453,23 +453,62 @@ public class ResponseModeValidatorTests
     }
 
     /// <summary>
-    /// Verifies that ValidateAsync accepts jwt response_mode for authorization code flow.
-    /// Per OAuth 2.0 JWT Secured Authorization Response Mode (JARM), jwt mode is valid.
-    /// Tests support for JWT-secured response mode.
+    /// Verifies that ValidateAsync accepts JARM response modes (JWT Secured Authorization Response Mode).
+    /// <c>query.jwt</c>, <c>fragment.jwt</c>, <c>form_post.jwt</c> and the <c>jwt</c> shortcut are valid for
+    /// the authorization code flow; the requested mode is preserved on the context for the formatter to encode.
     /// </summary>
-    [Fact]
-    public async Task ValidateAsync_AuthorizationCodeFlowWithJwt_ShouldReturnError()
+    [Theory]
+    [InlineData(ResponseModes.QueryJwt)]
+    [InlineData(ResponseModes.FragmentJwt)]
+    [InlineData(ResponseModes.FormPostJwt)]
+    [InlineData(ResponseModes.Jwt)]
+    public async Task ValidateAsync_AuthorizationCodeFlowWithJarmMode_ShouldSucceed(string responseMode)
     {
         // Arrange
-        var context = CreateContext(FlowTypes.AuthorizationCode, responseMode: "jwt");
+        var context = CreateContext(FlowTypes.AuthorizationCode, responseMode);
 
         // Act
         var result = await _validator.ValidateAsync(context);
 
         // Assert
-        // JWT mode is not in the explicitly allowed list, so it should fail
-        Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Null(result);
+        Assert.Equal(responseMode, context.ResponseMode);
+    }
+
+    /// <summary>
+    /// Verifies that <c>query.jwt</c> inherits <c>query</c>'s prohibition for token-bearing flows (JARM §2.3.1):
+    /// the JWT does not exempt the response from the rule that credentials must not appear in the URL query.
+    /// The <c>jwt</c> shortcut, by contrast, resolves to fragment for these flows and is accepted.
+    /// </summary>
+    [Theory]
+    [InlineData(FlowTypes.Implicit, ResponseModes.QueryJwt, false)]
+    [InlineData(FlowTypes.Implicit, ResponseModes.FragmentJwt, true)]
+    [InlineData(FlowTypes.Implicit, ResponseModes.FormPostJwt, true)]
+    [InlineData(FlowTypes.Implicit, ResponseModes.Jwt, true)]
+    [InlineData(FlowTypes.Hybrid, ResponseModes.QueryJwt, false)]
+    [InlineData(FlowTypes.Hybrid, ResponseModes.Jwt, true)]
+    public async Task ValidateAsync_TokenBearingFlowWithJarmMode_ShouldRespectQueryProhibition(
+        FlowTypes flowType,
+        string responseMode,
+        bool shouldSucceed)
+    {
+        // Arrange
+        var context = CreateContext(flowType, responseMode);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Null(result);
+            Assert.Equal(responseMode, context.ResponseMode);
+        }
+        else
+        {
+            Assert.NotNull(result);
+            Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        }
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Configuration/JwtAlgorithmsProviderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Configuration/JwtAlgorithmsProviderTests.cs
@@ -112,4 +112,38 @@ public class JwtAlgorithmsProviderTests
 
         Assert.Equal(contentEncryption, result);
     }
+
+    [Fact]
+    public void AuthorizationSigningAlgValuesSupported_ForwardsCreatorSignedResponseAlgorithms()
+    {
+        // JARM responses are signed with the same service keys as ID tokens — the creator's signing set.
+        string[] signing = [SigningAlgorithms.RS256, SigningAlgorithms.ES256];
+        _creator.Setup(c => c.SignedResponseAlgorithmsSupported).Returns(signing);
+
+        var result = CreateProvider().AuthorizationSigningAlgValuesSupported.ToArray();
+
+        Assert.Equal(signing, result);
+    }
+
+    [Fact]
+    public void AuthorizationEncryptionAlgValuesSupported_ForwardsValidatorKeyManagementAlgorithms()
+    {
+        string[] keyManagement = [EncryptionAlgorithms.KeyManagement.RsaOaep256];
+        _validator.Setup(v => v.EncryptionAlgorithmsSupported).Returns(keyManagement);
+
+        var result = CreateProvider().AuthorizationEncryptionAlgValuesSupported.ToArray();
+
+        Assert.Equal(keyManagement, result);
+    }
+
+    [Fact]
+    public void AuthorizationEncryptionEncValuesSupported_ForwardsValidatorContentEncryptionAlgorithms()
+    {
+        string[] contentEncryption = [EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256];
+        _validator.Setup(v => v.EncryptionMethodsSupported).Returns(contentEncryption);
+
+        var result = CreateProvider().AuthorizationEncryptionEncValuesSupported.ToArray();
+
+        Assert.Equal(contentEncryption, result);
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthorizationResponseEncoderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthorizationResponseEncoderTests.cs
@@ -1,0 +1,215 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Formatters;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Moq;
+using Xunit;
+using JsonWebKey = Abblix.Jwt.JsonWebKey;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Formatters;
+
+/// <summary>
+/// Unit tests for <see cref="AuthorizationResponseEncoder"/> verifying JARM (JWT Secured Authorization Response
+/// Mode) JWT construction: the mandated <c>iss</c>/<c>aud</c>/<c>exp</c> claims (JARM §2.1), signing with the
+/// client's registered algorithm (default RS256, JARM §3), optional signed-then-encrypted output, and the
+/// resolution of the JARM response mode to its plaintext delivery counterpart (JARM §2.3).
+/// </summary>
+public class AuthorizationResponseEncoderTests
+{
+    private const string ClientId = TestConstants.DefaultClientId;
+    private const string Issuer = TestConstants.DefaultIssuer;
+    private const string EncodedJwt = "header.payload.signature";
+
+    private readonly Mock<IClientInfoProvider> _clientInfoProvider = new(MockBehavior.Strict);
+    private readonly Mock<IJsonWebTokenCreator> _jwtCreator = new(MockBehavior.Strict);
+    private readonly Mock<IClientKeysProvider> _clientKeys = new(MockBehavior.Strict);
+    private readonly Mock<IAuthServiceKeysProvider> _serviceKeys = new(MockBehavior.Strict);
+    private readonly Mock<IIssuerProvider> _issuerProvider = new(MockBehavior.Strict);
+    private readonly Mock<TimeProvider> _timeProvider = new(MockBehavior.Strict);
+
+    private readonly AuthorizationResponseEncoder _encoder;
+    private readonly ClientInfo _client = new(ClientId);
+
+    private readonly JsonWebKey _signingKeyRS256 = new RsaJsonWebKey { KeyId = "sig-rs256", Algorithm = SigningAlgorithms.RS256 };
+    private readonly JsonWebKey _clientEncryptionKey = new RsaJsonWebKey { KeyId = "client-enc", Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256 };
+    private readonly DateTimeOffset _now = new(2026, 6, 2, 12, 0, 0, TimeSpan.Zero);
+
+    public AuthorizationResponseEncoderTests()
+    {
+        _clientInfoProvider.Setup(p => p.TryFindClientAsync(ClientId)).ReturnsAsync(_client);
+        _issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
+        _timeProvider.Setup(t => t.GetUtcNow()).Returns(_now);
+        _serviceKeys.Setup(p => p.GetSigningKeys(true)).Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
+
+        _encoder = new AuthorizationResponseEncoder(
+            _clientInfoProvider.Object,
+            _jwtCreator.Object,
+            _clientKeys.Object,
+            _serviceKeys.Object,
+            _issuerProvider.Object,
+            _timeProvider.Object);
+    }
+
+    /// <summary>
+    /// Mutable holder for the arguments the encoder passes to <see cref="IJsonWebTokenCreator.IssueAsync"/>.
+    /// The callback writes into it during the call, so the test reads it <em>after</em> awaiting EncodeAsync.
+    /// </summary>
+    private sealed class IssuedToken
+    {
+        public JsonWebToken Token { get; set; } = null!;
+        public JsonWebKey? EncryptionKey { get; set; }
+        public string KeyAlgorithm { get; set; } = null!;
+        public string ContentAlgorithm { get; set; } = null!;
+    }
+
+    private IssuedToken CaptureIssue()
+    {
+        var captured = new IssuedToken();
+
+        _jwtCreator
+            .Setup(c => c.IssueAsync(
+                It.IsAny<JsonWebToken>(), It.IsAny<JsonWebKey?>(), It.IsAny<JsonWebKey?>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey?, JsonWebKey?, string, string>((t, _, enc, ka, ca) =>
+            {
+                captured.Token = t;
+                captured.EncryptionKey = enc;
+                captured.KeyAlgorithm = ka;
+                captured.ContentAlgorithm = ca;
+            })
+            .ReturnsAsync(EncodedJwt);
+
+        return captured;
+    }
+
+    [Fact]
+    public async Task EncodeAsync_SignedOnly_PopulatesJarmClaimsAndSignsWithDefaultRs256()
+    {
+        var capture = CaptureIssue();
+
+        var result = await _encoder.EncodeAsync(
+            ResponseModes.QueryJwt, ClientId, carriesTokens: false,
+            [("code", "auth-code"), ("state", "client-state")]);
+
+        Assert.Equal(EncodedJwt, result.ResponseJwt);
+        Assert.Equal(ResponseModes.Query, result.DeliveryMode);
+
+        // JARM §2.1 mandated claims.
+        Assert.Equal(Issuer, capture.Token.Payload.Issuer);
+        Assert.Equal([ClientId], capture.Token.Payload.Audiences);
+        Assert.Equal(_now + TimeSpan.FromMinutes(10), capture.Token.Payload.ExpiresAt);
+
+        // Response parameters carried as claims.
+        Assert.Equal("auth-code", capture.Token.Payload["code"]!.GetValue<string>());
+        Assert.Equal("client-state", capture.Token.Payload["state"]!.GetValue<string>());
+
+        // Signed with the client's algorithm (default RS256, JARM §3).
+        Assert.Equal(SigningAlgorithms.RS256, capture.Token.Header.Algorithm);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_WithoutEncryptionAlgorithm_DoesNotEncrypt()
+    {
+        var capture = CaptureIssue();
+
+        await _encoder.EncodeAsync(ResponseModes.QueryJwt, ClientId, carriesTokens: false, [("code", "auth-code")]);
+
+        // Signed-only: no encryption key is resolved or passed.
+        Assert.Null(capture.EncryptionKey);
+        _clientKeys.Verify(p => p.GetEncryptionKeys(It.IsAny<ClientInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_WithEncryptionAlgorithm_SignsThenEncryptsWithClientKey()
+    {
+        var capture = CaptureIssue();
+        _clientKeys
+            .Setup(p => p.GetEncryptionKeys(It.IsAny<ClientInfo>()))
+            .Returns(new[] { _clientEncryptionKey }.ToAsyncEnumerable());
+
+        _client.AuthorizationEncryptedResponseAlgorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256;
+        _client.AuthorizationEncryptedResponseEncryption = EncryptionAlgorithms.ContentEncryption.Aes256Gcm;
+
+        await _encoder.EncodeAsync(ResponseModes.QueryJwt, ClientId, carriesTokens: false, [("code", "auth-code")]);
+
+        Assert.Same(_clientEncryptionKey, capture.EncryptionKey);
+        Assert.Equal(EncryptionAlgorithms.KeyManagement.RsaOaep256, capture.KeyAlgorithm);
+        Assert.Equal(EncryptionAlgorithms.ContentEncryption.Aes256Gcm, capture.ContentAlgorithm);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_WithEncryptionAlgorithmButNoEnc_DefaultsToA128CbcHs256()
+    {
+        var capture = CaptureIssue();
+        _clientKeys
+            .Setup(p => p.GetEncryptionKeys(It.IsAny<ClientInfo>()))
+            .Returns(new[] { _clientEncryptionKey }.ToAsyncEnumerable());
+
+        _client.AuthorizationEncryptedResponseAlgorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256;
+        // AuthorizationEncryptedResponseEncryption omitted → JARM §3 default
+
+        await _encoder.EncodeAsync(ResponseModes.QueryJwt, ClientId, carriesTokens: false, [("code", "auth-code")]);
+
+        Assert.Equal(EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256, capture.ContentAlgorithm);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_HonoursClientConfiguredSigningAlgorithm()
+    {
+        var signingKeyRS384 = new RsaJsonWebKey { KeyId = "sig-rs384", Algorithm = SigningAlgorithms.RS384 };
+        _serviceKeys
+            .Setup(p => p.GetSigningKeys(true))
+            .Returns(new[] { _signingKeyRS256, signingKeyRS384 }.ToAsyncEnumerable());
+
+        var capture = CaptureIssue();
+        _client.AuthorizationSignedResponseAlgorithm = SigningAlgorithms.RS384;
+
+        await _encoder.EncodeAsync(ResponseModes.QueryJwt, ClientId, carriesTokens: false, [("code", "auth-code")]);
+
+        Assert.Equal(SigningAlgorithms.RS384, capture.Token.Header.Algorithm);
+    }
+
+    [Theory]
+    [InlineData(ResponseModes.QueryJwt, false, ResponseModes.Query)]
+    [InlineData(ResponseModes.FragmentJwt, false, ResponseModes.Fragment)]
+    [InlineData(ResponseModes.FormPostJwt, false, ResponseModes.FormPost)]
+    [InlineData(ResponseModes.Jwt, false, ResponseModes.Query)]
+    [InlineData(ResponseModes.Jwt, true, ResponseModes.Fragment)]
+    public async Task EncodeAsync_ResolvesDeliveryMode(string responseMode, bool carriesTokens, string expectedDeliveryMode)
+    {
+        CaptureIssue();
+
+        var result = await _encoder.EncodeAsync(responseMode, ClientId, carriesTokens, [("code", "auth-code")]);
+
+        Assert.Equal(expectedDeliveryMode, result.DeliveryMode);
+    }
+}

--- a/Abblix.Oidc.Server/Common/Constants/ResponseModes.cs
+++ b/Abblix.Oidc.Server/Common/Constants/ResponseModes.cs
@@ -44,4 +44,35 @@ public static class ResponseModes
 	/// redirect URI.
 	/// </summary>
 	public const string Fragment = "fragment";
+
+	/// <summary>
+	/// JARM (JWT Secured Authorization Response Mode) variant of <see cref="Query"/>: the response parameters
+	/// are packed into a single JWT delivered via the <c>response</c> query parameter of the redirect URI.
+	/// </summary>
+	public const string QueryJwt = "query.jwt";
+
+	/// <summary>
+	/// JARM variant of <see cref="Fragment"/>: the response parameters are packed into a single JWT delivered
+	/// via the <c>response</c> fragment parameter of the redirect URI.
+	/// </summary>
+	public const string FragmentJwt = "fragment.jwt";
+
+	/// <summary>
+	/// JARM variant of <see cref="FormPost"/>: the response parameters are packed into a single JWT delivered
+	/// as an auto-submitting HTML form's <c>response</c> field.
+	/// </summary>
+	public const string FormPostJwt = "form_post.jwt";
+
+	/// <summary>
+	/// JARM shortcut response mode: indicates the default JWT redirect encoding for the requested response type
+	/// (<see cref="QueryJwt"/> for the code flow, <see cref="FragmentJwt"/> for token-bearing flows), per JARM §2.3.4.
+	/// </summary>
+	public const string Jwt = "jwt";
+
+	/// <summary>
+	/// Determines whether the given response mode is a JARM (JWT-secured) mode — one of <see cref="QueryJwt"/>,
+	/// <see cref="FragmentJwt"/>, <see cref="FormPostJwt"/> or <see cref="Jwt"/>.
+	/// </summary>
+	public static bool IsJwtMode(string responseMode)
+		=> responseMode is QueryJwt or FragmentJwt or FormPostJwt or Jwt;
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Interfaces/AuthorizationEndpointMetadata.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Interfaces/AuthorizationEndpointMetadata.cs
@@ -61,7 +61,15 @@ public record AuthorizationEndpointMetadata
     [
         ResponseModes.Query,
         ResponseModes.Fragment,
-        ResponseModes.FormPost
+        ResponseModes.FormPost,
+
+        // JARM (JWT Secured Authorization Response Mode). A client opts in per request by selecting one of
+        // these modes; the response is then signed (and optionally encrypted) per the client's registered
+        // authorization_signed/encrypted_response_* metadata.
+        ResponseModes.QueryJwt,
+        ResponseModes.FragmentJwt,
+        ResponseModes.FormPostJwt,
+        ResponseModes.Jwt
     ];
 
     /// <summary>

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ResponseModeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ResponseModeValidator.cs
@@ -65,10 +65,29 @@ public partial class ResponseModeValidator(ILogger<ResponseModeValidator> logger
 	/// <param name="responseMode">The response mode to validate.</param>
 	/// <param name="flowType">The flow type associated with the authorization request.</param>
 	/// <returns>A boolean value indicating whether the response mode is allowed for the specified flow type.</returns>
-	private static bool IsResponseModeAllowed(string responseMode, FlowTypes flowType) => flowType switch
+	private static bool IsResponseModeAllowed(string responseMode, FlowTypes flowType)
 	{
-		FlowTypes.AuthorizationCode => responseMode is ResponseModes.Query or ResponseModes.FormPost or ResponseModes.Fragment,
-		FlowTypes.Implicit or FlowTypes.Hybrid => responseMode is ResponseModes.FormPost or ResponseModes.Fragment,
-		_ => throw new UnexpectedTypeException(nameof(flowType), flowType.GetType()),
-	};
+		// JARM (.jwt) modes are accepted whenever their base delivery mode is: each maps to a base mode and
+		// is then subject to the same flow-compatibility rules as its plaintext counterpart — so query.jwt
+		// inherits query's prohibition for token-bearing flows (JARM §2.3.1). The `jwt` shortcut resolves to
+		// query for the code flow and fragment otherwise (JARM §2.3.4), both of which are acceptable.
+		if (ResponseModes.IsJwtMode(responseMode))
+		{
+			responseMode = responseMode switch
+			{
+				ResponseModes.QueryJwt => ResponseModes.Query,
+				ResponseModes.FragmentJwt => ResponseModes.Fragment,
+				ResponseModes.FormPostJwt => ResponseModes.FormPost,
+				ResponseModes.Jwt => flowType == FlowTypes.AuthorizationCode ? ResponseModes.Query : ResponseModes.Fragment,
+				_ => responseMode,
+			};
+		}
+
+		return flowType switch
+		{
+			FlowTypes.AuthorizationCode => responseMode is ResponseModes.Query or ResponseModes.FormPost or ResponseModes.Fragment,
+			FlowTypes.Implicit or FlowTypes.Hybrid => responseMode is ResponseModes.FormPost or ResponseModes.Fragment,
+			_ => throw new UnexpectedTypeException(nameof(flowType), flowType.GetType()),
+		};
+	}
 }

--- a/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
@@ -88,6 +88,12 @@ public sealed class ConfigurationHandler(
 			? jwtAlgorithms.RequestObjectEncryptionEncValuesSupported
 			: null,
 
+		// JARM (JWT Secured Authorization Response Mode) is always available — a client opts in per request
+		// by selecting a *.jwt response mode — so the supported algorithms are advertised unconditionally.
+		AuthorizationSigningAlgValuesSupported = jwtAlgorithms.AuthorizationSigningAlgValuesSupported,
+		AuthorizationEncryptionAlgValuesSupported = jwtAlgorithms.AuthorizationEncryptionAlgValuesSupported,
+		AuthorizationEncryptionEncValuesSupported = jwtAlgorithms.AuthorizationEncryptionEncValuesSupported,
+
 		RequirePushedAuthorizationRequests = options.Value.RequirePushedAuthorizationRequests,
 		RequireSignedRequestObject = options.Value.RequireSignedRequestObject,
 

--- a/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
@@ -156,6 +156,23 @@ public record ConfigurationResponse
 	public IEnumerable<string>? RequestObjectEncryptionEncValuesSupported { init; get; }
 
 	/// <summary>
+	/// Specifies the JWS algorithms supported for signing JARM authorization responses (JARM §4).
+	/// </summary>
+	public IEnumerable<string>? AuthorizationSigningAlgValuesSupported { init; get; }
+
+	/// <summary>
+	/// Specifies the JWE key-management algorithms (the <c>alg</c> values) supported for encrypting JARM
+	/// authorization responses (JARM §4).
+	/// </summary>
+	public IEnumerable<string>? AuthorizationEncryptionAlgValuesSupported { init; get; }
+
+	/// <summary>
+	/// Specifies the JWE content-encryption algorithms (the <c>enc</c> values) supported for encrypting JARM
+	/// authorization responses (JARM §4).
+	/// </summary>
+	public IEnumerable<string>? AuthorizationEncryptionEncValuesSupported { init; get; }
+
+	/// <summary>
 	/// Indicates whether the OpenID Provider requires clients to use Pushed Authorization Requests (PAR) only.
 	/// </summary>
 	public bool? RequirePushedAuthorizationRequests { get; set; }

--- a/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/IJwtAlgorithmsProvider.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/IJwtAlgorithmsProvider.cs
@@ -59,4 +59,24 @@ public interface IJwtAlgorithmsProvider
 	/// advertised via <c>request_object_encryption_enc_values_supported</c>.
 	/// </summary>
 	IEnumerable<string> RequestObjectEncryptionEncValuesSupported { get; }
+
+	/// <summary>
+	/// Lists the JWS algorithms the authorization server uses to sign JARM authorization responses,
+	/// advertised via <c>authorization_signing_alg_values_supported</c> (JARM §4).
+	/// </summary>
+	IEnumerable<string> AuthorizationSigningAlgValuesSupported { get; }
+
+	/// <summary>
+	/// Lists the JWE key-management algorithms (the <c>alg</c> values) the authorization server can use to
+	/// encrypt JARM authorization responses, advertised via <c>authorization_encryption_alg_values_supported</c>
+	/// (JARM §4).
+	/// </summary>
+	IEnumerable<string> AuthorizationEncryptionAlgValuesSupported { get; }
+
+	/// <summary>
+	/// Lists the JWE content-encryption algorithms (the <c>enc</c> values) the authorization server can use to
+	/// encrypt JARM authorization responses, advertised via <c>authorization_encryption_enc_values_supported</c>
+	/// (JARM §4).
+	/// </summary>
+	IEnumerable<string> AuthorizationEncryptionEncValuesSupported { get; }
 }

--- a/Abblix.Oidc.Server/Endpoints/Configuration/JwtAlgorithmsProvider.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/JwtAlgorithmsProvider.cs
@@ -48,4 +48,13 @@ public sealed class JwtAlgorithmsProvider(
 
 	/// <inheritdoc />
 	public IEnumerable<string> RequestObjectEncryptionEncValuesSupported => jwtValidator.EncryptionMethodsSupported;
+
+	/// <inheritdoc />
+	public IEnumerable<string> AuthorizationSigningAlgValuesSupported => jwtCreator.SignedResponseAlgorithmsSupported;
+
+	/// <inheritdoc />
+	public IEnumerable<string> AuthorizationEncryptionAlgValuesSupported => jwtValidator.EncryptionAlgorithmsSupported;
+
+	/// <inheritdoc />
+	public IEnumerable<string> AuthorizationEncryptionEncValuesSupported => jwtValidator.EncryptionMethodsSupported;
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -152,6 +152,8 @@ public class RegisterClientRequestProcessor(
             IdentityTokenEncryptedResponseEncryption = model.IdTokenEncryptedResponseEnc,
             UserInfoEncryptedResponseAlgorithm = model.UserInfoEncryptedResponseAlg,
             UserInfoEncryptedResponseEncryption = model.UserInfoEncryptedResponseEnc,
+            AuthorizationEncryptedResponseAlgorithm = model.AuthorizationEncryptedResponseAlg,
+            AuthorizationEncryptedResponseEncryption = model.AuthorizationEncryptedResponseEnc,
             RequestObjectSigningAlgorithm = model.RequestObjectSigningAlg,
             RequestObjectEncryptionAlgorithm = model.RequestObjectEncryptionAlg,
             RequestObjectEncryptionMethod = model.RequestObjectEncryptionEnc,
@@ -201,6 +203,11 @@ public class RegisterClientRequestProcessor(
         if (model.IdTokenSignedResponseAlg.HasValue())
         {
             clientInfo.IdentityTokenSignedResponseAlgorithm = model.IdTokenSignedResponseAlg;
+        }
+
+        if (model.AuthorizationSignedResponseAlg.HasValue())
+        {
+            clientInfo.AuthorizationSignedResponseAlgorithm = model.AuthorizationSignedResponseAlg;
         }
 
         if (model.BackChannelLogoutUri != null)

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -98,6 +98,8 @@ public class UpdateClientRequestProcessor(
             IdentityTokenEncryptedResponseEncryption = model.IdTokenEncryptedResponseEnc,
             UserInfoEncryptedResponseAlgorithm = model.UserInfoEncryptedResponseAlg,
             UserInfoEncryptedResponseEncryption = model.UserInfoEncryptedResponseEnc,
+            AuthorizationEncryptedResponseAlgorithm = model.AuthorizationEncryptedResponseAlg,
+            AuthorizationEncryptedResponseEncryption = model.AuthorizationEncryptedResponseEnc,
             RequestObjectSigningAlgorithm = model.RequestObjectSigningAlg,
             RequestObjectEncryptionAlgorithm = model.RequestObjectEncryptionAlg,
             RequestObjectEncryptionMethod = model.RequestObjectEncryptionEnc,
@@ -110,6 +112,11 @@ public class UpdateClientRequestProcessor(
             SoftwareId = model.SoftwareId,
             SoftwareVersion = model.SoftwareVersion,
         };
+
+        if (model.AuthorizationSignedResponseAlg.HasValue())
+        {
+            updatedClient.AuthorizationSignedResponseAlgorithm = model.AuthorizationSignedResponseAlg;
+        }
 
         // Update logout configuration using wrapper objects
         if (model.BackChannelLogoutUri != null)

--- a/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -382,6 +382,27 @@ public record ClientInfo(string ClientId)
     public string? UserInfoEncryptedResponseEncryption { get; set; }
 
     /// <summary>
+    /// JARM (<c>authorization_signed_response_alg</c>): the JWS algorithm used to sign authorization responses
+    /// packed into a JWT for this client. Defaults to <see cref="SigningAlgorithms.RS256"/> per JARM §3; the
+    /// algorithm <c>none</c> is not permitted. Only consulted when the client requests a JWT response mode.
+    /// </summary>
+    public string AuthorizationSignedResponseAlgorithm { get; set; } = SigningAlgorithms.RS256;
+
+    /// <summary>
+    /// JARM (<c>authorization_encrypted_response_alg</c>): the JWE key-management algorithm used to encrypt
+    /// authorization responses for this client. When set, the signed response JWT is additionally encrypted
+    /// (a Nested JWT). <c>null</c> means no encryption is performed.
+    /// </summary>
+    public string? AuthorizationEncryptedResponseAlgorithm { get; set; }
+
+    /// <summary>
+    /// JARM (<c>authorization_encrypted_response_enc</c>): the JWE content-encryption algorithm used to encrypt
+    /// authorization responses for this client. Only meaningful when
+    /// <see cref="AuthorizationEncryptedResponseAlgorithm"/> is set.
+    /// </summary>
+    public string? AuthorizationEncryptedResponseEncryption { get; set; }
+
+    /// <summary>
     /// Specifies the algorithm required for signing request objects sent to the authorization server.
     /// </summary>
     public string? RequestObjectSigningAlgorithm { get; set; }

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -335,6 +335,7 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddSingleton<IClientJwtValidator, ClientJwtValidator>();
         services.TryAddSingleton<IClientJwtFormatter, ClientJwtFormatter>();
+        services.TryAddSingleton<IAuthorizationResponseEncoder, AuthorizationResponseEncoder>();
         return services;
     }
 

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthorizationResponseEncoder.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthorizationResponseEncoder.cs
@@ -1,0 +1,132 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Utils;
+
+namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
+
+/// <summary>
+/// Default <see cref="IAuthorizationResponseEncoder"/>: resolves the client, builds the JARM response JWT,
+/// signs it with the authorization server's key and — when the client registered an encryption algorithm —
+/// additionally encrypts it to the client's public key (a Nested JWT per JARM §2.2), then maps the JARM
+/// response mode onto its plaintext delivery counterpart.
+/// </summary>
+/// <param name="clientInfoProvider">Resolves the client the response is intended for.</param>
+/// <param name="jwtCreator">Issues the signed/encrypted JWT.</param>
+/// <param name="clientKeysProvider">Resolves the client's public encryption keys.</param>
+/// <param name="serviceKeysProvider">Resolves the authorization server's signing keys.</param>
+/// <param name="issuerProvider">Supplies the issuer identifier placed in the <c>iss</c> claim.</param>
+/// <param name="timeProvider">Supplies the current time for the <c>iat</c>/<c>exp</c> claims.</param>
+public class AuthorizationResponseEncoder(
+    IClientInfoProvider clientInfoProvider,
+    IJsonWebTokenCreator jwtCreator,
+    IClientKeysProvider clientKeysProvider,
+    IAuthServiceKeysProvider serviceKeysProvider,
+    IIssuerProvider issuerProvider,
+    TimeProvider timeProvider) : IAuthorizationResponseEncoder
+{
+    /// <summary>
+    /// The maximum lifetime of a JARM response JWT. JARM §2.1 RECOMMENDS a maximum of 10 minutes; the
+    /// authorization response is consumed by the client immediately upon redirect, so a short window suffices.
+    /// </summary>
+    private static readonly TimeSpan ResponseLifetime = TimeSpan.FromMinutes(10);
+
+    /// <inheritdoc />
+    public async Task<JarmResponse> EncodeAsync(
+        string responseMode,
+        string? clientId,
+        bool carriesTokens,
+        IReadOnlyList<(string name, string? value)> parameters)
+    {
+        var clientInfo = (await clientInfoProvider.TryFindClientAsync(clientId.NotNull(nameof(clientId))))
+            .NotNull(nameof(ClientInfo));
+
+        var responseJwt = await BuildResponseJwtAsync(clientInfo, parameters);
+
+        // Map the JARM mode to the plaintext delivery mode that carries the `response` JWT. The `jwt` shortcut
+        // resolves to fragment for token-bearing flows and query otherwise (JARM §2.3.4).
+        var deliveryMode = responseMode switch
+        {
+            ResponseModes.QueryJwt => ResponseModes.Query,
+            ResponseModes.FragmentJwt => ResponseModes.Fragment,
+            ResponseModes.FormPostJwt => ResponseModes.FormPost,
+            ResponseModes.Jwt when carriesTokens => ResponseModes.Fragment,
+            ResponseModes.Jwt => ResponseModes.Query,
+            _ => responseMode,
+        };
+
+        return new JarmResponse(responseJwt, deliveryMode);
+    }
+
+    private async Task<string> BuildResponseJwtAsync(
+        ClientInfo clientInfo,
+        IReadOnlyList<(string name, string? value)> parameters)
+    {
+        var now = timeProvider.GetUtcNow();
+
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = clientInfo.AuthorizationSignedResponseAlgorithm },
+            Payload =
+            {
+                IssuedAt = now,
+                ExpiresAt = now + ResponseLifetime,
+                Issuer = issuerProvider.GetIssuer(),
+                Audiences = [clientInfo.ClientId],
+            },
+        };
+
+        foreach (var (name, value) in parameters)
+        {
+            if (value != null)
+                token.Payload[name] = value;
+        }
+
+        var signingCredentials = await serviceKeysProvider.GetSigningKeys(true)
+            .FirstByAlgorithmAsync(token.Header.Algorithm);
+
+        // JARM §2.2 / §3: encrypt only when the client registered authorization_encrypted_response_alg.
+        // Otherwise the response is signed only.
+        if (clientInfo.AuthorizationEncryptedResponseAlgorithm is not { } keyEncryptionAlgorithm)
+            return await jwtCreator.IssueAsync(token, signingCredentials);
+
+        var encryptingCredentials = await clientKeysProvider.GetEncryptionKeys(clientInfo)
+            .FirstOrDefaultAsync();
+
+        // JARM §3: when authorization_encrypted_response_enc is omitted the default is A128CBC-HS256.
+        var contentEncryptionAlgorithm = clientInfo.AuthorizationEncryptedResponseEncryption
+            ?? EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256;
+
+        return await jwtCreator.IssueAsync(
+            token,
+            signingCredentials,
+            encryptingCredentials,
+            keyEncryptionAlgorithm,
+            contentEncryptionAlgorithm);
+    }
+}

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/IAuthorizationResponseEncoder.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/IAuthorizationResponseEncoder.cs
@@ -1,0 +1,63 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
+
+/// <summary>
+/// The result of encoding an authorization response per JARM (JWT Secured Authorization Response Mode):
+/// the response JWT to place in the <c>response</c> parameter and the plaintext delivery mode (query,
+/// fragment or form_post) that carries it.
+/// </summary>
+/// <param name="ResponseJwt">The signed (and optionally encrypted) authorization response JWT.</param>
+/// <param name="DeliveryMode">The plaintext response mode the host should use to deliver the JWT.</param>
+public readonly record struct JarmResponse(string ResponseJwt, string DeliveryMode);
+
+/// <summary>
+/// Encodes authorization endpoint response parameters into a JWT secured for a specific client, as defined by
+/// JWT Secured Authorization Response Mode for OAuth 2.0 (JARM). This is the framework-agnostic core of JARM:
+/// it builds, signs and optionally encrypts the response JWT and resolves the JARM response mode to its
+/// plaintext delivery counterpart. Hosts (MVC, Minimal API, …) supply the response parameters and emit the
+/// resulting <c>response</c> parameter through their own transport layer.
+/// </summary>
+public interface IAuthorizationResponseEncoder
+{
+    /// <summary>
+    /// Builds the JARM response JWT for the requested JWT response mode and resolves the plaintext delivery mode.
+    /// The JWT carries the JARM-mandated <c>iss</c>, <c>aud</c> and <c>exp</c> claims (JARM §2.1) in addition to
+    /// the supplied response parameters, is signed with the client's configured algorithm (default RS256), and is
+    /// additionally encrypted when the client registered an encryption algorithm (JARM §2.2).
+    /// </summary>
+    /// <param name="responseMode">The requested JARM response mode (<c>query.jwt</c>, <c>fragment.jwt</c>,
+    /// <c>form_post.jwt</c> or the <c>jwt</c> shortcut).</param>
+    /// <param name="clientId">The client the response is intended for; supplies the signing/encryption algorithms
+    /// and the <c>aud</c> claim.</param>
+    /// <param name="carriesTokens">Whether the response carries front-channel tokens, used to resolve the
+    /// <c>jwt</c> shortcut to its default delivery mode (fragment for token-bearing flows, query otherwise).</param>
+    /// <param name="parameters">The authorization response parameters (the same set the plaintext response modes
+    /// would place on the wire), as name-value pairs.</param>
+    /// <returns>A task that returns the encoded response JWT together with the plaintext delivery mode.</returns>
+    Task<JarmResponse> EncodeAsync(
+        string responseMode,
+        string? clientId,
+        bool carriesTokens,
+        IReadOnlyList<(string name, string? value)> parameters);
+}

--- a/Abblix.Oidc.Server/Model/AuthorizationRequest.cs
+++ b/Abblix.Oidc.Server/Model/AuthorizationRequest.cs
@@ -95,10 +95,13 @@ public record AuthorizationRequest
 
 	/// <summary>
 	/// The OAuth 2.0 <c>response_mode</c> parameter (OAuth 2.0 Multiple Response Types / OAuth 2.0 Form Post Response Mode)
-	/// selecting how the authorization response is delivered: <c>query</c>, <c>fragment</c>, or <c>form_post</c>.
+	/// selecting how the authorization response is delivered: <c>query</c>, <c>fragment</c>, <c>form_post</c>,
+	/// or their JARM JWT-secured variants <c>query.jwt</c>, <c>fragment.jwt</c>, <c>form_post.jwt</c> and <c>jwt</c>.
 	/// </summary>
 	[JsonPropertyName(Parameters.ResponseMode)]
-    [AllowedValues(ResponseModes.FormPost, ResponseModes.Fragment, ResponseModes.Query)]
+    [AllowedValues(
+        ResponseModes.FormPost, ResponseModes.Fragment, ResponseModes.Query,
+        ResponseModes.QueryJwt, ResponseModes.FragmentJwt, ResponseModes.FormPostJwt, ResponseModes.Jwt)]
     public string? ResponseMode { get; init; }
 
 	/// <summary>

--- a/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -211,6 +211,30 @@ public record ClientRegistrationRequest
     public string? UserInfoEncryptedResponseEnc { get; init; }
 
     /// <summary>
+    /// The <c>authorization_signed_response_alg</c> (JARM §3): the JWS algorithm the OP must use to sign
+    /// authorization responses packed into a JWT for this client. Defaults to <c>RS256</c>; <c>none</c> is
+    /// not permitted.
+    /// </summary>
+    [JsonPropertyName(Parameters.AuthorizationSignedResponseAlg)]
+    public string? AuthorizationSignedResponseAlg { get; init; }
+
+    /// <summary>
+    /// The <c>authorization_encrypted_response_alg</c> (JARM §3): the JWE key-management algorithm the OP must
+    /// use when encrypting authorization responses for this client. When set, the signed response JWT is
+    /// additionally encrypted (a Nested JWT).
+    /// </summary>
+    [JsonPropertyName(Parameters.AuthorizationEncryptedResponseAlg)]
+    public string? AuthorizationEncryptedResponseAlg { get; init; }
+
+    /// <summary>
+    /// The <c>authorization_encrypted_response_enc</c> (JARM §3): the JWE content-encryption algorithm paired
+    /// with <see cref="AuthorizationEncryptedResponseAlg"/> for authorization responses to this client.
+    /// Defaults to <c>A128CBC-HS256</c> when the encryption algorithm is set.
+    /// </summary>
+    [JsonPropertyName(Parameters.AuthorizationEncryptedResponseEnc)]
+    public string? AuthorizationEncryptedResponseEnc { get; init; }
+
+    /// <summary>
     /// The <c>request_object_signing_alg</c>: the JWS algorithm the client uses when signing Request Objects
     /// (OIDC Core §6) sent to the authorization endpoint. <c>none</c> indicates an unsigned Request Object.
     /// </summary>
@@ -546,6 +570,18 @@ public record ClientRegistrationRequest
         /// <summary>The <c>userinfo_encrypted_response_enc</c> registration parameter naming the JWE
         /// content-encryption algorithm for UserInfo responses.</summary>
         public const string UserInfoEncryptedResponseEnc = "userinfo_encrypted_response_enc";
+
+        /// <summary>The <c>authorization_signed_response_alg</c> registration parameter naming the JWS algorithm
+        /// the OP must use to sign JARM authorization responses for this client.</summary>
+        public const string AuthorizationSignedResponseAlg = "authorization_signed_response_alg";
+
+        /// <summary>The <c>authorization_encrypted_response_alg</c> registration parameter naming the JWE
+        /// key-management algorithm used when encrypting JARM authorization responses.</summary>
+        public const string AuthorizationEncryptedResponseAlg = "authorization_encrypted_response_alg";
+
+        /// <summary>The <c>authorization_encrypted_response_enc</c> registration parameter naming the JWE
+        /// content-encryption algorithm for JARM authorization responses.</summary>
+        public const string AuthorizationEncryptedResponseEnc = "authorization_encrypted_response_enc";
 
         /// <summary>The <c>request_object_signing_alg</c> registration parameter naming the JWS algorithm
         /// the client uses when signing Request Objects.</summary>

--- a/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
@@ -168,6 +168,18 @@ public record ConfigurationResponse
         /// content-encryption algorithms accepted on encrypted Request Objects.</summary>
         public const string RequestObjectEncryptionEncValuesSupported = "request_object_encryption_enc_values_supported";
 
+        /// <summary>The <c>authorization_signing_alg_values_supported</c> metadata field listing JWS algorithms
+        /// the provider uses to sign JARM authorization responses (JARM §4).</summary>
+        public const string AuthorizationSigningAlgValuesSupported = "authorization_signing_alg_values_supported";
+
+        /// <summary>The <c>authorization_encryption_alg_values_supported</c> metadata field listing JWE
+        /// key-management algorithms the provider uses to encrypt JARM authorization responses (JARM §4).</summary>
+        public const string AuthorizationEncryptionAlgValuesSupported = "authorization_encryption_alg_values_supported";
+
+        /// <summary>The <c>authorization_encryption_enc_values_supported</c> metadata field listing JWE
+        /// content-encryption algorithms the provider uses to encrypt JARM authorization responses (JARM §4).</summary>
+        public const string AuthorizationEncryptionEncValuesSupported = "authorization_encryption_enc_values_supported";
+
         /// <summary>The <c>userinfo_signing_alg_values_supported</c> metadata field listing JWS algorithms
         /// the provider may use when signing UserInfo responses.</summary>
         public const string UserInfoSigningAlgValuesSupported = "userinfo_signing_alg_values_supported";
@@ -466,6 +478,26 @@ public record ConfigurationResponse
     /// </summary>
     [JsonPropertyName(Parameters.RequestObjectEncryptionEncValuesSupported)]
     public IEnumerable<string>? RequestObjectEncryptionEncValuesSupported { init; get; }
+
+    /// <summary>
+    /// Specifies the JWS algorithms the OpenID Provider uses to sign JARM authorization responses (JARM §4).
+    /// </summary>
+    [JsonPropertyName(Parameters.AuthorizationSigningAlgValuesSupported)]
+    public IEnumerable<string>? AuthorizationSigningAlgValuesSupported { init; get; }
+
+    /// <summary>
+    /// Specifies the JWE key-management algorithms (the <c>alg</c> values) the OpenID Provider uses to encrypt
+    /// JARM authorization responses (JARM §4).
+    /// </summary>
+    [JsonPropertyName(Parameters.AuthorizationEncryptionAlgValuesSupported)]
+    public IEnumerable<string>? AuthorizationEncryptionAlgValuesSupported { init; get; }
+
+    /// <summary>
+    /// Specifies the JWE content-encryption algorithms (the <c>enc</c> values) the OpenID Provider uses to
+    /// encrypt JARM authorization responses (JARM §4).
+    /// </summary>
+    [JsonPropertyName(Parameters.AuthorizationEncryptionEncValuesSupported)]
+    public IEnumerable<string>? AuthorizationEncryptionEncValuesSupported { init; get; }
 
     /// <summary>
     /// Indicates whether the OpenID Provider mandates that all request objects must be signed.


### PR DESCRIPTION
Implements **JARM** (JWT Secured Authorization Response Mode — OpenID Foundation, Final).

## What
The authorization endpoint can return its response parameters packed into a **signed** (and optionally **signed-then-encrypted**) JWT, via the response modes `query.jwt`, `fragment.jwt`, `form_post.jwt` and the `jwt` shortcut. This protects the authorization response's integrity, authenticity (issuer binding, audience restriction) and — when encrypted — confidentiality. JARM is part of the FAPI 2.0 profile.

## Design
- **Framework-agnostic core** (`Abblix.Oidc.Server`): `IAuthorizationResponseEncoder` builds the response JWT (`iss`/`aud`/`exp` per JARM §2.1, signed with the client's algorithm — default RS256 — and optionally encrypted to the client's key) and resolves the JWT response mode to its plaintext delivery mode. The MVC layer only extracts response parameters and emits the `response` parameter, so a non-MVC host (e.g. Minimal API) reuses the core unchanged.
- **Always available, controlled per client** — by the requested response mode plus `authorization_signed_response_alg` / `authorization_encrypted_response_alg` / `authorization_encrypted_response_enc` client metadata (bound via DCR). No global toggle.
- **Discovery** advertises the four JWT response modes plus `authorization_signing_alg_values_supported` / `authorization_encryption_alg_values_supported` / `authorization_encryption_enc_values_supported`, the algorithm sets self-reported by the registered signers/encryptors.
- `query.jwt` inherits `query`'s prohibition for token-bearing flows (JARM §2.3.1); the `jwt` shortcut resolves to `query` for the code flow and `fragment` otherwise (JARM §2.3.4).

## Tests
Unit tests for the encoder (claims, default RS256, signed-only vs signed+encrypted, delivery-mode resolution), the response-mode validator (JARM acceptance + flow rules) and the discovery provider; an end-to-end test driving `response_mode=query.jwt` through to a redeemable authorization code. Full suite green: unit 2093, E2E 49.

Standards registry updated in the Docs repo (`implemented-standards.md` + multilang mirror).

Part of the FAPI 2.0 profile (relates to #150).