### PR TITLE
fix(codeql): default security-only suite + exclude unit-test projects

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,17 +9,21 @@
 
 name: "Abblix CodeQL config"
 
-# security-and-quality is the lighter standard suite.
-# security-extended adds expensive taint-tracking queries
-# that doubled May 2026 runtime — avoid until proven needed.
-queries:
-  - uses: security-and-quality
+# Query suite: the DEFAULT security suite (used when `queries:` is omitted).
+# We deliberately do NOT use security-and-quality — its maintainability/quality queries
+# (cs/useless-upcast, cs/missed-ternary-operator, cs/missed-readonly-modifier, …) duplicate
+# SonarAnalyzer.CSharp and flooded code-scanning with ~260 style warnings.
+# security-extended adds expensive taint-tracking queries that doubled May 2026 runtime — avoid
+# until proven needed. The default suite is security-only and the lightest runtime; code quality
+# stays SonarAnalyzer's job, security stays CodeQL's.
 
 paths-ignore:
   - "**/bin/**"
   - "**/obj/**"
   - "**/node_modules/**"
   - "**/*.Tests/**"
+  - "**/*.UnitTests/**"    # the *.Tests glob does not match the *.UnitTests suffix
+  - "**/*.TestHost/**"     # E2E test host project, not production code
   - "**/*.IntegrationTests/**"
   - "**/*.ConformanceTests/**"
   - "external/**"          # vendored / submodule code — owned upstream


### PR DESCRIPTION
code-scanning held 266 open CodeQL alerts, ~260 of them noise:

- `paths-ignore` used the `**/*.Tests/**` glob, which does not match the `*.UnitTests` / `*.TestHost` project suffixes — so unit-test code was scanned (200 alerts, 184 in Abblix.Oidc.Server.UnitTests).
- the `security-and-quality` suite pulled maintainability queries (cs/useless-upcast x147, cs/missed-ternary-operator, …) that duplicate SonarAnalyzer.CSharp.

This switches to the default security-only suite (quality stays SonarAnalyzer's job) and adds `*.UnitTests` / `*.TestHost` to `paths-ignore`. After this merges to develop and CodeQL re-runs, the now-unanalyzed and no-longer-produced alerts auto-close as fixed, leaving the genuine security findings (1 high — likely a false positive in the post-logout redirect validator — and 5 cs/log-forging) to triage.