### PR TITLE
fix(token-exchange): bind id_token origin via aud/azp and relax subject-token audience

### DIFF
--- a/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -143,6 +143,17 @@ public class JsonWebTokenPayload(JsonObject json)
 	}
 
 	/// <summary>
+	/// The authorized party (azp) the JWT was issued to. OpenID Connect Core mandates this claim
+	/// in an id_token when there is a single audience that differs from the issuer, and whenever
+	/// the token has more than one audience, naming the party the token was minted for.
+	/// </summary>
+	public string? AuthorizedParty
+	{
+		get => Json.GetProperty<string>(IanaClaimTypes.Azp);
+		set => Json.SetProperty(IanaClaimTypes.Azp, value);
+	}
+
+	/// <summary>
 	/// The scope of access granted by the JWT.
 	/// Scope is typically a space-separated list of permissions or access levels and is not part of the standard JWT claims.
 	/// </summary>

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenExchangeTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenExchangeTests.cs
@@ -18,6 +18,7 @@ public class TokenExchangeTests(TestFactory factory) : TestBase(factory)
 {
     private const string TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange";
     private const string AccessTokenType = "urn:ietf:params:oauth:token-type:access_token";
+    private const string IdTokenType = "urn:ietf:params:oauth:token-type:id_token";
 
     private const string PaymentInitiationWireJson =
         """[{"type":"payment_initiation","actions":["initiate"],"instructedAmount":{"currency":"EUR","amount":"500.00"}}]""";
@@ -119,6 +120,44 @@ public class TokenExchangeTests(TestFactory factory) : TestBase(factory)
         Assert.Equal(2, echoed!.Count);
         Assert.Equal("urn:ietf:params:oauth:token-type:access_token", echoed[0]!.GetValue<string>());
         Assert.Equal("urn:ietf:params:oauth:token-type:id_token", echoed[1]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task Cross_client_id_token_exchange_rejected_by_default()
+    {
+        // Client A obtains an id_token whose audience names client A. A different client B presents
+        // that id_token as subject_token. The confused-deputy guard must reject the exchange even
+        // though the id_token is a valid, AS-signed token: an id_token carries no client_id claim,
+        // so its origin is recovered from the audience. Without that recovery any client could
+        // exchange any user's id_token for an access token bound to itself.
+        var clientA = TestConstants.ConfidentialClientId;
+        var issued = await PerformParFlowAsync(
+            clientA, TestConstants.ConfidentialClientSecret,
+            TestConstants.RedirectUri, PaymentInitiationWireJson);
+        var idToken = issued["id_token"]!.GetValue<string>();
+
+        // Premise of the finding: the id_token's aud is client A and it has no client_id claim.
+        var idPayload = DecodeJwtPayload(idToken);
+        Assert.Equal(clientA, idPayload["aud"]!.GetValue<string>());
+        Assert.Null(idPayload["client_id"]);
+
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var response = await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = TokenExchangeGrantType,
+            ["subject_token"] = idToken,
+            ["subject_token_type"] = IdTokenType,
+            // Client B presents client A's id_token. Same shared secret across pre-seeded clients.
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.UnrestrictedClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+        var raw = await response.Content.ReadAsStringAsync();
+        Assert.False(response.IsSuccessStatusCode,
+            $"Expected cross-client exchange to be rejected, but got {(int)response.StatusCode}: {raw}");
+        var error = JsonNode.Parse(raw)?.AsObject();
+        Assert.Equal(ErrorCodes.InvalidRequest, error?["error"]?.GetValue<string>());
     }
 
     private async Task<JsonObject> PerformTokenExchangeAsync(Dictionary<string, string> form)

--- a/Abblix.Oidc.Server.UnitTests/Features/TokenExchange/JwtSubjectTokenResolverTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/TokenExchange/JwtSubjectTokenResolverTests.cs
@@ -41,6 +41,12 @@ public class JwtSubjectTokenResolverTests
 {
     private const string TokenWire = "header.payload.signature";
 
+    // RFC 8693 subject tokens are not minted for this AS, so the resolver must validate them with
+    // the audience constraint dropped (signature + issuer + lifetime only). Strict mocks assert
+    // this exact option set -- a regression that re-enables audience validation fails to match.
+    private const ValidationOptions SubjectTokenValidation =
+        ValidationOptions.Default & ~ValidationOptions.RequireValidAudience;
+
     private readonly Mock<IAuthServiceJwtValidator> _jwtValidator = new(MockBehavior.Strict);
     private readonly FakeTimeProvider _timeProvider = new();
     private readonly JwtSubjectTokenResolver _resolver;
@@ -56,7 +62,7 @@ public class JwtSubjectTokenResolverTests
         var jwt = NewJwt(subject: "user-1", issuer: "https://idp.example.com");
         jwt.Payload.Scope = ["openid", "profile"];
         _jwtValidator
-            .Setup(v => v.ValidateAsync(TokenWire, ValidationOptions.Default))
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
             .ReturnsAsync(jwt);
 
         var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
@@ -75,7 +81,7 @@ public class JwtSubjectTokenResolverTests
         var jwt = NewJwt(subject: "user-1", issuer: null);
         jwt.Payload.Json[IanaClaimTypes.AuthorizationDetails] = (JsonArray)JsonNode.Parse(adWire)!;
         _jwtValidator
-            .Setup(v => v.ValidateAsync(TokenWire, ValidationOptions.Default))
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
             .ReturnsAsync(jwt);
 
         var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
@@ -91,7 +97,7 @@ public class JwtSubjectTokenResolverTests
     public async Task JwtValidationFailure_Rejected()
     {
         _jwtValidator
-            .Setup(v => v.ValidateAsync(TokenWire, ValidationOptions.Default))
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
             .ReturnsAsync(new JwtValidationError(JwtError.InvalidToken, "expired"));
 
         var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
@@ -106,7 +112,7 @@ public class JwtSubjectTokenResolverTests
     {
         var jwt = NewJwt(subject: null, issuer: null);
         _jwtValidator
-            .Setup(v => v.ValidateAsync(TokenWire, ValidationOptions.Default))
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
             .ReturnsAsync(jwt);
 
         var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
@@ -116,7 +122,75 @@ public class JwtSubjectTokenResolverTests
         Assert.Contains("sub", error.ErrorDescription);
     }
 
-    private JsonWebToken NewJwt(string? subject, string? issuer)
+    [Fact]
+    public async Task IdTokenShape_OriginalClientId_DerivedFromSingleAudience()
+    {
+        // An id_token carries no client_id claim. The client it was minted for is the sole
+        // audience, and the resolver must surface that so the handler confused-deputy guard can
+        // fire. Otherwise any client could exchange any user id_token.
+        var jwt = NewJwt(subject: "user-1", issuer: null, audiences: ["client-A"]);
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
+            .ReturnsAsync(jwt);
+
+        var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
+
+        Assert.True(result.TryGetSuccess(out var ctx));
+        Assert.Equal("client-A", ctx.OriginalClientId);
+    }
+
+    [Fact]
+    public async Task ClientIdClaim_TakesPrecedenceOverAzpAndAudience()
+    {
+        // Access tokens carry client_id directly and may also list resource-server audiences
+        // (RFC 8707). client_id is the authoritative origin and must win over both.
+        var jwt = NewJwt(subject: "user-1", issuer: null, audiences: ["https://api.example.com"]);
+        jwt.Payload.ClientId = "client-A";
+        jwt.Payload.AuthorizedParty = "client-Z";
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
+            .ReturnsAsync(jwt);
+
+        var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
+
+        Assert.True(result.TryGetSuccess(out var ctx));
+        Assert.Equal("client-A", ctx.OriginalClientId);
+    }
+
+    [Fact]
+    public async Task Azp_UsedWhenClientIdAbsentAndMultipleAudiences()
+    {
+        // Multi-audience id_token: OIDC Core mandates azp, and the single-audience shortcut does
+        // not apply. azp names the client the token was issued to.
+        var jwt = NewJwt(subject: "user-1", issuer: null, audiences: ["client-A", "client-B"]);
+        jwt.Payload.AuthorizedParty = "client-A";
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
+            .ReturnsAsync(jwt);
+
+        var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
+
+        Assert.True(result.TryGetSuccess(out var ctx));
+        Assert.Equal("client-A", ctx.OriginalClientId);
+    }
+
+    [Fact]
+    public async Task NoClientIdNoAzpMultipleAudiences_OriginalClientIdNull()
+    {
+        // Genuinely ambiguous: no client_id, no azp, more than one audience. The resolver leaves
+        // origin undetermined rather than guessing; the cross-client guard then cannot narrow it.
+        var jwt = NewJwt(subject: "user-1", issuer: null, audiences: ["a", "b"]);
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(TokenWire, SubjectTokenValidation))
+            .ReturnsAsync(jwt);
+
+        var result = await _resolver.ResolveAsync(TokenWire, CancellationToken.None);
+
+        Assert.True(result.TryGetSuccess(out var ctx));
+        Assert.Null(ctx.OriginalClientId);
+    }
+
+    private JsonWebToken NewJwt(string? subject, string? issuer, string[]? audiences = null)
     {
         var now = _timeProvider.GetUtcNow();
         var jwt = new JsonWebToken
@@ -126,6 +200,7 @@ public class JwtSubjectTokenResolverTests
         };
         if (issuer is not null) jwt.Payload.Issuer = issuer;
         if (subject is not null) jwt.Payload.Subject = subject;
+        if (audiences is not null) jwt.Payload.Audiences = audiences;
         return jwt;
     }
 }

--- a/Abblix.Oidc.Server/Features/TokenExchange/JwtSubjectTokenResolver.cs
+++ b/Abblix.Oidc.Server/Features/TokenExchange/JwtSubjectTokenResolver.cs
@@ -45,12 +45,23 @@ namespace Abblix.Oidc.Server.Features.TokenExchange;
 /// <param name="jwtValidator">Validates own-issued JWTs (signature against AS keys, claims).</param>
 public sealed class JwtSubjectTokenResolver(IAuthServiceJwtValidator jwtValidator) : ISubjectTokenResolver
 {
+    /// <summary>
+    /// An RFC 8693 subject_token was minted for a client or, under RFC 8707, for a resource server
+    /// -- never for this AS as its audience. Enforcing the default "aud must be a registered client"
+    /// rule would wrongly reject a resource-scoped access token presented for exchange. The token's
+    /// binding to the requesting client is enforced separately by the confused-deputy guard in
+    /// <see cref="Endpoints.Token.Grants.TokenExchangeGrantHandler"/>, so here we validate signature,
+    /// issuer and lifetime but deliberately drop the audience constraint.
+    /// </summary>
+    private const ValidationOptions SubjectTokenValidation =
+        ValidationOptions.Default & ~ValidationOptions.RequireValidAudience;
+
     /// <inheritdoc/>
     public async Task<Result<SubjectTokenContext, OidcError>> ResolveAsync(
         string subjectToken,
         CancellationToken cancellationToken)
     {
-        var validation = await jwtValidator.ValidateAsync(subjectToken);
+        var validation = await jwtValidator.ValidateAsync(subjectToken, SubjectTokenValidation);
         if (!validation.TryGetSuccess(out var jwt))
         {
             return new OidcError(ErrorCodes.InvalidRequest, "The subject_token is invalid or has expired.");
@@ -81,10 +92,16 @@ public sealed class JwtSubjectTokenResolver(IAuthServiceJwtValidator jwtValidato
         {
             Act = act,
 
-            // Origin tracking for the confused-deputy guard: the JWT's client_id claim names
-            // the party the token was originally minted for. Null when the claim was absent
-            // (which itself surfaces at the handler's cross-client check).
-            OriginalClientId = jwt.Payload.ClientId,
+            // Origin tracking for the confused-deputy guard. Access and refresh tokens name their
+            // client in the client_id claim, but an id_token carries no such claim -- it identifies
+            // its client through a sole audience, or through azp when several audiences are present.
+            // Without this fallback the guard would silently skip every id_token exchange, letting
+            // any client exchange any user's id_token. The preference order matches how each token
+            // shape encodes its client; a token with several audiences and neither client_id nor azp
+            // stays null, i.e. its origin is genuinely undeterminable.
+            OriginalClientId = jwt.Payload.ClientId
+                ?? jwt.Payload.AuthorizedParty
+                ?? SingleAudience(jwt),
 
             // typ header for cross-type confusion check (e.g. id+jwt presented as access_token).
             JwtTokenType = jwt.Header.Type,
@@ -93,4 +110,23 @@ public sealed class JwtSubjectTokenResolver(IAuthServiceJwtValidator jwtValidato
 
     private static T? Extract<T>(JsonWebToken jwt, string name) where T: JsonNode
         => jwt.Payload.Json[name] is T node ? (T?)node.DeepClone() : null;
+
+    /// <summary>
+    /// Returns the sole audience of the token, or null when there is none or more than one. A
+    /// single-audience own-issued token (id_token, logout_token) puts the client there; multiple
+    /// audiences are ambiguous, so origin is determined from azp instead (handled by the caller).
+    /// </summary>
+    private static string? SingleAudience(JsonWebToken jwt)
+    {
+        string? single = null;
+        foreach (var audience in jwt.Payload.Audiences)
+        {
+            if (single is not null)
+                return null;
+
+            single = audience;
+        }
+
+        return single;
+    }
 }


### PR DESCRIPTION
Two interdependent RFC 8693 Token Exchange hardening fixes found while reviewing how subject tokens are trusted.

## Confused-deputy guard blind to id_token

The cross-client guard recovered a subject_token's originating client only from the `client_id` claim. id_tokens carry no `client_id` — they identify their client through `aud` (or `azp` when several audiences are present) — so the guard silently skipped every id_token exchange. Any client could present another user's id_token and exchange it for an access token bound to itself.\n\n`JwtSubjectTokenResolver` now resolves `OriginalClientId` as `client_id → azp → sole audience`, and a new `JsonWebTokenPayload.AuthorizedParty` accessor exposes `azp` through a typed property.\n\n## Strict audience rejected resource-scoped subject tokens\n\nSubject tokens are minted for a client or, under RFC 8707, a resource server — never for this AS as audience. The default "aud must be a registered client" rule wrongly rejected resource-scoped access tokens presented for exchange. Subject tokens are now validated with the audience constraint dropped (signature, issuer and lifetime still enforced); the client binding is provided by the confused-deputy guard above, which is why the two fixes ship together — relaxing audience is only safe once the origin guard works for every token shape.