### PR TITLE
fix(dcr): validate encrypted_response_alg/enc + type test URI constants

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -94,7 +94,7 @@ public class AuthorizationRequestProcessorTests
         {
             ClientId = TestConstants.DefaultClientId,
             ResponseType = responseType ?? [ResponseTypes.Code],
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
             Scope = scope ?? [Scopes.OpenId],
             Prompt = prompt,
             MaxAge = maxAge,
@@ -780,7 +780,7 @@ public class AuthorizationRequestProcessorTests
         {
             ClientId = TestConstants.DefaultClientId,
             ResponseType = [ResponseTypes.Code],
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
             Scope = [Scopes.OpenId, "email"],
             Nonce = nonce,
             CodeChallenge = codeChallenge,

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestValidatorTests.cs
@@ -53,7 +53,7 @@ public class AuthorizationRequestValidatorTests
     {
         ClientId = TestConstants.DefaultClientId,
         ResponseType = [ResponseTypes.Code],
-        RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+        RedirectUri = TestConstants.DefaultRedirectUri,
         Scope = [Scopes.OpenId],
     };
 
@@ -298,7 +298,7 @@ public class AuthorizationRequestValidatorTests
         {
             ClientId = "client_1",
             ResponseType = [ResponseTypes.Code],
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
             Scope = [Scopes.OpenId],
         };
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
@@ -70,7 +70,7 @@ public class PushModeValidatorRegistrationTests
 
         services.AddOidcServices(options =>
         {
-            options.Issuer = TestConstants.DefaultIssuer;
+            options.Issuer = TestConstants.DefaultIssuer.OriginalString;
             options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)];
             options.RequireInitialAccessToken = false;
         });

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/InitialAccessTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/InitialAccessTokenServiceTests.cs
@@ -53,7 +53,7 @@ public class InitialAccessTokenServiceTests
 
         _issuerProvider
             .Setup(p => p.GetIssuer())
-            .Returns(TestConstants.DefaultIssuer);
+            .Returns(TestConstants.DefaultIssuer.OriginalString);
 
         _service = new InitialAccessTokenService(
             _jwtFormatter.Object,

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -68,7 +68,7 @@ public class RegisterClientHandlerIntegrationTests
 
         services.AddOidcServices(opts =>
         {
-            opts.Issuer = TestConstants.DefaultIssuer;
+            opts.Issuer = TestConstants.DefaultIssuer.OriginalString;
 
             // Generate an in-memory RS256 signing key for the registration access token the
             // success-path test asserts on. Production hosts feed real certificates in this

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/AuthorizationDetailsTypesValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/AuthorizationDetailsTypesValidatorTests.cs
@@ -64,7 +64,7 @@ public class AuthorizationDetailsTypesValidatorTests
     private static ClientRegistrationValidationContext Context(string[]? authorizationDetailsTypes)
         => new(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             AuthorizationDetailsTypes = authorizationDetailsTypes,
         });
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
@@ -54,7 +54,7 @@ public class BackChannelAuthenticationValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             BackChannelTokenDeliveryMode = tokenDeliveryMode,
             BackChannelClientNotificationEndpoint = notificationEndpoint,
             BackChannelAuthenticationRequestSigningAlg = signingAlg

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ClientIdValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ClientIdValidatorTests.cs
@@ -55,7 +55,7 @@ public class ClientIdValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             ClientId = clientId
         };
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidatorTests.cs
@@ -1,0 +1,126 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="EncryptedResponseAlgorithmsValidator"/> verifying that the JWE algorithms a client
+/// registers for encrypted ID tokens, UserInfo responses, request objects and JARM authorization responses are
+/// checked against the server's supported key-management (<c>alg</c>) and content-encryption (<c>enc</c>) sets.
+/// </summary>
+public class EncryptedResponseAlgorithmsValidatorTests
+{
+    private const string SupportedAlg = EncryptionAlgorithms.KeyManagement.RsaOaep256;
+    private const string SupportedEnc = EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256;
+
+    private readonly Mock<IJsonWebTokenValidator> _jwtValidator = new(MockBehavior.Strict);
+    private readonly EncryptedResponseAlgorithmsValidator _validator;
+
+    public EncryptedResponseAlgorithmsValidatorTests()
+    {
+        _jwtValidator.Setup(v => v.EncryptionAlgorithmsSupported).Returns([SupportedAlg]);
+        _jwtValidator.Setup(v => v.EncryptionMethodsSupported).Returns([SupportedEnc]);
+        _validator = new EncryptedResponseAlgorithmsValidator(_jwtValidator.Object);
+    }
+
+    private static ClientRegistrationValidationContext CreateContext(ClientRegistrationRequest request)
+        => new(request);
+
+    private static ClientRegistrationRequest Request()
+        => new() { RedirectUris = [TestConstants.DefaultRedirectUri] };
+
+    [Fact]
+    public async Task ValidateAsync_WithNoAlgorithms_ShouldReturnNull()
+    {
+        var result = await _validator.ValidateAsync(CreateContext(Request()));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithSupportedAlgorithmsForEveryField_ShouldReturnNull()
+    {
+        var request = Request() with
+        {
+            IdTokenEncryptedResponseAlg = SupportedAlg,
+            IdTokenEncryptedResponseEnc = SupportedEnc,
+            UserInfoEncryptedResponseAlg = SupportedAlg,
+            UserInfoEncryptedResponseEnc = SupportedEnc,
+            RequestObjectEncryptionAlg = SupportedAlg,
+            RequestObjectEncryptionEnc = SupportedEnc,
+            AuthorizationEncryptedResponseAlg = SupportedAlg,
+            AuthorizationEncryptedResponseEnc = SupportedEnc,
+        };
+
+        var result = await _validator.ValidateAsync(CreateContext(request));
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("id_token_encrypted_response_alg")]
+    [InlineData("userinfo_encrypted_response_alg")]
+    [InlineData("request_object_encryption_alg")]
+    [InlineData("authorization_encrypted_response_alg")]
+    public async Task ValidateAsync_WithUnsupportedKeyManagementAlg_ShouldReturnError(string wireName)
+    {
+        const string unsupported = EncryptionAlgorithms.KeyManagement.Rsa1_5;
+        var request = wireName switch
+        {
+            "id_token_encrypted_response_alg" => Request() with { IdTokenEncryptedResponseAlg = unsupported },
+            "userinfo_encrypted_response_alg" => Request() with { UserInfoEncryptedResponseAlg = unsupported },
+            "request_object_encryption_alg" => Request() with { RequestObjectEncryptionAlg = unsupported },
+            _ => Request() with { AuthorizationEncryptedResponseAlg = unsupported },
+        };
+
+        var result = await _validator.ValidateAsync(CreateContext(request));
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Contains(wireName, result.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithUnsupportedContentEncryption_ShouldReturnError()
+    {
+        var request = Request() with
+        {
+            AuthorizationEncryptedResponseAlg = SupportedAlg,
+            AuthorizationEncryptedResponseEnc = EncryptionAlgorithms.ContentEncryption.Aes256Gcm,
+        };
+
+        var result = await _validator.ValidateAsync(CreateContext(request));
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Contains("authorization_encrypted_response_enc", result.ErrorDescription);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/GrantTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/GrantTypeValidatorTests.cs
@@ -44,7 +44,7 @@ public class GrantTypeValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             ResponseTypes = responseTypes,
             GrantTypes = grantTypes
         };

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/InitialAccessTokenValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/InitialAccessTokenValidatorTests.cs
@@ -69,7 +69,7 @@ public class InitialAccessTokenValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             AuthorizationHeader = authHeader,
         };
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/InitiateLoginUriValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/InitiateLoginUriValidatorTests.cs
@@ -42,7 +42,7 @@ public class InitiateLoginUriValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             InitiateLoginUri = initiateLoginUri
         };
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/PostLogoutRedirectUrisValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/PostLogoutRedirectUrisValidatorTests.cs
@@ -44,7 +44,7 @@ public class PostLogoutRedirectUrisValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             PostLogoutRedirectUris = postLogoutRedirectUris,
             ApplicationType = applicationType
         };

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/RedirectUrisValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/RedirectUrisValidatorTests.cs
@@ -71,7 +71,7 @@ public class RedirectUrisValidatorTests
     {
         // Arrange
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             grantTypes: [GrantTypes.AuthorizationCode],
             applicationType: ApplicationTypes.Web);
 
@@ -304,7 +304,7 @@ public class RedirectUrisValidatorTests
     {
         // Arrange
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             grantTypes: [GrantTypes.AuthorizationCode],
             applicationType: ApplicationTypes.Native);
 
@@ -477,7 +477,7 @@ public class RedirectUrisValidatorTests
     {
         // Arrange
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             grantTypes: [GrantTypes.RefreshToken],
             applicationType: ApplicationTypes.Web);
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ScopeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ScopeValidatorTests.cs
@@ -50,7 +50,7 @@ public class ScopeValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             Scope = scope,
         };
         return new ClientRegistrationValidationContext(request);

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
@@ -54,7 +54,7 @@ public class SignedResponseAlgorithmsValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             IdTokenSignedResponseAlg = idTokenSignedResponseAlg,
             UserInfoSignedResponseAlg = userInfoSignedResponseAlg,
             AuthorizationSignedResponseAlg = authorizationSignedResponseAlg

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SigningAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SigningAlgorithmsValidatorTests.cs
@@ -54,7 +54,7 @@ public class SigningAlgorithmsValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             RequestObjectSigningAlg = requestObjectSigningAlg,
             BackChannelAuthenticationRequestSigningAlg = backChannelAuthSigningAlg,
             TokenEndpointAuthSigningAlg = tokenEndpointAuthSigningAlg

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SoftwareStatementValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SoftwareStatementValidatorTests.cs
@@ -64,7 +64,7 @@ public class SoftwareStatementValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             SoftwareStatement = softwareStatement,
         };
         return new ClientRegistrationValidationContext(request);

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
@@ -76,7 +76,7 @@ public class SubjectTypeValidatorTests
     {
         // Arrange
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             subjectType: SubjectTypes.Public);
 
         // Act
@@ -121,7 +121,7 @@ public class SubjectTypeValidatorTests
         var context = CreateContext(
             redirectUris:
             [
-                new Uri(TestConstants.DefaultRedirectUri),
+                TestConstants.DefaultRedirectUri,
                 new Uri("https://other.com/callback")
             ],
             subjectType: SubjectTypes.Pairwise);
@@ -197,7 +197,7 @@ public class SubjectTypeValidatorTests
     {
         // Arrange
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             subjectType: SubjectTypes.Pairwise,
             sectorIdentifierUri: new Uri("http://example.com/sector.json"));
 
@@ -222,7 +222,7 @@ public class SubjectTypeValidatorTests
         var sectorUri = new Uri("https://example.com/sector.json");
         var sectorContent = new[]
         {
-            new Uri(TestConstants.DefaultRedirectUri),
+            TestConstants.DefaultRedirectUri,
             new Uri("http://example.com/callback2") // Invalid HTTP
         };
 
@@ -231,7 +231,7 @@ public class SubjectTypeValidatorTests
             .ReturnsAsync(Result<Uri[], OidcError>.Success(sectorContent));
 
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             subjectType: SubjectTypes.Pairwise,
             sectorIdentifierUri: sectorUri);
 
@@ -255,7 +255,7 @@ public class SubjectTypeValidatorTests
         var sectorUri = new Uri("https://example.com/sector.json");
         var sectorContent = new[]
         {
-            new Uri(TestConstants.DefaultRedirectUri),
+            TestConstants.DefaultRedirectUri,
             new Uri("https://example.com/extra") // Not in redirect URIs
         };
 
@@ -264,7 +264,7 @@ public class SubjectTypeValidatorTests
             .ReturnsAsync(Result<Uri[], OidcError>.Success(sectorContent));
 
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             subjectType: SubjectTypes.Pairwise,
             sectorIdentifierUri: sectorUri);
 
@@ -293,7 +293,7 @@ public class SubjectTypeValidatorTests
             .ReturnsAsync(Result<Uri[], OidcError>.Failure(fetchError));
 
         var context = CreateContext(
-            redirectUris: [new Uri(TestConstants.DefaultRedirectUri)],
+            redirectUris: [TestConstants.DefaultRedirectUri],
             subjectType: SubjectTypes.Pairwise,
             sectorIdentifierUri: sectorUri);
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedGrantTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedGrantTypeValidatorTests.cs
@@ -51,7 +51,7 @@ public class SupportedGrantTypeValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             GrantTypes = grantTypes,
         };
         return new ClientRegistrationValidationContext(request);

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedResponseTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedResponseTypeValidatorTests.cs
@@ -58,7 +58,7 @@ public class SupportedResponseTypeValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             ResponseTypes = responseTypes,
         };
         return new ClientRegistrationValidationContext(request);

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TlsClientAuthValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TlsClientAuthValidatorTests.cs
@@ -51,7 +51,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
         });
 
@@ -72,7 +72,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
         });
 
@@ -95,7 +95,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSubjectDn = "CN=client.example.com,O=Example Corp,C=US",
             TlsClientAuthSanDns = ["client.example.com"],
@@ -119,7 +119,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSubjectDn = "CN=client.example.com,O=Example Corp,C=US",
         });
@@ -141,7 +141,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSubjectDn = "not a valid DN format!@#",
         });
@@ -167,7 +167,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanDns = [dnsName],
         });
@@ -189,7 +189,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanDns = [""],
         });
@@ -215,7 +215,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanDns = [dnsName],
         });
@@ -241,7 +241,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanUri = [new Uri(uri)],
         });
@@ -266,7 +266,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanIp = [ip],
         });
@@ -293,7 +293,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanIp = [ip],
         });
@@ -317,7 +317,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanIp = [ip],
         });
@@ -343,7 +343,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanEmail = [email],
         });
@@ -367,7 +367,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanEmail = [email],
         });
@@ -391,7 +391,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSubjectDn = "CN=client.example.com,O=Example Corp",
             TlsClientAuthSanDns = ["client.example.com", "*.example.com"],
@@ -418,7 +418,7 @@ public class TlsClientAuthValidatorTests
         // Arrange
         var context = CreateContext(new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
             TlsClientAuthSanDns = ["valid.example.com", "invalid dns name"],
         });

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TokenEndpointAuthMethodValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TokenEndpointAuthMethodValidatorTests.cs
@@ -51,7 +51,7 @@ public class TokenEndpointAuthMethodValidatorTests
     {
         var request = new ClientRegistrationRequest
         {
-            RedirectUris = [new Uri(TestConstants.DefaultRedirectUri)],
+            RedirectUris = [TestConstants.DefaultRedirectUri],
             TokenEndpointAuthMethod = tokenEndpointAuthMethod!
         };
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/EndSessionRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/EndSessionRequestProcessorTests.cs
@@ -44,7 +44,7 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.EndSession;
 [Collection("License")]
 public class EndSessionRequestProcessorTests
 {
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
 
     private readonly Mock<ILogger<EndSessionRequestProcessor>> _logger;
     private readonly Mock<IAuthSessionService> _authSessionService;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestValidatorTests.cs
@@ -54,7 +54,7 @@ public class TokenRequestValidatorTests
     {
         GrantType = GrantTypes.AuthorizationCode,
         Code = "auth_code_123",
-        RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+        RedirectUri = TestConstants.DefaultRedirectUri,
     };
 
     private static ClientRequest CreateClientRequest() => new()
@@ -334,7 +334,7 @@ public class TokenRequestValidatorTests
         {
             GrantType = GrantTypes.AuthorizationCode,
             Code = "auth_code_123",
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
         };
 
         var refreshTokenRequest = new TokenRequest

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestProcessorTests.cs
@@ -44,7 +44,7 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.UserInfo;
 [Collection("License")]
 public class UserInfoRequestProcessorTests
 {
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
 
     private readonly Mock<IIssuerProvider> _issuerProvider;
     private readonly Mock<IUserClaimsProvider> _userClaimsProvider;
@@ -300,7 +300,7 @@ public class UserInfoRequestProcessorTests
         // Arrange
         var validRequest = CreateValidUserInfoRequest();
         var userClaims = CreateUserClaims();
-        var issuer = TestConstants.DefaultIssuer;
+        var issuer = TestConstants.DefaultIssuer.OriginalString;
 
         _userClaimsProvider
             .Setup(p => p.GetUserClaimsAsync(

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/AddAuthorizationGrantTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/AddAuthorizationGrantTests.cs
@@ -255,7 +255,7 @@ public class AddAuthorizationGrantTests
     public void AddOidcServices_RegistersBuiltInGrantHandlersAsGrantTypeInformer()
     {
         var services = new ServiceCollection();
-        services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer);
+        services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString);
 
         var informerImpls = services
             .Where(d => d.ServiceType == typeof(IGrantTypeInformer))
@@ -278,7 +278,7 @@ public class AddAuthorizationGrantTests
     public void AddOidcServices_WithoutPasswordOptIn_ExcludesPasswordGrantFromInformer()
     {
         var services = new ServiceCollection();
-        services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer);
+        services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString);
 
         var informerImpls = services
             .Where(d => d.ServiceType == typeof(IGrantTypeInformer))
@@ -299,7 +299,7 @@ public class AddAuthorizationGrantTests
     {
         var services = new ServiceCollection();
         services
-            .AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer)
+            .AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString)
             .EnablePasswordGrant();
 
         var informerImpls = services

--- a/Abblix.Oidc.Server.UnitTests/Features/RequestObject/RequestObjectFetcherTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/RequestObject/RequestObjectFetcherTests.cs
@@ -106,7 +106,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, "state123");
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, "state123");
 
         // Act
         var result = await fetcher.FetchAsync(request, null);
@@ -125,7 +125,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
 
         // Act
         var result = await fetcher.FetchAsync(request, string.Empty);
@@ -144,7 +144,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var originalRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var originalRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId, ["state"] = "newstate" };
         var token = new JsonWebToken
@@ -152,7 +152,7 @@ public class RequestObjectFetcherTests
             Header = new JsonWebTokenHeader(new JsonObject()),
             Payload = new JsonWebTokenPayload(payload)
         };
-        var boundRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, "newstate");
+        var boundRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, "newstate");
 
         _jwtValidator
             .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationOptions>()))
@@ -180,7 +180,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var originalRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var originalRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
         var payload = new JsonObject { ["invalid"] = "data" };
         var token = new JsonWebToken
@@ -215,7 +215,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange — the request object is signed with RS384, but the client registered RS256.
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "header.payload.signature";
         var token = new JsonWebToken
         {
@@ -245,7 +245,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "header.payload.signature";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
         var token = new JsonWebToken
@@ -279,7 +279,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "invalid.jwt.token";
         var validationError = new JwtValidationError(JwtError.InvalidToken, "Invalid JWT format");
 
@@ -305,7 +305,7 @@ public class RequestObjectFetcherTests
         // Arrange
         _oidcOptions.RequireSignedRequestObject = true;
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
         var token = new JsonWebToken
@@ -343,7 +343,7 @@ public class RequestObjectFetcherTests
         // Arrange
         _oidcOptions.RequireSignedRequestObject = false;
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJub25lIn0.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
         var token = new JsonWebToken
@@ -380,7 +380,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
         var token = new JsonWebToken
@@ -414,7 +414,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
         var token = new JsonWebToken
@@ -495,7 +495,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.expired.signature";
         var validationError = new JwtValidationError(JwtError.InvalidToken, "Token has expired");
 
@@ -520,7 +520,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.payload.badsignature";
         var validationError = new JwtValidationError(JwtError.InvalidToken, "Invalid signature");
 
@@ -545,7 +545,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var originalRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var originalRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.complex.signature";
         var payload = new JsonObject
         {
@@ -588,7 +588,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
         var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
         var token = new JsonWebToken
@@ -623,7 +623,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "this.is.not.a.valid.jwt.structure";
         var validationError = new JwtValidationError(JwtError.InvalidToken, "Malformed JWT");
 
@@ -648,7 +648,7 @@ public class RequestObjectFetcherTests
     {
         // Arrange
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
         var jwt = "eyJhbGciOiJub25lIn0.e30."; // JWT with empty payload
         var payload = new JsonObject();
         var token = new JsonWebToken
@@ -720,7 +720,7 @@ public class RequestObjectFetcherTests
         // Arrange
         _oidcOptions.RequireSignedRequestObject = false;
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
 
         // Unsigned JWT with alg=none (no signature part)
         var unsignedJwt = "eyJhbGciOiJub25lIn0.eyJjbGllbnRfaWQiOiJjbGllbnQxIiwic3RhdGUiOiJ0ZXN0X3N0YXRlIn0.";
@@ -734,7 +734,7 @@ public class RequestObjectFetcherTests
             Header = new JsonWebTokenHeader(new JsonObject { ["alg"] = "none" }),
             Payload = new JsonWebTokenPayload(payload)
         };
-        var boundRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, "test_state");
+        var boundRequest = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, "test_state");
 
         _jwtValidator
             .Setup(v => v.ValidateAsync(unsignedJwt, It.IsAny<ValidationOptions>()))
@@ -769,7 +769,7 @@ public class RequestObjectFetcherTests
         // Arrange
         _oidcOptions.RequireSignedRequestObject = true;
         var fetcher = CreateFetcher();
-        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, null);
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
 
         // Unsigned JWT with alg=none
         var unsignedJwt = "eyJhbGciOiJub25lIn0.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.";

--- a/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
@@ -47,7 +47,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Jarm;
 public class ResponseJwtBuilderTests
 {
     private const string ClientId = TestConstants.DefaultClientId;
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string EncodedJwt = "header.payload.signature";
 
     private readonly Mock<IClientInfoProvider> _clientInfoProvider = new(MockBehavior.Strict);

--- a/Abblix.Oidc.Server.UnitTests/Features/Storages/Proto/MappersTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Storages/Proto/MappersTests.cs
@@ -585,7 +585,7 @@ public class MappersTests
             },
             ResponseType = ["code", "id_token"],
             ClientId = "client-123",
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
             State = "state-xyz",
             ResponseMode = "form_post",
             Nonce = "nonce-abc",
@@ -610,7 +610,7 @@ public class MappersTests
         Assert.NotNull(proto.Claims);
         Assert.Equal(2, proto.ResponseType.Count);
         Assert.Equal("client-123", proto.ClientId);
-        Assert.Equal(TestConstants.DefaultRedirectUri, proto.RedirectUri);
+        Assert.Equal(TestConstants.DefaultRedirectUri.OriginalString, proto.RedirectUri);
         Assert.Equal("state-xyz", proto.State);
         Assert.Equal("form_post", proto.ResponseMode);
         Assert.Equal("nonce-abc", proto.Nonce);

--- a/Abblix.Oidc.Server.UnitTests/Features/Storages/ProtobufBinarySerializerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Storages/ProtobufBinarySerializerTests.cs
@@ -165,7 +165,7 @@ public class ProtobufSerializerTests
             })
         {
             CertificateSha256Thumbprint = "abc123def456",
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
             Nonce = "nonce-789",
             CodeChallenge = "challenge-xyz",
             CodeChallengeMethod = "S256",
@@ -227,7 +227,7 @@ public class ProtobufSerializerTests
             Scope = [TestConstants.DefaultScope, "profile", "email"],
             ResponseType = ["code"],
             ClientId = "client-123",
-            RedirectUri = new Uri(TestConstants.DefaultRedirectUri),
+            RedirectUri = TestConstants.DefaultRedirectUri,
             State = "state-xyz",
             ResponseMode = "query",
             Nonce = "nonce-abc",

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
@@ -46,7 +46,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens;
 /// </summary>
 public class AccessTokenServiceTests
 {
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string ClientId = "test_client_123";
     private const string UserId = "user_456";
     private const string SessionId = "session_789";

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -50,7 +50,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens;
 /// </summary>
 public class IdentityTokenServiceTests
 {
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string ClientId = "test_client_123";
     private const string UserId = "user_456";
     private const string SessionId = "session_789";

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
@@ -50,7 +50,7 @@ public class LogoutTokenServiceTests
     private const string ClientId = TestConstants.DefaultClientId;
     private const string SubjectId = "user_456";
     private const string SessionId = "session_789";
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string EncodedJwt = "encoded.logout.token";
 
     private readonly Mock<ISubjectTypeConverter> _subjectTypeConverter;

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -49,7 +49,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens;
 /// </summary>
 public class RefreshTokenServiceTests
 {
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string ClientId = "test_client_123";
     private const string UserId = "user_456";
     private const string SessionId = "session_789";

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/AuthServiceJwtValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/AuthServiceJwtValidatorTests.cs
@@ -42,7 +42,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Validation;
 /// </summary>
 public class AuthServiceJwtValidatorTests
 {
-    private const string ExpectedIssuer = TestConstants.DefaultIssuer;
+    private static readonly string ExpectedIssuer = TestConstants.DefaultIssuer.OriginalString;
     private const string ValidClientId = TestConstants.DefaultClientId;
     private const string InvalidClientId = "invalid_client";
     private const string ValidJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature";

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
@@ -46,7 +46,7 @@ public class ClientJwtValidatorTests
     private const string ValidClientId = TestConstants.DefaultClientId;
     private const string AnotherClientId = "client_456";
     private const string RequestUri = "https://auth.example.com/token";
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string ValidJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGllbnRfMTIzIn0.signature";
 
     private readonly Mock<IJsonWebTokenValidator> _tokenValidator;

--- a/Abblix.Oidc.Server.UnitTests/Features/UriValidation/CompositeUriValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/UriValidation/CompositeUriValidatorTests.cs
@@ -41,7 +41,7 @@ public class CompositeUriValidatorTests
     [Fact]
     public void Composite_WithSingleValidator_MatchingUri_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new CompositeUriValidator(new ExactMatchUriValidator(validUri));
 
         var result = validator.IsValid(validUri);
@@ -151,12 +151,12 @@ public class CompositeUriValidatorTests
     public void Composite_WithDifferentSchemes_MatchesCorrectly()
     {
         var validator = new CompositeUriValidator(
-            new ExactMatchUriValidator(new Uri(TestConstants.DefaultRedirectUri)),
+            new ExactMatchUriValidator(TestConstants.DefaultRedirectUri),
             new ExactMatchUriValidator(new Uri("http://example.com/callback")),
             new ExactMatchUriValidator(new Uri("custom://example.com/callback"))
         );
 
-        Assert.True(validator.IsValid(new Uri(TestConstants.DefaultRedirectUri)));
+        Assert.True(validator.IsValid(TestConstants.DefaultRedirectUri));
         Assert.True(validator.IsValid(new Uri("http://example.com/callback")));
         Assert.True(validator.IsValid(new Uri("custom://example.com/callback")));
         Assert.False(validator.IsValid(new Uri("ftp://example.com/callback")));
@@ -188,7 +188,7 @@ public class CompositeUriValidatorTests
     {
         var validator = new CompositeUriValidator(Array.Empty<IUriValidator>());
 
-        var testUri = new Uri(TestConstants.DefaultRedirectUri);
+        var testUri = TestConstants.DefaultRedirectUri;
         var result = validator.IsValid(testUri);
 
         Assert.False(result);
@@ -203,11 +203,11 @@ public class CompositeUriValidatorTests
     {
         var validator = new CompositeUriValidator(
             new ExactMatchUriValidator(new Uri("http://localhost:3000/callback")),
-            new ExactMatchUriValidator(new Uri(TestConstants.DefaultRedirectUri))
+            new ExactMatchUriValidator(TestConstants.DefaultRedirectUri)
         );
 
         Assert.True(validator.IsValid(new Uri("http://localhost:3000/callback")));
-        Assert.True(validator.IsValid(new Uri(TestConstants.DefaultRedirectUri)));
+        Assert.True(validator.IsValid(TestConstants.DefaultRedirectUri));
         Assert.False(validator.IsValid(new Uri("http://localhost:3001/callback")));
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/UriValidation/ExactMatchUriValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/UriValidation/ExactMatchUriValidatorTests.cs
@@ -41,7 +41,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_ValidUri_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var result = validator.IsValid(validUri);
@@ -56,7 +56,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_DifferentUri_ReturnsFalse()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var testUri = new Uri("https://example.com/different");
@@ -72,7 +72,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_WithQueryString_Default_ReturnsFalse()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var testUri = new Uri("https://example.com/callback?param=value");
@@ -88,7 +88,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_WithFragment_Default_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var testUri = new Uri("https://example.com/callback#fragment");
@@ -104,7 +104,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_WithQueryString_IgnoreEnabled_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri, ignoreQueryAndFragment: true);
 
         var testUri = new Uri("https://example.com/callback?param=value");
@@ -120,7 +120,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_WithFragment_IgnoreEnabled_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri, ignoreQueryAndFragment: true);
 
         var testUri = new Uri("https://example.com/callback#fragment");
@@ -136,7 +136,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_WithQueryAndFragment_IgnoreEnabled_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri, ignoreQueryAndFragment: true);
 
         var testUri = new Uri("https://example.com/callback?param=value#fragment");
@@ -152,7 +152,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_DifferentScheme_ReturnsFalse()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var testUri = new Uri("http://example.com/callback");
@@ -168,7 +168,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_DifferentHost_ReturnsFalse()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var testUri = new Uri("https://different.com/callback");
@@ -200,7 +200,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_DifferentPath_ReturnsFalse()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri);
 
         var testUri = new Uri("https://example.com/callback/sub");
@@ -270,7 +270,7 @@ public class ExactMatchUriValidatorTests
     [Fact]
     public void ExactMatch_WithComplexQueryString_IgnoreEnabled_ReturnsTrue()
     {
-        var validUri = new Uri(TestConstants.DefaultRedirectUri);
+        var validUri = TestConstants.DefaultRedirectUri;
         var validator = new ExactMatchUriValidator(validUri, ignoreQueryAndFragment: true);
 
         var testUri = new Uri("https://example.com/callback?param1=value1&param2=value2&param3=value%20with%20spaces");

--- a/Abblix.Oidc.Server.UnitTests/Features/UriValidation/UriValidatorFactoryTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/UriValidation/UriValidatorFactoryTests.cs
@@ -41,7 +41,7 @@ public class UriValidatorFactoryTests
     [Fact]
     public void Create_WithSingleUri_ReturnsExactMatchValidator()
     {
-        var uri = new Uri(TestConstants.DefaultRedirectUri);
+        var uri = TestConstants.DefaultRedirectUri;
 
         var validator = UriValidatorFactory.Create(uri);
 
@@ -73,7 +73,7 @@ public class UriValidatorFactoryTests
     [Fact]
     public void Create_WithIgnoreQueryAndFragment_ValidatorIgnoresQueryAndFragment()
     {
-        var baseUri = new Uri(TestConstants.DefaultRedirectUri);
+        var baseUri = TestConstants.DefaultRedirectUri;
         var uriWithQuery = new Uri("https://example.com/callback?param=value");
 
         var validator = UriValidatorFactory.Create(ignoreQueryAndFragment: true, baseUri);
@@ -89,7 +89,7 @@ public class UriValidatorFactoryTests
     [Fact]
     public void Create_WithoutIgnoreQueryAndFragment_ValidatorDoesNotIgnore()
     {
-        var baseUri = new Uri(TestConstants.DefaultRedirectUri);
+        var baseUri = TestConstants.DefaultRedirectUri;
         var uriWithQuery = new Uri("https://example.com/callback?param=value");
 
         var validator = UriValidatorFactory.Create(ignoreQueryAndFragment: false, baseUri);
@@ -161,7 +161,7 @@ public class UriValidatorFactoryTests
     public void Create_WithLocalhostAndProduction_ValidatesBoth()
     {
         var localhost = new Uri("http://localhost:3000/callback");
-        var production = new Uri(TestConstants.DefaultRedirectUri);
+        var production = TestConstants.DefaultRedirectUri;
 
         var validator = UriValidatorFactory.Create(localhost, production);
 

--- a/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
@@ -46,7 +46,7 @@ namespace Abblix.Oidc.Server.UnitTests.Mvc.Controllers;
 /// </summary>
 public class DiscoverySignedMetadataTests
 {
-    private const string Issuer = TestConstants.DefaultIssuer;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.OriginalString;
     private const string SignedJws = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ4In0.sig";
 
     private readonly Mock<IOptionsSnapshot<OidcOptions>> _optionsMock = new();

--- a/Abblix.Oidc.Server.UnitTests/TestInfrastructure/Builders/ClientInfoBuilder.cs
+++ b/Abblix.Oidc.Server.UnitTests/TestInfrastructure/Builders/ClientInfoBuilder.cs
@@ -47,7 +47,7 @@ public class ClientInfoBuilder
     private string[] _clientSecrets = [TestConstants.DefaultClientSecret];
     private string _authMethod = ClientAuthenticationMethods.ClientSecretPost;
     private string[] _grantTypes = [GrantTypes.AuthorizationCode];
-    private Uri[] _redirectUris = [new(TestConstants.DefaultRedirectUri)];
+    private Uri[] _redirectUris = [TestConstants.DefaultRedirectUri];
     private TimeSpan _accessTokenExpiresIn = TestConstants.DefaultAccessTokenLifetime;
     private TimeSpan _authorizationCodeExpiresIn = TestConstants.DefaultAuthorizationCodeLifetime;
     private bool? _pkceRequired;

--- a/Abblix.Oidc.Server.UnitTests/TestInfrastructure/TestConstants.cs
+++ b/Abblix.Oidc.Server.UnitTests/TestInfrastructure/TestConstants.cs
@@ -49,20 +49,17 @@ public static class TestConstants
     /// </summary>
     public const string InvalidClientSecret = "wrong_secret";
 
-    /// <summary>
-    /// Default redirect URI for authorization flows.
-    /// </summary>
-    public const string DefaultRedirectUri = "https://example.com/callback";
+    public static readonly Uri DefaultRedirectUri = new Uri("https://example.com/callback");
 
     /// <summary>
     /// Alternative redirect URI for multi-URI scenarios.
     /// </summary>
-    public const string AlternativeRedirectUri = "https://example.com/callback2";
+    public static readonly Uri AlternativeRedirectUri = new Uri("https://example.com/callback2");
 
     /// <summary>
     /// Invalid redirect URI for negative testing.
     /// </summary>
-    public const string InvalidRedirectUri = "https://evil.com/steal-tokens";
+    public static readonly Uri InvalidRedirectUri = new Uri("https://evil.com/steal-tokens");
 
     /// <summary>
     /// Default scope value (OpenID Connect mandatory scope).
@@ -157,12 +154,12 @@ public static class TestConstants
     /// <summary>
     /// Default issuer URI for token generation.
     /// </summary>
-    public const string DefaultIssuer = "https://auth.example.com";
+    public static readonly Uri DefaultIssuer = new Uri("https://auth.example.com");
 
     /// <summary>
     /// Default audience for token validation.
     /// </summary>
-    public const string DefaultAudience = "https://api.example.com";
+    public static readonly Uri DefaultAudience = new Uri("https://api.example.com");
 
     /// <summary>
     /// Default username for resource owner password credentials flow.

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidator.cs
@@ -1,0 +1,86 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using static Abblix.Oidc.Server.Model.ClientRegistrationRequest;
+
+namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
+
+/// <summary>
+/// Validates the JWE algorithms a client requests for the JWTs this server encrypts or decrypts:
+/// <c>id_token_encrypted_response_alg</c>/<c>enc</c> and <c>userinfo_encrypted_response_alg</c>/<c>enc</c>
+/// (OIDC Core), <c>request_object_encryption_alg</c>/<c>enc</c> (RFC 9101) and
+/// <c>authorization_encrypted_response_alg</c>/<c>enc</c> (JARM §3). Each key-management (<c>alg</c>) value
+/// must appear in the server's supported key-management algorithms and each content-encryption (<c>enc</c>)
+/// value in its supported content-encryption algorithms.
+/// </summary>
+/// <param name="jwtValidator">Source of the JWE algorithms the server supports (the registered encryptors).</param>
+public class EncryptedResponseAlgorithmsValidator(IJsonWebTokenValidator jwtValidator)
+    : SyncClientRegistrationContextValidator
+{
+    /// <inheritdoc />
+    protected override OidcError? Validate(ClientRegistrationValidationContext context)
+    {
+        var request = context.Request;
+        return ValidateAlg(request.IdTokenEncryptedResponseAlg, Parameters.IdTokenEncryptedResponseAlg)
+            ?? ValidateEnc(request.IdTokenEncryptedResponseEnc, Parameters.IdTokenEncryptedResponseEnc)
+            ?? ValidateAlg(request.UserInfoEncryptedResponseAlg, Parameters.UserInfoEncryptedResponseAlg)
+            ?? ValidateEnc(request.UserInfoEncryptedResponseEnc, Parameters.UserInfoEncryptedResponseEnc)
+            ?? ValidateAlg(request.RequestObjectEncryptionAlg, Parameters.RequestObjectEncryptionAlg)
+            ?? ValidateEnc(request.RequestObjectEncryptionEnc, Parameters.RequestObjectEncryptionEnc)
+            ?? ValidateAlg(request.AuthorizationEncryptedResponseAlg, Parameters.AuthorizationEncryptedResponseAlg)
+            ?? ValidateEnc(request.AuthorizationEncryptedResponseEnc, Parameters.AuthorizationEncryptedResponseEnc);
+    }
+
+    /// <summary>
+    /// Validates a JWE key-management (<c>alg</c>) value against the server's supported key-management algorithms.
+    /// </summary>
+    private OidcError? ValidateAlg(string? alg, string description)
+    {
+        if (alg is not null && !jwtValidator.EncryptionAlgorithmsSupported.Contains(alg, StringComparer.Ordinal))
+        {
+            return new OidcError(
+                ErrorCodes.InvalidRequest,
+                $"The encryption key-management algorithm for {description} is not supported");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a JWE content-encryption (<c>enc</c>) value against the server's supported content-encryption
+    /// algorithms.
+    /// </summary>
+    private OidcError? ValidateEnc(string? enc, string description)
+    {
+        if (enc is not null && !jwtValidator.EncryptionMethodsSupported.Contains(enc, StringComparer.Ordinal))
+        {
+            return new OidcError(
+                ErrorCodes.InvalidRequest,
+                $"The encryption method for {description} is not supported");
+        }
+
+        return null;
+    }
+}

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -571,6 +571,7 @@ public static class ServiceCollectionExtensions
             ServiceDescriptor.Singleton<IClientRegistrationContextValidator, BackChannelAuthenticationValidator>(),
             ServiceDescriptor.Singleton<IClientRegistrationContextValidator, SigningAlgorithmsValidator>(),
             ServiceDescriptor.Singleton<IClientRegistrationContextValidator, SignedResponseAlgorithmsValidator>(),
+            ServiceDescriptor.Singleton<IClientRegistrationContextValidator, EncryptedResponseAlgorithmsValidator>(),
             ServiceDescriptor.Singleton<IClientRegistrationContextValidator, TokenEndpointAuthMethodValidator>(),
             ServiceDescriptor.Singleton<IClientRegistrationContextValidator, CredentialsValidator>(),
             ServiceDescriptor.Singleton<IClientRegistrationContextValidator, TlsClientAuthValidator>(),


### PR DESCRIPTION
Closes the second JAR↔JARM symmetry-review finding: DCR never validated the JWE algorithms a client registers for encrypted responses.

## Two commits / two concerns
This branch carries two separable changes — they got co-mingled because an in-progress test refactor was live in the working tree. Happy to split into two PRs if preferred.

**1. `fix(dcr)` — DCR encryption-algorithm validation (the actual fix)**
New `EncryptedResponseAlgorithmsValidator`: validates `id_token_encrypted_response_alg/enc`, `userinfo_encrypted_response_alg/enc`, `request_object_encryption_alg/enc` and `authorization_encrypted_response_alg/enc` against the server's supported JWE key-management (`alg`) and content-encryption (`enc`) sets (from the registered encryptors via `IJsonWebTokenValidator`). Previously unsupported values were only caught at runtime. 3 files.

**2. `test` — type test URI constants as `Uri`**
Completes an in-flight refactor: `DefaultRedirectUri`/`AlternativeRedirectUri`/`InvalidRedirectUri`/`DefaultIssuer`/`DefaultAudience` in `TestConstants` become `Uri`; call sites drop redundant `new Uri(...)` wrappers and use `.OriginalString` at string boundaries. Mechanical, ~42 test files.

## Note
The `test` commit touches `SignedResponseAlgorithmsValidatorTests.cs` (and other shared test files) that PR #173 also modifies — expect a small rebase/conflict depending on merge order.

Unit 2100 + E2E 49 green.