### PR TITLE
refactor(utils): rename EnumExtensions to EnumFlagExtensions to dodge CS0104 collisions

### DIFF
--- a/Abblix.Utils/EnumFlagExtensions.cs
+++ b/Abblix.Utils/EnumFlagExtensions.cs
@@ -23,9 +23,12 @@
 namespace Abblix.Utils;
 
 /// <summary>
-/// Extension methods for <see cref="Enum"/> values that complement the BCL surface.
+/// Extension methods for <c>[Flags]</c> enum values that complement the BCL surface.
+/// Named with the <c>Flag</c> qualifier so it does not collide with the very common
+/// <c>EnumExtensions</c> class name used by other libraries (e.g. <c>Fido2NetLib.EnumExtensions</c>),
+/// which would surface as <c>CS0104</c> in any consumer that imports both namespaces.
 /// </summary>
-public static class EnumExtensions
+public static class EnumFlagExtensions
 {
     /// <summary>
     /// Returns <c>true</c> when at least one flag in <paramref name="mask"/> is set in


### PR DESCRIPTION
`Abblix.Utils.EnumExtensions` (the `HasAnyFlag<T>` helper, added in #76) uses a very common class name that collides with other libraries — e.g. `Fido2NetLib.EnumExtensions` — producing `CS0104 ambiguous reference` in any consumer that imports both namespaces. Rename the class and file to `EnumFlagExtensions` to disambiguate.

Not a breaking change: the type is unpublished (added this cycle, not in v2.2), and nothing references it by class name (all call sites use the extension-method form `value.HasAnyFlag(...)`, which is unaffected by the class rename). No `[Obsolete]` alias needed.

(Supersedes the abandoned `refactor/rename-enum-extensions` branch.)