### PR TITLE
ci(codeql): bump CodeQL Action from v3 to v4.36.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,14 +43,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - uses: github/codeql-action/init@fee9466b8957867761f2d78f922ab084e3e2dd17 # v3
+      - uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         timeout-minutes: 3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@fee9466b8957867761f2d78f922ab084e3e2dd17 # v3
+      - uses: github/codeql-action/autobuild@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         timeout-minutes: 5
 
-      - uses: github/codeql-action/analyze@fee9466b8957867761f2d78f922ab084e3e2dd17 # v3
+      - uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         timeout-minutes: 5


### PR DESCRIPTION
CodeQL Action v3 is deprecated as of December 2026 ([GitHub changelog 2025-10-28](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)).

Bumps the `init` / `autobuild` / `analyze` steps from v3 to **v4.36.1**, SHA-pinned (`@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1`) with the version as a trailing comment per the GitHub Actions security checklist. actionlint clean.