### PR TITLE
fix: carry RFC 8707 resource indicators through direct grants into the access token aud

### DIFF
--- a/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -46,6 +46,23 @@ builder.Services.AddOidcServices(options =>
         Mint(TestConstants.DPoPOpportunisticClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: false),
         // RFC 9449 §5 public client: same-key MUST be presented on refresh.
         Mint(TestConstants.DPoPPublicClientId, secret, redirect, allowlist: null, idTokenRar: false, requireDPoP: false, isPublic: true),
+
+        // RFC 6749 §4.4 client_credentials client, used to verify that an RFC 8707 resource
+        // indicator reaches the issued access token's aud. This grant has no user-agent leg, so
+        // no redirect_uri / PKCE is configured.
+        new ClientInfo(TestConstants.ClientCredentialsClientId)
+        {
+            ClientSecrets = [secret],
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+            AllowedGrantTypes = [GrantTypes.ClientCredentials],
+        },
+    ];
+
+    // A single registered RFC 8707 resource indicator. The AS only mints audience-restricted
+    // tokens for a resource it knows; an unregistered target is rejected with invalid_target.
+    options.Resources =
+    [
+        new ResourceDefinition(new Uri(TestConstants.ApiResource)),
     ];
     return;
 

--- a/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -54,8 +54,19 @@ public static class TestConstants
     /// constraint comes from DPoP alone, not from client authentication.</summary>
     public const string DPoPPublicClientId = "e2e-dpop-public";
 
+    /// <summary>Pre-seeded client restricted to the client_credentials grant (RFC 6749 §4.4),
+    /// used to verify RFC 8707 resource indicators reach the issued access token's audience.</summary>
+    public const string ClientCredentialsClientId = "e2e-client-credentials";
+
     /// <summary>Shared secret across every pre-seeded client.</summary>
     public const string ConfidentialClientSecret = "e2e-secret";
+
+    /// <summary>A registered RFC 8707 resource indicator (absolute URI) the AS mints
+    /// audience-restricted access tokens for. An unregistered target is rejected with
+    /// <c>invalid_target</c>.</summary>
+    [SuppressMessage("Minor Code Smell", "S1075",
+        Justification = "Canonical test resource indicator shared by resource-indicator scenarios; not a deployment URL.")]
+    public const string ApiResource = "https://api.example.com/orders";
 
     /// <summary>The single canonical redirect_uri.</summary>
     [SuppressMessage("Minor Code Smell", "S1075",

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
@@ -1,0 +1,94 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Linq;
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Common.Constants;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// RFC 8707 Resource Indicators end-to-end against the test OIDC provider. The client_credentials
+/// grant is the canonical resource-indicator scenario: it is a direct grant with no prior
+/// authorization step, so the requested resource is itself the authorized audience and must land
+/// in the issued access token's aud claim.
+/// </summary>
+public class ResourceIndicatorTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task ClientCredentials_with_registered_resource_sets_token_audience()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.ClientCredentials,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ClientCredentialsClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.Resource] = TestConstants.ApiResource,
+        });
+
+        var payload = DecodeJwtPayload(tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var audiences = ExtractAudiences(payload);
+
+        // The requested resource is the audience; the client id is NOT folded in alongside it.
+        Assert.Contains(TestConstants.ApiResource, audiences);
+        Assert.DoesNotContain(TestConstants.ClientCredentialsClientId, audiences);
+    }
+
+    [Fact]
+    public async Task ClientCredentials_without_resource_falls_back_to_client_id_audience()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.ClientCredentials,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ClientCredentialsClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+        var payload = DecodeJwtPayload(tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var audiences = ExtractAudiences(payload);
+
+        // No resource indicator: the OIDC convention falls back to the client id as the audience.
+        Assert.Contains(TestConstants.ClientCredentialsClientId, audiences);
+    }
+
+    [Fact]
+    public async Task ClientCredentials_with_unregistered_resource_is_rejected_as_invalid_target()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var response = await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.ClientCredentials,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ClientCredentialsClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.Resource] = "https://unregistered.example.com/api",
+        });
+
+        var raw = await response.Content.ReadAsStringAsync();
+        Assert.False(response.IsSuccessStatusCode,
+            $"Expected invalid_target rejection, but got {(int)response.StatusCode}: {raw}");
+        var error = JsonNode.Parse(raw)?.AsObject();
+        Assert.Equal(ErrorCodes.InvalidTarget, error?["error"]?.GetValue<string>());
+    }
+
+    // RFC 7519 §4.1.3: aud is serialized as a single string when there is one value, or an array
+    // when there are several. Normalize both shapes to a flat list for assertion.
+    private static string[] ExtractAudiences(JsonObject payload) =>
+        payload[JwtClaimTypes.Audience] switch
+        {
+            JsonArray array => array.Select(node => node!.GetValue<string>()).ToArray(),
+            JsonValue value => [value.GetValue<string>()],
+            _ => [],
+        };
+}

--- a/Abblix.Oidc.Server.UnitTests/Common/AuthorizationContextExtensionsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/AuthorizationContextExtensionsTests.cs
@@ -20,7 +20,9 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
@@ -50,5 +52,41 @@ public class AuthorizationContextExtensionsTests
         Assert.NotNull(ac2.RequestedClaims);
         Assert.NotNull(ac2.RequestedClaims.UserInfo);
         Assert.True(ac2.RequestedClaims.UserInfo["abc"].Essential);
+    }
+
+    [Fact]
+    public void Resources_RoundTrip_Through_AudienceClaim()
+    {
+        // RFC 8707 resource indicators are emitted into the aud claim and reconstructed back into
+        // Resources when the token is re-read (e.g. on refresh). This pins both ApplyTo and
+        // ToAuthorizationContext, which are the two halves of the resource <-> aud mapping.
+        var resources = new[] { new Uri("https://api1.example.com/"), new Uri("https://api2.example.com/") };
+        var ac = new AuthorizationContext("clientId", ["scope1"], null, resources);
+
+        var payload = new JsonWebTokenPayload(new JsonObject());
+        ac.ApplyTo(payload);
+
+        Assert.Equal(
+            new[] { "https://api1.example.com/", "https://api2.example.com/" },
+            payload.Audiences.ToArray());
+
+        var ac2 = payload.ToAuthorizationContext();
+        Assert.Equal(resources, ac2.Resources);
+    }
+
+    [Fact]
+    public void NoResources_AudienceFallsBackToClientId()
+    {
+        // With no resource indicator the OIDC convention puts the client id in aud; re-reading such
+        // a token yields no resources (a single client-id audience is not treated as a resource).
+        var ac = new AuthorizationContext("clientId", ["scope1"], null);
+
+        var payload = new JsonWebTokenPayload(new JsonObject());
+        ac.ApplyTo(payload);
+
+        Assert.Equal(["clientId"], payload.Audiences.ToArray());
+
+        var ac2 = payload.ToAuthorizationContext();
+        Assert.Null(ac2.Resources);
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Common/AuthorizationContextTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/AuthorizationContextTests.cs
@@ -1,0 +1,77 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common;
+
+/// <summary>
+/// Pins the single resource-normalization contract of <see cref="AuthorizationContext"/>: every
+/// construction path funnels the RFC 8707 resource set through the primitive constructor, which
+/// canonicalizes an empty set to <c>null</c> (an empty resource set means "no audience
+/// restriction", same as a missing one).
+/// </summary>
+public class AuthorizationContextTests
+{
+    [Fact]
+    public void Ctor_EmptyResources_CanonicalizedToNull()
+    {
+        var context = new AuthorizationContext("clientId", ["scope"], null, []);
+
+        Assert.Null(context.Resources);
+    }
+
+    [Fact]
+    public void Ctor_NonEmptyResources_Preserved()
+    {
+        var resources = new[] { new Uri("https://api.example.com/") };
+
+        var context = new AuthorizationContext("clientId", ["scope"], null, resources);
+
+        Assert.Equal(resources, context.Resources);
+    }
+
+    [Fact]
+    public void Ctor_NullResources_StayNull()
+    {
+        var context = new AuthorizationContext("clientId", ["scope"], null);
+
+        Assert.Null(context.Resources);
+    }
+
+    [Fact]
+    public void RichCtor_EmptyResourceDefinitions_CanonicalizedToNull()
+    {
+        // The ScopeDefinition/ResourceDefinition overload forwards through the primitive ctor, so
+        // the same empty -> null canonicalization applies to the authorize/CIBA/device path.
+        var context = new AuthorizationContext(
+            "clientId",
+            Array.Empty<ScopeDefinition>(),
+            Array.Empty<ResourceDefinition>(),
+            null);
+
+        Assert.Null(context.Resources);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/ClientCredentialsGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/ClientCredentialsGrantHandlerTests.cs
@@ -307,4 +307,56 @@ public class ClientCredentialsGrantHandlerTests
         Assert.Equal("client1", grant1.AuthSession.Subject);
         Assert.Equal("client2", grant2.AuthSession.Subject);
     }
+
+    /// <summary>
+    /// Verifies that RFC 8707 resource indicators on the request are seeded onto the grant's
+    /// authorization context, so they reach the issued access token's audience. client_credentials
+    /// is a direct grant: the token request itself is the authorization, so a requested resource is
+    /// the authorized audience (the token endpoint's resource validator has already rejected any
+    /// unregistered target before this handler runs).
+    /// </summary>
+    [Fact]
+    public async Task Request_WithResources_ShouldSeedResourcesOntoContext()
+    {
+        // Arrange
+        var sessionIdGenerator = new Mock<ISessionIdGenerator>(MockBehavior.Strict);
+        sessionIdGenerator.Setup(g => g.GenerateSessionId()).Returns("session_123");
+        var handler = new ClientCredentialsGrantHandler(sessionIdGenerator.Object, TimeProvider.System);
+        var clientInfo = new ClientInfo(ClientId);
+        var resources = new[] { new Uri("https://api.example.com/orders") };
+        var tokenRequest = new TokenRequest
+        {
+            Scope = ["api.read"],
+            Resources = resources,
+        };
+
+        // Act
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+
+        // Assert
+        Assert.True(result.TryGetSuccess(out var grant));
+        Assert.Equal(resources, grant.Context.Resources);
+    }
+
+    /// <summary>
+    /// Verifies that when no resource indicator is supplied the grant carries no resources (the
+    /// audience falls back to the client id downstream) rather than an empty array.
+    /// </summary>
+    [Fact]
+    public async Task Request_WithoutResources_ShouldLeaveContextResourcesNull()
+    {
+        // Arrange
+        var sessionIdGenerator = new Mock<ISessionIdGenerator>(MockBehavior.Strict);
+        sessionIdGenerator.Setup(g => g.GenerateSessionId()).Returns("session_123");
+        var handler = new ClientCredentialsGrantHandler(sessionIdGenerator.Object, TimeProvider.System);
+        var clientInfo = new ClientInfo(ClientId);
+        var tokenRequest = new TokenRequest { Scope = ["api.read"] };
+
+        // Act
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+
+        // Assert
+        Assert.True(result.TryGetSuccess(out var grant));
+        Assert.Null(grant.Context.Resources);
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -317,6 +317,35 @@ public class JwtBearerGrantHandlerTests
 	}
 
 	/// <summary>
+	/// Verifies that RFC 8707 resource indicators on the request are seeded onto the authorization
+	/// context, so they reach the issued access token's audience. jwt-bearer is a direct grant: the
+	/// token request itself is the authorization, so a requested resource is the authorized audience.
+	/// </summary>
+	[Fact]
+	public async Task ValidRequest_WithResources_ShouldSeedResourcesInContext()
+	{
+		// Arrange
+		var (handler, mocks) = CreateHandler();
+		var jwt = CreateValidJwt();
+		SetupValidJwtValidation(mocks.JwtValidator, jwt);
+		var clientInfo = new ClientInfo(ClientId);
+		var resources = new[] { new Uri("https://api.example.com/orders") };
+		var tokenRequest = new TokenRequest
+		{
+			GrantType = GrantTypes.JwtBearer,
+			Assertion = Assertion,
+			Resources = resources
+		};
+
+		// Act
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+
+		// Assert
+		Assert.True(result.TryGetSuccess(out var grant));
+		Assert.Equal(resources, grant.Context.Resources);
+	}
+
+	/// <summary>
 	/// Verifies that a request without scope still succeeds with null scope in context.
 	/// </summary>
 	[Fact]

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/PasswordGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/PasswordGrantHandlerTests.cs
@@ -321,4 +321,46 @@ public class PasswordGrantHandlerTests
         Assert.Equal(ClientId, capturedContext.ClientId);
         Assert.Equal(tokenRequest.Scope, capturedContext.Scope);
     }
+
+    /// <summary>
+    /// Verifies that RFC 8707 resource indicators on the request are seeded onto the authorization
+    /// context handed to the credentials authenticator, so they reach the issued token's audience.
+    /// password is a direct grant: the token request itself is the authorization, so a requested
+    /// resource is the authorized audience.
+    /// </summary>
+    [Fact]
+    public async Task Request_WithResources_ShouldSeedResourcesOntoContext()
+    {
+        // Arrange
+        var clientInfo = new ClientInfo(ClientId);
+        var resources = new[] { new Uri("https://api.example.com/orders") };
+        var tokenRequest = new TokenRequest
+        {
+            UserName = UserName,
+            Password = Password,
+            Scope = [Scopes.OpenId],
+            Resources = resources,
+        };
+
+        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
+        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
+
+        var fixedTime = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expectedGrant = new AuthorizedGrant(
+            new AuthSession("user123", "session1", fixedTime, "192.168.1.1"),
+            Context: new AuthorizationContext(ClientId, tokenRequest.Scope, null));
+
+        AuthorizationContext? capturedContext = null;
+        _credentialsAuthenticator
+            .Setup(a => a.ValidateAsync(UserName, Password, It.IsAny<AuthorizationContext>()))
+            .ReturnsAsync(expectedGrant)
+            .Callback<string, string, AuthorizationContext>((_, _, ctx) => capturedContext = ctx);
+
+        // Act
+        await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+
+        // Assert
+        Assert.NotNull(capturedContext);
+        Assert.Equal(resources, capturedContext.Resources);
+    }
 }

--- a/Abblix.Oidc.Server/Common/AuthorizationContext.cs
+++ b/Abblix.Oidc.Server/Common/AuthorizationContext.cs
@@ -56,12 +56,21 @@ public record AuthorizationContext
     /// Optional claims that the client is requesting as part of the authorization process,
     /// providing additional information about the user's identity.
     /// </param>
+    /// <param name="resources">
+    /// Optional RFC 8707 resource indicators (absolute URIs) the issued token is bound to. This is
+    /// the single construction point every path funnels the resource set through: the direct grants
+    /// (client_credentials, password, jwt-bearer, token-exchange), the authorize/CIBA/device path
+    /// (via the <see cref="ScopeDefinition"/>/<see cref="ResourceDefinition"/> overload below), and
+    /// the JWT round-trip. An empty set is canonicalized to <c>null</c> (no audience restriction).
+    /// </param>
     [JsonConstructor]
-    public AuthorizationContext(string clientId, string[] scope, RequestedClaims? requestedClaims)
+    public AuthorizationContext(
+        string clientId, string[] scope, RequestedClaims? requestedClaims, Uri[]? resources = null)
     {
         ClientId = clientId;
         Scope = scope;
         RequestedClaims = requestedClaims;
+        Resources = resources is { Length: > 0 } ? resources : null;
     }
 
     /// <summary>
@@ -77,9 +86,12 @@ public record AuthorizationContext
         ScopeDefinition[] scopes,
         ResourceDefinition[] resources,
         RequestedClaims? requestedClaims)
-        : this(clientId, GetScopeNames(scopes, resources), requestedClaims)
+        : this(
+            clientId,
+            GetScopeNames(scopes, resources),
+            requestedClaims,
+            Array.ConvertAll(resources, resource => resource.Resource))
     {
-        Resources = Array.ConvertAll(resources, resource => resource.Resource);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Common/AuthorizationContextExtensions.cs
+++ b/Abblix.Oidc.Server/Common/AuthorizationContextExtensions.cs
@@ -129,10 +129,10 @@ public static class AuthorizationContextExtensions
         return new AuthorizationContext(
             payload.ClientId.NotNull(nameof(payload.ClientId)),
             payload.Scope.NotNull(nameof(payload.Scope)).ToArray(),
-            payload[JwtClaimTypes.RequestedClaims].Deserialize<RequestedClaims>(JsonSerializerOptions))
+            payload[JwtClaimTypes.RequestedClaims].Deserialize<RequestedClaims>(JsonSerializerOptions),
+            resources)
         {
             Nonce = payload.Nonce,
-            Resources = resources,
             CertificateSha256Thumbprint = cnf?.CertificateSha256Thumbprint,
             ProofKeyThumbprint = cnf?.JwkThumbprint,
             AuthorizationDetails = payload.Json[IanaClaimTypes.AuthorizationDetails] is JsonArray raw

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/ClientCredentialsGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/ClientCredentialsGrantHandler.cs
@@ -75,8 +75,12 @@ public class ClientCredentialsGrantHandler(
 		// Extract the requested scope from the request (may be null/empty)
 		var scope = request.Scope;
 
-		// Create an authorization context for the client with the requested scope
-		var context = new AuthorizationContext(clientInfo.ClientId, scope, null);
+		// Create an authorization context for the client with the requested scope.
+		// client_credentials is a direct grant: the token request itself IS the authorization, so
+		// the RFC 8707 resource indicators are the authorized audience and are passed to the context
+		// so they reach the issued token's aud claim. The resource validator has already rejected
+		// any unregistered target with invalid_target before this handler runs.
+		var context = new AuthorizationContext(clientInfo.ClientId, scope, null, request.Resources);
 
 		// Create an authentication session representing the client (not a user)
 		// In client credentials flow, the client itself is the "subject"

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -122,7 +122,7 @@ public partial class JwtBearerGrantHandler(
 			.Bind(ctx => ValidateJwtAge(ctx, clientInfo))
 			.BindAsync(ctx => ValidateReplayProtectionAsync(ctx, clientInfo))
 			.Bind(ctx => ValidateScopes(ctx, request.Scope))
-			.MapSuccessAsync(ctx => Task.FromResult(CreateAuthorizedGrant(ctx, request.Scope, clientInfo)));
+			.MapSuccessAsync(ctx => Task.FromResult(CreateAuthorizedGrant(ctx, request.Scope, request.Resources, clientInfo)));
 	}
 
 	/// <summary>
@@ -331,13 +331,18 @@ public partial class JwtBearerGrantHandler(
 	/// <summary>
 	/// Creates the authorized grant after successful validation.
 	/// </summary>
-	private AuthorizedGrant CreateAuthorizedGrant(ValidationContext ctx, string[] scope, ClientInfo clientInfo)
+	private AuthorizedGrant CreateAuthorizedGrant(
+		ValidationContext ctx, string[] scope, Uri[]? resources, ClientInfo clientInfo)
 	{
 		LogGrantSucceeded(
 			clientInfo.ClientId, ctx.Subject, ctx.Issuer, ctx.Jwt.Payload.JwtId ?? "none",
 			ctx.Jwt.Header.KeyId ?? "none", requestInfoProvider.RemoteIpAddress);
 
-		var context = new AuthorizationContext(clientInfo.ClientId, scope, null);
+		// jwt-bearer is a direct grant: the token request itself IS the authorization, so the
+		// RFC 8707 resource indicators are the authorized audience and are passed to the context
+		// so they reach the issued token's aud claim. The resource validator has already rejected
+		// any unregistered target with invalid_target before this handler runs.
+		var context = new AuthorizationContext(clientInfo.ClientId, scope, null, resources);
 
 		var authSession = new AuthSession(
 			Subject: ctx.Subject,

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/PasswordGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/PasswordGrantHandler.cs
@@ -74,7 +74,12 @@ public class PasswordGrantHandler(
         var userName = request.UserName;
         var password = request.Password;
         var scope = request.Scope;
-        var context = new AuthorizationContext(clientInfo.ClientId, scope, null);
+
+        // password is a direct grant: the token request itself IS the authorization, so the
+        // RFC 8707 resource indicators are the authorized audience and are passed to the context
+        // so they reach the issued token's aud claim. The resource validator has already rejected
+        // any unregistered target with invalid_target before this handler runs.
+        var context = new AuthorizationContext(clientInfo.ClientId, scope, null, request.Resources);
 
         // Delegate the actual user credential validation and authentication to the custom authenticator.
         return userCredentialsAuthenticator.ValidateAsync(userName, password, context);

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -405,14 +405,13 @@ public class TokenExchangeGrantHandler(
             }
         }
 
-        var authContext = new AuthorizationContext(clientInfo.ClientId, scope, null)
+        // propagate the requested resource(s) (RFC 8707) through the ctor and audience(s)
+        // (RFC 8693 §2.1) through the initializer into the issued token's claims rather than
+        // silently dropping them
+        var authContext = new AuthorizationContext(clientInfo.ClientId, scope, null, request.Resources)
         {
             AuthorizationDetails = subject.AuthorizationDetails,
             Actor = actorClaim,
-
-            // propagate the requested resource(s) (RFC 8707) and audience(s) (RFC 8693 §2.1)
-            // into the issued token's claims rather than silently dropping them
-            Resources = request.Resources is { Length: > 0 } ? request.Resources : null,
             Audiences = request.Audiences is { Length: > 0 } ? request.Audiences : null,
         };
 


### PR DESCRIPTION
## Problem

The `client_credentials`, `password` and `jwt-bearer` grants validated the RFC 8707 `resource` parameter (rejecting an unregistered target with `invalid_target`) but never placed the validated resource on the `AuthorizationContext`. The token-endpoint evaluator only *narrows* an existing resource set, so for these direct grants the requested resource was dropped after validation and the issued access token's `aud` fell back to `client_id`.

Only the user-interactive flows (authorization code, CIBA, device) and token-exchange carried it — `client_credentials`, the canonical resource-indicator scenario, did not.

## Fix

Funnel the resource set through a single `AuthorizationContext` construction point:

- the primitive constructor now accepts the resource URIs and canonicalizes an empty set to `null`;
- the `ScopeDefinition`/`ResourceDefinition` overload and the JWT round-trip forward through it;
- all four direct grants (`client_credentials`, `password`, `jwt-bearer`, `token-exchange`) pass `request.Resources` to the constructor instead of an object initializer.

The token-endpoint evaluator's narrowing-only contract is unchanged, preserving the RFC 8707 §2.2 anti-escalation guarantee for authorization codes (a code that authorized no resource cannot gain one at the token endpoint).

Handler unit regressions and an end-to-end resource-indicator scenario (registered resource → `aud`, no resource → `client_id`, unregistered → `invalid_target`) are included; the test host gains a `client_credentials` client and one registered resource.