### PR TITLE
feat: JWT Response for OAuth Token Introspection (RFC 9701)

### DIFF
--- a/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
@@ -48,4 +48,8 @@ public sealed record DiscoveryDocument
     /// <summary>RFC 9449 §5.1: JWS algorithms the AS accepts for DPoP proofs.</summary>
     [JsonPropertyName("dpop_signing_alg_values_supported")]
     public string[]? DPoPSigningAlgValuesSupported { get; init; }
+
+    /// <summary>RFC 9701 §7: JWS algorithms the AS uses to sign JWT introspection responses.</summary>
+    [JsonPropertyName("introspection_signing_alg_values_supported")]
+    public string[]? IntrospectionSigningAlgValuesSupported { get; init; }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtIntrospectionResponseTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtIntrospectionResponseTests.cs
@@ -1,0 +1,150 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Net.Http.Headers;
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// JWT Response for OAuth Token Introspection (RFC 9701). A client registered with
+/// <c>introspection_signed_response_alg</c> that introspects a token with
+/// <c>Accept: application/token-introspection+jwt</c> receives the RFC 7662 response wrapped in a signed JWT under
+/// the <c>token_introspection</c> claim; otherwise it receives the plain JSON document.
+/// </summary>
+public class JwtIntrospectionResponseTests(TestFactory factory) : TestBase(factory)
+{
+    private const string IntrospectionJwtMediaType = MediaTypes.TokenIntrospectionJwt;
+
+    [Fact]
+    public async Task Introspection_with_jwt_accept_returns_signed_jwt_with_token_introspection_claim()
+    {
+        var httpClient = CreateClient();
+        var discovery = await FetchDiscoveryAsync(httpClient);
+        var (clientId, clientSecret, accessToken) = await RegisterClientAndGetAccessTokenAsync(
+            httpClient, discovery, introspectionSignedResponseAlg: SigningAlgorithms.RS256);
+
+        var response = await IntrospectAsync(
+            httpClient, discovery, clientId, clientSecret, accessToken, IntrospectionJwtMediaType);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(IntrospectionJwtMediaType, response.Content.Headers.ContentType?.MediaType);
+
+        var jwt = await response.Content.ReadAsStringAsync();
+        var payload = DecodeJwtPayload(jwt);
+
+        // RFC 9701 §5: addressed to the client and issued by the AS.
+        Assert.Equal(clientId, payload[IanaClaimTypes.Aud]!.GetValue<string>());
+        Assert.Equal(
+            discovery.Issuer.AbsoluteUri.TrimEnd('/'),
+            payload[IanaClaimTypes.Iss]!.GetValue<string>().TrimEnd('/'));
+
+        // The RFC 7662 response is carried under the token_introspection claim and reports the token as active.
+        var introspection = payload[IanaClaimTypes.TokenIntrospection]!.AsObject();
+        Assert.Equal("true", introspection["active"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task Introspection_without_jwt_accept_returns_plain_json()
+    {
+        var httpClient = CreateClient();
+        var discovery = await FetchDiscoveryAsync(httpClient);
+        var (clientId, clientSecret, accessToken) = await RegisterClientAndGetAccessTokenAsync(
+            httpClient, discovery, introspectionSignedResponseAlg: SigningAlgorithms.RS256);
+
+        // Even though the client registered a signing algorithm, a plain JSON Accept yields the RFC 7662 document.
+        var response = await IntrospectAsync(
+            httpClient, discovery, clientId, clientSecret, accessToken, "application/json");
+
+        response.EnsureSuccessStatusCode();
+        Assert.NotEqual(IntrospectionJwtMediaType, response.Content.Headers.ContentType?.MediaType);
+
+        var body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        Assert.Equal("true", body["active"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task Discovery_advertises_introspection_signing_alg_values()
+    {
+        var httpClient = CreateClient();
+        var discovery = await FetchDiscoveryAsync(httpClient);
+
+        Assert.NotNull(discovery.IntrospectionSigningAlgValuesSupported);
+        Assert.Contains(SigningAlgorithms.RS256, discovery.IntrospectionSigningAlgValuesSupported!);
+    }
+
+    private async Task<(string ClientId, string ClientSecret, string AccessToken)> RegisterClientAndGetAccessTokenAsync(
+        HttpClient httpClient,
+        DiscoveryDocument discovery,
+        string introspectionSignedResponseAlg)
+    {
+        var (verifier, challenge) = GeneratePkcePair();
+
+        var dcrBody = new JsonObject
+        {
+            ["redirect_uris"] = new JsonArray { TestConstants.RedirectUri },
+            ["grant_types"] = new JsonArray { GrantTypes.AuthorizationCode },
+            ["response_types"] = new JsonArray { ResponseTypes.Code },
+            ["token_endpoint_auth_method"] = "client_secret_post",
+            [ClientRegistrationRequest.Parameters.IntrospectionSignedResponseAlg] = introspectionSignedResponseAlg,
+        };
+        var registered = await RegisterClientAsync(httpClient, discovery, dcrBody);
+        var clientId = registered[AuthorizationRequest.Parameters.ClientId]!.GetValue<string>();
+        var clientSecret = registered[ClientRequest.Parameters.ClientSecret]!.GetValue<string>();
+
+        var code = await AuthorizeAndExtractCodeAsync(httpClient, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+
+        var tokenResponse = await ExchangeCodeForTokensAsync(httpClient, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = clientSecret,
+        });
+
+        var accessToken = tokenResponse[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
+        return (clientId, clientSecret, accessToken);
+    }
+
+    private static async Task<HttpResponseMessage> IntrospectAsync(
+        HttpClient httpClient,
+        DiscoveryDocument discovery,
+        string clientId,
+        string clientSecret,
+        string token,
+        string acceptMediaType)
+    {
+        Assert.NotNull(discovery.IntrospectionEndpoint);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, discovery.IntrospectionEndpoint)
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                [IntrospectionRequest.Parameters.Token] = token,
+                [AuthorizationRequest.Parameters.ClientId] = clientId,
+                [ClientRequest.Parameters.ClientSecret] = clientSecret,
+            }),
+        };
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(acceptMediaType));
+
+        return await httpClient.SendAsync(request);
+    }
+}

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/IntrospectionResponseFormatterTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/IntrospectionResponseFormatterTests.cs
@@ -1,0 +1,136 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Formatters;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.Formatters;
+using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.Mvc.UnitTests.Formatters;
+
+/// <summary>
+/// Unit tests for <see cref="IntrospectionResponseFormatter"/> verifying RFC 9701 content negotiation: a plain
+/// RFC 7662 JSON document unless the client registered <c>introspection_signed_response_alg</c> and requested the
+/// JWT media type via <c>Accept</c>, in which case a JWT carrying the <c>token_introspection</c> claim is returned.
+/// </summary>
+public class IntrospectionResponseFormatterTests
+{
+    private const string Issuer = "https://auth.example.com";
+    private const string ClientId = "test_client";
+    private const string EncodedJwt = "header.payload.signature";
+
+    private readonly Mock<IClientJwtFormatter> _clientJwtFormatter = new(MockBehavior.Strict);
+
+    private async Task<ActionResult> FormatAsync(IntrospectionSuccess success, string? acceptHeader)
+    {
+        var issuerProvider = new Mock<IIssuerProvider>();
+        issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
+
+        var options = new Mock<IOptionsSnapshot<OidcOptions>>();
+        options.Setup(o => o.Value).Returns(new OidcOptions());
+
+        var httpContext = new DefaultHttpContext();
+        if (acceptHeader != null)
+            httpContext.Request.Headers.Accept = acceptHeader;
+
+        var httpContextAccessor = new Mock<IHttpContextAccessor>();
+        httpContextAccessor.Setup(a => a.HttpContext).Returns(httpContext);
+
+        var formatter = new IntrospectionResponseFormatter(
+            issuerProvider.Object,
+            _clientJwtFormatter.Object,
+            TimeProvider.System,
+            options.Object,
+            httpContextAccessor.Object);
+
+        Result<IntrospectionSuccess, OidcError> response = success;
+        return await formatter.FormatResponseAsync(new IntrospectionRequest { Token = "token" }, response);
+    }
+
+    private static IntrospectionSuccess ActiveResponse(string signedResponseAlgorithm) => new(
+        true,
+        new JsonObject { ["sub"] = "user_123" },
+        new ClientInfo(ClientId) { IntrospectionSignedResponseAlgorithm = signedResponseAlgorithm });
+
+    [Fact]
+    public async Task FormatResponseAsync_WhenClientHasNoSignedAlgorithm_ReturnsPlainJson()
+    {
+        var result = await FormatAsync(ActiveResponse(SigningAlgorithms.None), MediaTypes.TokenIntrospectionJwt);
+
+        Assert.IsType<JsonResult>(result);
+        _clientJwtFormatter.Verify(
+            f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ClientInfo>(), It.IsAny<ClientJwtEncryption>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task FormatResponseAsync_WhenClientDidNotRequestJwt_ReturnsPlainJson()
+    {
+        // The client registered a signing algorithm but did not ask for the JWT media type.
+        var result = await FormatAsync(ActiveResponse(SigningAlgorithms.RS256), "application/json");
+
+        Assert.IsType<JsonResult>(result);
+        _clientJwtFormatter.Verify(
+            f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ClientInfo>(), It.IsAny<ClientJwtEncryption>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task FormatResponseAsync_WhenClientRegisteredAlgAndRequestsJwt_ReturnsJwt()
+    {
+        JsonWebToken? capturedToken = null;
+        _clientJwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ClientInfo>(), It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((token, _, _) => capturedToken = token)
+            .ReturnsAsync(EncodedJwt);
+
+        var result = await FormatAsync(ActiveResponse(SigningAlgorithms.RS256), MediaTypes.TokenIntrospectionJwt);
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(MediaTypes.TokenIntrospectionJwt, content.ContentType);
+        Assert.Equal(EncodedJwt, content.Content);
+
+        // RFC 9701 §5: typ header is the introspection JWT type, signed with the client's algorithm, addressed to
+        // the client, and the response carried under the token_introspection claim.
+        Assert.NotNull(capturedToken);
+        Assert.Equal(JwtTypes.TokenIntrospection, capturedToken!.Header.Type);
+        Assert.Equal(SigningAlgorithms.RS256, capturedToken.Header.Algorithm);
+        Assert.Contains(ClientId, capturedToken.Payload.Audiences);
+
+        var introspection = capturedToken.Payload[IanaClaimTypes.TokenIntrospection]!.AsObject();
+        Assert.Equal("user_123", introspection["sub"]!.GetValue<string>());
+        Assert.True(introspection.ContainsKey("active"));
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
@@ -123,6 +123,10 @@ public class ConfigurationResponseFormatter(
 			AuthorizationEncryptionAlgValuesSupported = response.AuthorizationEncryptionAlgValuesSupported,
 			AuthorizationEncryptionEncValuesSupported = response.AuthorizationEncryptionEncValuesSupported,
 
+			IntrospectionSigningAlgValuesSupported = response.IntrospectionSigningAlgValuesSupported,
+			IntrospectionEncryptionAlgValuesSupported = response.IntrospectionEncryptionAlgValuesSupported,
+			IntrospectionEncryptionEncValuesSupported = response.IntrospectionEncryptionEncValuesSupported,
+
 			RequirePushedAuthorizationRequests = response.RequirePushedAuthorizationRequests,
 			RequireSignedRequestObject = response.RequireSignedRequestObject,
 

--- a/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
@@ -1,44 +1,61 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
-// 
+//
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
 // warranty. Use at your own risk. Abblix LLP is not liable for any damages
 // arising from the use of this software.
-// 
+//
 // LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
 // in any form outside of the official GitHub repository at:
 // https://github.com/Abblix/OIDC.Server. All development and modifications
 // must occur within the official repository and are managed solely by Abblix LLP.
-// 
+//
 // Unauthorized use, modification, or distribution of this software is strictly
 // prohibited and may be subject to legal action.
-// 
+//
 // For full licensing terms, please visit:
-// 
+//
 // https://oidc.abblix.com/license
-// 
+//
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using Abblix.Oidc.Server.Common;
+using System.Linq;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
 using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Mvc.ActionResults;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Mvc.Formatters;
 
 /// <summary>
-/// Provides a response formatter for introspection responses.
+/// Provides a response formatter for introspection responses, returning either a plain JSON document (RFC 7662) or,
+/// when the client registered <c>introspection_signed_response_alg</c> and requests it via
+/// <c>Accept: application/token-introspection+jwt</c>, a signed/encrypted JWT (RFC 9701).
 /// </summary>
+/// <param name="issuerProvider">Supplies the issuer identifier for error responses and the JWT <c>iss</c> claim.</param>
+/// <param name="clientJwtFormatter">Signs and optionally encrypts the JWT introspection response.</param>
+/// <param name="clock">Supplies the current time for the JWT <c>iat</c> claim.</param>
+/// <param name="options">Supplies the default content-encryption algorithm for JWT introspection responses.</param>
+/// <param name="httpContextAccessor">Provides the current request so the formatter can honor the <c>Accept</c>
+/// header negotiation defined by RFC 9701 §4.</param>
 public class IntrospectionResponseFormatter(
-    IIssuerProvider issuerProvider) : IIntrospectionResponseFormatter
+    IIssuerProvider issuerProvider,
+    IClientJwtFormatter clientJwtFormatter,
+    TimeProvider clock,
+    IOptionsSnapshot<OidcOptions> options,
+    IHttpContextAccessor httpContextAccessor) : IIntrospectionResponseFormatter
 {
     /// <summary>
     /// Formats an introspection response asynchronously.
@@ -48,22 +65,67 @@ public class IntrospectionResponseFormatter(
     /// <returns>
     /// A <see cref="Task"/> representing the asynchronous operation, with the formatted response as an <see cref="ActionResult"/>.
     /// </returns>
-    /// <remarks>
-    /// This method is used to format introspection responses.
-    /// Depending on the response type, it creates different types of ActionResult to be returned to the client.
-    /// </remarks>
     public Task<ActionResult> FormatResponseAsync(IntrospectionRequest request, Result<IntrospectionSuccess, OidcError> response)
     {
-        return Task.FromResult(response.Match(
-            onSuccess: FormatSuccess,
-            onFailure: error => error.Format(StatusCodes.Status401Unauthorized, issuerProvider.GetIssuer())));
+        return response.MatchAsync(
+            onSuccess: FormatSuccessAsync,
+            onFailure: error => Task.FromResult(
+                error.Format(StatusCodes.Status401Unauthorized, issuerProvider.GetIssuer())));
     }
 
-    private static ActionResult FormatSuccess(IntrospectionSuccess success)
+    private async Task<ActionResult> FormatSuccessAsync(IntrospectionSuccess success)
     {
-        var result = success.Claims ?? new JsonObject();
-        result.SetProperty("active", success.Active ? "true" : "false");
+        var introspectionResponse = success.Claims ?? new JsonObject();
+        introspectionResponse.SetProperty("active", success.Active ? "true" : "false");
 
-        return new JsonResult(result);
+        var clientInfo = success.ClientInfo;
+
+        // RFC 9701 §4: a JWT response is returned only when the client registered a signing algorithm AND requested
+        // the JWT media type via Accept; otherwise the plain RFC 7662 JSON document is returned.
+        if (clientInfo.IntrospectionSignedResponseAlgorithm == SigningAlgorithms.None || !AcceptsTokenIntrospectionJwt())
+        {
+            return new JsonResult(introspectionResponse);
+        }
+
+        var now = clock.GetUtcNow();
+        var token = new JsonWebToken
+        {
+            Header =
+            {
+                Type = JwtTypes.TokenIntrospection,
+                Algorithm = clientInfo.IntrospectionSignedResponseAlgorithm,
+            },
+            Payload =
+            {
+                IssuedAt = now,
+                Issuer = issuerProvider.GetIssuer(),
+                Audiences = [clientInfo.ClientId],
+
+                // RFC 9701 §5: the introspection response object is carried as the token_introspection claim. The
+                // object is cloned because it is otherwise still parented to the introspected token's payload.
+                [IanaClaimTypes.TokenIntrospection] = introspectionResponse.DeepClone(),
+            },
+        };
+
+        return new ContentResult
+        {
+            ContentType = MediaTypes.TokenIntrospectionJwt,
+            Content = await clientJwtFormatter.FormatAsync(
+                token, clientInfo, ClientJwtEncryption.ForIntrospection(clientInfo, options.Value)),
+        };
+    }
+
+    private bool AcceptsTokenIntrospectionJwt()
+    {
+        var request = httpContextAccessor.HttpContext?.Request;
+        if (request == null)
+            return false;
+
+        return request.GetTypedHeaders().Accept.Any(
+            mediaType => mediaType.MediaType.HasValue &&
+                         string.Equals(
+                             mediaType.MediaType.Value,
+                             MediaTypes.TokenIntrospectionJwt,
+                             StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
@@ -22,6 +22,7 @@
 
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.UserInfo.Interfaces;
 using Abblix.Oidc.Server.Features.DPoP;
@@ -33,6 +34,7 @@ using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Mvc.Formatters;
 
@@ -42,7 +44,8 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 public class UserInfoResponseFormatter(
     TimeProvider clock,
     IClientJwtFormatter clientJwtFormatter,
-    IIssuerProvider issuerProvider) : IUserInfoResponseFormatter
+    IIssuerProvider issuerProvider,
+    IOptionsSnapshot<OidcOptions> options) : IUserInfoResponseFormatter
 {
     /// <summary>
     /// Asynchronously formats the response for a user information request.
@@ -91,9 +94,9 @@ public class UserInfoResponseFormatter(
         return new ContentResult
         {
             ContentType = MediaTypes.Jwt,
-            // The UserInfo token carries no id_token/logout type, so the formatter encrypts it with
-            // the client's userinfo_encrypted_response_* metadata rather than the id_token fields.
-            Content = await clientJwtFormatter.FormatAsync(token, found.ClientInfo),
+            // A UserInfo response is encrypted with the client's userinfo_encrypted_response_* metadata.
+            Content = await clientJwtFormatter.FormatAsync(
+                token, found.ClientInfo, ClientJwtEncryption.ForUserInfo(found.ClientInfo, options.Value)),
         };
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
@@ -205,6 +205,25 @@ public record ClientRegistrationRequest
     public string? UserInfoEncryptedResponseEnc { get; init; }
 
     /// <summary>
+    /// JWS algorithm required for signing introspection responses sent to this client (RFC 9701).
+    /// When omitted, introspection is returned as plain JSON.
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionSignedResponseAlg)]
+    public string? IntrospectionSignedResponseAlg { get; init; }
+
+    /// <summary>
+    /// JWE key-management algorithm required for encrypting introspection responses sent to this client (RFC 9701).
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionEncryptedResponseAlg)]
+    public string? IntrospectionEncryptedResponseAlg { get; init; }
+
+    /// <summary>
+    /// JWE content-encryption method required for encrypting introspection responses sent to this client (RFC 9701).
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionEncryptedResponseEnc)]
+    public string? IntrospectionEncryptedResponseEnc { get; init; }
+
+    /// <summary>
     /// JSON Web Signature (JWS) algorithm that MUST be used for Request Objects sent to the OP.
     /// Specifies the client's preferred algorithm for signing Request Objects.
     /// </summary>
@@ -435,6 +454,10 @@ public record ClientRegistrationRequest
             UserInfoEncryptedResponseAlg = UserInfoEncryptedResponseAlg,
             UserInfoEncryptedResponseEnc = UserInfoEncryptedResponseEnc,
             UserInfoSignedResponseAlg = UserInfoSignedResponseAlg,
+
+            IntrospectionSignedResponseAlg = IntrospectionSignedResponseAlg,
+            IntrospectionEncryptedResponseAlg = IntrospectionEncryptedResponseAlg,
+            IntrospectionEncryptedResponseEnc = IntrospectionEncryptedResponseEnc,
 
             BackChannelLogoutUri = BackChannelLogoutUri,
             BackChannelLogoutSessionRequired = BackChannelLogoutSessionRequired,

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -277,4 +277,23 @@ public class RegisterClientHandlerIntegrationTests
         Assert.Equal(new Uri("https://client.example.com/callback"), success.RedirectUris[0]);
         Assert.True(success.DpopBoundAccessTokens);
     }
+
+    /// <summary>
+    /// RFC 9701 §6: the registration response echoes a registered <c>introspection_signed_response_alg</c>, while a
+    /// client that did not register one (the implicit <c>none</c> default) gets no such field in the response.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RegistrationResponse_EchoesIntrospectionSignedResponseAlg()
+    {
+        var provider = BuildProvider();
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+
+        var withAlg = CreateRequest() with { IntrospectionSignedResponseAlg = SigningAlgorithms.RS256 };
+        Assert.True((await handler.HandleAsync(withAlg)).TryGetSuccess(out var registered));
+        Assert.Equal(SigningAlgorithms.RS256, registered.IntrospectionSignedResponseAlg);
+
+        var withoutAlg = CreateRequest();
+        Assert.True((await handler.HandleAsync(withoutAlg)).TryGetSuccess(out var registeredDefault));
+        Assert.Null(registeredDefault.IntrospectionSignedResponseAlg);
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidatorTests.cs
@@ -74,6 +74,8 @@ public class EncryptedResponseAlgorithmsValidatorTests
             IdTokenEncryptedResponseEnc = SupportedEnc,
             UserInfoEncryptedResponseAlg = SupportedAlg,
             UserInfoEncryptedResponseEnc = SupportedEnc,
+            IntrospectionEncryptedResponseAlg = SupportedAlg,
+            IntrospectionEncryptedResponseEnc = SupportedEnc,
             RequestObjectEncryptionAlg = SupportedAlg,
             RequestObjectEncryptionEnc = SupportedEnc,
             AuthorizationEncryptedResponseAlg = SupportedAlg,
@@ -86,18 +88,20 @@ public class EncryptedResponseAlgorithmsValidatorTests
     }
 
     [Theory]
-    [InlineData("id_token_encrypted_response_alg")]
-    [InlineData("userinfo_encrypted_response_alg")]
-    [InlineData("request_object_encryption_alg")]
-    [InlineData("authorization_encrypted_response_alg")]
+    [InlineData(ClientRegistrationRequest.Parameters.IdTokenEncryptedResponseAlg)]
+    [InlineData(ClientRegistrationRequest.Parameters.UserInfoEncryptedResponseAlg)]
+    [InlineData(ClientRegistrationRequest.Parameters.IntrospectionEncryptedResponseAlg)]
+    [InlineData(ClientRegistrationRequest.Parameters.RequestObjectEncryptionAlg)]
+    [InlineData(ClientRegistrationRequest.Parameters.AuthorizationEncryptedResponseAlg)]
     public async Task ValidateAsync_WithUnsupportedKeyManagementAlg_ShouldReturnError(string wireName)
     {
         const string unsupported = EncryptionAlgorithms.KeyManagement.Rsa1_5;
         var request = wireName switch
         {
-            "id_token_encrypted_response_alg" => Request() with { IdTokenEncryptedResponseAlg = unsupported },
-            "userinfo_encrypted_response_alg" => Request() with { UserInfoEncryptedResponseAlg = unsupported },
-            "request_object_encryption_alg" => Request() with { RequestObjectEncryptionAlg = unsupported },
+            ClientRegistrationRequest.Parameters.IdTokenEncryptedResponseAlg => Request() with { IdTokenEncryptedResponseAlg = unsupported },
+            ClientRegistrationRequest.Parameters.UserInfoEncryptedResponseAlg => Request() with { UserInfoEncryptedResponseAlg = unsupported },
+            ClientRegistrationRequest.Parameters.IntrospectionEncryptedResponseAlg => Request() with { IntrospectionEncryptedResponseAlg = unsupported },
+            ClientRegistrationRequest.Parameters.RequestObjectEncryptionAlg => Request() with { RequestObjectEncryptionAlg = unsupported },
             _ => Request() with { AuthorizationEncryptedResponseAlg = unsupported },
         };
 
@@ -121,6 +125,6 @@ public class EncryptedResponseAlgorithmsValidatorTests
 
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("authorization_encrypted_response_enc", result.ErrorDescription);
+        Assert.Contains(ClientRegistrationRequest.Parameters.AuthorizationEncryptedResponseEnc, result.ErrorDescription);
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
@@ -50,17 +50,55 @@ public class SignedResponseAlgorithmsValidatorTests
     private ClientRegistrationValidationContext CreateContext(
         string? idTokenSignedResponseAlg = null,
         string? userInfoSignedResponseAlg = null,
-        string? authorizationSignedResponseAlg = null)
+        string? authorizationSignedResponseAlg = null,
+        string? introspectionSignedResponseAlg = null)
     {
         var request = new ClientRegistrationRequest
         {
             RedirectUris = [TestConstants.DefaultRedirectUri],
             IdTokenSignedResponseAlg = idTokenSignedResponseAlg,
             UserInfoSignedResponseAlg = userInfoSignedResponseAlg,
-            AuthorizationSignedResponseAlg = authorizationSignedResponseAlg
+            AuthorizationSignedResponseAlg = authorizationSignedResponseAlg,
+            IntrospectionSignedResponseAlg = introspectionSignedResponseAlg
         };
 
         return new ClientRegistrationValidationContext(request);
+    }
+
+    /// <summary>
+    /// Verifies validation succeeds with a supported introspection_signed_response_alg (RFC 9701).
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithSupportedIntrospectionAlg_ShouldReturnNull()
+    {
+        _jwtCreator
+            .Setup(c => c.SignedResponseAlgorithmsSupported)
+            .Returns([SigningAlgorithms.RS256, SigningAlgorithms.ES256]);
+
+        var context = CreateContext(introspectionSignedResponseAlg: SigningAlgorithms.ES256);
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies error when introspection_signed_response_alg is not supported (RFC 9701).
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithUnsupportedIntrospectionAlg_ShouldReturnError()
+    {
+        _jwtCreator
+            .Setup(c => c.SignedResponseAlgorithmsSupported)
+            .Returns([SigningAlgorithms.RS256]);
+
+        var context = CreateContext(introspectionSignedResponseAlg: SigningAlgorithms.PS384);
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Contains(ClientRegistrationRequest.Parameters.IntrospectionSignedResponseAlg, result.ErrorDescription);
     }
 
     /// <summary>
@@ -96,7 +134,7 @@ public class SignedResponseAlgorithmsValidatorTests
 
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("authorization_signed_response_alg", result.ErrorDescription);
+        Assert.Contains(ClientRegistrationRequest.Parameters.AuthorizationSignedResponseAlg, result.ErrorDescription);
     }
 
     /// <summary>
@@ -116,7 +154,7 @@ public class SignedResponseAlgorithmsValidatorTests
 
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("authorization_signed_response_alg", result.ErrorDescription);
+        Assert.Contains(ClientRegistrationRequest.Parameters.AuthorizationSignedResponseAlg, result.ErrorDescription);
     }
 
     /// <summary>
@@ -177,7 +215,7 @@ public class SignedResponseAlgorithmsValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("id_token_signed_response_alg", result.ErrorDescription);
+        Assert.Contains(ClientRegistrationRequest.Parameters.IdTokenSignedResponseAlg, result.ErrorDescription);
         Assert.Contains("not supported", result.ErrorDescription);
     }
 
@@ -222,7 +260,7 @@ public class SignedResponseAlgorithmsValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("userinfo_signed_response_alg", result.ErrorDescription);
+        Assert.Contains(ClientRegistrationRequest.Parameters.UserInfoSignedResponseAlg, result.ErrorDescription);
     }
 
     /// <summary>
@@ -269,7 +307,7 @@ public class SignedResponseAlgorithmsValidatorTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Contains("id_token_signed_response_alg", result.ErrorDescription);
+        Assert.Contains(ClientRegistrationRequest.Parameters.IdTokenSignedResponseAlg, result.ErrorDescription);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionHandlerTests.cs
@@ -26,6 +26,7 @@ using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Introspection;
 using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -65,13 +66,13 @@ public class IntrospectionHandlerTests
     private static ValidIntrospectionRequest CreateValidIntrospectionRequest(IntrospectionRequest request)
     {
         var token = new Jwt.JsonWebToken();
-        return new ValidIntrospectionRequest(request, token);
+        return new ValidIntrospectionRequest(request, new ClientInfo(TestConstants.DefaultClientId), token);
     }
 
     private static IntrospectionSuccess CreateIntrospectionSuccess(bool active)
     {
         var claims = active ? new JsonObject { ["sub"] = "user_123" } : null;
-        return new IntrospectionSuccess(active, claims);
+        return new IntrospectionSuccess(active, claims, new ClientInfo(TestConstants.DefaultClientId));
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestProcessorTests.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Endpoints.Introspection;
 using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Xunit;
 
@@ -62,7 +63,7 @@ public class IntrospectionRequestProcessorTests
         IntrospectionRequest request,
         JsonWebToken? token = null)
     {
-        return new ValidIntrospectionRequest(request, token!);
+        return new ValidIntrospectionRequest(request, new ClientInfo("test_client"), token!);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
@@ -73,11 +73,17 @@ public class ResponseJwtBuilderTests
         _timeProvider.Setup(t => t.GetUtcNow()).Returns(_now);
         _serviceKeys.Setup(p => p.GetSigningKeys(true)).Returns(new[] { _signingKeyRs256 }.ToAsyncEnumerable());
 
-        _builder = new ResponseJwtBuilder(
-            _clientInfoProvider.Object,
+        // The builder now delegates signing/encryption to a real ClientJwtFormatter built over the same mocks,
+        // so the assertions on IJsonWebTokenCreator.IssueAsync continue to exercise the end-to-end JARM behavior.
+        var clientJwtFormatter = new ClientJwtFormatter(
             _jwtCreator.Object,
             _clientKeys.Object,
             _serviceKeys.Object,
+            Options.Create(new OidcOptions()));
+
+        _builder = new ResponseJwtBuilder(
+            _clientInfoProvider.Object,
+            clientJwtFormatter,
             _issuerProvider.Object,
             _timeProvider.Object,
             Options.Create(new OidcOptions()));
@@ -182,6 +188,34 @@ public class ResponseJwtBuilderTests
         await _builder.BuildAsync(ClientId, [("code", "auth-code")]);
 
         Assert.Equal(EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256, capture.ContentAlgorithm);
+    }
+
+    /// <summary>
+    /// Characterizes the unified key-management algorithm selection shared by all client-addressed JWTs: when the
+    /// client's encryption key declares its own <c>alg</c>, that algorithm is used in preference to the registered
+    /// <c>authorization_encrypted_response_alg</c>. This is the long-standing UserInfo/ID-token rule, now applied to
+    /// JARM as well; it is observable only when a client's JWK declares an <c>alg</c> different from the registered
+    /// value (a contradictory configuration).
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_WhenClientKeyDeclaresAlgorithm_PrefersKeyDeclaredAlgorithm()
+    {
+        var capture = CaptureIssue();
+        var keyWithOwnAlgorithm = new RsaJsonWebKey
+        {
+            KeyId = "client-enc",
+            Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256,
+        };
+        _clientKeys
+            .Setup(p => p.GetEncryptionKeys(It.IsAny<ClientInfo>()))
+            .Returns(new[] { (JsonWebKey)keyWithOwnAlgorithm }.ToAsyncEnumerable());
+
+        // Registered key-management algorithm differs from the key's own declared algorithm.
+        _client.AuthorizationEncryptedResponseAlgorithm = EncryptionAlgorithms.KeyManagement.RsaOaep;
+
+        await _builder.BuildAsync(ClientId, [("code", "auth-code")]);
+
+        Assert.Equal(EncryptionAlgorithms.KeyManagement.RsaOaep256, capture.KeyAlgorithm);
     }
 
     [Fact]

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/ClientJwtFormatterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/ClientJwtFormatterTests.cs
@@ -35,6 +35,10 @@ using Moq;
 using Xunit;
 using JsonWebKey = Abblix.Jwt.JsonWebKey;
 
+// These tests deliberately exercise the obsolete type-dispatch FormatAsync(token, clientInfo) overload to lock its
+// back-compat behavior (it now delegates to the policy overload via the token's header type).
+#pragma warning disable CS0618
+
 namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Formatters;
 
 /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -27,6 +27,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
@@ -35,6 +36,7 @@ using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -77,7 +79,8 @@ public class IdentityTokenServiceTests
             issuerProvider.Object,
             timeProvider,
             _jwtFormatter.Object,
-            _userClaimsProvider.Object);
+            _userClaimsProvider.Object,
+            Options.Create(new OidcOptions()));
     }
 
     /// <summary>
@@ -99,8 +102,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -129,8 +132,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -172,8 +175,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -208,8 +211,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -245,8 +248,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -309,7 +312,7 @@ public class IdentityTokenServiceTests
             .ReturnsAsync(userClaims);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -349,7 +352,7 @@ public class IdentityTokenServiceTests
             .ReturnsAsync(userClaims);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -385,8 +388,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -420,8 +423,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -454,8 +457,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -491,8 +494,8 @@ public class IdentityTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((jwt, _) => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -536,7 +539,7 @@ public class IdentityTokenServiceTests
             .ReturnsAsync(userClaims);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -572,7 +575,7 @@ public class IdentityTokenServiceTests
             .ReturnsAsync(userClaims);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -601,14 +604,14 @@ public class IdentityTokenServiceTests
             .ReturnsAsync(userClaims);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
         await _service.CreateIdentityTokenAsync(authSession, authContext, clientInfo, true, null, null);
 
         // Assert
-        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo), Times.Once);
+        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()), Times.Once);
     }
 
     // Helper methods to create test objects

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
@@ -33,6 +33,7 @@ using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Moq;
@@ -81,7 +82,8 @@ public class LogoutTokenServiceTests
             timeProvider,
             _subjectTypeConverter.Object,
             _jwtFormatter.Object,
-            _tokenIdGenerator.Object);
+            _tokenIdGenerator.Object,
+            Options.Create(new OidcOptions()));
     }
 
     #region JWT Structure Tests
@@ -468,8 +470,8 @@ public class LogoutTokenServiceTests
             .Returns(string.Empty);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((token, _) => capturedToken = token)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((token, _, _) => capturedToken = token)
             .ReturnsAsync(EncodedJwt);
 
         // Act
@@ -507,7 +509,7 @@ public class LogoutTokenServiceTests
         Assert.Same(capturedToken, result.Token);
         Assert.Equal(EncodedJwt, result.EncodedJwt);
 
-        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo), Times.Once);
+        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()), Times.Once);
     }
 
     /// <summary>
@@ -529,8 +531,8 @@ public class LogoutTokenServiceTests
             .Returns(SubjectId);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ClientInfo>()))
-            .Callback<JsonWebToken, ClientInfo>((token, client) =>
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ClientInfo>(), It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((token, client, _) =>
             {
                 formattedToken = token;
                 formattedClient = client;
@@ -544,7 +546,7 @@ public class LogoutTokenServiceTests
         Assert.NotNull(formattedToken);
         Assert.Same(clientInfo, formattedClient);
 
-        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo), Times.Once);
+        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()), Times.Once);
     }
 
     #endregion
@@ -588,8 +590,8 @@ public class LogoutTokenServiceTests
             .Returns(logoutContext.SubjectId);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo))
-            .Callback<JsonWebToken, ClientInfo>((token, _) => captureToken(token))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((token, _, _) => captureToken(token))
             .ReturnsAsync(EncodedJwt);
     }
 

--- a/Abblix.Oidc.Server/Common/Constants/JwtTypes.cs
+++ b/Abblix.Oidc.Server/Common/Constants/JwtTypes.cs
@@ -73,4 +73,10 @@ public static class JwtTypes
 	/// per the RFC 8725 §3.11 token-class-confusion guidance.
 	/// </summary>
 	public const string DPoPProof = "dpop+jwt";
+
+	/// <summary>
+	/// The "token introspection response" JWT type per RFC 9701 §5. The <c>typ</c> header equals this value so a
+	/// signed introspection response cannot be replayed as a different JWT class (RFC 8725 §3.11).
+	/// </summary>
+	public const string TokenIntrospection = "token-introspection+jwt";
 }

--- a/Abblix.Oidc.Server/Common/Constants/MediaTypes.cs
+++ b/Abblix.Oidc.Server/Common/Constants/MediaTypes.cs
@@ -38,6 +38,13 @@ public static class MediaTypes
 	public const string Jwt = "application/jwt";
 
 	/// <summary>
+	/// Represents the "application/token-introspection+jwt" media type for a JWT-formatted token introspection
+	/// response (RFC 9701 §4): the media type a client sends in <c>Accept</c> to request a JWT response, and the
+	/// <c>Content-Type</c> the server returns it with.
+	/// </summary>
+	public const string TokenIntrospectionJwt = "application/token-introspection+jwt";
+
+	/// <summary>
 	/// Represents the "text/javascript" media type for JavaScript code.
 	/// </summary>
 	public const string Javascript = "text/javascript";

--- a/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
@@ -94,6 +94,12 @@ public sealed class ConfigurationHandler(
 		AuthorizationEncryptionAlgValuesSupported = jwtAlgorithms.AuthorizationEncryptionAlgValuesSupported,
 		AuthorizationEncryptionEncValuesSupported = jwtAlgorithms.AuthorizationEncryptionEncValuesSupported,
 
+		// RFC 9701 JWT introspection responses are always available — a client opts in per request via Accept and
+		// its registered introspection_signed_response_alg — so the supported algorithms are advertised unconditionally.
+		IntrospectionSigningAlgValuesSupported = jwtAlgorithms.IntrospectionSigningAlgValuesSupported,
+		IntrospectionEncryptionAlgValuesSupported = jwtAlgorithms.IntrospectionEncryptionAlgValuesSupported,
+		IntrospectionEncryptionEncValuesSupported = jwtAlgorithms.IntrospectionEncryptionEncValuesSupported,
+
 		RequirePushedAuthorizationRequests = options.Value.RequirePushedAuthorizationRequests,
 		RequireSignedRequestObject = options.Value.RequireSignedRequestObject,
 

--- a/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
@@ -173,6 +173,23 @@ public record ConfigurationResponse
 	public IEnumerable<string>? AuthorizationEncryptionEncValuesSupported { init; get; }
 
 	/// <summary>
+	/// Specifies the JWS algorithms supported for signing JWT introspection responses (RFC 9701 §7).
+	/// </summary>
+	public IEnumerable<string>? IntrospectionSigningAlgValuesSupported { init; get; }
+
+	/// <summary>
+	/// Specifies the JWE key-management algorithms (the <c>alg</c> values) supported for encrypting JWT
+	/// introspection responses (RFC 9701 §7).
+	/// </summary>
+	public IEnumerable<string>? IntrospectionEncryptionAlgValuesSupported { init; get; }
+
+	/// <summary>
+	/// Specifies the JWE content-encryption algorithms (the <c>enc</c> values) supported for encrypting JWT
+	/// introspection responses (RFC 9701 §7).
+	/// </summary>
+	public IEnumerable<string>? IntrospectionEncryptionEncValuesSupported { init; get; }
+
+	/// <summary>
 	/// Indicates whether the OpenID Provider requires clients to use Pushed Authorization Requests (PAR) only.
 	/// </summary>
 	public bool? RequirePushedAuthorizationRequests { get; set; }

--- a/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/IJwtAlgorithmsProvider.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/IJwtAlgorithmsProvider.cs
@@ -79,4 +79,24 @@ public interface IJwtAlgorithmsProvider
 	/// (JARM §4).
 	/// </summary>
 	IEnumerable<string> AuthorizationEncryptionEncValuesSupported { get; }
+
+	/// <summary>
+	/// Lists the JWS algorithms the authorization server uses to sign JWT introspection responses,
+	/// advertised via <c>introspection_signing_alg_values_supported</c> (RFC 9701 §7).
+	/// </summary>
+	IEnumerable<string> IntrospectionSigningAlgValuesSupported { get; }
+
+	/// <summary>
+	/// Lists the JWE key-management algorithms (the <c>alg</c> values) the authorization server can use to encrypt
+	/// JWT introspection responses, advertised via <c>introspection_encryption_alg_values_supported</c>
+	/// (RFC 9701 §7).
+	/// </summary>
+	IEnumerable<string> IntrospectionEncryptionAlgValuesSupported { get; }
+
+	/// <summary>
+	/// Lists the JWE content-encryption algorithms (the <c>enc</c> values) the authorization server can use to
+	/// encrypt JWT introspection responses, advertised via <c>introspection_encryption_enc_values_supported</c>
+	/// (RFC 9701 §7).
+	/// </summary>
+	IEnumerable<string> IntrospectionEncryptionEncValuesSupported { get; }
 }

--- a/Abblix.Oidc.Server/Endpoints/Configuration/JwtAlgorithmsProvider.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/JwtAlgorithmsProvider.cs
@@ -57,4 +57,13 @@ public sealed class JwtAlgorithmsProvider(
 
 	/// <inheritdoc />
 	public IEnumerable<string> AuthorizationEncryptionEncValuesSupported => jwtValidator.EncryptionMethodsSupported;
+
+	/// <inheritdoc />
+	public IEnumerable<string> IntrospectionSigningAlgValuesSupported => jwtCreator.SignedResponseAlgorithmsSupported;
+
+	/// <inheritdoc />
+	public IEnumerable<string> IntrospectionEncryptionAlgValuesSupported => jwtValidator.EncryptionAlgorithmsSupported;
+
+	/// <inheritdoc />
+	public IEnumerable<string> IntrospectionEncryptionEncValuesSupported => jwtValidator.EncryptionMethodsSupported;
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ClientRegistrationSuccessResponse.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ClientRegistrationSuccessResponse.cs
@@ -146,6 +146,24 @@ public record ClientRegistrationSuccessResponse(
     public string? UserInfoEncryptedResponseEnc { get; init; }
 
     /// <summary>
+    /// JWS algorithm for signing introspection responses. Optional. Per RFC 9701 §6.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.IntrospectionSignedResponseAlg)]
+    public string? IntrospectionSignedResponseAlg { get; init; }
+
+    /// <summary>
+    /// JWE <c>alg</c> algorithm for encrypting introspection responses. Optional. Per RFC 9701 §6.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.IntrospectionEncryptedResponseAlg)]
+    public string? IntrospectionEncryptedResponseAlg { get; init; }
+
+    /// <summary>
+    /// JWE <c>enc</c> algorithm for encrypting introspection responses. Optional. Per RFC 9701 §6.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.IntrospectionEncryptedResponseEnc)]
+    public string? IntrospectionEncryptedResponseEnc { get; init; }
+
+    /// <summary>
     /// Array of contact email addresses for people responsible for this client.
     /// Optional client metadata. Per RFC 7591 §2.
     /// </summary>
@@ -238,6 +256,9 @@ public record ClientRegistrationSuccessResponse(
         public const string JwksUri = "jwks_uri";
         public const string UserInfoEncryptedResponseAlg = "userinfo_encrypted_response_alg";
         public const string UserInfoEncryptedResponseEnc = "userinfo_encrypted_response_enc";
+        public const string IntrospectionSignedResponseAlg = "introspection_signed_response_alg";
+        public const string IntrospectionEncryptedResponseAlg = "introspection_encrypted_response_alg";
+        public const string IntrospectionEncryptedResponseEnc = "introspection_encrypted_response_enc";
         public const string Contacts = "contacts";
         public const string RequestUris = "request_uris";
         public const string InitiateLoginUri = "initiate_login_uri";

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
@@ -87,6 +88,17 @@ public class RegisterClientRequestProcessor(
             JwksUri = clientInfo.JwksUri,
             UserInfoEncryptedResponseAlg = clientInfo.UserInfoEncryptedResponseAlgorithm,
             UserInfoEncryptedResponseEnc = clientInfo.UserInfoEncryptedResponseEncryption,
+
+            // RFC 9701: echo the registered introspection response algorithms. The signed algorithm is omitted
+            // when it is the implicit "none" default so the response only advertises an explicit opt-in.
+            IntrospectionSignedResponseAlg = clientInfo.IntrospectionSignedResponseAlgorithm switch
+            {
+                SigningAlgorithms.None => null,
+                _ => clientInfo.IntrospectionSignedResponseAlgorithm,
+            },
+            IntrospectionEncryptedResponseAlg = clientInfo.IntrospectionEncryptedResponseAlgorithm,
+            IntrospectionEncryptedResponseEnc = clientInfo.IntrospectionEncryptedResponseEncryption,
+
             Contacts = clientInfo.Contacts,
             RequestUris = clientInfo.RequestUris,
             InitiateLoginUri = clientInfo.InitiateLoginUri,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -152,6 +152,8 @@ public class RegisterClientRequestProcessor(
             IdentityTokenEncryptedResponseEncryption = model.IdTokenEncryptedResponseEnc,
             UserInfoEncryptedResponseAlgorithm = model.UserInfoEncryptedResponseAlg,
             UserInfoEncryptedResponseEncryption = model.UserInfoEncryptedResponseEnc,
+            IntrospectionEncryptedResponseAlgorithm = model.IntrospectionEncryptedResponseAlg,
+            IntrospectionEncryptedResponseEncryption = model.IntrospectionEncryptedResponseEnc,
             AuthorizationEncryptedResponseAlgorithm = model.AuthorizationEncryptedResponseAlg,
             AuthorizationEncryptedResponseEncryption = model.AuthorizationEncryptedResponseEnc,
             RequestObjectSigningAlgorithm = model.RequestObjectSigningAlg,
@@ -198,6 +200,11 @@ public class RegisterClientRequestProcessor(
         if (model.UserInfoSignedResponseAlg.HasValue())
         {
             clientInfo.UserInfoSignedResponseAlgorithm = model.UserInfoSignedResponseAlg;
+        }
+
+        if (model.IntrospectionSignedResponseAlg.HasValue())
+        {
+            clientInfo.IntrospectionSignedResponseAlgorithm = model.IntrospectionSignedResponseAlg;
         }
 
         if (model.IdTokenSignedResponseAlg.HasValue())

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidator.cs
@@ -47,6 +47,8 @@ public class EncryptedResponseAlgorithmsValidator(IJsonWebTokenValidator jwtVali
             ?? ValidateEnc(request.IdTokenEncryptedResponseEnc, Parameters.IdTokenEncryptedResponseEnc)
             ?? ValidateAlg(request.UserInfoEncryptedResponseAlg, Parameters.UserInfoEncryptedResponseAlg)
             ?? ValidateEnc(request.UserInfoEncryptedResponseEnc, Parameters.UserInfoEncryptedResponseEnc)
+            ?? ValidateAlg(request.IntrospectionEncryptedResponseAlg, Parameters.IntrospectionEncryptedResponseAlg)
+            ?? ValidateEnc(request.IntrospectionEncryptedResponseEnc, Parameters.IntrospectionEncryptedResponseEnc)
             ?? ValidateAlg(request.RequestObjectEncryptionAlg, Parameters.RequestObjectEncryptionAlg)
             ?? ValidateEnc(request.RequestObjectEncryptionEnc, Parameters.RequestObjectEncryptionEnc)
             ?? ValidateAlg(request.AuthorizationEncryptedResponseAlg, Parameters.AuthorizationEncryptedResponseAlg)

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidator.cs
@@ -50,6 +50,7 @@ public class SignedResponseAlgorithmsValidator(IJsonWebTokenCreator jwtCreator) 
         var request = context.Request;
         return Validate(request.IdTokenSignedResponseAlg, Parameters.IdTokenSignedResponseAlg) ??
                Validate(request.UserInfoSignedResponseAlg, Parameters.UserInfoSignedResponseAlg) ??
+               Validate(request.IntrospectionSignedResponseAlg, Parameters.IntrospectionSignedResponseAlg) ??
                ValidateAuthorizationSignedResponseAlg(request.AuthorizationSignedResponseAlg);
     }
 

--- a/Abblix.Oidc.Server/Endpoints/Introspection/Interfaces/IntrospectionSuccess.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/Interfaces/IntrospectionSuccess.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Features.ClientInformation;
 
 
 namespace Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
@@ -31,7 +32,7 @@ namespace Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
 /// JSON via additional top-level members; cross-domain extensions should be listed in the
 /// IANA "OAuth Token Introspection Response" registry (RFC 7662 §3.1).
 /// </summary>
-public record IntrospectionSuccess(bool Active, JsonObject? Claims)
+public record IntrospectionSuccess(bool Active, JsonObject? Claims, ClientInfo ClientInfo)
 {
     /// <summary>
     /// RFC 7662 <c>active</c> field: <c>true</c> only if the token is currently valid and the
@@ -46,4 +47,10 @@ public record IntrospectionSuccess(bool Active, JsonObject? Claims)
     /// guidance not to leak information about inactive tokens.
     /// </summary>
     public JsonObject? Claims { get; } = Claims;
+
+    /// <summary>
+    /// The authenticated client that requested the introspection. Not serialized into the response body; it selects
+    /// the response format (plain JSON vs. a signed/encrypted JWT per RFC 9701).
+    /// </summary>
+    public ClientInfo ClientInfo { get; } = ClientInfo;
 }

--- a/Abblix.Oidc.Server/Endpoints/Introspection/Interfaces/ValidIntrospectionRequest.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/Interfaces/ValidIntrospectionRequest.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 
 
@@ -40,10 +41,13 @@ public record ValidIntrospectionRequest
 	/// passed validation.
 	/// </summary>
 	/// <param name="model">The introspection request model.</param>
+	/// <param name="clientInfo">The authenticated client making the introspection request; it determines the
+	/// response format (plain JSON vs. a signed/encrypted JWT per RFC 9701).</param>
 	/// <param name="token">The parsed JWT to be reported as <c>active=true</c>.</param>
-	public ValidIntrospectionRequest(IntrospectionRequest model, JsonWebToken token)
+	public ValidIntrospectionRequest(IntrospectionRequest model, ClientInfo clientInfo, JsonWebToken token)
 	{
 		Model = model;
+		ClientInfo = clientInfo;
 		Token = token;
 	}
 
@@ -51,9 +55,11 @@ public record ValidIntrospectionRequest
 	/// Initializes a new instance of the <see cref="ValidIntrospectionRequest"/> class when the token is not provided.
 	/// </summary>
 	/// <param name="model">The introspection request model.</param>
-	private ValidIntrospectionRequest(IntrospectionRequest model)
+	/// <param name="clientInfo">The authenticated client making the introspection request.</param>
+	private ValidIntrospectionRequest(IntrospectionRequest model, ClientInfo clientInfo)
 	{
 		Model = model;
+		ClientInfo = clientInfo;
 		Token = null;
 	}
 
@@ -61,11 +67,12 @@ public record ValidIntrospectionRequest
 	/// Creates a valid introspection request for an invalid token.
 	/// </summary>
 	/// <param name="model">The introspection request model.</param>
+	/// <param name="clientInfo">The authenticated client making the introspection request.</param>
 	/// <returns>A valid introspection request with the "active" field set to "false."</returns>
 	/// <remarks>
 	/// See https://www.rfc-editor.org/rfc/rfc7662#section-5.2
 	/// </remarks>
-	public static ValidIntrospectionRequest InvalidToken(IntrospectionRequest model)
+	public static ValidIntrospectionRequest InvalidToken(IntrospectionRequest model, ClientInfo clientInfo)
 	{
 		// Note that to avoid disclosing too much of the authorization server's state to a third party,
 		// the authorization server SHOULD NOT include any additional information about an inactive token,
@@ -73,13 +80,18 @@ public record ValidIntrospectionRequest
 
 		// That is why we do not return the token here even if it is valid, but for example,
 		// it was issued for another client.
-		return new(model);
+		return new(model, clientInfo);
 	}
 
 	/// <summary>
 	/// The introspection request model.
 	/// </summary>
 	public IntrospectionRequest Model { get; }
+
+	/// <summary>
+	/// The authenticated client making the introspection request, used to select the response format (RFC 9701).
+	/// </summary>
+	public ClientInfo ClientInfo { get; }
 
 	/// <summary>
 	/// The JSON Web Token to introspect.

--- a/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
@@ -58,13 +58,13 @@ public class IntrospectionRequestProcessor : IIntrospectionRequestProcessor
 
 			// Note that to avoid disclosing too much of the authorization server's state to a third party, the authorization server
 			// SHOULD NOT include any additional information about an inactive token, including why the token is inactive.
-			return new IntrospectionSuccess(false, null);
+			return new IntrospectionSuccess(false, null, request.ClientInfo);
 		}
 
 		// The authorization server MAY respond differently to different protected resources making the same request.
 		// For instance, an authorization server MAY limit which scopes from a given token are returned for each protected resource
 		// to prevent a protected resource from learning more about the larger network than is necessary for its operation.
 
-		return new IntrospectionSuccess(true, request.Token.Payload.Json);
+		return new IntrospectionSuccess(true, request.Token.Payload.Json, request.ClientInfo);
 	}
 }

--- a/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestValidator.cs
@@ -76,16 +76,16 @@ public partial class IntrospectionRequestValidator(
 				if (token is { Payload.ClientId: {} clientId } && clientId != clientInfo.ClientId)
 				{
 					// The token was issued to another client
-					return ValidIntrospectionRequest.InvalidToken(introspectionRequest);
+					return ValidIntrospectionRequest.InvalidToken(introspectionRequest, clientInfo);
 				}
 
-				return new ValidIntrospectionRequest(introspectionRequest, token);
+				return new ValidIntrospectionRequest(introspectionRequest, clientInfo, token);
 
 			},
 			error =>
 			{
 				LogInvalidJwt(error);
-				return ValidIntrospectionRequest.InvalidToken(introspectionRequest);
+				return ValidIntrospectionRequest.InvalidToken(introspectionRequest, clientInfo);
 			});
 	}
 }

--- a/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -382,6 +382,25 @@ public record ClientInfo(string ClientId)
     public string? UserInfoEncryptedResponseEncryption { get; set; }
 
     /// <summary>
+    /// RFC 9701 (<c>introspection_signed_response_alg</c>): the JWS algorithm used to sign introspection responses
+    /// returned to this client as a JWT. <see cref="SigningAlgorithms.None"/> (the default) means the client receives
+    /// a plain JSON introspection response; any other value opts the client into a signed JWT response.
+    /// </summary>
+    public string IntrospectionSignedResponseAlgorithm { get; set; } = SigningAlgorithms.None;
+
+    /// <summary>
+    /// RFC 9701 (<c>introspection_encrypted_response_alg</c>): the key-management algorithm used to encrypt
+    /// introspection-response JWTs returned to the client.
+    /// </summary>
+    public string? IntrospectionEncryptedResponseAlgorithm { get; set; }
+
+    /// <summary>
+    /// RFC 9701 (<c>introspection_encrypted_response_enc</c>): the content-encryption algorithm used to encrypt
+    /// introspection-response JWTs returned to the client.
+    /// </summary>
+    public string? IntrospectionEncryptedResponseEncryption { get; set; }
+
+    /// <summary>
     /// JARM (<c>authorization_signed_response_alg</c>): the JWS algorithm used to sign authorization responses
     /// packed into a JWT for this client. Defaults to <see cref="SigningAlgorithms.RS256"/> per JARM §3; the
     /// algorithm <c>none</c> is not permitted. Only consulted when the client requests a JWT response mode.

--- a/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
+++ b/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
@@ -21,11 +21,10 @@
 // info@abblix.com
 
 using Abblix.Jwt;
-using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
-using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
@@ -34,21 +33,17 @@ namespace Abblix.Oidc.Server.Features.ResponseObject;
 /// <summary>
 /// Default <see cref="IResponseJwtBuilder"/>: resolves the client, builds the JARM
 /// (<see href="https://openid.net/specs/oauth-v2-jarm-final.html">JWT Secured Authorization Response Mode</see>)
-/// response JWT, signs it with the authorization server's key and — when the client registered an encryption
-/// algorithm — additionally encrypts it to the client's public key (a Nested JWT per JARM §2.2).
+/// response JWT and hands it to <see cref="IClientJwtFormatter"/> for signing and — when the client registered an
+/// encryption algorithm — encryption to the client's public key (a Nested JWT per JARM §2.2).
 /// </summary>
 /// <param name="clientInfoProvider">Resolves the client the response is intended for.</param>
-/// <param name="jwtCreator">Issues the signed/encrypted JWT.</param>
-/// <param name="clientKeysProvider">Resolves the client's public encryption keys.</param>
-/// <param name="serviceKeysProvider">Resolves the authorization server's signing keys.</param>
+/// <param name="clientJwtFormatter">Signs and optionally encrypts the assembled JARM response JWT.</param>
 /// <param name="issuerProvider">Supplies the issuer identifier placed in the <c>iss</c> claim.</param>
 /// <param name="timeProvider">Supplies the current time for the <c>iat</c>/<c>exp</c> claims.</param>
 /// <param name="options">Supplies the JARM response-JWT lifetime (<c>exp</c> window).</param>
 public class ResponseJwtBuilder(
     IClientInfoProvider clientInfoProvider,
-    IJsonWebTokenCreator jwtCreator,
-    IClientKeysProvider clientKeysProvider,
-    IAuthServiceKeysProvider serviceKeysProvider,
+    IClientJwtFormatter clientJwtFormatter,
     IIssuerProvider issuerProvider,
     TimeProvider timeProvider,
     IOptions<OidcOptions> options) : IResponseJwtBuilder
@@ -79,26 +74,8 @@ public class ResponseJwtBuilder(
                 token.Payload[name] = value;
         }
 
-        var signingCredentials = await serviceKeysProvider.GetSigningKeys(true)
-            .FirstByAlgorithmAsync(token.Header.Algorithm);
-
-        // JARM §2.2 / §3: encrypt only when the client registered authorization_encrypted_response_alg.
-        // Otherwise the response is signed only.
-        if (clientInfo.AuthorizationEncryptedResponseAlgorithm is not { } keyEncryptionAlgorithm)
-            return await jwtCreator.IssueAsync(token, signingCredentials);
-
-        var encryptingCredentials = await clientKeysProvider.GetEncryptionKeys(clientInfo)
-            .FirstOrDefaultAsync();
-
-        // JARM §3: when authorization_encrypted_response_enc is omitted the default is A128CBC-HS256.
-        var contentEncryptionAlgorithm = clientInfo.AuthorizationEncryptedResponseEncryption
-            ?? EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256;
-
-        return await jwtCreator.IssueAsync(
-            token,
-            signingCredentials,
-            encryptingCredentials,
-            keyEncryptionAlgorithm,
-            contentEncryptionAlgorithm);
+        // JARM §2.2 / §3: encrypt only when the client registered authorization_encrypted_response_alg, defaulting
+        // the content-encryption to A128CBC-HS256 when authorization_encrypted_response_enc is omitted.
+        return await clientJwtFormatter.FormatAsync(token, clientInfo, ClientJwtEncryption.ForJarm(clientInfo));
     }
 }

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtEncryption.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtEncryption.cs
@@ -1,0 +1,80 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.ClientInformation;
+
+namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
+
+/// <summary>
+/// The encryption policy a caller hands to <see cref="ClientJwtFormatter"/> when formatting a client-addressed JWT.
+/// It makes explicit which registered client metadata governs encryption, so the formatter no longer has to infer it
+/// from the token type. Each client-JWT class (UserInfo, ID token, JARM authorization response, introspection)
+/// supplies its own policy via the static factories below.
+/// </summary>
+/// <param name="KeyManagementAlgorithm">The client's registered <c>*_encrypted_response_alg</c>, or <c>null</c> when
+/// the client did not register one.</param>
+/// <param name="ContentEncryptionAlgorithm">The client's registered <c>*_encrypted_response_enc</c>, or <c>null</c>
+/// to fall back to <see cref="DefaultContentEncryptionAlgorithm"/>.</param>
+/// <param name="DefaultContentEncryptionAlgorithm">The content-encryption algorithm to use when the client did not
+/// register one.</param>
+/// <param name="RequireRegisteredAlgorithm">When <c>true</c> the JWT is encrypted only if the client registered a
+/// key-management algorithm (and the client's encryption keys are not even resolved otherwise) — the JARM §2.2 / §3
+/// opt-in rule. When <c>false</c> the JWT is encrypted whenever the client published encryption keys.</param>
+public sealed record ClientJwtEncryption(
+	string? KeyManagementAlgorithm,
+	string? ContentEncryptionAlgorithm,
+	string DefaultContentEncryptionAlgorithm,
+	bool RequireRegisteredAlgorithm)
+{
+	/// <summary>
+	/// Policy for a signed/encrypted UserInfo response (OIDC Core §5.3.2): encrypts whenever the client published
+	/// encryption keys, using its <c>userinfo_encrypted_response_*</c> metadata.
+	/// </summary>
+	public static ClientJwtEncryption ForUserInfo(ClientInfo clientInfo, OidcOptions options) => new(
+		clientInfo.UserInfoEncryptedResponseAlgorithm,
+		clientInfo.UserInfoEncryptedResponseEncryption,
+		options.DefaultContentEncryptionAlgorithm,
+		RequireRegisteredAlgorithm: false);
+
+	/// <summary>
+	/// Policy for an ID token or logout token: encrypts whenever the client published encryption keys, using its
+	/// <c>id_token_encrypted_response_*</c> metadata.
+	/// </summary>
+	public static ClientJwtEncryption ForIdentityToken(ClientInfo clientInfo, OidcOptions options) => new(
+		clientInfo.IdentityTokenEncryptedResponseAlgorithm,
+		clientInfo.IdentityTokenEncryptedResponseEncryption,
+		options.DefaultContentEncryptionAlgorithm,
+		RequireRegisteredAlgorithm: false);
+
+	/// <summary>
+	/// Policy for a JARM authorization response JWT: encrypts only when the client registered
+	/// <c>authorization_encrypted_response_alg</c> (JARM §2.2 / §3 opt-in), defaulting the content-encryption to
+	/// <c>A128CBC-HS256</c> when <c>authorization_encrypted_response_enc</c> is omitted (JARM §3).
+	/// </summary>
+	public static ClientJwtEncryption ForJarm(ClientInfo clientInfo) => new(
+		clientInfo.AuthorizationEncryptedResponseAlgorithm,
+		clientInfo.AuthorizationEncryptedResponseEncryption,
+		EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256,
+		RequireRegisteredAlgorithm: true);
+}

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtEncryption.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtEncryption.cs
@@ -68,6 +68,16 @@ public sealed record ClientJwtEncryption(
 		RequireRegisteredAlgorithm: false);
 
 	/// <summary>
+	/// Policy for a signed/encrypted token introspection response (RFC 9701): encrypts whenever the client published
+	/// encryption keys, using its <c>introspection_encrypted_response_*</c> metadata.
+	/// </summary>
+	public static ClientJwtEncryption ForIntrospection(ClientInfo clientInfo, OidcOptions options) => new(
+		clientInfo.IntrospectionEncryptedResponseAlgorithm,
+		clientInfo.IntrospectionEncryptedResponseEncryption,
+		options.DefaultContentEncryptionAlgorithm,
+		RequireRegisteredAlgorithm: false);
+
+	/// <summary>
 	/// Policy for a JARM authorization response JWT: encrypts only when the client registered
 	/// <c>authorization_encrypted_response_alg</c> (JARM §2.2 / §3 opt-in), defaulting the content-encryption to
 	/// <c>A128CBC-HS256</c> when <c>authorization_encrypted_response_enc</c> is omitted (JARM §3).

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtFormatter.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtFormatter.cs
@@ -45,46 +45,56 @@ public class ClientJwtFormatter(
     IOptions<OidcOptions> options) : IClientJwtFormatter
 {
     /// <summary>
-    /// Asynchronously formats a JWT for a specific client, applying the necessary cryptographic operations
-    /// based on the client's configuration and the authentication service's capabilities.
+    /// Asynchronously formats a JWT for a specific client, inferring the encryption metadata from the token's
+    /// header <c>typ</c> (id_token/logout_token vs. UserInfo).
     /// </summary>
     /// <param name="token">The JSON Web Token (JWT) to be formatted for the client.</param>
     /// <param name="clientInfo">Information about the client to which the JWT is issued, including any requirements for encryption.</param>
     /// <returns>A task that returns a JWT string formatted and ready for use by the client.</returns>
-    /// <remarks>
-    /// This method ensures the JWT is signed with the appropriate key from the authentication service. If the client's configuration supports encryption,
-    /// the method also encrypts the JWT using the client's public key and the client's preferred encryption algorithms.
-    /// The result is a JWT that conforms to the security requirements of both the client and the authentication service.
-    /// </remarks>
-    public async Task<string> FormatAsync(JsonWebToken token, ClientInfo clientInfo)
+    [Obsolete("Use FormatAsync(JsonWebToken, ClientInfo, ClientJwtEncryption) with an explicit encryption policy. " +
+              "This overload infers the policy from token.Header.Type and is kept for backward compatibility.")]
+    public Task<string> FormatAsync(JsonWebToken token, ClientInfo clientInfo)
+    {
+        // The legacy contract picks the client's registered encryption metadata by JWT class: id_token and
+        // logout_token use id_token_encrypted_response_*, everything else (UserInfo) uses userinfo_encrypted_response_*.
+        var encryption = token.Header.Type switch
+        {
+            JwtTypes.IdToken or JwtTypes.LogoutToken => ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value),
+            _ => ClientJwtEncryption.ForUserInfo(clientInfo, options.Value),
+        };
+
+        return FormatAsync(token, clientInfo, encryption);
+    }
+
+    /// <summary>
+    /// Asynchronously formats a JWT for a specific client, signing it with the authentication service's key chosen by
+    /// the token's header algorithm and — per the supplied <paramref name="encryption"/> policy — optionally
+    /// encrypting it to the client's registered public key.
+    /// </summary>
+    /// <param name="token">The JSON Web Token (JWT) to be formatted for the client.</param>
+    /// <param name="clientInfo">Information about the client to which the JWT is issued.</param>
+    /// <param name="encryption">The encryption policy: which registered client metadata governs encryption, the
+    /// content-encryption default, and whether encryption requires a registered key-management algorithm.</param>
+    /// <returns>A task that returns a JWT string formatted and ready for use by the client.</returns>
+    public async Task<string> FormatAsync(JsonWebToken token, ClientInfo clientInfo, ClientJwtEncryption encryption)
     {
         var signingCredentials = await serviceKeysProvider.GetSigningKeys(true)
             .FirstByAlgorithmAsync(token.Header.Algorithm);
 
+        // JARM §2.2 / §3 opt-in: when the policy requires a registered key-management algorithm and the client has
+        // not registered one, the response is signed only — the client's encryption keys are not even resolved.
+        if (encryption is { RequireRegisteredAlgorithm: true, KeyManagementAlgorithm: null })
+            return await jwtCreator.IssueAsync(token, signingCredentials);
+
         var encryptingCredentials = await clientKeysProvider.GetEncryptionKeys(clientInfo)
             .FirstOrDefaultAsync();
 
-        // This formatter is shared across client-addressed JWT classes, which carry different
-        // registered encryption metadata. A UserInfo response (no id_token/logout type) must use the
-        // client's userinfo_encrypted_response_* values; id_token and logout_token use the
-        // id_token_encrypted_response_* values.
-        var (registeredKeyAlgorithm, registeredContentEncryption) = token.Header.Type switch
-        {
-            JwtTypes.IdToken or JwtTypes.LogoutToken => (
-                clientInfo.IdentityTokenEncryptedResponseAlgorithm,
-                clientInfo.IdentityTokenEncryptedResponseEncryption),
-
-            _ => (
-                clientInfo.UserInfoEncryptedResponseAlgorithm,
-                clientInfo.UserInfoEncryptedResponseEncryption),
-        };
-
         var keyEncryptionAlgorithm = encryptingCredentials?.Algorithm
-            ?? registeredKeyAlgorithm
+            ?? encryption.KeyManagementAlgorithm
             ?? EncryptionAlgorithms.KeyManagement.RsaOaep256;
 
-        var contentEncryptionAlgorithm = registeredContentEncryption
-            ?? options.Value.DefaultContentEncryptionAlgorithm;
+        var contentEncryptionAlgorithm = encryption.ContentEncryptionAlgorithm
+            ?? encryption.DefaultContentEncryptionAlgorithm;
 
         return await jwtCreator.IssueAsync(
             token,

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/IClientJwtFormatter.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/IClientJwtFormatter.cs
@@ -34,10 +34,24 @@ namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
 public interface IClientJwtFormatter
 {
     /// <summary>
-    /// Formats a JWT for a client using the provided token and client information.
+    /// Formats a JWT for a client, inferring the encryption metadata from the token's header <c>typ</c>.
     /// </summary>
     /// <param name="token">The JWT token to format.</param>
     /// <param name="clientInfo">The client information.</param>
     /// <returns>The formatted JWT string.</returns>
+    [Obsolete("Use FormatAsync(JsonWebToken, ClientInfo, ClientJwtEncryption) with an explicit " +
+              "encryption policy. This overload infers the policy from token.Header.Type and is kept for backward " +
+              "compatibility.")]
     Task<string> FormatAsync(JsonWebToken token, ClientInfo clientInfo);
+
+    /// <summary>
+    /// Formats a JWT for a client, signing it with the authentication service's key chosen by the token's header
+    /// algorithm and — per the supplied <paramref name="encryption"/> policy — optionally encrypting it to the
+    /// client's registered public key.
+    /// </summary>
+    /// <param name="token">The JWT token to format.</param>
+    /// <param name="clientInfo">The client information.</param>
+    /// <param name="encryption">The encryption policy governing whether and how the JWT is encrypted.</param>
+    /// <returns>The formatted JWT string.</returns>
+    Task<string> FormatAsync(JsonWebToken token, ClientInfo clientInfo, ClientJwtEncryption encryption);
 }

--- a/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -24,6 +24,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
@@ -32,6 +33,7 @@ using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Abblix.Utils;
+using Microsoft.Extensions.Options;
 
 using System.Buffers.Text;
 
@@ -50,11 +52,14 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// the security requirements for transmission.</param>
 /// <param name="userClaimsProvider">Retrieves user-specific claims to be embedded in the identity token,
 /// based on the authentication session and client's requested scopes and claims.</param>
+/// <param name="options">Supplies the default content-encryption algorithm used when the client registered a
+/// key-management algorithm but no <c>id_token_encrypted_response_enc</c>.</param>
 internal class IdentityTokenService(
 	IIssuerProvider issuerProvider,
 	TimeProvider clock,
 	IClientJwtFormatter jwtFormatter,
-	IUserClaimsProvider userClaimsProvider) : IIdentityTokenService
+	IUserClaimsProvider userClaimsProvider,
+	IOptions<OidcOptions> options) : IIdentityTokenService
 {
 	/// <summary>
 	/// Generates an identity token encapsulating the user's authenticated session, optionally embedding claims based on
@@ -143,7 +148,10 @@ internal class IdentityTokenService(
 
 		AppendAdditionalClaims(identityToken, authorizationCode, accessToken);
 
-		return new EncodedJsonWebToken(identityToken, await jwtFormatter.FormatAsync(identityToken, clientInfo));
+		return new EncodedJsonWebToken(
+			identityToken,
+			await jwtFormatter.FormatAsync(
+				identityToken, clientInfo, ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
 	}
 
 	private static void AppendAdditionalClaims(

--- a/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
@@ -22,6 +22,7 @@
 
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.LogoutNotification;
@@ -30,6 +31,7 @@ using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Abblix.Utils;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.Tokens;
 
@@ -43,12 +45,15 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// <param name="jwtFormatter">Formatter for encoding the generated logout token into a compact serialized format.
 /// </param>
 /// <param name="tokenIdGenerator">Generator for creating unique JWT identifiers.</param>
+/// <param name="options">Supplies the default content-encryption algorithm used when the client registered a
+/// key-management algorithm but no <c>id_token_encrypted_response_enc</c>.</param>
 public partial class LogoutTokenService(
     ILogger<LogoutTokenService> logger,
     TimeProvider clock,
     ISubjectTypeConverter subjectTypeConverter,
     IClientJwtFormatter jwtFormatter,
-    ITokenIdGenerator tokenIdGenerator) : ILogoutTokenService
+    ITokenIdGenerator tokenIdGenerator,
+    IOptions<OidcOptions> options) : ILogoutTokenService
 {
     /// <summary>
     /// Asynchronously creates a logout token based on the provided client information and logout event context.
@@ -110,6 +115,9 @@ public partial class LogoutTokenService(
 
         LogTokenPrepared(logoutToken);
 
-        return new EncodedJsonWebToken(logoutToken, await jwtFormatter.FormatAsync(logoutToken, clientInfo));
+        return new EncodedJsonWebToken(
+            logoutToken,
+            await jwtFormatter.FormatAsync(
+                logoutToken, clientInfo, ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
     }
 }

--- a/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -211,6 +211,27 @@ public record ClientRegistrationRequest
     public string? UserInfoEncryptedResponseEnc { get; init; }
 
     /// <summary>
+    /// The <c>introspection_signed_response_alg</c> (RFC 9701): the JWS algorithm the OP must use when signing
+    /// introspection responses returned to this client. When omitted, introspection is returned as plain JSON.
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionSignedResponseAlg)]
+    public string? IntrospectionSignedResponseAlg { get; init; }
+
+    /// <summary>
+    /// The <c>introspection_encrypted_response_alg</c> (RFC 9701): the JWE key-management algorithm the OP must use
+    /// when encrypting introspection responses for this client.
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionEncryptedResponseAlg)]
+    public string? IntrospectionEncryptedResponseAlg { get; init; }
+
+    /// <summary>
+    /// The <c>introspection_encrypted_response_enc</c> (RFC 9701): the JWE content-encryption algorithm paired with
+    /// <see cref="IntrospectionEncryptedResponseAlg"/> for introspection responses to this client.
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionEncryptedResponseEnc)]
+    public string? IntrospectionEncryptedResponseEnc { get; init; }
+
+    /// <summary>
     /// The <c>authorization_signed_response_alg</c> (JARM §3): the JWS algorithm the OP must use to sign
     /// authorization responses packed into a JWT for this client. Defaults to <c>RS256</c>; <c>none</c> is
     /// not permitted.
@@ -570,6 +591,18 @@ public record ClientRegistrationRequest
         /// <summary>The <c>userinfo_encrypted_response_enc</c> registration parameter naming the JWE
         /// content-encryption algorithm for UserInfo responses.</summary>
         public const string UserInfoEncryptedResponseEnc = "userinfo_encrypted_response_enc";
+
+        /// <summary>The <c>introspection_signed_response_alg</c> registration parameter (RFC 9701) naming the JWS
+        /// algorithm the OP must use when signing introspection responses for this client.</summary>
+        public const string IntrospectionSignedResponseAlg = "introspection_signed_response_alg";
+
+        /// <summary>The <c>introspection_encrypted_response_alg</c> registration parameter (RFC 9701) naming the JWE
+        /// key-management algorithm used when encrypting introspection responses.</summary>
+        public const string IntrospectionEncryptedResponseAlg = "introspection_encrypted_response_alg";
+
+        /// <summary>The <c>introspection_encrypted_response_enc</c> registration parameter (RFC 9701) naming the JWE
+        /// content-encryption algorithm for introspection responses.</summary>
+        public const string IntrospectionEncryptedResponseEnc = "introspection_encrypted_response_enc";
 
         /// <summary>The <c>authorization_signed_response_alg</c> registration parameter naming the JWS algorithm
         /// the OP must use to sign JARM authorization responses for this client.</summary>

--- a/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
+++ b/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
@@ -184,6 +184,18 @@ public record ConfigurationResponse
         /// the provider may use when signing UserInfo responses.</summary>
         public const string UserInfoSigningAlgValuesSupported = "userinfo_signing_alg_values_supported";
 
+        /// <summary>The <c>introspection_signing_alg_values_supported</c> metadata field listing JWS algorithms
+        /// the provider uses to sign JWT introspection responses (RFC 9701 §7).</summary>
+        public const string IntrospectionSigningAlgValuesSupported = "introspection_signing_alg_values_supported";
+
+        /// <summary>The <c>introspection_encryption_alg_values_supported</c> metadata field listing JWE
+        /// key-management algorithms the provider uses to encrypt JWT introspection responses (RFC 9701 §7).</summary>
+        public const string IntrospectionEncryptionAlgValuesSupported = "introspection_encryption_alg_values_supported";
+
+        /// <summary>The <c>introspection_encryption_enc_values_supported</c> metadata field listing JWE
+        /// content-encryption algorithms the provider uses to encrypt JWT introspection responses (RFC 9701 §7).</summary>
+        public const string IntrospectionEncryptionEncValuesSupported = "introspection_encryption_enc_values_supported";
+
         /// <summary>The <c>dpop_signing_alg_values_supported</c> metadata field listing JWS algorithms
         /// accepted on DPoP proofs (RFC 9449 §5.1).</summary>
         public const string DpopSigningAlgValuesSupported = "dpop_signing_alg_values_supported";
@@ -498,6 +510,26 @@ public record ConfigurationResponse
     /// </summary>
     [JsonPropertyName(Parameters.AuthorizationEncryptionEncValuesSupported)]
     public IEnumerable<string>? AuthorizationEncryptionEncValuesSupported { init; get; }
+
+    /// <summary>
+    /// Specifies the JWS algorithms the OpenID Provider uses to sign JWT introspection responses (RFC 9701 §7).
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionSigningAlgValuesSupported)]
+    public IEnumerable<string>? IntrospectionSigningAlgValuesSupported { init; get; }
+
+    /// <summary>
+    /// Specifies the JWE key-management algorithms (the <c>alg</c> values) the OpenID Provider uses to encrypt
+    /// JWT introspection responses (RFC 9701 §7).
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionEncryptionAlgValuesSupported)]
+    public IEnumerable<string>? IntrospectionEncryptionAlgValuesSupported { init; get; }
+
+    /// <summary>
+    /// Specifies the JWE content-encryption algorithms (the <c>enc</c> values) the OpenID Provider uses to
+    /// encrypt JWT introspection responses (RFC 9701 §7).
+    /// </summary>
+    [JsonPropertyName(Parameters.IntrospectionEncryptionEncValuesSupported)]
+    public IEnumerable<string>? IntrospectionEncryptionEncValuesSupported { init; get; }
 
     /// <summary>
     /// Indicates whether the OpenID Provider mandates that all request objects must be signed.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,20 @@
 sonar.projectKey=Abblix_Oidc.Server
 sonar.organization=abblix
 
+# Copy-paste detection exclusions.
+# The MVC ClientRegistrationRequest DTO mirrors the framework-agnostic Model ClientRegistrationRequest
+# property-for-property by design: the MVC layer binds the wire request, the core model is what the rest of the
+# library consumes. Every property maps one distinct registration parameter, so the cross-file similarity is
+# irreducible wire-DTO boilerplate, not refactorable logic — collapsing it would couple the MVC binding layer to
+# the core model. Exclude both files from duplication detection so the metric reflects real logic duplication.
+#
+# NOTE: SonarCloud Automatic Analysis does NOT apply analysis-scope properties (cpd.exclusions, exclusions) from
+# this file — only the issue-ignore properties above are honored. The same pattern is therefore mirrored in the
+# project's Analysis Scope > Duplications settings in the SonarCloud UI, which is what actually takes effect under
+# Automatic Analysis. This declaration is kept for discoverability and applies as-is if analysis ever moves to a
+# CI-based scanner.
+sonar.cpd.exclusions=**/Model/ClientRegistrationRequest.cs
+
 # Per-rule, per-path exclusions for SonarCloud Automatic Analysis.
 # Each `eN` block is independent; ruleKey + resourceKey are globs evaluated together.
 


### PR DESCRIPTION
## Summary

Implements **RFC 9701 — JWT Response for OAuth Token Introspection**: the introspection endpoint returns a signed (and optionally encrypted) JWT instead of plain JSON when the client is registered with `introspection_signed_response_alg` and requests it via `Accept: application/token-introspection+jwt`. The RFC 7662 response object is carried under the `token_introspection` claim.

## What's included

**Client-JWT crypto unification (foundation).** The three client-addressed JWT paths (UserInfo, ID/logout token, JARM authorization response) duplicated the same "resolve signing key → conditionally encrypt to the client key → issue" tail. That tail is extracted behind an explicit `ClientJwtEncryption` policy on `ClientJwtFormatter`; the existing type-dispatch overload is kept and deprecated for backward compatibility. JARM's `ResponseJwtBuilder` and the new introspection path both reuse it. The public `IClientJwtFormatter` keeps its existing member (now `[Obsolete]`) and gains the policy overload.

**Introspection JWT response.** The authenticated client flows from the validator through `ValidIntrospectionRequest` to `IntrospectionSuccess` (mirroring how `UserInfoFoundResponse` carries `ClientInfo`), so the formatter can select the response format. `IntrospectionResponseFormatter` performs the `Accept` negotiation, wraps the response under the `token_introspection` claim, and delegates signing/encryption to the unified formatter.

**Client metadata + DCR.** `ClientInfo` gains the introspection signing/encryption algorithms; Dynamic Client Registration accepts `introspection_signed_response_alg` / `introspection_encrypted_response_alg` / `introspection_encrypted_response_enc` (RFC 9701 §6), validated against the supported-algorithm sets.

**Discovery.** The metadata document advertises `introspection_signing_alg_values_supported`, `introspection_encryption_alg_values_supported` and `introspection_encryption_enc_values_supported` (RFC 9701 §7).

## Coverage

Unit tests for the formatter negotiation paths and DCR validation; an end-to-end round-trip that registers a client, introspects a token with the JWT `Accept`, and verifies the signed JWT and its `token_introspection` claim, plus the plain-JSON and discovery cases. The behavior-preserving crypto refactor keeps the existing `ClientJwtFormatter` and `ResponseJwtBuilder` assertions unchanged.

## Compatibility

Additive on the wire. `IClientJwtFormatter` gains a method and deprecates (does not remove) the type-dispatch overload; the introspection request/response models carry the authenticated `ClientInfo` internally.

Standards registry updated separately in the Docs repository.