### PR TITLE
fix(log-forging): strip CR/LF from user-controlled values before logging

### DIFF
--- a/Abblix.Oidc.Server/Common/LogSanitizer.cs
+++ b/Abblix.Oidc.Server/Common/LogSanitizer.cs
@@ -1,0 +1,45 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Common;
+
+/// <summary>
+/// Helpers for safely emitting user-controlled values into logs.
+/// </summary>
+internal static class LogSanitizer
+{
+    /// <summary>
+    /// Removes carriage-return and line-feed characters from a user-controlled value before it is
+    /// written to a log.
+    /// </summary>
+    /// <remarks>
+    /// A plain-text log sink (e.g. the default console logger) renders a structured-logging
+    /// parameter inline into the message line, so a newline in an attacker-supplied value — such as
+    /// an <c>auth_req_id</c> echoed back on a poll, or a requested scope — would forge an extra log
+    /// line (CRLF injection / log forging). As a library we do not control the host's sink, so we
+    /// strip the line breaks at the source to neutralize this regardless of how the host logs.
+    /// </remarks>
+    /// <param name="value">The user-controlled value about to be logged.</param>
+    /// <returns>The value with all CR and LF characters removed.</returns>
+    public static string Sanitized(this string value)
+        => value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -321,7 +321,7 @@ public partial class JwtBearerGrantHandler(
 		if (invalidScopes.Length == 0)
 			return ctx;
 
-		LogScopesNotAllowed(string.Join(", ", invalidScopes), ctx.Issuer);
+		LogScopesNotAllowed(string.Join(", ", invalidScopes).Sanitized(), ctx.Issuer);
 
 		return new OidcError(
 			ErrorCodes.InvalidScope,

--- a/Abblix.Oidc.Server/Features/BackChannelAuthentication/InMemoryLongPollingService.cs
+++ b/Abblix.Oidc.Server/Features/BackChannelAuthentication/InMemoryLongPollingService.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Collections.Concurrent;
+using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Microsoft.Extensions.Logging;
 
@@ -76,7 +77,7 @@ public partial class InMemoryLongPollingService(
         var waiters = _waiters.GetOrAdd(authenticationRequestId, _ => new ConcurrentBag<TaskCompletionSource<bool>>());
         waiters.Add(tcs);
 
-        LogWaitingForStatusChange(authenticationRequestId, timeout);
+        LogWaitingForStatusChange(authenticationRequestId.Sanitized(), timeout);
 
         try
         {
@@ -90,11 +91,11 @@ public partial class InMemoryLongPollingService(
 
             if (completedTask == tcs.Task)
             {
-                LogStatusChangeReceived(authenticationRequestId);
+                LogStatusChangeReceived(authenticationRequestId.Sanitized());
                 return true;
             }
 
-            LogWaitTimedOut(authenticationRequestId);
+            LogWaitTimedOut(authenticationRequestId.Sanitized());
             return false;
         }
         catch (OperationCanceledException ex) when (LogCancellation(ex, authenticationRequestId))
@@ -113,7 +114,7 @@ public partial class InMemoryLongPollingService(
     // Exception-filter helper: logs cancellation details while letting the original exception propagate unchanged.
     private bool LogCancellation(OperationCanceledException ex, string authenticationRequestId)
     {
-        LogWaitCancelled(ex, authenticationRequestId);
+        LogWaitCancelled(ex, authenticationRequestId.Sanitized());
         return false;
     }
 
@@ -128,11 +129,11 @@ public partial class InMemoryLongPollingService(
         if (!_waiters.TryRemove(authenticationRequestId, out var waiters))
         {
             // No one waiting - this is normal and expected
-            LogNoWaiters(newStatus, authenticationRequestId);
+            LogNoWaiters(newStatus, authenticationRequestId.Sanitized());
             return Task.CompletedTask;
         }
 
-        LogNotifyingWaiters(waiters.Count, newStatus, authenticationRequestId);
+        LogNotifyingWaiters(waiters.Count, newStatus, authenticationRequestId.Sanitized());
 
         // Signal all waiting tasks
         foreach (var waiter in waiters)


### PR DESCRIPTION
Closes the 5 CodeQL `cs/log-forging` findings that survived the scope fix (#179).

A user-controlled value reaches a log call at five sites: the `auth_req_id` echoed back on a CIBA poll (InMemoryLongPollingService) and rejected scope names on the JWT-bearer grant (JwtBearerGrantHandler). With a plain-text log sink (e.g. the default console logger) a newline in the value would forge an extra log line; as a library we cannot control the host's sink.

Adds an internal `LogSanitizer.Sanitized()` helper that removes CR/LF and applies it at each affected log site. Normal values contain no line breaks and are unaffected. After this merges to develop and CodeQL re-runs, the 5 alerts auto-close as fixed.

The 1 high `cs/user-controlled-bypass` was separately dismissed as a false positive (spec-mandated post-logout null path).