### PR TITLE
chore: bump deps, privatize SonarAnalyzer, formatter cleanup

### DIFF
--- a/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
+++ b/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -36,6 +36,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
+++ b/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
@@ -23,6 +23,10 @@
         <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/Abblix.Jwt/Abblix.Jwt.csproj
@@ -36,6 +36,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/Abblix.Oidc.Server.E2E.TestHost/Abblix.Oidc.Server.E2E.TestHost.csproj
+++ b/Abblix.Oidc.Server.E2E.TestHost/Abblix.Oidc.Server.E2E.TestHost.csproj
@@ -25,5 +25,11 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Abblix.Oidc.Server.E2E.Tests" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/Abblix.Oidc.Server.E2E.Tests/Abblix.Oidc.Server.E2E.Tests.csproj
+++ b/Abblix.Oidc.Server.E2E.Tests/Abblix.Oidc.Server.E2E.Tests.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/DPoPTestBase.cs
@@ -25,9 +25,7 @@ using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
-using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Abblix.Oidc.Server.Model;
-using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
@@ -19,6 +19,10 @@
 		<PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+		<PackageReference Update="SonarAnalyzer.CSharp">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/IntrospectionResponseFormatterTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/IntrospectionResponseFormatterTests.cs
@@ -36,7 +36,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Moq;
-using Xunit;
 
 namespace Abblix.Oidc.Server.Mvc.UnitTests.Formatters;
 

--- a/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -40,6 +40,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
     
     <ItemGroup>

--- a/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
@@ -111,7 +111,9 @@ public class IntrospectionResponseFormatter(
         {
             ContentType = MediaTypes.TokenIntrospectionJwt,
             Content = await clientJwtFormatter.FormatAsync(
-                token, clientInfo, ClientJwtEncryption.ForIntrospection(clientInfo, options.Value)),
+                token,
+                clientInfo,
+                ClientJwtEncryption.ForIntrospection(clientInfo, options.Value)),
         };
     }
 

--- a/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System.Linq;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
@@ -107,13 +106,15 @@ public class IntrospectionResponseFormatter(
             },
         };
 
+        var jwt = await clientJwtFormatter.FormatAsync(
+            token,
+            clientInfo,
+            ClientJwtEncryption.ForIntrospection(clientInfo, options.Value));
+
         return new ContentResult
         {
             ContentType = MediaTypes.TokenIntrospectionJwt,
-            Content = await clientJwtFormatter.FormatAsync(
-                token,
-                clientInfo,
-                ClientJwtEncryption.ForIntrospection(clientInfo, options.Value)),
+            Content = jwt,
         };
     }
 

--- a/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
@@ -96,7 +96,9 @@ public class UserInfoResponseFormatter(
             ContentType = MediaTypes.Jwt,
             // A UserInfo response is encrypted with the client's userinfo_encrypted_response_* metadata.
             Content = await clientJwtFormatter.FormatAsync(
-                token, found.ClientInfo, ClientJwtEncryption.ForUserInfo(found.ClientInfo, options.Value)),
+                token,
+                found.ClientInfo,
+                ClientJwtEncryption.ForUserInfo(found.ClientInfo, options.Value)),
         };
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/UserInfoResponseFormatter.cs
@@ -91,14 +91,16 @@ public class UserInfoResponseFormatter(
             }
         };
 
+        // A UserInfo response is encrypted with the client's userinfo_encrypted_response_* metadata.
+        var jwt = await clientJwtFormatter.FormatAsync(
+            token,
+            found.ClientInfo,
+            ClientJwtEncryption.ForUserInfo(found.ClientInfo, options.Value));
+
         return new ContentResult
         {
             ContentType = MediaTypes.Jwt,
-            // A UserInfo response is encrypted with the client's userinfo_encrypted_response_* metadata.
-            Content = await clientJwtFormatter.FormatAsync(
-                token,
-                found.ClientInfo,
-                ClientJwtEncryption.ForUserInfo(found.ClientInfo, options.Value)),
+            Content = jwt,
         };
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Abblix.Jwt;
-using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
 using Abblix.Oidc.Server.Features.UserInfo;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ClientIdValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ClientIdValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/EncryptedResponseAlgorithmsValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/GrantTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/GrantTypeValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ScopeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/ScopeValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SigningAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SigningAlgorithmsValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedGrantTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedGrantTypeValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedResponseTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SupportedResponseTypeValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TokenEndpointAuthMethodValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/TokenEndpointAuthMethodValidatorTests.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;

--- a/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
@@ -21,7 +21,6 @@
 // info@abblix.com
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Abblix.Jwt;

--- a/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -47,6 +47,10 @@
       <PackageReference Include="Microsoft.Extensions.Http" />
       <PackageReference Include="Microsoft.Extensions.Options" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+      <PackageReference Update="SonarAnalyzer.CSharp">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Abblix.Oidc.Server/Features/ResponseObject/IResponseJwtBuilder.cs
+++ b/Abblix.Oidc.Server/Features/ResponseObject/IResponseJwtBuilder.cs
@@ -20,8 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using Abblix.Oidc.Server.Common.Constants;
-
 namespace Abblix.Oidc.Server.Features.ResponseObject;
 
 /// <summary>

--- a/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
+++ b/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
@@ -76,6 +76,9 @@ public class ResponseJwtBuilder(
 
         // JARM §2.2 / §3: encrypt only when the client registered authorization_encrypted_response_alg, defaulting
         // the content-encryption to A128CBC-HS256 when authorization_encrypted_response_enc is omitted.
-        return await clientJwtFormatter.FormatAsync(token, clientInfo, ClientJwtEncryption.ForJarm(clientInfo));
+        return await clientJwtFormatter.FormatAsync(
+            token,
+            clientInfo,
+            ClientJwtEncryption.ForJarm(clientInfo));
     }
 }

--- a/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -148,12 +148,12 @@ internal class IdentityTokenService(
 
 		AppendAdditionalClaims(identityToken, authorizationCode, accessToken);
 
-		return new EncodedJsonWebToken(
+		var jwt = await jwtFormatter.FormatAsync(
 			identityToken,
-			await jwtFormatter.FormatAsync(
-				identityToken,
-				clientInfo,
-				ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
+			clientInfo,
+			ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value));
+
+		return new EncodedJsonWebToken(identityToken, jwt);
 	}
 
 	private static void AppendAdditionalClaims(

--- a/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -151,7 +151,9 @@ internal class IdentityTokenService(
 		return new EncodedJsonWebToken(
 			identityToken,
 			await jwtFormatter.FormatAsync(
-				identityToken, clientInfo, ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
+				identityToken,
+				clientInfo,
+				ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
 	}
 
 	private static void AppendAdditionalClaims(

--- a/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
@@ -118,6 +118,8 @@ public partial class LogoutTokenService(
         return new EncodedJsonWebToken(
             logoutToken,
             await jwtFormatter.FormatAsync(
-                logoutToken, clientInfo, ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
+                logoutToken,
+                clientInfo,
+                ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
     }
 }

--- a/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
@@ -115,11 +115,11 @@ public partial class LogoutTokenService(
 
         LogTokenPrepared(logoutToken);
 
-        return new EncodedJsonWebToken(
+        var jwt = await jwtFormatter.FormatAsync(
             logoutToken,
-            await jwtFormatter.FormatAsync(
-                logoutToken,
-                clientInfo,
-                ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value)));
+            clientInfo,
+            ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value));
+
+        return new EncodedJsonWebToken(logoutToken, jwt);
     }
 }

--- a/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -20,6 +20,10 @@
         <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Abblix.Utils/Abblix.Utils.csproj
+++ b/Abblix.Utils/Abblix.Utils.csproj
@@ -38,6 +38,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,9 @@
          fails restore (NU1010). Forces conscious updates instead of silent drift. -->
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
-    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
@@ -33,8 +32,8 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Three maintenance commits:

- **style**: wrap the FormatAsync call sites added in the RFC 9701 work (#177) one argument per line (.editorconfig reflow).
- **chore(deps)**: bump Google.Protobuf, Grpc.Tools, SonarAnalyzer.CSharp, and System.IdentityModel.Tokens.Jwt to current stable; scope SonarAnalyzer.CSharp to `PrivateAssets=all` in every project so it does not flow as a transitive dependency to package consumers. Microsoft.Testing.Extensions.* is held on the 1.x / 18.0.x line per the in-file HOLD (the 2.x line breaks xunit.v3 3.2.2 test-host launch with a TypeLoadException on IDataConsumer).
- **refactor**: remove unused using directives across validator tests and the response-object interface; extract the formatted JWT into a local before returning it in the introspection and userinfo formatters.

No behavior change.