### PR TITLE
Security and conformance review fixes (June 2026)

### DIFF
--- a/Abblix.Jwt.UnitTests/InteropTests.cs
+++ b/Abblix.Jwt.UnitTests/InteropTests.cs
@@ -554,7 +554,9 @@ public class InteropTests
 		{ EncryptionAlgorithms.KeyManagement.RsaOaep, SecurityAlgorithms.RsaOAEP,
 		  EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512, SecurityAlgorithms.Aes256CbcHmacSha512 },
 
-		// RSA1_5 with all AES-CBC-HMAC variants (Microsoft supports, but deprecated)
+		// RSA1_5 with all AES-CBC-HMAC variants (Microsoft supports, but deprecated). RSA1_5 stays
+		// supported for backward compatibility; the Bleichenbacher oracle on its decryption path is
+		// closed by the RFC 7516 §11.5 random-CEK mitigation in JsonWebTokenEncryptor.
 		{ EncryptionAlgorithms.KeyManagement.Rsa1_5, SecurityAlgorithms.RsaPKCS1,
 		  EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256, SecurityAlgorithms.Aes128CbcHmacSha256 },
 		{ EncryptionAlgorithms.KeyManagement.Rsa1_5, SecurityAlgorithms.RsaPKCS1,

--- a/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
+++ b/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
@@ -20,8 +20,10 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Buffers.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
@@ -137,6 +139,84 @@ public class JwtEncryptionTests
 
         Assert.Contains(EncryptionAlgorithms.ContentEncryption.Aes256Gcm, validator.EncryptionMethodsSupported);
         Assert.Contains(EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256, validator.EncryptionMethodsSupported);
+    }
+
+    /// <summary>
+    /// Verifies RSA1_5 (RSAES-PKCS1-v1_5) round-trips: it is kept for backward compatibility, and a
+    /// JWE encrypted with it decrypts correctly. The Bleichenbacher oracle that PKCS1-v1.5 would
+    /// otherwise expose is closed by the RFC 7516 §11.5 random-CEK mitigation (see
+    /// <see cref="TamperedEncryptedKey_IsRejected_Uniformly"/>).
+    /// </summary>
+    [Fact]
+    public async Task Rsa1_5_RoundTrips()
+    {
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        Assert.Contains(EncryptionAlgorithms.KeyManagement.Rsa1_5, validator.EncryptionAlgorithmsSupported);
+
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithms.RS256 },
+            Payload = { Issuer = "abblix.com", Audiences = [nameof(Rsa1_5_RoundTrips)], ["test"] = "value" },
+        };
+
+        var creator = ServiceProvider.GetRequiredService<IJsonWebTokenCreator>();
+        var jwe = await creator.IssueAsync(
+            token, SigningKey, encryptionKey,
+            keyEncryptionAlgorithm: EncryptionAlgorithms.KeyManagement.Rsa1_5);
+
+        var parameters = new ValidationParameters
+        {
+            ValidateAudience = _ => Task.FromResult(true),
+            ValidateIssuer = _ => Task.FromResult(true),
+            ResolveTokenDecryptionKeys = _ => new[] { encryptionKey }.ToAsyncEnumerable(),
+            ResolveIssuerSigningKeys = _ => new[] { SigningKey }.ToAsyncEnumerable(),
+        };
+
+        var result = await validator.ValidateAsync(jwe, parameters);
+
+        Assert.True(result.TryGetSuccess(out var validated));
+        Assert.Equal("value", validated.Payload.Json["test"]?.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Verifies the RFC 7516 §11.5 mitigation: when the encrypted Content Encryption Key cannot be
+    /// decrypted (here the encrypted-key segment is replaced with random bytes), the decryptor
+    /// substitutes a random CEK and still runs the AEAD step, which fails the authentication tag.
+    /// The outcome is a uniform invalid_token result — no exception and no distinct error that
+    /// could serve as a padding oracle.
+    /// </summary>
+    [Fact]
+    public async Task TamperedEncryptedKey_IsRejected_Uniformly()
+    {
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithms.RS256 },
+            Payload = { Issuer = "abblix.com", Audiences = [nameof(TamperedEncryptedKey_IsRejected_Uniformly)] },
+        };
+
+        var creator = ServiceProvider.GetRequiredService<IJsonWebTokenCreator>();
+        var jwe = await creator.IssueAsync(token, SigningKey, encryptionKey);
+
+        // Replace the encrypted-key segment (index 1) with random bytes of the same length so the
+        // CEK decryption fails while the JWE stays structurally valid.
+        var parts = jwe.Split('.');
+        var originalKeyLength = Base64Url.DecodeFromChars(parts[1]).Length;
+        parts[1] = Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(originalKeyLength));
+        var tampered = string.Join('.', parts);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = new ValidationParameters
+        {
+            ValidateAudience = _ => Task.FromResult(true),
+            ValidateIssuer = _ => Task.FromResult(true),
+            ResolveTokenDecryptionKeys = _ => new[] { encryptionKey }.ToAsyncEnumerable(),
+            ResolveIssuerSigningKeys = _ => new[] { SigningKey }.ToAsyncEnumerable(),
+        };
+
+        var result = await validator.ValidateAsync(tampered, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
     }
 
     private static IEnumerable<(string Key, string?)> ExtractClaims(JsonWebToken token)

--- a/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -33,8 +33,11 @@ namespace Abblix.Jwt.Encryption;
 /// Section 4.3 (Key Encryption with RSAES OAEP).
 /// </summary>
 /// <remarks>
-/// RSA1_5 (RSAES-PKCS1-v1_5) is deprecated but still supported for backward compatibility.
-/// RSA-OAEP and RSA-OAEP-256 are recommended for new implementations.
+/// RSA-OAEP and RSA-OAEP-256 are the recommended algorithms. RSA1_5 (RSAES-PKCS1-v1_5) is supported
+/// for backward compatibility despite RFC 8725 §3.2's advice to prefer RSAES-OAEP. Its PKCS1-v1.5
+/// padding would expose the decryption endpoint to a Bleichenbacher oracle; that oracle is closed
+/// upstream in <see cref="JsonWebTokenEncryptor"/> by the RFC 7516 §11.5 mitigation (a failed CEK
+/// decryption is replaced with a random CEK so the outcome is uniform), not in this encryptor.
 /// This is a stateless service that can be registered as a singleton in DI.
 /// </remarks>
 internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, string algorithm) : IKeyEncryptor<RsaJsonWebKey>

--- a/Abblix.Jwt/JsonWebTokenEncryptor.cs
+++ b/Abblix.Jwt/JsonWebTokenEncryptor.cs
@@ -155,10 +155,18 @@ internal class JsonWebTokenEncryptor(IServiceProvider serviceProvider) : IJsonWe
         if (header.KeyId.HasValue())
             decryptionKeys = decryptionKeys.Where(key => string.Equals(key.KeyId, header.KeyId, StringComparison.Ordinal));
 
+        // Resolve the content decryptor by 'enc'. The registered set is the allow-list of content
+        // encryption algorithms for incoming JWE — an unregistered 'enc' yields no decryptor and is
+        // rejected outright.
+        var contentDecryptor = serviceProvider.GetKeyedService<IDataEncryptor>(encryptionAlgorithm);
+        if (contentDecryptor == null)
+            return new JwtValidationError(JwtError.InvalidToken, "Unsupported 'enc' content encryption algorithm in JWE");
+
         var encryptedKey = decodedParts[1];
         var iv = decodedParts[2];
         var ciphertext = decodedParts[3];
         var authTag = decodedParts[4];
+        var aad = Encoding.ASCII.GetBytes(jwtParts[0]);
 
         var keyFound = false;
         await foreach (var key in decryptionKeys)
@@ -172,14 +180,21 @@ internal class JsonWebTokenEncryptor(IServiceProvider serviceProvider) : IJsonWe
                     $"Decryption operation requires private key material, but key (kid={key.KeyId}) contains only public key data.");
             }
 
+            // RFC 7516 §11.5: if CEK decryption fails — wrong key, malformed padding, or an
+            // unregistered key-management 'alg' — substitute a randomly generated CEK of the
+            // correct size and still run the AEAD step. The authentication tag then fails exactly
+            // as it would for a successful-but-wrong CEK, so a decryption failure is processed
+            // identically regardless of its cause. This is what makes RSA1_5 (RSAES-PKCS1-v1_5)
+            // safe to support: it closes the Bleichenbacher/Manger padding oracle by removing the
+            // observable difference between valid and invalid padding.
             if (!TryDecryptContentKey(header, key, algorithm, encryptedKey, out var contentEncryptionKey))
-                continue;
+                contentEncryptionKey = CryptoRandom.GetRandomBytes(contentDecryptor.KeySizeInBytes);
 
-            var plaintext = TryDecryptContent(jwtParts[0], encryptionAlgorithm, contentEncryptionKey, iv, ciphertext, authTag);
-            if (plaintext == null)
-                continue;
-
-            return Encoding.UTF8.GetString(plaintext);
+            if (contentDecryptor.TryDecrypt(
+                    contentEncryptionKey, new EncryptedData(iv, ciphertext, authTag), aad, out var plaintext))
+            {
+                return Encoding.UTF8.GetString(plaintext);
+            }
         }
 
         return new JwtValidationError(
@@ -220,32 +235,5 @@ internal class JsonWebTokenEncryptor(IServiceProvider serviceProvider) : IJsonWe
             }
             return keyEncryptor.TryDecryptKey(header, jwk, encryptedKey, out decryptedKey);
         }
-    }
-
-    /// <summary>
-    /// Attempts to decrypt the JWE content using the Content Encryption Key.
-    /// Per RFC 7516, AAD is the ASCII encoding of the base64url-encoded JWE header.
-    /// </summary>
-    private byte[]? TryDecryptContent(
-        string headerPart,
-        string encAlgorithm,
-        byte[] contentEncryptionKey,
-        byte[] iv,
-        byte[] ciphertext,
-        byte[] authTag)
-    {
-        var contentDecryptor = serviceProvider.GetKeyedService<IDataEncryptor>(encAlgorithm);
-        if (contentDecryptor == null)
-            return null;
-
-        var aad = Encoding.ASCII.GetBytes(headerPart);
-
-        var encryptedData = new EncryptedData(iv, ciphertext, authTag);
-
-        return contentDecryptor.TryDecrypt(
-            contentEncryptionKey,
-            encryptedData,
-            aad,
-            out var plaintext) ? plaintext : null;
     }
 }

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -63,8 +63,13 @@ public static class ServiceCollectionExtensions
         // Tracks the registered JWE algorithms for discovery (request_object_encryption_*_values_supported).
         var encryptionAlgorithmsProvider = new EncryptionAlgorithmsProvider();
 
-        // Register key encryptors by algorithm
-        // RSA-based key encryption
+        // Register key encryptors by algorithm.
+        // RSA-OAEP and RSA-OAEP-256 are the recommended algorithms. RSA1_5 (RSAES-PKCS1-v1_5) is
+        // kept for backward compatibility despite RFC 8725 §3.2's advice to prefer RSAES-OAEP: its
+        // padding would otherwise make the decryption endpoint a Bleichenbacher oracle. That oracle
+        // is closed in JsonWebTokenEncryptor.DecryptAsync by the RFC 7516 §11.5 mitigation — a CEK
+        // that fails to decrypt is replaced with a random CEK and the AEAD step still runs, so a
+        // decryption failure is processed identically regardless of padding validity.
         services
             .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep, encryptionAlgorithmsProvider)
             .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep256, encryptionAlgorithmsProvider)

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
@@ -67,7 +67,9 @@ public class JarRichAuthorizationRequestsTests(TestFactory factory) : TestBase(f
 
         // 3. Build the request JWT containing every authorize parameter -- including the wire-shape
         // authorization_details JSON array attached as a custom claim. RFC 9101 §6: iss = client_id,
-        // aud = the AS issuer; iat / exp pin the request lifetime.
+        // aud = the AS issuer; iat / exp pin the request lifetime. The aud must be the issuer
+        // identifier byte-exact: AbsoluteUri appends a trailing slash to a root URL, which the
+        // server's exact-match audience validation rightly rejects.
         var now = TimeProvider.System.GetUtcNow();
         var requestJwt = new JsonWebToken
         {
@@ -75,7 +77,7 @@ public class JarRichAuthorizationRequestsTests(TestFactory factory) : TestBase(f
             Payload =
             {
                 Issuer = clientId,
-                Audiences = [discovery.Issuer.AbsoluteUri],
+                Audiences = [discovery.Issuer.OriginalString],
                 IssuedAt = now,
                 ExpiresAt = now.AddMinutes(5),
             },

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtIntrospectionResponseTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtIntrospectionResponseTests.cs
@@ -7,6 +7,7 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
 using Abblix.Oidc.Server.Model;
 using Xunit;
 
@@ -46,8 +47,9 @@ public class JwtIntrospectionResponseTests(TestFactory factory) : TestBase(facto
             payload[IanaClaimTypes.Iss]!.GetValue<string>().TrimEnd('/'));
 
         // The RFC 7662 response is carried under the token_introspection claim and reports the token as active.
+        // RFC 7662 §2.2 types active as a JSON boolean, so the assertion reads it as bool.
         var introspection = payload[IanaClaimTypes.TokenIntrospection]!.AsObject();
-        Assert.Equal("true", introspection["active"]!.GetValue<string>());
+        Assert.True(introspection[IntrospectionSuccess.Parameters.Active]!.GetValue<bool>());
     }
 
     [Fact]
@@ -66,7 +68,7 @@ public class JwtIntrospectionResponseTests(TestFactory factory) : TestBase(facto
         Assert.NotEqual(IntrospectionJwtMediaType, response.Content.Headers.ContentType?.MediaType);
 
         var body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
-        Assert.Equal("true", body["active"]!.GetValue<string>());
+        Assert.True(body[IntrospectionSuccess.Parameters.Active]!.GetValue<bool>());
     }
 
     [Fact]

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarMetadataTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarMetadataTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Model;
 using Xunit;
@@ -102,8 +103,8 @@ public class RarMetadataTests(TestFactory factory) : RarTestBase(factory)
         {
             [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
             [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-            ["token"] = accessToken,
-            ["token_type_hint"] = UserInfoRequest.Parameters.AccessToken,
+            [IntrospectionRequest.Parameters.Token] = accessToken,
+            [IntrospectionRequest.Parameters.TokenTypeHint] = UserInfoRequest.Parameters.AccessToken,
         });
         var response = await client.SendAsync(introspectRequest, TestContext.Current.CancellationToken);
         var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -111,7 +112,7 @@ public class RarMetadataTests(TestFactory factory) : RarTestBase(factory)
 
         var body = JsonNode.Parse(raw)?.AsObject();
         Assert.NotNull(body);
-        Assert.Equal("true", body["active"]?.GetValue<string>());
+        Assert.True(body[IntrospectionSuccess.Parameters.Active]!.GetValue<bool>());
 
         var echoed = body[AuthorizationRequest.Parameters.AuthorizationDetails] as JsonArray;
         Assert.NotNull(echoed);

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RequirePushedAuthorizationRequestsTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RequirePushedAuthorizationRequestsTests.cs
@@ -1,0 +1,86 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// RFC 9126 §6 per-client <c>require_pushed_authorization_requests</c> end-to-end: a flagged
+/// client can only start an authorization flow via PAR. The critical property locked here is that
+/// the PAR endpoint itself accepts the flagged client — the requirement must not deadlock the only
+/// entry point the client is allowed to use — while a plain /authorize request is rejected.
+/// </summary>
+public class RequirePushedAuthorizationRequestsTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task FlaggedClient_CompletesParFlow_WhilePlainAuthorizeIsRejected()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        // 1. Register a client committed to PAR; the flag must round-trip in the DCR response.
+        var registered = await RegisterClientAsync(client, discovery, new JsonObject
+        {
+            [ClientRegistrationRequest.Parameters.RedirectUris] = new JsonArray { TestConstants.RedirectUri },
+            [ClientRegistrationRequest.Parameters.GrantTypes] = new JsonArray { GrantTypes.AuthorizationCode },
+            [ClientRegistrationRequest.Parameters.ResponseTypes] = new JsonArray { ResponseTypes.Code },
+            [ClientRegistrationRequest.Parameters.TokenEndpointAuthMethod] =
+                ClientAuthenticationMethods.ClientSecretPost,
+            [ClientRegistrationRequest.Parameters.RequirePushedAuthorizationRequests] = true,
+        });
+        var clientId = registered[AuthorizationRequest.Parameters.ClientId]!.GetValue<string>();
+        var clientSecret = registered[ClientRequest.Parameters.ClientSecret]!.GetValue<string>();
+        Assert.True(
+            registered[ClientRegistrationRequest.Parameters.RequirePushedAuthorizationRequests]!.GetValue<bool>());
+
+        // 2. The PAR endpoint accepts the flagged client and issues a request_uri — the per-client
+        // requirement is enforced only at the authorization endpoint.
+        var (_, challenge) = GeneratePkcePair();
+        var parResponse = await PushAuthorizationRequestAsync(client, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [ClientRequest.Parameters.ClientSecret] = clientSecret,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+        var requestUri = parResponse[AuthorizationRequest.Parameters.RequestUri]!.GetValue<string>();
+
+        // 3. /authorize with the PAR-issued request_uri completes and yields a code.
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.RequestUri] = requestUri,
+        });
+        Assert.NotEmpty(code);
+
+        // 4. A plain /authorize request from the same client is rejected: no code may be issued
+        // outside PAR. The rejection happens at the fetch stage, before redirect validation, so
+        // it surfaces as a direct error response rather than an error redirect.
+        var (_, plainChallenge) = GeneratePkcePair();
+        var plainAuthorizeUri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = clientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.CodeChallenge] = plainChallenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+        var plainResponse = await client.GetAsync(plainAuthorizeUri);
+
+        Assert.Equal(HttpStatusCode.BadRequest, plainResponse.StatusCode);
+        var body = JsonNode.Parse(await plainResponse.Content.ReadAsStringAsync())!.AsObject();
+        Assert.Equal(ErrorCodes.InvalidRequestObject, body["error"]!.GetValue<string>());
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenEndpointClientAuthTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenEndpointClientAuthTests.cs
@@ -1,0 +1,51 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// RFC 6749 §5.2 client-authentication failures at the token endpoint: when the client attempted
+/// to authenticate via the Authorization header, the server MUST respond with 401 and a
+/// WWW-Authenticate challenge matching the scheme the client used.
+/// </summary>
+public class TokenEndpointClientAuthTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task Token_request_with_wrong_basic_credentials_returns_401_with_basic_challenge()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.TokenEndpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TokenTypes.Basic,
+            Convert.ToBase64String(
+                Encoding.UTF8.GetBytes($"{TestConstants.ConfidentialClientId}:wrong-secret")));
+        request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = "irrelevant-code",
+            [TokenRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+        });
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // RFC 6749 §5.2: Authorization-header authentication failure -> 401 (not 400) with a
+        // WWW-Authenticate challenge matching the scheme the client used (Basic).
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.Basic);
+
+        var body = JsonNode.Parse(
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+        Assert.Equal(ErrorCodes.InvalidClient, body["error"]!.GetValue<string>());
+    }
+}

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/DeviceAuthorizationResponseFormatterTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/DeviceAuthorizationResponseFormatterTests.cs
@@ -1,0 +1,71 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.Formatters;
+using Abblix.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using CoreResponse = Abblix.Oidc.Server.Model.DeviceAuthorizationResponse;
+using MvcResponse = Abblix.Oidc.Server.Mvc.Model.DeviceAuthorizationResponse;
+
+namespace Abblix.Oidc.Server.Mvc.UnitTests.Formatters;
+
+/// <summary>
+/// Unit tests for <see cref="DeviceAuthorizationResponseFormatter"/> verifying the RFC 8628 §3.2
+/// response shape, in particular that verification_uri_complete carries the user code so capable
+/// devices can render a direct link or QR code.
+/// </summary>
+public class DeviceAuthorizationResponseFormatterTests
+{
+    private static DeviceAuthorizationResponseFormatter CreateFormatter(Uri verificationUri)
+        => new(Options.Create(new OidcOptions
+        {
+            DeviceAuthorization = new DeviceAuthorizationOptions
+            {
+                VerificationUri = verificationUri,
+                CodeLifetime = TimeSpan.FromMinutes(15),
+                PollingInterval = TimeSpan.FromSeconds(5),
+                DeviceCodeLength = 32,
+                UserCodeLength = 8,
+            },
+        }));
+
+    [Fact]
+    public async Task FormatResponseAsync_PopulatesVerificationUriComplete()
+    {
+        var formatter = CreateFormatter(new Uri("https://auth.example.com/device"));
+        Result<CoreResponse, OidcError> coreResponse =
+            new CoreResponse { DeviceCode = "device-code-1", UserCode = "WDJB-MJHT" };
+
+        var result = await formatter.FormatResponseAsync(new DeviceAuthorizationRequest(), coreResponse);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<MvcResponse>(ok.Value);
+        Assert.Equal(new Uri("https://auth.example.com/device"), response.VerificationUri);
+        Assert.Equal(
+            new Uri("https://auth.example.com/device?user_code=WDJB-MJHT"),
+            response.VerificationUriComplete);
+    }
+}

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/IntrospectionResponseFormatterTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/IntrospectionResponseFormatterTests.cs
@@ -80,7 +80,7 @@ public class IntrospectionResponseFormatterTests
 
     private static IntrospectionSuccess ActiveResponse(string signedResponseAlgorithm) => new(
         true,
-        new JsonObject { ["sub"] = "user_123" },
+        new JsonObject { [IanaClaimTypes.Sub] = "user_123" },
         new ClientInfo(ClientId) { IntrospectionSignedResponseAlgorithm = signedResponseAlgorithm });
 
     [Fact]
@@ -88,10 +88,31 @@ public class IntrospectionResponseFormatterTests
     {
         var result = await FormatAsync(ActiveResponse(SigningAlgorithms.None), MediaTypes.TokenIntrospectionJwt);
 
-        Assert.IsType<JsonResult>(result);
+        // RFC 7662 §2.2: active is a JSON boolean, not the string "true".
+        var json = Assert.IsType<JsonResult>(result);
+        var introspection = Assert.IsType<JsonObject>(json.Value);
+        Assert.True(introspection[IntrospectionSuccess.Parameters.Active]!.GetValue<bool>());
+
         _clientJwtFormatter.Verify(
             f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ClientInfo>(), It.IsAny<ClientJwtEncryption>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task FormatResponseAsync_WhenTokenInactive_ReturnsBooleanFalse()
+    {
+        var inactiveResponse = new IntrospectionSuccess(
+            false,
+            null,
+            new ClientInfo(ClientId) { IntrospectionSignedResponseAlgorithm = SigningAlgorithms.None });
+
+        var result = await FormatAsync(inactiveResponse, acceptHeader: null);
+
+        // The dangerous regression case: a string "false" is truthy for lenient JSON consumers, so a revoked
+        // token would read as active. The boolean false has no such failure mode.
+        var json = Assert.IsType<JsonResult>(result);
+        var introspection = Assert.IsType<JsonObject>(json.Value);
+        Assert.False(introspection[IntrospectionSuccess.Parameters.Active]!.GetValue<bool>());
     }
 
     [Fact]
@@ -129,7 +150,7 @@ public class IntrospectionResponseFormatterTests
         Assert.Contains(ClientId, capturedToken.Payload.Audiences);
 
         var introspection = capturedToken.Payload[IanaClaimTypes.TokenIntrospection]!.AsObject();
-        Assert.Equal("user_123", introspection["sub"]!.GetValue<string>());
-        Assert.True(introspection.ContainsKey("active"));
+        Assert.Equal("user_123", introspection[IanaClaimTypes.Sub]!.GetValue<string>());
+        Assert.True(introspection[IntrospectionSuccess.Parameters.Active]!.GetValue<bool>());
     }
 }

--- a/Abblix.Oidc.Server.Mvc/ActionResults/ActionResultExtensions.cs
+++ b/Abblix.Oidc.Server.Mvc/ActionResults/ActionResultExtensions.cs
@@ -135,6 +135,8 @@ public static class ActionResultExtensions
 	/// Formats an <see cref="OidcError"/> as an appropriate HTTP error response per RFC 6750 Section 3.
 	/// Bearer token errors (<c>invalid_token</c>) return HTTP 401 with only a <c>WWW-Authenticate</c> header
 	/// and no response body. Scope errors (<c>insufficient_scope</c>) return HTTP 403 with the header.
+	/// Client authentication failures (<c>invalid_client</c>) return HTTP 401 with a Basic challenge
+	/// and the JSON error body per RFC 6749 Section 5.2.
 	/// All other errors use the specified fallback status code with a JSON body.
 	/// </summary>
 	/// <param name="error">The OIDC error to format.</param>
@@ -152,6 +154,15 @@ public static class ActionResultExtensions
 
 			(ErrorCodes.InsufficientScope, _) => new StatusCodeResult(StatusCodes.Status403Forbidden)
 				.WithHeader(HeaderNames.WWWAuthenticate, challenge),
+
+			// RFC 6749 §5.2: a 401 is REQUIRED when the client authenticated via the Authorization
+			// header and allowed otherwise, so the uniform 401 satisfies both cases. Basic is the
+			// only Authorization-header scheme the client-authenticating endpoints (token,
+			// introspection, revocation) support, hence the Basic challenge; the error itself stays
+			// in the JSON body because RFC 7617 defines no error attributes for the Basic scheme.
+			(ErrorCodes.InvalidClient, _)
+				=> new UnauthorizedObjectResult(new ErrorResponse(error.Error, error.ErrorDescription))
+					.WithHeader(HeaderNames.WWWAuthenticate, WwwAuthenticateBuilder.BuildBasicChallenge(realm)),
 
 			(_, StatusCodes.Status400BadRequest)
 				=> new BadRequestObjectResult(new ErrorResponse(error.Error, error.ErrorDescription)),
@@ -181,13 +192,15 @@ public static class ActionResultExtensions
 
 		ActionResult result = error switch
 		{
-			InvalidDPoPProofError or UseDPoPNonceError => new UnauthorizedResult(),
-			_ when error.Error == ErrorCodes.InvalidToken => new UnauthorizedResult(),
-			_ when error.Error == ErrorCodes.InsufficientScope => new StatusCodeResult(StatusCodes.Status403Forbidden),
+			InvalidDPoPProofError or UseDPoPNonceError or { Error: ErrorCodes.InvalidToken } => new UnauthorizedResult(),
+			{ Error: ErrorCodes.InsufficientScope } => new StatusCodeResult(StatusCodes.Status403Forbidden),
+
 			_ when fallbackStatusCode == StatusCodes.Status400BadRequest
 				=> new BadRequestObjectResult(new ErrorResponse(error.Error, error.ErrorDescription)),
+
 			_ when fallbackStatusCode == StatusCodes.Status401Unauthorized
 				=> new UnauthorizedObjectResult(new ErrorResponse(error.Error, error.ErrorDescription)),
+
 			_ => new ObjectResult(new ErrorResponse(error.Error, error.ErrorDescription))
 				{ StatusCode = fallbackStatusCode },
 		};

--- a/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
@@ -65,16 +65,19 @@ public class TokenController : ControllerBase
     /// OpenID Connect Token Endpoint Documentation
     /// </see>
     /// </remarks>
-    [HttpGetOrPost(Path.Token)]
-    //[Consumes(MediaTypes.FormUrlEncoded)]
+    // RFC 6749 §3.2: the token endpoint MUST accept POST with application/x-www-form-urlencoded.
+    // GET is rejected so credentials (code, client_secret, refresh_token) never travel in the URL,
+    // where they would be logged by proxies, servers and browser history.
+    [HttpPost(Path.Token)]
+    [Consumes(MediaTypes.FormUrlEncoded)]
     [Produces(MediaTypeNames.Application.Json)]
     [EnableCors(OidcConstants.CorsPolicyName)]
     [EnabledBy(OidcEndpoints.Token)]
     public async Task<ActionResult<TokenResponse>> TokenAsync(
         [FromServices] ITokenHandler handler,
         [FromServices] ITokenResponseFormatter formatter,
-        [FromQueryOrForm] TokenRequest tokenRequest,
-        [FromQueryOrForm] ClientRequest clientRequest)
+        [FromForm] TokenRequest tokenRequest,
+        [FromForm] ClientRequest clientRequest)
     {
         var mappedTokenRequest = tokenRequest.Map();
         var mappedClientRequest = clientRequest.Map();

--- a/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationResponseFormatter.cs
@@ -90,6 +90,16 @@ public class AuthorizationResponseFormatter(
                 return await RedirectAsync(
                     options.Value.LoginUri.NotNull(nameof(OidcOptions.LoginUri)), response.Model);
 
+            // prompt=create (Initiating User Registration via OpenID Connect 1.0): a dedicated
+            // registration UI when the host configured one, otherwise the login UI — the original
+            // request parameters (including prompt=create) travel in the redirect, so a combined
+            // login/registration page can still branch on them.
+            case RegistrationRequired:
+                return await RedirectAsync(
+                    options.Value.RegistrationUri
+                        ?? options.Value.LoginUri.NotNull(nameof(OidcOptions.LoginUri)),
+                    response.Model);
+
             // iss/scope gating and JARM packing are applied upstream by the core response encoder (run from
             // the handler); here we only map the encoded response onto the MVC wire DTO and deliver it.
 
@@ -179,6 +189,12 @@ public class AuthorizationResponseFormatter(
         Code = success.Code,
         TokenType = success.TokenType,
         AccessToken = success.AccessToken?.EncodedJwt,
+        // RFC 6749 §4.2.2: expires_in is RECOMMENDED whenever an access token is delivered from
+        // the authorization endpoint (implicit/hybrid). Derived from the issued token's own
+        // iat/exp pair, so the advertised lifetime always matches the token itself.
+        ExpiresIn = success.AccessToken is { Token.Payload: { ExpiresAt: { } expiresAt, IssuedAt: { } issuedAt } }
+            ? expiresAt - issuedAt
+            : null,
         IdToken = success.IdToken?.EncodedJwt,
         SessionState = success.SessionState,
     };

--- a/Abblix.Oidc.Server.Mvc/Formatters/DeviceAuthorizationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/DeviceAuthorizationResponseFormatter.cs
@@ -59,6 +59,12 @@ public class DeviceAuthorizationResponseFormatter(
                     DeviceCode = success.DeviceCode,
                     UserCode = success.UserCode,
                     VerificationUri = deviceAuthOptions.VerificationUri,
+                    // RFC 8628 §3.2: verification_uri_complete lets capable devices render a
+                    // direct link / QR code so the user skips typing the code. The field was
+                    // declared on the wire model but never populated.
+                    VerificationUriComplete = new Uri(
+                        deviceAuthOptions.VerificationUri.AddToQuery(
+                            [(CoreResponse.Parameters.UserCode, success.UserCode)])),
                     ExpiresIn = deviceAuthOptions.CodeLifetime,
                     Interval = deviceAuthOptions.PollingInterval,
                 };

--- a/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/IntrospectionResponseFormatter.cs
@@ -75,7 +75,12 @@ public class IntrospectionResponseFormatter(
     private async Task<ActionResult> FormatSuccessAsync(IntrospectionSuccess success)
     {
         var introspectionResponse = success.Claims ?? new JsonObject();
-        introspectionResponse.SetProperty("active", success.Active ? "true" : "false");
+
+        // RFC 7662 §2.2: active is the only REQUIRED member and its type is a JSON boolean. Serializing it
+        // as the strings "true"/"false" (as before) broke strict deserializers and, worse, inverted the
+        // semantics for lenient ones: a non-empty string "false" is truthy, so a revoked token could be
+        // treated as active by the resource server.
+        introspectionResponse.SetProperty(IntrospectionSuccess.Parameters.Active, JsonValue.Create(success.Active));
 
         var clientInfo = success.ClientInfo;
 

--- a/Abblix.Oidc.Server.Mvc/Formatters/RegisterClientResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/RegisterClientResponseFormatter.cs
@@ -85,7 +85,9 @@ public class RegisterClientResponseFormatter(IUriResolver uriResolver) : IRegist
             InitiateLoginUri = success.InitiateLoginUri ?? request.InitiateLoginUri,
             TokenEndpointAuthMethod = success.TokenEndpointAuthMethod ?? request.TokenEndpointAuthMethod,
 
-            Scope = request.Scope,
+            // RFC 7591 §3.2.1: scope echoes the registered value (the server may narrow or default
+            // it), not the literal request input.
+            Scope = success.Scope ?? request.Scope,
             SoftwareId = request.SoftwareId,
             SoftwareVersion = request.SoftwareVersion,
             SoftwareStatement = request.SoftwareStatement,
@@ -93,6 +95,8 @@ public class RegisterClientResponseFormatter(IUriResolver uriResolver) : IRegist
             // RFC 7591 §3.2.1: echo registered metadata so clients can confirm what was stored.
             ApplicationType = success.ApplicationType,
             RedirectUris = success.RedirectUris,
+            GrantTypes = success.GrantTypes,
+            ResponseTypes = success.ResponseTypes,
             ClientName = success.ClientName,
             LogoUri = success.LogoUri,
             SubjectType = success.SubjectType,
@@ -109,6 +113,10 @@ public class RegisterClientResponseFormatter(IUriResolver uriResolver) : IRegist
             TlsClientAuthSanEmail = success.TlsClientAuthSanEmail,
             // RFC 9449 §5.2: dpop_bound_access_tokens echo.
             DpopBoundAccessTokens = success.DpopBoundAccessTokens,
+            // RFC 9126 §6 / RFC 9101 §10.5 / RFC 8705 §3.4: per-client enforcement flags echo.
+            RequirePushedAuthorizationRequests = success.RequirePushedAuthorizationRequests,
+            RequireSignedRequestObject = success.RequireSignedRequestObject,
+            TlsClientCertificateBoundAccessTokens = success.TlsClientCertificateBoundAccessTokens,
             // RFC 9396 §5.1: authorization_details_types echo.
             AuthorizationDetailsTypes = success.AuthorizationDetailsTypes,
             // Non-standard extension: token_exchange_subject_token_types echo.

--- a/Abblix.Oidc.Server.Mvc/Formatters/RegisterClientResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/RegisterClientResponseFormatter.cs
@@ -113,6 +113,8 @@ public class RegisterClientResponseFormatter(IUriResolver uriResolver) : IRegist
             AuthorizationDetailsTypes = success.AuthorizationDetailsTypes,
             // Non-standard extension: token_exchange_subject_token_types echo.
             TokenExchangeSubjectTokenTypes = success.TokenExchangeSubjectTokenTypes,
+            // Non-standard extension: token_exchange_audiences echo.
+            TokenExchangeAudiences = success.TokenExchangeAudiences,
         };
 
         return new ObjectResult(modelResponse) { StatusCode = StatusCodes.Status201Created };

--- a/Abblix.Oidc.Server.Mvc/Formatters/RevocationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/RevocationResponseFormatter.cs
@@ -22,9 +22,12 @@
 
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Endpoints.Revocation.Interfaces;
+using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.ActionResults;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Abblix.Oidc.Server.Mvc.Formatters;
@@ -32,7 +35,9 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// <summary>
 /// Formatter for responses to token revocation requests.
 /// </summary>
-public class RevocationResponseFormatter : IRevocationResponseFormatter
+/// <param name="issuerProvider">Supplies the issuer identifier used as the realm value on
+/// <c>WWW-Authenticate</c> challenges for client-authentication failures.</param>
+public class RevocationResponseFormatter(IIssuerProvider issuerProvider) : IRevocationResponseFormatter
 {
     /// <summary>
     /// Asynchronously formats the response for a token revocation request.
@@ -50,6 +55,8 @@ public class RevocationResponseFormatter : IRevocationResponseFormatter
     {
         return Task.FromResult(response.Match<ActionResult>(
             onSuccess: _ => new OkResult(),
-            onFailure: error => new BadRequestObjectResult(new ErrorResponse(error.Error, error.ErrorDescription))));
+            // RFC 7009 §2.2.1 defers to RFC 6749 §5.2 for error semantics, so the shared formatter
+            // applies: invalid_client becomes a 401 with a Basic challenge, other errors stay 400.
+            onFailure: error => error.Format(StatusCodes.Status400BadRequest, issuerProvider.GetIssuer())));
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Formatters/TokenResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/TokenResponseFormatter.cs
@@ -23,10 +23,12 @@
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Mvc.ActionResults;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
 using Abblix.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using TokenResponse = Abblix.Oidc.Server.Mvc.Model.TokenResponse;
 
@@ -35,7 +37,9 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// <summary>
 /// Formatter for token responses.
 /// </summary>
-public class TokenResponseFormatter : ITokenResponseFormatter
+/// <param name="issuerProvider">Supplies the issuer identifier used as the realm value on
+/// <c>WWW-Authenticate</c> challenges for client-authentication failures.</param>
+public class TokenResponseFormatter(IIssuerProvider issuerProvider) : ITokenResponseFormatter
 {
     /// <summary>
     /// Asynchronously formats the response for a token request.
@@ -71,10 +75,11 @@ public class TokenResponseFormatter : ITokenResponseFormatter
             onFailure: FormatError));
     }
 
-    private static ActionResult<TokenResponse> FormatError(OidcError error)
+    private ActionResult<TokenResponse> FormatError(OidcError error)
     {
-        ActionResult result = new BadRequestObjectResult(
-            new ErrorResponse(error.Error, error.ErrorDescription));
+        // The shared formatter owns the status-code policy: invalid_client comes back as a 401
+        // with a Basic challenge (RFC 6749 §5.2), everything else as 400 with the JSON envelope.
+        var result = error.Format(StatusCodes.Status400BadRequest, issuerProvider.GetIssuer());
 
         // Per RFC 9449 §8 a use_dpop_nonce error MUST carry the fresh nonce on a
         // DPoP-Nonce response header alongside the standard error JSON envelope.

--- a/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
@@ -336,6 +336,14 @@ public record ClientRegistrationRequest
     public string[]? TokenExchangeSubjectTokenTypes { get; init; }
 
     /// <summary>
+    /// Non-standard extension: default-deny per-client allowlist of RFC 8693 <c>audience</c> values
+    /// this client may request when exchanging a token. Maps to
+    /// <see cref="ClientInfo.TokenExchangeAllowedAudiences"/>.
+    /// </summary>
+    [JsonPropertyName(Parameters.TokenExchangeAudiences)]
+    public string[]? TokenExchangeAudiences { get; init; }
+
+    /// <summary>
     /// Indicates whether a back-channel logout session is required for this client.
     /// This is relevant for scenarios where the client needs to be notified when the user logs out.
     /// </summary>
@@ -437,6 +445,7 @@ public record ClientRegistrationRequest
             DpopBoundAccessTokens = DpopBoundAccessTokens,
             AuthorizationDetailsTypes = AuthorizationDetailsTypes,
             TokenExchangeSubjectTokenTypes = TokenExchangeSubjectTokenTypes,
+            TokenExchangeAudiences = TokenExchangeAudiences,
             RequireAuthTime = RequireAuthTime,
             SectorIdentifierUri = SectorIdentifierUri,
 

--- a/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/ClientRegistrationRequest.cs
@@ -319,6 +319,32 @@ public record ClientRegistrationRequest
     public bool? DpopBoundAccessTokens { get; init; }
 
     /// <summary>
+    /// The <c>require_pushed_authorization_requests</c> client metadata per RFC 9126 §6: when
+    /// <c>true</c>, pushed authorization requests are the only way this client may start an
+    /// authorization flow. Maps to <c>ClientInfo.RequirePushedAuthorizationRequests</c> via
+    /// <see cref="Map"/>.
+    /// </summary>
+    [JsonPropertyName(Parameters.RequirePushedAuthorizationRequests)]
+    public bool? RequirePushedAuthorizationRequests { get; init; }
+
+    /// <summary>
+    /// The <c>require_signed_request_object</c> client metadata per RFC 9101 §10.5: when
+    /// <c>true</c>, the client must deliver its authorization request parameters as a signed
+    /// request object. Maps to <c>ClientInfo.RequireSignedRequestObject</c> via <see cref="Map"/>.
+    /// </summary>
+    [JsonPropertyName(Parameters.RequireSignedRequestObject)]
+    public bool? RequireSignedRequestObject { get; init; }
+
+    /// <summary>
+    /// The <c>tls_client_certificate_bound_access_tokens</c> client metadata per RFC 8705 §3.4:
+    /// when <c>true</c>, access tokens are certificate-bound whenever the token request arrives
+    /// over mutual TLS, independently of the authentication method. Maps to
+    /// <c>ClientInfo.TlsClientCertificateBoundAccessTokens</c> via <see cref="Map"/>.
+    /// </summary>
+    [JsonPropertyName(Parameters.TlsClientCertificateBoundAccessTokens)]
+    public bool? TlsClientCertificateBoundAccessTokens { get; init; }
+
+    /// <summary>
     /// The <c>authorization_details_types</c> client metadata per RFC 9396 §5.1:
     /// per-client allowlist of authorization-detail <c>type</c> values this client
     /// may use in Rich Authorization Requests. <c>null</c> means no per-client
@@ -443,6 +469,9 @@ public record ClientRegistrationRequest
             InitiateLoginUri = InitiateLoginUri,
             OfflineAccessAllowed = OfflineAccessAllowed,
             DpopBoundAccessTokens = DpopBoundAccessTokens,
+            RequirePushedAuthorizationRequests = RequirePushedAuthorizationRequests,
+            RequireSignedRequestObject = RequireSignedRequestObject,
+            TlsClientCertificateBoundAccessTokens = TlsClientCertificateBoundAccessTokens,
             AuthorizationDetailsTypes = AuthorizationDetailsTypes,
             TokenExchangeSubjectTokenTypes = TokenExchangeSubjectTokenTypes,
             TokenExchangeAudiences = TokenExchangeAudiences,

--- a/Abblix.Oidc.Server.Mvc/Model/TokenRequest.cs
+++ b/Abblix.Oidc.Server.Mvc/Model/TokenRequest.cs
@@ -39,7 +39,7 @@ public record TokenRequest
     /// Specifies the OAuth 2.0 grant type of the token request.
     /// This property defines the mechanism used to obtain the access token, such as authorization code, client credentials, or refresh token.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.GrantType)]
+    [BindProperty(Name = Parameters.GrantType)]
     [Required]
     [AllowedValues(
         GrantTypes.AuthorizationCode,
@@ -56,35 +56,35 @@ public record TokenRequest
     /// The authorization code received from the authorization server.
     /// This is used in the authorization code grant type to exchange the code for an access token.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.Code)]
+    [BindProperty(Name = Parameters.Code)]
     public string? Code { get; set; }
 
     /// <summary>
     /// The URI where the client will be redirected after authorization.
     /// This is used in conjunction with the authorization code grant type.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.RedirectUri)]
+    [BindProperty(Name = Parameters.RedirectUri)]
     public Uri? RedirectUri { get; set; }
 
     /// <summary>
     /// Specifies the resource for which the access token is requested.
     /// As defined in RFC 8707, this parameter is used to request access tokens with a specific scope for a particular resource.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.Resource)]
+    [BindProperty(Name = Parameters.Resource)]
     public Uri[]? Resource { get; set; }
 
     /// <summary>
     /// The refresh token used to obtain a new access token.
     /// This is applicable in scenarios where the client already holds a refresh token and requires a new access token.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.RefreshToken)]
+    [BindProperty(Name = Parameters.RefreshToken)]
     public string? RefreshToken { get; set; }
 
     /// <summary>
     /// Array of scope values indicating the permissions the client is requesting.
     /// Scopes specify the level of access required and the associated permissions.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.Scope)]
+    [BindProperty(Name = Parameters.Scope)]
     [ModelBinder(typeof(SpaceSeparatedValuesBinder))]
     public string[] Scope { get; set; } = [];
 
@@ -106,14 +106,14 @@ public record TokenRequest
     /// The code verifier for Proof Key for Code Exchange (PKCE) used in the authorization code grant type.
     /// This is used to mitigate authorization code interception attacks.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.CodeVerifier)]
+    [BindProperty(Name = Parameters.CodeVerifier)]
     public string? CodeVerifier { get; set; }
 
     /// <summary>
     /// The authentication request identifier for Client Initiated Backchannel Authentication (CIBA).
     /// This is used in the CIBA grant type to reference a previously initiated authentication request.
     /// </summary>
-    [BindProperty(SupportsGet = true, Name = Parameters.AuthenticationRequestId)]
+    [BindProperty(Name = Parameters.AuthenticationRequestId)]
     public string? AuthenticationRequestId { get; set; }
 
     /// <summary>RFC 8693 §2.1 <c>subject_token</c> -- the security token being exchanged.</summary>

--- a/Abblix.Oidc.Server.UnitTests/Common/WwwAuthenticateBuilderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/WwwAuthenticateBuilderTests.cs
@@ -72,6 +72,41 @@ public class WwwAuthenticateBuilderTests
             challenge);
     }
 
+    /// <summary>
+    /// RFC 6750 §3.1: a request that carried no authentication information at all gets a bare
+    /// challenge — realm only, no error attributes — on both the Bearer and the DPoP lines.
+    /// </summary>
+    [Fact]
+    public void BuildChallenges_MissingAuthentication_EmitsBareChallenges()
+    {
+        var missingAuthentication = new MissingAuthenticationError("No access token provided");
+
+        Assert.Equal(
+            $"Bearer realm=\"{Realm}\"",
+            WwwAuthenticateBuilder.BuildBearerChallenge(missingAuthentication, Realm));
+        Assert.Equal(
+            $"DPoP realm=\"{Realm}\", algs=\"RS256 ES256\"",
+            WwwAuthenticateBuilder.BuildDPoPChallenge(missingAuthentication, Realm, DPoPAlgs));
+    }
+
+    [Fact]
+    public void BuildBasicChallenge_WithRealm_EmitsRealmOnly()
+    {
+        // RFC 7617 defines no error attributes for the Basic scheme, so the challenge carries
+        // only the realm — the error itself travels in the JSON body (RFC 6749 §5.2).
+        var challenge = WwwAuthenticateBuilder.BuildBasicChallenge(Realm);
+
+        Assert.Equal($"Basic realm=\"{Realm}\"", challenge);
+    }
+
+    [Fact]
+    public void BuildBasicChallenge_NullRealm_EmitsBareScheme()
+    {
+        var challenge = WwwAuthenticateBuilder.BuildBasicChallenge(realm: null);
+
+        Assert.Equal(TokenTypes.Basic, challenge);
+    }
+
     [Fact]
     public void BuildDPoPChallenge_EmitsAllAttributesIncludingSpaceSeparatedAlgs()
     {

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -186,6 +186,50 @@ public class AuthorizationRequestProcessorTests
     }
 
     /// <summary>
+    /// Initiating User Registration via OpenID Connect 1.0: prompt=create yields the registration
+    /// signal even when no session exists — previously the value fell through to the generic
+    /// no-session branch and the host saw an ordinary login request.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_WithPromptCreate_NoSessions_ShouldReturnRegistrationRequired()
+    {
+        // Arrange
+        var request = CreateRequest(prompt: Prompts.Create);
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(AsyncEnumerable.Empty<AuthSession>());
+
+        // Act
+        var result = await _processor.ProcessAsync(request);
+
+        // Assert
+        Assert.IsType<RegistrationRequired>(result);
+    }
+
+    /// <summary>
+    /// Initiating User Registration via OpenID Connect 1.0: the registration experience is shown
+    /// regardless of whether the user is currently logged in — an existing session must not make
+    /// the request proceed as a normal authentication.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_WithPromptCreate_ExistingSession_ShouldReturnRegistrationRequired()
+    {
+        // Arrange
+        var request = CreateRequest(prompt: Prompts.Create);
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(new[] { CreateAuthSession() }.ToAsyncEnumerable());
+
+        // Act
+        var result = await _processor.ProcessAsync(request);
+
+        // Assert
+        Assert.IsType<RegistrationRequired>(result);
+    }
+
+    /// <summary>
     /// Verifies that when the request omits max_age, the client's registered default_max_age is
     /// applied (OIDC Core §2 / §3.1.2.1): a session older than default_max_age is filtered out.
     /// </summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
@@ -35,6 +36,7 @@ using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Consents;
 using Abblix.Oidc.Server.Features.ImplicitFlow;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.UserAuthentication;
@@ -57,6 +59,7 @@ public class AuthorizationRequestProcessorTests
     private readonly Mock<IAuthorizationCodeService> _authorizationCodeService;
     private readonly Mock<IAccessTokenService> _accessTokenService;
     private readonly Mock<IIdentityTokenService> _identityTokenService;
+    private readonly Mock<IAuthorizationDetailsPolicy> _authorizationDetailsPolicy;
     private readonly FakeTimeProvider _timeProvider;
     private readonly AuthorizationRequestProcessor _processor;
 
@@ -67,9 +70,22 @@ public class AuthorizationRequestProcessorTests
         _authorizationCodeService = new Mock<IAuthorizationCodeService>(MockBehavior.Strict);
         _accessTokenService = new Mock<IAccessTokenService>(MockBehavior.Strict);
         _identityTokenService = new Mock<IIdentityTokenService>(MockBehavior.Strict);
+        _authorizationDetailsPolicy = new Mock<IAuthorizationDetailsPolicy>(MockBehavior.Strict);
+
+        // The anti-escalation backstop re-runs granted authorization_details through the per-type
+        // policy. For the processor tests the granted set is already a valid narrowing, so the
+        // policy passes it through unchanged; AD escalation/failure cases are covered in
+        // ConsentConstraintEnforcerTests against the real enforcer.
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => ad);
 
         _timeProvider = new FakeTimeProvider();
 
+        // A real ConsentConstraintEnforcer (not a mock) so the anti-escalation backstop is
+        // exercised end-to-end through the processor — granted scopes/resources that exceed the
+        // request must throw before the grant is built.
         _processor = new AuthorizationRequestProcessor(
             _authSessionService.Object,
             _consentsProvider.Object,
@@ -78,7 +94,8 @@ public class AuthorizationRequestProcessorTests
                 new AuthorizationCodeBuilder(_authorizationCodeService.Object),
                 new TokenResponseBuilder(_accessTokenService.Object),
                 new IdTokenResponseBuilder(_identityTokenService.Object),
-            ]);
+            ],
+            new ConsentConstraintEnforcer(_authorizationDetailsPolicy.Object));
     }
 
     private static ValidAuthorizationRequest CreateRequest(
@@ -516,6 +533,66 @@ public class AuthorizationRequestProcessorTests
         Assert.Equal(expectedCode, success.Code);
         Assert.Null(success.AccessToken);
         Assert.Null(success.IdToken);
+    }
+
+    /// <summary>
+    /// Anti-escalation backstop (#185): the IUserConsentsProvider contract permits a narrower grant
+    /// than the request, never a broader one. A granted scope absent from the request is a host-side
+    /// contract violation and must fail loud with an exception instead of issuing an escalated grant.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_GrantedScopeExceedsRequest_ShouldThrow()
+    {
+        // Arrange — request carries only openid; the consent provider returns an extra "admin"
+        // scope that was never requested (e.g. browser tampering it failed to intersect away).
+        var request = CreateRequest(responseType: [ResponseTypes.Code], scope: [Scopes.OpenId]);
+        var session = CreateAuthSession();
+        var consents = CreateConsents(
+            grantedScopes: [new ScopeDefinition(Scopes.OpenId), new ScopeDefinition("admin")]);
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(new[] { session }.ToAsyncEnumerable());
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .ReturnsAsync(consents);
+        _authSessionService.Setup(s => s.SignInAsync(session)).Returns(Task.CompletedTask);
+        _authorizationCodeService
+            .Setup(s => s.GenerateAuthorizationCodeAsync(
+                It.IsAny<AuthorizedGrant>(), request.ClientInfo.AuthorizationCodeExpiresIn))
+            .ReturnsAsync("code");
+
+        // Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(request));
+    }
+
+    /// <summary>
+    /// Anti-escalation backstop (#185): a granted resource absent from the request is likewise a
+    /// host-side contract violation and must fail loud.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_GrantedResourceNotRequested_ShouldThrow()
+    {
+        // Arrange — the request carries no resources; the provider grants one anyway.
+        var request = CreateRequest(responseType: [ResponseTypes.Code]);
+        var session = CreateAuthSession();
+        var consents = CreateConsents(
+            grantedResources: [new ResourceDefinition(new Uri("https://api.example/admin"))]);
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(new[] { session }.ToAsyncEnumerable());
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .ReturnsAsync(consents);
+        _authSessionService.Setup(s => s.SignInAsync(session)).Returns(Task.CompletedTask);
+        _authorizationCodeService
+            .Setup(s => s.GenerateAuthorizationCodeAsync(
+                It.IsAny<AuthorizedGrant>(), request.ClientInfo.AuthorizationCodeExpiresIn))
+            .ReturnsAsync("code");
+
+        // Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(request));
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -101,7 +101,10 @@ public class ConsentConstraintEnforcerTests
         var request = CreateRequest(scopes: [new ScopeDefinition(Scopes.OpenId), new ScopeDefinition(Scopes.Profile)]);
         var granted = Granted(scopes: [new ScopeDefinition(Scopes.OpenId)]);
 
-        await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+        var exception = await Record.ExceptionAsync(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Null(exception);
     }
 
     [Fact]
@@ -185,6 +188,9 @@ public class ConsentConstraintEnforcerTests
             new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "200" }));
         SetupPolicyPassThrough();
 
-        await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+        var exception = await Record.ExceptionAsync(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Null(exception);
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -1,0 +1,190 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Authorization;
+using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Authorization.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Consents;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+using Abblix.Oidc.Server.Model;
+using Abblix.Utils;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization;
+
+/// <summary>
+/// Unit tests for <see cref="ConsentConstraintEnforcer"/> (#185): the anti-escalation backstop
+/// asserts the consent decision is a subset of the request and throws when it is not, since a
+/// broader granted set is a host-side <see cref="IUserConsentsProvider"/> contract violation.
+/// </summary>
+public class ConsentConstraintEnforcerTests
+{
+    private const string ClientId = "test-client";
+
+    private readonly Mock<IAuthorizationDetailsPolicy> _authorizationDetailsPolicy =
+        new(MockBehavior.Strict);
+    private readonly ConsentConstraintEnforcer _enforcer;
+
+    public ConsentConstraintEnforcerTests()
+    {
+        _enforcer = new ConsentConstraintEnforcer(_authorizationDetailsPolicy.Object);
+    }
+
+    private static ValidAuthorizationRequest CreateRequest(
+        ScopeDefinition[]? scopes = null,
+        ResourceDefinition[]? resources = null,
+        JsonArray? authorizationDetails = null)
+    {
+        var model = new AuthorizationRequest
+        {
+            ClientId = ClientId,
+            ResponseType = [ResponseTypes.Code],
+            RedirectUri = new Uri("https://client.example.com/cb"),
+        };
+
+        return new ValidAuthorizationRequest(new AuthorizationValidationContext(model)
+        {
+            ClientInfo = new ClientInfo(ClientId),
+            ResponseMode = ResponseModes.Query,
+            Scope = scopes ?? [new ScopeDefinition(Scopes.OpenId)],
+            Resources = resources ?? [],
+            AuthorizationDetails = authorizationDetails,
+        });
+    }
+
+    private static ConsentDefinition Granted(
+        ScopeDefinition[]? scopes = null,
+        ResourceDefinition[]? resources = null,
+        JsonArray? authorizationDetails = null)
+        => new(scopes ?? [new ScopeDefinition(Scopes.OpenId)], resources ?? [])
+        {
+            AuthorizationDetails = authorizationDetails,
+        };
+
+    private void SetupPolicyPassThrough() =>
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) =>
+                Result<JsonArray?, OidcError>.Success(ad));
+
+    [Fact]
+    public async Task EnforceAsync_GrantedEqualsRequested_DoesNotThrow()
+    {
+        var request = CreateRequest(scopes: [new ScopeDefinition(Scopes.OpenId), new ScopeDefinition(Scopes.Profile)]);
+        var granted = Granted(scopes: [new ScopeDefinition(Scopes.OpenId)]);
+
+        await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedScopeNotRequested_Throws()
+    {
+        var request = CreateRequest(scopes: [new ScopeDefinition(Scopes.OpenId)]);
+        var granted = Granted(scopes: [new ScopeDefinition(Scopes.OpenId), new ScopeDefinition("admin")]);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+        Assert.Contains("admin", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedResourceNotRequested_Throws()
+    {
+        var request = CreateRequest();
+        var granted = Granted(resources: [new ResourceDefinition(new Uri("https://api.example/admin"))]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedResourceScopeExceedsRequested_Throws()
+    {
+        var resource = new Uri("https://api.example/payments");
+        // The resource itself is requested, but the granted nested scope set is broader.
+        var request = CreateRequest(resources: [new ResourceDefinition(resource, new ScopeDefinition("read"))]);
+        var granted = Granted(resources:
+            [new ResourceDefinition(resource, new ScopeDefinition("read"), new ScopeDefinition("write"))]);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+        Assert.Contains("write", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedAuthorizationDetailsTypeNotRequested_Throws()
+    {
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "account_information" }));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+        Assert.Contains("account_information", ex.Message);
+
+        // The type-level subset check fails before any per-type re-validation is attempted.
+        _authorizationDetailsPolicy.Verify(
+            p => p.ApplyAsync(It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedAuthorizationDetailsFailRevalidation_Throws()
+    {
+        var ad = new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "999" });
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "100" }));
+        var granted = Granted(authorizationDetails: ad);
+
+        // The per-type policy rejects the granted entry (e.g. amount escalated beyond the client's cap).
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Failure(
+                new OidcError(ErrorCodes.InvalidAuthorizationDetails, "amount exceeds the client's cap")));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedAuthorizationDetailsValidNarrowing_DoesNotThrow()
+    {
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "500" }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "200" }));
+        SetupPolicyPassThrough();
+
+        await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/PushedRequestFetcherTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/PushedRequestFetcherTests.cs
@@ -1,0 +1,107 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Authorization.RequestFetching;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization.RequestFetching;
+
+/// <summary>
+/// Unit tests for <see cref="PushedRequestFetcher"/> verifying the RFC 9126 §6 per-client
+/// require_pushed_authorization_requests metadata: a flagged client may start an authorization
+/// flow only via PAR, independent of the server-wide requirement.
+/// </summary>
+public class PushedRequestFetcherTests
+{
+    private readonly Mock<IAuthorizationRequestStorage> _storage = new(MockBehavior.Strict);
+    private readonly Mock<IClientInfoProvider> _clientInfoProvider = new(MockBehavior.Strict);
+
+    private PushedRequestFetcher CreateFetcher(bool serverWideRequirement = false)
+    {
+        var snapshot = new Mock<IOptionsSnapshot<OidcOptions>>();
+        snapshot
+            .Setup(s => s.Value)
+            .Returns(new OidcOptions { RequirePushedAuthorizationRequests = serverWideRequirement });
+
+        return new PushedRequestFetcher(snapshot.Object, _storage.Object, _clientInfoProvider.Object);
+    }
+
+    private static AuthorizationRequest CreateRequest() => new()
+    {
+        ClientId = TestConstants.DefaultClientId,
+        ResponseType = [ResponseTypes.Code],
+        RedirectUri = TestConstants.DefaultRedirectUri,
+        Scope = [Scopes.OpenId],
+    };
+
+    [Fact]
+    public async Task FetchAsync_FlaggedClientWithoutPushedRequest_ReturnsError()
+    {
+        _clientInfoProvider
+            .Setup(p => p.TryFindClientAsync(TestConstants.DefaultClientId))
+            .ReturnsAsync(new ClientInfo(TestConstants.DefaultClientId)
+            {
+                RequirePushedAuthorizationRequests = true,
+            });
+
+        var result = await CreateFetcher().FetchAsync(CreateRequest());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequestObject, error.Error);
+    }
+
+    [Fact]
+    public async Task FetchAsync_UnflaggedClientWithoutPushedRequest_PassesThrough()
+    {
+        _clientInfoProvider
+            .Setup(p => p.TryFindClientAsync(TestConstants.DefaultClientId))
+            .ReturnsAsync(new ClientInfo(TestConstants.DefaultClientId));
+
+        var request = CreateRequest();
+        var result = await CreateFetcher().FetchAsync(request);
+
+        Assert.True(result.TryGetSuccess(out var passed));
+        Assert.Same(request, passed);
+    }
+
+    /// <summary>
+    /// The server-wide requirement keeps precedence and fires before any client lookup.
+    /// </summary>
+    [Fact]
+    public async Task FetchAsync_ServerWideRequirement_ReturnsErrorWithoutClientLookup()
+    {
+        var result = await CreateFetcher(serverWideRequirement: true).FetchAsync(CreateRequest());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequestObject, error.Error);
+        _clientInfoProvider.Verify(p => p.TryFindClientAsync(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/RequestObjectFetchAdapterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/RequestObjectFetchAdapterTests.cs
@@ -1,0 +1,113 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Authorization.RequestFetching;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RequestObject;
+using Abblix.Oidc.Server.Model;
+using Abblix.Utils;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization.RequestFetching;
+
+/// <summary>
+/// Unit tests for <see cref="RequestObjectFetchAdapter"/> verifying the OIDC Core §6.1 rule:
+/// response_type and client_id passed in the OAuth request syntax must match the values inside
+/// the request object when the object carries them.
+/// </summary>
+public class RequestObjectFetchAdapterTests
+{
+    private const string ClientId = "client-1";
+    private const string RequestJwt = "header.payload.signature";
+
+    private readonly Mock<IRequestObjectFetcher> _requestObjectFetcher = new(MockBehavior.Strict);
+    private readonly RequestObjectFetchAdapter _adapter;
+
+    public RequestObjectFetchAdapterTests()
+    {
+        _adapter = new RequestObjectFetchAdapter(_requestObjectFetcher.Object);
+    }
+
+    private static AuthorizationRequest CreateRequest(
+        string? clientId = ClientId,
+        string[]? responseType = null) => new()
+    {
+        ClientId = clientId,
+        ResponseType = responseType ?? [ResponseTypes.Code],
+        RedirectUri = new Uri("https://client.example.com/cb"),
+        Request = RequestJwt,
+    };
+
+    private void SetupFetcher(AuthorizationRequest merged) =>
+        _requestObjectFetcher
+            .Setup(f => f.FetchAsync(
+                It.IsAny<AuthorizationRequest>(), RequestJwt, It.IsAny<Func<ClientInfo, string?>?>()))
+            .ReturnsAsync(merged);
+
+    [Fact]
+    public async Task FetchAsync_MatchingParameters_ReturnsMergedRequest()
+    {
+        var outer = CreateRequest();
+        SetupFetcher(CreateRequest());
+
+        var result = await _adapter.FetchAsync(outer);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// OIDC Core §6.1: a request object carrying a different client_id than the OAuth request
+    /// syntax must be rejected — otherwise the object could silently swap the client identity.
+    /// </summary>
+    [Fact]
+    public async Task FetchAsync_ClientIdMismatch_ReturnsError()
+    {
+        var outer = CreateRequest(clientId: ClientId);
+        SetupFetcher(CreateRequest(clientId: "another-client"));
+
+        var result = await _adapter.FetchAsync(outer);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequestObject, error.Error);
+    }
+
+    /// <summary>
+    /// OIDC Core §6.1: the same matching rule applies to response_type — a request object must not
+    /// silently switch the flow relative to what the plain OAuth parameters declared.
+    /// </summary>
+    [Fact]
+    public async Task FetchAsync_ResponseTypeMismatch_ReturnsError()
+    {
+        var outer = CreateRequest(responseType: [ResponseTypes.Code]);
+        SetupFetcher(CreateRequest(responseType: [ResponseTypes.Code, ResponseTypes.IdToken]));
+
+        var result = await _adapter.FetchAsync(outer);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequestObject, error.Error);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/FlowTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/FlowTypeValidatorTests.cs
@@ -237,8 +237,8 @@ public class FlowTypeValidatorTests
 
     /// <summary>
     /// Verifies that ValidateAsync rejects null response_type.
-    /// Per OAuth 2.0, response_type is REQUIRED parameter.
-    /// Critical for ensuring valid authorization requests.
+    /// Per RFC 6749 §4.1.2.1, response_type is REQUIRED and a missing required parameter
+    /// is invalid_request.
     /// </summary>
     [Fact]
     public async Task ValidateAsync_NullResponseType_ShouldReturnError()
@@ -251,14 +251,13 @@ public class FlowTypeValidatorTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.UnsupportedResponseType, result.Error);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
         Assert.Equal(ResponseModes.Query, context.ResponseMode); // Default fallback
     }
 
     /// <summary>
     /// Verifies that ValidateAsync rejects empty response_type array.
-    /// Empty response_type is invalid per OAuth 2.0 spec.
-    /// Tests defensive programming for malformed requests.
+    /// Per RFC 6749 §4.1.2.1, an absent required parameter is invalid_request.
     /// </summary>
     [Fact]
     public async Task ValidateAsync_EmptyResponseType_ShouldReturnError()
@@ -271,7 +270,7 @@ public class FlowTypeValidatorTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.UnsupportedResponseType, result.Error);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
     }
 
     /// <summary>
@@ -296,8 +295,9 @@ public class FlowTypeValidatorTests
 
     /// <summary>
     /// Verifies that ValidateAsync rejects response_type not allowed by client.
-    /// Per OAuth 2.0, client must be registered for specific response types.
-    /// Critical security check preventing unauthorized flow usage.
+    /// Per RFC 6749 §4.1.2.1 / §4.2.2.1 this is unauthorized_client (the server supports the
+    /// method, this client is not registered for it), and per OAuth 2.0 Multiple Response Types §5
+    /// the error for a fragment-encoded response_type must travel in the fragment.
     /// </summary>
     [Fact]
     public async Task ValidateAsync_ResponseTypeNotAllowedForClient_ShouldReturnError()
@@ -310,8 +310,8 @@ public class FlowTypeValidatorTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.UnsupportedResponseType, result.Error);
-        Assert.Contains("not allowed", result.ErrorDescription);
+        Assert.Equal(ErrorCodes.UnauthorizedClient, result.Error);
+        Assert.Equal(ResponseModes.Fragment, context.ResponseMode);
     }
 
     /// <summary>
@@ -547,7 +547,8 @@ public class FlowTypeValidatorTests
     /// <summary>
     /// Verifies that ValidateAsync rejects response_type subset not matching client config.
     /// Client registered for [code id_token] should NOT accept [code] alone.
-    /// Tests strict response type matching - all components must match.
+    /// Tests strict response type matching - all components must match. The code-only request
+    /// carries no fragment-encoded value, so the error stays in the query.
     /// </summary>
     [Fact]
     public async Task ValidateAsync_ResponseTypeSubsetNotAllowed_ShouldReturnError()
@@ -562,7 +563,35 @@ public class FlowTypeValidatorTests
 
         // Assert
         Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.UnauthorizedClient, result.Error);
+        Assert.Equal(ResponseModes.Query, context.ResponseMode);
+    }
+
+    /// <summary>
+    /// OAuth 2.0 Multiple Response Types §5: a rejected hybrid request (contains token) must get
+    /// its error in the fragment even when the rejection happens at the server-level support gate.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_TokenBearingResponseTypeRejected_ShouldDefaultErrorModeToFragment()
+    {
+        // Arrange — only Code processor registered, request asks for code token
+        var logger = new Mock<ILogger<FlowTypeValidator>>(MockBehavior.Loose);
+        IAuthorizationResponseBuilder[] codeOnlyProcessors =
+        [
+            Mock.Of<IAuthorizationResponseBuilder>(p => p.ResponseType == ResponseTypes.Code),
+        ];
+        var validator = new FlowTypeValidator(logger.Object, codeOnlyProcessors);
+        var context = CreateContext(
+            [ResponseTypes.Code, ResponseTypes.Token],
+            [[ResponseTypes.Code, ResponseTypes.Token]]);
+
+        // Act
+        var result = await validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
         Assert.Equal(ErrorCodes.UnsupportedResponseType, result.Error);
+        Assert.Equal(ResponseModes.Fragment, context.ResponseMode);
     }
 
     /// <summary>
@@ -601,7 +630,7 @@ public class FlowTypeValidatorTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.UnsupportedResponseType, result.Error);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
         // Note: Cannot access context.FlowType - it throws when not set
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/NonceValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/NonceValidatorTests.cs
@@ -108,8 +108,26 @@ public class NonceValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
-        Assert.Contains("nonce", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("id_token", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// OIDC Core 1.0 §3.3.2.11: nonce is REQUIRED for every Hybrid Flow combination, including
+    /// code token — no id_token is returned from the authorization endpoint, but the one minted
+    /// later from the code must carry the nonce binding. Previously only response types containing
+    /// id_token were checked.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_CodeTokenResponseTypeWithoutNonce_ShouldReturnError()
+    {
+        // Arrange
+        var context = CreateContext([ResponseTypes.Code, ResponseTypes.Token], nonce: null);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/SignedRequestObjectRequirementValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/SignedRequestObjectRequirementValidatorTests.cs
@@ -1,0 +1,107 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Authorization.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="SignedRequestObjectRequirementValidator"/> verifying the
+/// RFC 9101 §10.5 require_signed_request_object client metadata: plain-parameter requests from a
+/// committed client are rejected, while request-object and PAR-originated requests pass.
+/// </summary>
+public class SignedRequestObjectRequirementValidatorTests
+{
+    private readonly SignedRequestObjectRequirementValidator _validator = new();
+
+    private static AuthorizationValidationContext CreateContext(
+        bool requireSignedRequestObject,
+        string? requestObject = null,
+        Uri? pushedRequestUri = null)
+    {
+        var request = new AuthorizationRequest
+        {
+            ClientId = TestConstants.DefaultClientId,
+            ResponseType = [ResponseTypes.Code],
+            RedirectUri = TestConstants.DefaultRedirectUri,
+            Scope = [Scopes.OpenId],
+            Request = requestObject,
+            PushedRequestUri = pushedRequestUri,
+        };
+
+        return new AuthorizationValidationContext(request)
+        {
+            ClientInfo = new ClientInfo(TestConstants.DefaultClientId)
+            {
+                RequireSignedRequestObject = requireSignedRequestObject,
+            },
+        };
+    }
+
+    [Fact]
+    public async Task ValidateAsync_FlaggedClientWithPlainParameters_ReturnsError()
+    {
+        var context = CreateContext(requireSignedRequestObject: true);
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_FlaggedClientWithRequestObject_Passes()
+    {
+        var context = CreateContext(requireSignedRequestObject: true, requestObject: "header.payload.signature");
+
+        Assert.Null(await _validator.ValidateAsync(context));
+    }
+
+    /// <summary>
+    /// A PAR-stored request already went through this validator at push time, so the
+    /// authorize-time pass must not reject it again.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_FlaggedClientWithPushedRequest_Passes()
+    {
+        var context = CreateContext(
+            requireSignedRequestObject: true,
+            pushedRequestUri: new Uri("urn:ietf:params:oauth:request_uri:abc"));
+
+        Assert.Null(await _validator.ValidateAsync(context));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UnflaggedClientWithPlainParameters_Passes()
+    {
+        var context = CreateContext(requireSignedRequestObject: false);
+
+        Assert.Null(await _validator.ValidateAsync(context));
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Configuration/JwtAlgorithmsProviderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Configuration/JwtAlgorithmsProviderTests.cs
@@ -125,6 +125,29 @@ public class JwtAlgorithmsProviderTests
         Assert.Equal(signing, result);
     }
 
+    /// <summary>
+    /// OIDC Core §10.1: HS* signatures key on the client_secret, which this server stores only as
+    /// a hash — so HMAC algorithms must not be advertised on any client-addressed response-signing
+    /// list, even when the JWT layer has HMAC signers registered. Previously the full signer set
+    /// (HS* included) leaked into discovery, a client could register HS256 via DCR, and the first
+    /// issued id_token failed with a server error at signing-key lookup.
+    /// </summary>
+    [Fact]
+    public void ClientAddressedSigningLists_ExcludeHmacAlgorithms()
+    {
+        _creator.Setup(c => c.SignedResponseAlgorithmsSupported).Returns(
+        [
+            SigningAlgorithms.RS256, SigningAlgorithms.ES256,
+            SigningAlgorithms.HS256, SigningAlgorithms.HS384, SigningAlgorithms.HS512,
+        ]);
+        var provider = CreateProvider();
+
+        string[] expected = [SigningAlgorithms.RS256, SigningAlgorithms.ES256];
+        Assert.Equal(expected, provider.SignedResponseAlgorithmsSupported.ToArray());
+        Assert.Equal(expected, provider.AuthorizationSigningAlgValuesSupported.ToArray());
+        Assert.Equal(expected, provider.IntrospectionSigningAlgValuesSupported.ToArray());
+    }
+
     [Fact]
     public void AuthorizationEncryptionAlgValuesSupported_ForwardsValidatorKeyManagementAlgorithms()
     {

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -296,4 +296,80 @@ public class RegisterClientHandlerIntegrationTests
         Assert.True((await handler.HandleAsync(withoutAlg)).TryGetSuccess(out var registeredDefault));
         Assert.Null(registeredDefault.IntrospectionSignedResponseAlg);
     }
+
+    /// <summary>
+    /// RFC 9126 §6 / RFC 9101 §10.5 / RFC 8705 §3.4: the per-client FAPI-grade enforcement flags
+    /// round-trip through registration into the stored ClientInfo and are echoed on the response
+    /// (RFC 7591 §3.2.1).
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_FapiEnforcementFlags_RoundTripAndEcho()
+    {
+        var provider = BuildProvider();
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+        var clientInfoProvider = provider.GetRequiredService<Abblix.Oidc.Server.Features.ClientInformation.IClientInfoProvider>();
+
+        var request = CreateRequest() with
+        {
+            RequirePushedAuthorizationRequests = true,
+            RequireSignedRequestObject = true,
+            TlsClientCertificateBoundAccessTokens = true,
+        };
+
+        var result = await handler.HandleAsync(request);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        Assert.True(success.RequirePushedAuthorizationRequests);
+        Assert.True(success.RequireSignedRequestObject);
+        Assert.True(success.TlsClientCertificateBoundAccessTokens);
+
+        var stored = await clientInfoProvider.TryFindClientAsync(success.ClientId);
+        Assert.NotNull(stored);
+        Assert.True(stored.RequirePushedAuthorizationRequests);
+        Assert.True(stored.RequireSignedRequestObject);
+        Assert.True(stored.TlsClientCertificateBoundAccessTokens);
+    }
+
+    /// <summary>
+    /// OIDC Core §10.1: HS* signing keys on the client_secret, which this server stores only as a
+    /// hash — registration asking for an HMAC-signed id_token must be rejected at DCR time instead
+    /// of failing with a server error on the first issued token.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.HS256)]
+    [InlineData(SigningAlgorithms.HS512)]
+    public async Task HandleAsync_HmacIdTokenSignedResponseAlg_RejectsAtRegistration(string algorithm)
+    {
+        var provider = BuildProvider();
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+
+        var request = CreateRequest() with { IdTokenSignedResponseAlg = algorithm };
+
+        var result = await handler.HandleAsync(request);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+    }
+
+    /// <summary>
+    /// RFC 7591 §3.2.1: the response carries grant_types, response_types and scope read back from
+    /// the stored registration. Without them a client cannot learn the server-assigned defaults
+    /// (authorization_code / code) when its request omitted these fields — the DCR conformance
+    /// profile checks exactly this.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RegistrationResponse_EchoesGrantResponseTypesAndScope()
+    {
+        var provider = BuildProvider();
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+
+        var request = CreateRequest() with { Scope = [Scopes.OpenId, Scopes.Profile] };
+
+        var result = await handler.HandleAsync(request);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        Assert.Equal([GrantTypes.AuthorizationCode], success.GrantTypes);
+        Assert.Equal([[ResponseTypes.Code]], success.ResponseTypes);
+        Assert.Equal([Scopes.OpenId, Scopes.Profile], success.Scope);
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegistrationAccessTokenValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegistrationAccessTokenValidatorTests.cs
@@ -1,0 +1,103 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net.Http.Headers;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
+using Abblix.Oidc.Server.Features.Tokens.Validation;
+using Abblix.Utils;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement;
+
+/// <summary>
+/// Verifies the RFC 7592 §5 registration-access-token binding in
+/// <see cref="RegistrationAccessTokenValidator"/>: a token is accepted only when its jti matches
+/// the value recorded on the client, so a rotated token invalidates its predecessors, while a null
+/// expectation keeps statically configured / pre-existing clients working unchanged.
+/// </summary>
+public class RegistrationAccessTokenValidatorTests
+{
+    private const string ClientId = "client-1";
+
+    private static RegistrationAccessTokenValidator CreateValidator(JsonWebToken token)
+    {
+        var jwtValidator = new Mock<IAuthServiceJwtValidator>(MockBehavior.Strict);
+        jwtValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(token);
+
+        return new RegistrationAccessTokenValidator(jwtValidator.Object);
+    }
+
+    private static JsonWebToken CreateToken(string jti) => new()
+    {
+        Header = new JsonWebTokenHeader(new JsonObject
+        {
+            [JwtClaimTypes.Type] = JwtTypes.RegistrationAccessToken,
+        }),
+        Payload = new JsonWebTokenPayload(new JsonObject
+        {
+            [JwtClaimTypes.JwtId] = jti,
+            [JwtClaimTypes.Subject] = ClientId,
+            [JwtClaimTypes.Audience] = ClientId,
+        }),
+    };
+
+    private static AuthenticationHeaderValue Bearer => new(TokenTypes.Bearer, "the.jwt.token");
+
+    [Fact]
+    public async Task MatchingJti_IsAccepted()
+    {
+        var validator = CreateValidator(CreateToken("jti-current"));
+
+        var error = await validator.ValidateAsync(Bearer, ClientId, "jti-current");
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public async Task MismatchedJti_IsRejected()
+    {
+        // A token issued before the last rotation carries a stale jti; binding rejects it.
+        var validator = CreateValidator(CreateToken("jti-old"));
+
+        var error = await validator.ValidateAsync(Bearer, ClientId, "jti-current");
+
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public async Task NullExpectation_SkipsBinding()
+    {
+        // Statically configured or pre-existing client with no recorded jti: binding not enforced.
+        var validator = CreateValidator(CreateToken("any-jti"));
+
+        var error = await validator.ValidateAsync(Bearer, ClientId, expectedTokenId: null);
+
+        Assert.Null(error);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Model;
 using Moq;
 using Xunit;
@@ -32,30 +33,45 @@ using Xunit;
 namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement;
 
 /// <summary>
-/// Verifies that an RFC 7592 client update (a full replacement) re-persists the per-client scope
-/// set. Dropping AllowedScopes on update would revert the client to "any scope" (null = unrestricted),
-/// defeating the scope enforcement applied at the authorization and token endpoints.
+/// Verifies RFC 7592 client-update behavior: the update (a full replacement) re-persists the
+/// per-client scope set, and it rotates the registration access token's jti so previously issued
+/// tokens are invalidated (RFC 7592 §5).
 /// </summary>
 public class UpdateClientRequestProcessorTests
 {
+    private static (UpdateClientRequestProcessor processor, Mock<IClientInfoManager> manager,
+        Mock<IRegistrationAccessTokenService> tokenService, Mock<IRegistrationAccessTokenStore> tokenStore,
+        Mock<ITokenIdGenerator> idGenerator)
+        CreateProcessor(Action<ClientInfo> onSave)
+    {
+        var clientInfoManager = new Mock<IClientInfoManager>(MockBehavior.Strict);
+        clientInfoManager
+            .Setup(m => m.UpdateClientAsync(It.IsAny<ClientInfo>()))
+            .Callback<ClientInfo>(onSave)
+            .Returns(Task.CompletedTask);
+
+        var tokenService = new Mock<IRegistrationAccessTokenService>(MockBehavior.Loose);
+        tokenService
+            .Setup(s => s.IssueTokenAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<TimeSpan?>(), It.IsAny<string>()))
+            .ReturnsAsync("registration-access-token");
+
+        var tokenStore = new Mock<IRegistrationAccessTokenStore>(MockBehavior.Loose);
+        var idGenerator = new Mock<ITokenIdGenerator>(MockBehavior.Strict);
+
+        var processor = new UpdateClientRequestProcessor(
+            clientInfoManager.Object, tokenService.Object, tokenStore.Object, idGenerator.Object, TimeProvider.System);
+
+        return (processor, clientInfoManager, tokenService, tokenStore, idGenerator);
+    }
+
     [Fact]
     public async Task Update_PreservesAllowedScopes()
     {
         // Arrange
         ClientInfo? saved = null;
-        var clientInfoManager = new Mock<IClientInfoManager>(MockBehavior.Strict);
-        clientInfoManager
-            .Setup(m => m.UpdateClientAsync(It.IsAny<ClientInfo>()))
-            .Callback<ClientInfo>(c => saved = c)
-            .Returns(Task.CompletedTask);
-
-        var tokenService = new Mock<IRegistrationAccessTokenService>(MockBehavior.Loose);
-        tokenService
-            .Setup(s => s.IssueTokenAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<TimeSpan?>()))
-            .ReturnsAsync("registration-access-token");
-
-        var processor = new UpdateClientRequestProcessor(
-            clientInfoManager.Object, tokenService.Object, TimeProvider.System);
+        var (processor, _, _, _, idGenerator) = CreateProcessor(c => saved = c);
+        idGenerator.Setup(g => g.GenerateTokenId()).Returns("new-jti");
 
         var model = new ClientRegistrationRequest
         {
@@ -72,5 +88,35 @@ public class UpdateClientRequestProcessorTests
         // Assert
         Assert.NotNull(saved);
         Assert.Equal(model.Scope, saved.AllowedScopes);
+    }
+
+    /// <summary>
+    /// Verifies the update rotates the registration access token jti: a freshly generated id is
+    /// recorded in the binding store and embedded in the issued token. Because the validator binds
+    /// the token to the stored jti, this invalidates every token issued before the update (RFC 7592 §5).
+    /// </summary>
+    [Fact]
+    public async Task Update_RotatesRegistrationAccessTokenId()
+    {
+        // Arrange
+        var (processor, _, tokenService, tokenStore, idGenerator) = CreateProcessor(_ => { });
+        idGenerator.Setup(g => g.GenerateTokenId()).Returns("rotated-jti");
+
+        var model = new ClientRegistrationRequest
+        {
+            RedirectUris = [new Uri("https://client.example.com/cb")],
+        };
+        var existing = new ClientInfo("client-1");
+        var request = new ValidUpdateClientRequest(
+            new UpdateClientRequest(new ClientRequest(), model), existing, model);
+
+        // Act
+        await processor.ProcessAsync(request);
+
+        // Assert
+        tokenStore.Verify(s => s.SetTokenIdAsync("client-1", "rotated-jti"), Times.Once);
+        tokenService.Verify(
+            s => s.IssueTokenAsync("client-1", It.IsAny<DateTimeOffset>(), It.IsAny<TimeSpan?>(), "rotated-jti"),
+            Times.Once);
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
@@ -76,7 +77,7 @@ public class UpdateClientRequestProcessorTests
         var model = new ClientRegistrationRequest
         {
             RedirectUris = [new Uri("https://client.example.com/cb")],
-            Scope = ["openid", "profile"],
+            Scope = [Scopes.OpenId, Scopes.Profile],
         };
         var existing = new ClientInfo("client-1");
         var request = new ValidUpdateClientRequest(
@@ -118,5 +119,38 @@ public class UpdateClientRequestProcessorTests
         tokenService.Verify(
             s => s.IssueTokenAsync("client-1", It.IsAny<DateTimeOffset>(), It.IsAny<TimeSpan?>(), "rotated-jti"),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies the update response carries grant_types, response_types and scope per RFC 7592 §3:
+    /// the response must contain the full registered metadata (including DTO defaults), otherwise
+    /// the client cannot confirm the result of the full-replacement update.
+    /// </summary>
+    [Fact]
+    public async Task Update_ResponseEchoesGrantResponseTypesAndScope()
+    {
+        // Arrange
+        var (processor, _, _, _, idGenerator) = CreateProcessor(_ => { });
+        idGenerator.Setup(g => g.GenerateTokenId()).Returns("new-jti");
+
+        var model = new ClientRegistrationRequest
+        {
+            RedirectUris = [new Uri("https://client.example.com/cb")],
+            GrantTypes = [GrantTypes.AuthorizationCode, GrantTypes.RefreshToken],
+            ResponseTypes = [[ResponseTypes.Code]],
+            Scope = [Scopes.OpenId, Scopes.Profile],
+        };
+        var existing = new ClientInfo("client-1");
+        var request = new ValidUpdateClientRequest(
+            new UpdateClientRequest(new ClientRequest(), model), existing, model);
+
+        // Act
+        var result = await processor.ProcessAsync(request);
+
+        // Assert
+        Assert.True(result.TryGetSuccess(out var response));
+        Assert.Equal(model.GrantTypes, response.GrantTypes);
+        Assert.Equal(model.ResponseTypes, response.ResponseTypes);
+        Assert.Equal(model.Scope, response.Scope);
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidatorTests.cs
@@ -23,6 +23,7 @@
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 using Abblix.Oidc.Server.Model;
 using Moq;
@@ -37,13 +38,13 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement.Validat
 /// </summary>
 public class SignedResponseAlgorithmsValidatorTests
 {
-    private readonly Mock<IJsonWebTokenCreator> _jwtCreator;
+    private readonly Mock<IJwtAlgorithmsProvider> _jwtAlgorithms;
     private readonly SignedResponseAlgorithmsValidator _validator;
 
     public SignedResponseAlgorithmsValidatorTests()
     {
-        _jwtCreator = new Mock<IJsonWebTokenCreator>(MockBehavior.Strict);
-        _validator = new SignedResponseAlgorithmsValidator(_jwtCreator.Object);
+        _jwtAlgorithms = new Mock<IJwtAlgorithmsProvider>(MockBehavior.Strict);
+        _validator = new SignedResponseAlgorithmsValidator(_jwtAlgorithms.Object);
     }
 
     private ClientRegistrationValidationContext CreateContext(
@@ -65,12 +66,60 @@ public class SignedResponseAlgorithmsValidatorTests
     }
 
     /// <summary>
+    /// OIDC Registration 1.0 §2: id_token_signed_response_alg=none is allowed only for response
+    /// types that return no ID Token from the authorization endpoint — an unsigned ID Token
+    /// delivered through the browser would be modifiable in transit.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_NoneIdTokenAlg_WithIdTokenResponseType_ShouldReturnError()
+    {
+        _jwtAlgorithms
+            .Setup(c => c.SignedResponseAlgorithmsSupported)
+            .Returns([SigningAlgorithms.RS256, SigningAlgorithms.None]);
+
+        var context = new ClientRegistrationValidationContext(new ClientRegistrationRequest
+        {
+            RedirectUris = [TestConstants.DefaultRedirectUri],
+            IdTokenSignedResponseAlg = SigningAlgorithms.None,
+            ResponseTypes = [[ResponseTypes.Code, ResponseTypes.IdToken]],
+        });
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+    }
+
+    /// <summary>
+    /// The same none algorithm stays acceptable for the pure Authorization Code Flow, where the
+    /// ID Token is delivered from the token endpoint over TLS instead of through the browser.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_NoneIdTokenAlg_WithCodeOnlyResponseType_ShouldReturnNull()
+    {
+        _jwtAlgorithms
+            .Setup(c => c.SignedResponseAlgorithmsSupported)
+            .Returns([SigningAlgorithms.RS256, SigningAlgorithms.None]);
+
+        var context = new ClientRegistrationValidationContext(new ClientRegistrationRequest
+        {
+            RedirectUris = [TestConstants.DefaultRedirectUri],
+            IdTokenSignedResponseAlg = SigningAlgorithms.None,
+            ResponseTypes = [[ResponseTypes.Code]],
+        });
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
     /// Verifies validation succeeds with a supported introspection_signed_response_alg (RFC 9701).
     /// </summary>
     [Fact]
     public async Task ValidateAsync_WithSupportedIntrospectionAlg_ShouldReturnNull()
     {
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256, SigningAlgorithms.ES256]);
 
@@ -87,7 +136,7 @@ public class SignedResponseAlgorithmsValidatorTests
     [Fact]
     public async Task ValidateAsync_WithUnsupportedIntrospectionAlg_ShouldReturnError()
     {
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -106,7 +155,7 @@ public class SignedResponseAlgorithmsValidatorTests
     [Fact]
     public async Task ValidateAsync_WithSupportedAuthorizationAlg_ShouldReturnNull()
     {
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256, SigningAlgorithms.ES256]);
 
@@ -123,7 +172,7 @@ public class SignedResponseAlgorithmsValidatorTests
     [Fact]
     public async Task ValidateAsync_WithUnsupportedAuthorizationAlg_ShouldReturnError()
     {
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -143,7 +192,7 @@ public class SignedResponseAlgorithmsValidatorTests
     [Fact]
     public async Task ValidateAsync_WithNoneForAuthorizationAlg_ShouldReturnError()
     {
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.None, SigningAlgorithms.RS256]);
 
@@ -181,7 +230,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithSupportedIdTokenAlg_ShouldReturnNull()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256, SigningAlgorithms.ES256]);
 
@@ -202,7 +251,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithUnsupportedIdTokenAlg_ShouldReturnError()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -226,7 +275,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithSupportedUserInfoAlg_ShouldReturnNull()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256, SigningAlgorithms.ES256]);
 
@@ -247,7 +296,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithUnsupportedUserInfoAlg_ShouldReturnError()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -270,7 +319,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithBothSupportedAlgorithms_ShouldReturnNull()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256, SigningAlgorithms.ES256]);
 
@@ -293,7 +342,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithIdTokenAlgUnsupported_ShouldReturnErrorForIdToken()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.ES256]);
 
@@ -317,7 +366,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithDifferentCase_ShouldReturnError()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns(["RS256"]);
 
@@ -339,7 +388,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithMultipleSupportedAlgs_ShouldValidateCorrectly()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([
                 SigningAlgorithms.RS256,
@@ -372,7 +421,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithCustomAlgorithm_ShouldReturnError()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -394,7 +443,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_ShouldCheckJwtCreatorAlgorithms()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -404,7 +453,7 @@ public class SignedResponseAlgorithmsValidatorTests
         await _validator.ValidateAsync(context);
 
         // Assert
-        _jwtCreator.Verify(c => c.SignedResponseAlgorithmsSupported, Times.Once);
+        _jwtAlgorithms.Verify(c => c.SignedResponseAlgorithmsSupported, Times.Once);
     }
 
     /// <summary>
@@ -415,7 +464,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithNoneAlgorithmForUserInfo_ShouldValidate()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.None, SigningAlgorithms.RS256]);
 
@@ -436,7 +485,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithNoneAlgNotSupported_ShouldReturnError()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 
@@ -458,7 +507,7 @@ public class SignedResponseAlgorithmsValidatorTests
     public async Task ValidateAsync_WithSameAlgForBoth_ShouldReturnNull()
     {
         // Arrange
-        _jwtCreator
+        _jwtAlgorithms
             .Setup(c => c.SignedResponseAlgorithmsSupported)
             .Returns([SigningAlgorithms.RS256]);
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
@@ -245,18 +245,19 @@ public class SubjectTypeValidatorTests
     }
 
     /// <summary>
-    /// Verifies error when sector content has extra URIs.
-    /// Per OIDC Core, sector document must only contain registered redirect URIs.
+    /// Verifies a shared sector document listing URIs of other clients is accepted.
+    /// Per OIDC Core Section 8.1, the document may be shared across several clients of the same
+    /// sector — only the registered redirect URIs must be present in it, extra entries are fine.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_SectorContentWithExtraUris_ShouldReturnError()
+    public async Task ValidateAsync_SectorContentWithExtraUris_ShouldReturnNull()
     {
         // Arrange
         var sectorUri = new Uri("https://example.com/sector.json");
         var sectorContent = new[]
         {
             TestConstants.DefaultRedirectUri,
-            new Uri("https://example.com/extra") // Not in redirect URIs
+            new Uri("https://example.com/another-clients-callback") // Belongs to a sibling client
         };
 
         _secureHttpFetcher
@@ -272,9 +273,37 @@ public class SubjectTypeValidatorTests
         var result = await _validator.ValidateAsync(context);
 
         // Assert
+        Assert.Null(result);
+        Assert.Equal("example.com", context.SectorIdentifier);
+    }
+
+    /// <summary>
+    /// Verifies error when a registered redirect URI is absent from the sector document.
+    /// Per OIDC Core Section 8.1, all registered redirect URIs must be included in the document —
+    /// otherwise a client could claim a sector it does not belong to.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_RegisteredUriMissingFromSectorContent_ShouldReturnError()
+    {
+        // Arrange
+        var sectorUri = new Uri("https://example.com/sector.json");
+        var sectorContent = new[] { new Uri("https://example.com/listed-callback") };
+
+        _secureHttpFetcher
+            .Setup(f => f.FetchAsync<Uri[]>(sectorUri))
+            .ReturnsAsync(Result<Uri[], OidcError>.Success(sectorContent));
+
+        var context = CreateContext(
+            redirectUris: [TestConstants.DefaultRedirectUri], // Not listed in the sector document
+            subjectType: SubjectTypes.Pairwise,
+            sectorIdentifierUri: sectorUri);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
-        Assert.Contains("not in the registered list", result.ErrorDescription);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestValidatorTests.cs
@@ -142,6 +142,35 @@ public class IntrospectionRequestValidatorTests
     }
 
     /// <summary>
+    /// Verifies that a public client (token_endpoint_auth_method = none) is rejected. RFC 7662 §2.1
+    /// requires the introspection endpoint to require some form of authorization to prevent token
+    /// scanning; a client_id alone is not a credential, so the token is never even validated.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithPublicClient_ShouldReturnInvalidClientError()
+    {
+        // Arrange
+        var introspectionRequest = CreateIntrospectionRequest();
+        var clientRequest = CreateClientRequest();
+        var publicClient = new ClientInfo(TestConstants.DefaultClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.None,
+        };
+
+        _clientAuthenticator
+            .Setup(a => a.TryAuthenticateClientAsync(It.IsAny<ClientRequest>()))
+            .Returns(Task.FromResult<ClientInfo?>(publicClient));
+
+        // Act
+        var result = await _validator.ValidateAsync(introspectionRequest, clientRequest);
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidClient, error.Error);
+        _jwtValidator.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
     /// Verifies JWT validation error handling.
     /// Per RFC 7662, invalid tokens should return inactive token response.
     /// </summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Revocation/RevocationRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Revocation/RevocationRequestValidatorTests.cs
@@ -142,6 +142,35 @@ public class RevocationRequestValidatorTests
     }
 
     /// <summary>
+    /// Verifies that a public client (token_endpoint_auth_method = none) is rejected. The revocation
+    /// endpoint must authenticate the client (RFC 7009 §2.1); a client_id alone is not a credential,
+    /// so the token is never even validated.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithPublicClient_ShouldReturnInvalidClientError()
+    {
+        // Arrange
+        var revocationRequest = CreateRevocationRequest();
+        var clientRequest = CreateClientRequest();
+        var publicClient = new ClientInfo(TestConstants.DefaultClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.None,
+        };
+
+        _clientAuthenticator
+            .Setup(a => a.TryAuthenticateClientAsync(It.IsAny<ClientRequest>()))
+            .Returns(Task.FromResult<ClientInfo?>(publicClient));
+
+        // Act
+        var result = await _validator.ValidateAsync(revocationRequest, clientRequest);
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidClient, error.Error);
+        _jwtValidator.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
     /// Verifies JWT validation error handling.
     /// Per RFC 7009 section 2.2, invalid tokens should return success with null token.
     /// Invalid tokens do not cause error response since purpose is already achieved.

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeGrantHandlerTests.cs
@@ -38,23 +38,55 @@ using Moq;
 
 using Xunit;
 
-
 namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token;
 
 public class AuthorizationCodeGrantHandlerTests
 {
 	private readonly Mock<IAuthorizationCodeService> _authCodeService;
-	private readonly Mock<IParameterValidator> _parameterValidator;
 	private readonly AuthorizationCodeGrantHandler _handler;
 
 	public AuthorizationCodeGrantHandlerTests()
 	{
 		_authCodeService = new Mock<IAuthorizationCodeService>(MockBehavior.Strict);
-		_parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
 
 		_handler = new AuthorizationCodeGrantHandler(
-			_parameterValidator.Object,
 			_authCodeService.Object);
+	}
+
+	/// <summary>
+	/// RFC 6749 §5.2: a token request without the required code parameter is the caller's protocol
+	/// error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+	/// </summary>
+	[Fact]
+	public async Task AuthorizeAsync_MissingCode_ReturnsInvalidRequest()
+	{
+		var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo("client1"));
+
+		Assert.True(result.TryGetFailure(out var error));
+		Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+	}
+
+	/// <summary>
+	/// RFC 6749 §5.2 lists a code issued to another client explicitly under invalid_grant —
+	/// previously this case was reported as unauthorized_client, which describes a client barred
+	/// from the grant type itself.
+	/// </summary>
+	[Fact]
+	public async Task AuthorizeAsync_CodeIssuedToAnotherClient_ReturnsInvalidGrant()
+	{
+		var authenticationTime = DateTimeOffset.Parse("2026-06-11T00:00:00Z");
+		var tokenRequest = new TokenRequest { Code = "abc" };
+		_authCodeService
+			.Setup(s => s.AuthorizeByCodeAsync(tokenRequest.Code))
+			.ReturnsAsync(
+				new AuthorizedGrant(
+					new AuthSession("123", "session1", authenticationTime, "ip"),
+					Context: new AuthorizationContext("original-client", [Scopes.OpenId], null)));
+
+		var result = await _handler.AuthorizeAsync(tokenRequest, new ClientInfo("another-client"));
+
+		Assert.True(result.TryGetFailure(out var error));
+		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
 	}
 
 	/// <summary>
@@ -98,7 +130,6 @@ public class AuthorizationCodeGrantHandlerTests
 		// arrange
 		var clientInfo = new ClientInfo("client1");
 		var tokenRequest = new TokenRequest { Code = "abc", CodeVerifier = codeVerifier };
-		_parameterValidator.Setup(v => v.Required(tokenRequest.Code, "Code"));
 
 		_authCodeService
 			.Setup(s => s.AuthorizeByCodeAsync(tokenRequest.Code))

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -1,0 +1,162 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Token;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.Features.Tokens.Revocation;
+using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Oidc.Server.Model;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token;
+
+/// <summary>
+/// Verifies the authorization-code reuse defense in <see cref="AuthorizationCodeReusePreventingDecorator"/>.
+/// The decorator atomically claims the code before delegating to the inner processor, so a second
+/// (concurrent or sequential) redemption of the same code cannot issue a second set of tokens
+/// (RFC 6749 §4.1.2, OAuth 2.0 Security BCP §4.13).
+/// </summary>
+public class AuthorizationCodeReusePreventingDecoratorTests
+{
+    private const string Code = "the-authorization-code";
+
+    private readonly Mock<ITokenRequestProcessor> _inner = new(MockBehavior.Strict);
+    private readonly Mock<ITokenRegistry> _tokenRegistry = new(MockBehavior.Strict);
+    private readonly Mock<IAuthorizationCodeService> _codeService = new(MockBehavior.Strict);
+    private readonly AuthorizationCodeReusePreventingDecorator _decorator;
+
+    public AuthorizationCodeReusePreventingDecoratorTests()
+        => _decorator = new AuthorizationCodeReusePreventingDecorator(
+            _inner.Object, _tokenRegistry.Object, _codeService.Object);
+
+    private static ValidTokenRequest CreateRequest(AuthorizedGrant grant)
+    {
+        var model = new TokenRequest { GrantType = GrantTypes.AuthorizationCode, Code = Code };
+        return new ValidTokenRequest(model, grant, new ClientInfo("client-1"), [], []);
+    }
+
+    private static AuthorizedGrant CreateGrant(TokenInfo[]? issuedTokens = null)
+        => new(
+            new AuthSession("subject", "session-1", DateTimeOffset.UnixEpoch, "idp"),
+            new AuthorizationContext("client-1", ["openid"], null))
+        {
+            IssuedTokens = issuedTokens,
+        };
+
+    /// <summary>
+    /// When the code cannot be claimed (a concurrent request already claimed it, or it was already
+    /// consumed, so the atomic remove returns a failure), the decorator rejects with invalid_grant
+    /// and never invokes the inner processor — so no second set of tokens is issued.
+    /// </summary>
+    [Fact]
+    public async Task UnclaimableCode_IsRejected_WithoutIssuingTokens()
+    {
+        // Arrange
+        _codeService
+            .Setup(s => s.RemoveAuthorizationCodeAsync(Code))
+            .ReturnsAsync(new OidcError(ErrorCodes.InvalidGrant, "Authorization code is invalid"));
+
+        // Act
+        var result = await _decorator.ProcessAsync(CreateRequest(CreateGrant()));
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        _inner.Verify(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()), Times.Never);
+    }
+
+    /// <summary>
+    /// When the claimed grant already carries issued tokens (a sequential reuse), the decorator
+    /// revokes every previously issued token by jti and rejects, without issuing new tokens.
+    /// </summary>
+    [Fact]
+    public async Task ReusedCode_RevokesPreviouslyIssuedTokens_AndRejects()
+    {
+        // Arrange
+        var expiresAt = DateTimeOffset.UnixEpoch.AddHours(1);
+        var issued = new[] { new TokenInfo("access-jti", expiresAt), new TokenInfo("refresh-jti", expiresAt) };
+        _codeService.Setup(s => s.RemoveAuthorizationCodeAsync(Code)).ReturnsAsync(CreateGrant(issued));
+        _tokenRegistry
+            .Setup(r => r.SetStatusAsync(It.IsAny<string>(), JsonWebTokenStatus.Revoked, expiresAt))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _decorator.ProcessAsync(CreateRequest(CreateGrant(issued)));
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+        _tokenRegistry.Verify(r => r.SetStatusAsync("access-jti", JsonWebTokenStatus.Revoked, expiresAt), Times.Once);
+        _tokenRegistry.Verify(r => r.SetStatusAsync("refresh-jti", JsonWebTokenStatus.Revoked, expiresAt), Times.Once);
+        _inner.Verify(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()), Times.Never);
+    }
+
+    /// <summary>
+    /// When the claim succeeds and the grant has no prior tokens, the decorator delegates to the
+    /// inner processor (the winning redemption proceeds).
+    /// </summary>
+    [Fact]
+    public async Task FreshClaim_DelegatesToInnerProcessor()
+    {
+        // Arrange
+        _codeService.Setup(s => s.RemoveAuthorizationCodeAsync(Code)).ReturnsAsync(CreateGrant());
+        var innerError = new OidcError(ErrorCodes.InvalidGrant, "inner-marker");
+        _inner.Setup(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>())).ReturnsAsync(innerError);
+
+        // Act
+        var result = await _decorator.ProcessAsync(CreateRequest(CreateGrant()));
+
+        // Assert: the inner processor was invoked (its result flowed through unchanged).
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal("inner-marker", error.ErrorDescription);
+        _inner.Verify(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()), Times.Once);
+    }
+
+    /// <summary>
+    /// A non-authorization-code grant (e.g. refresh_token) is passed straight through without a
+    /// claim, since the reuse defense applies only to authorization codes.
+    /// </summary>
+    [Fact]
+    public async Task NonAuthorizationCodeGrant_IsPassedThrough()
+    {
+        // Arrange
+        var model = new TokenRequest { GrantType = GrantTypes.RefreshToken };
+        var request = new ValidTokenRequest(model, CreateGrant(), new ClientInfo("client-1"), [], []);
+        var innerError = new OidcError(ErrorCodes.InvalidGrant, "inner-marker");
+        _inner.Setup(p => p.ProcessAsync(request)).ReturnsAsync(innerError);
+
+        // Act
+        var result = await _decorator.ProcessAsync(request);
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal("inner-marker", error.ErrorDescription);
+        _codeService.Verify(s => s.RemoveAuthorizationCodeAsync(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -56,14 +56,12 @@ public class BackChannelAuthenticationGrantHandlerTests
     private const string UserId = "user_456";
 
     private readonly Mock<IBackChannelRequestStorage> _storage;
-    private readonly Mock<IParameterValidator> _parameterValidator;
     private readonly BackChannelAuthenticationGrantHandler _handler;
     private readonly DateTimeOffset _currentTime = new(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
     public BackChannelAuthenticationGrantHandlerTests()
     {
         _storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
-        _parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         var timeProvider = new FakeTimeProvider(_currentTime);
 
         var options = Options.Create(new OidcOptions
@@ -78,7 +76,6 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         _handler = new BackChannelAuthenticationGrantHandler(
             _storage.Object,
-            _parameterValidator.Object,
             timeProvider,
             options,
             serviceProvider);
@@ -122,6 +119,19 @@ public class BackChannelAuthenticationGrantHandlerTests
     }
 
     /// <summary>
+    /// RFC 6749 §5.2: a token request without the required auth_req_id parameter is the caller's
+    /// protocol error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+    /// </summary>
+    [Fact]
+    public async Task AuthorizeAsync_MissingAuthenticationRequestId_ReturnsInvalidRequest()
+    {
+        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId));
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+    }
+
+    /// <summary>
     /// Verifies that the handler supports the CIBA grant type.
     /// </summary>
     [Fact]
@@ -148,9 +158,6 @@ public class BackChannelAuthenticationGrantHandlerTests
             BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll,
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -188,9 +195,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync((BackChannelAuthenticationRequest?)null);
 
         // Act
@@ -214,9 +218,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var wrongClientInfo = new ClientInfo("different_client_456") { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -249,9 +250,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var nextPollAt = _currentTime.AddSeconds(5);
 
@@ -290,9 +288,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -326,9 +321,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var nextPollAt = _currentTime.AddSeconds(-1); // In the past
 
@@ -364,9 +356,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -398,18 +387,12 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = null };
 
-        _parameterValidator
-            .Setup(v => v.Required<string>(null, nameof(tokenRequest.AuthenticationRequestId)));
-
         _storage.Setup(s => s.TryGetAsync(null!)).ReturnsAsync((BackChannelAuthenticationRequest?)null);
 
         // Act
         await _handler.AuthorizeAsync(tokenRequest, clientInfo);
 
         // Assert
-        _parameterValidator.Verify(
-            v => v.Required<string>(null, nameof(tokenRequest.AuthenticationRequestId)),
-            Times.Once);
     }
 
     /// <summary>
@@ -425,9 +408,6 @@ public class BackChannelAuthenticationGrantHandlerTests
             BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll,
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -460,9 +440,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -492,9 +469,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var sessionId = "session_xyz";
         var authTime = _currentTime.AddMinutes(-5);
@@ -536,9 +510,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var nextPollAt = _currentTime; // Exactly now
 
         var expectedGrant = new AuthorizedGrant(
@@ -576,9 +547,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -614,9 +582,6 @@ public class BackChannelAuthenticationGrantHandlerTests
             BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Ping,
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -654,9 +619,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -686,7 +648,6 @@ public class BackChannelAuthenticationGrantHandlerTests
     {
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
-        var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         var timeProvider = new FakeTimeProvider(_currentTime);
 
         var statusNotifier = new Mock<IBackChannelLongPollingService>(MockBehavior.Strict);
@@ -704,7 +665,6 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
-            parameterValidator.Object,
             timeProvider,
             options,
             serviceProvider,
@@ -715,9 +675,6 @@ public class BackChannelAuthenticationGrantHandlerTests
             BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll,
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -779,7 +736,6 @@ public class BackChannelAuthenticationGrantHandlerTests
     {
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
-        var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         var timeProvider = new FakeTimeProvider(_currentTime);
 
         var statusNotifier = new Mock<IBackChannelLongPollingService>(MockBehavior.Strict);
@@ -797,7 +753,6 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
-            parameterValidator.Object,
             timeProvider,
             options,
             serviceProvider,
@@ -805,9 +760,6 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -852,9 +804,6 @@ public class BackChannelAuthenticationGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -887,7 +836,6 @@ public class BackChannelAuthenticationGrantHandlerTests
     {
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
-        var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         var timeProvider = new FakeTimeProvider(_currentTime);
 
         var options = Options.Create(new OidcOptions
@@ -903,16 +851,12 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
-            parameterValidator.Object,
             timeProvider,
             options,
             serviceProvider); // Status notifier is null
 
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -945,7 +889,6 @@ public class BackChannelAuthenticationGrantHandlerTests
     {
         // Arrange
         var storage = new Mock<IBackChannelRequestStorage>(MockBehavior.Strict);
-        var parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         var timeProvider = new FakeTimeProvider(_currentTime);
 
         var statusNotifier = new Mock<IBackChannelLongPollingService>(MockBehavior.Strict);
@@ -964,7 +907,6 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         var handler = new BackChannelAuthenticationGrantHandler(
             storage.Object,
-            parameterValidator.Object,
             timeProvider,
             options,
             serviceProvider,
@@ -972,9 +914,6 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
@@ -1017,9 +956,6 @@ public class BackChannelAuthenticationGrantHandlerTests
             BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Push,
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
-
-        _parameterValidator
-            .Setup(v => v.Required(AuthReqId, nameof(tokenRequest.AuthenticationRequestId)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "backchannel"),

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -54,7 +54,6 @@ public class DeviceCodeGrantHandlerTests
     private const string UserId = "user_456";
 
     private readonly Mock<IDeviceAuthorizationStorage> _storage;
-    private readonly Mock<IParameterValidator> _parameterValidator;
     private readonly DeviceCodeGrantHandler _handler;
     private readonly DateTimeOffset _currentTime = new(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
     private readonly TimeSpan _pollingInterval = TimeSpan.FromSeconds(5);
@@ -62,7 +61,6 @@ public class DeviceCodeGrantHandlerTests
     public DeviceCodeGrantHandlerTests()
     {
         _storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Strict);
-        _parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         var timeProvider = new FakeTimeProvider(_currentTime);
 
         var options = Options.Create(new OidcOptions
@@ -79,9 +77,21 @@ public class DeviceCodeGrantHandlerTests
 
         _handler = new DeviceCodeGrantHandler(
             _storage.Object,
-            _parameterValidator.Object,
             timeProvider,
             options);
+    }
+
+    /// <summary>
+    /// RFC 6749 §5.2: a token request without the required device_code parameter is the caller's
+    /// protocol error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+    /// </summary>
+    [Fact]
+    public async Task AuthorizeAsync_MissingDeviceCode_ReturnsInvalidRequest()
+    {
+        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId));
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
     }
 
     /// <summary>
@@ -107,9 +117,6 @@ public class DeviceCodeGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
-
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "device"),
@@ -148,9 +155,6 @@ public class DeviceCodeGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
 
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession(UserId, "session_123", _currentTime, "device"),
             new AuthorizationContext(ClientId, [Scopes.OpenId], null));
@@ -186,9 +190,6 @@ public class DeviceCodeGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
 
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
-
         _storage.Setup(s => s.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync((StoredDeviceAuthorizationRequest?)null);
 
         // Act
@@ -210,9 +211,6 @@ public class DeviceCodeGrantHandlerTests
         // Arrange
         var wrongClientInfo = new ClientInfo("different_client_456");
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
-
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
 
         var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
         {
@@ -240,9 +238,6 @@ public class DeviceCodeGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
-
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
 
         var nextPollAt = _currentTime.AddSeconds(5);
 
@@ -279,9 +274,6 @@ public class DeviceCodeGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
 
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
-
         var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
         {
             Status = DeviceAuthorizationStatus.Pending,
@@ -315,9 +307,6 @@ public class DeviceCodeGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
 
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
-
         var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
         {
             Status = DeviceAuthorizationStatus.Denied
@@ -347,18 +336,12 @@ public class DeviceCodeGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = null };
 
-        _parameterValidator
-            .Setup(v => v.Required<string>(null, nameof(tokenRequest.DeviceCode)));
-
         _storage.Setup(s => s.TryGetByDeviceCodeAsync(null!)).ReturnsAsync((StoredDeviceAuthorizationRequest?)null);
 
         // Act
         await _handler.AuthorizeAsync(tokenRequest, clientInfo);
 
         // Assert
-        _parameterValidator.Verify(
-            v => v.Required<string>(null, nameof(tokenRequest.DeviceCode)),
-            Times.Once);
     }
 
     /// <summary>
@@ -370,9 +353,6 @@ public class DeviceCodeGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
-
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
 
         var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
         {
@@ -399,9 +379,6 @@ public class DeviceCodeGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
-
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
 
         var sessionId = "session_xyz";
         var authTime = _currentTime.AddMinutes(-5);
@@ -444,9 +421,6 @@ public class DeviceCodeGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
 
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
-
         var nextPollAt = _currentTime;
 
         var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
@@ -476,9 +450,6 @@ public class DeviceCodeGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
-
-        _parameterValidator
-            .Setup(v => v.Required(DeviceCode, nameof(tokenRequest.DeviceCode)));
 
         var nextPollAt = _currentTime.AddSeconds(-1);
 

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/PasswordGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/PasswordGrantHandlerTests.cs
@@ -47,18 +47,34 @@ public class PasswordGrantHandlerTests
     private const string UserName = "testuser";
     private const string Password = "testpassword123";
 
-    private readonly Mock<IParameterValidator> _parameterValidator;
     private readonly Mock<IUserCredentialsAuthenticator> _credentialsAuthenticator;
     private readonly PasswordGrantHandler _handler;
 
     public PasswordGrantHandlerTests()
     {
-        _parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         _credentialsAuthenticator = new Mock<IUserCredentialsAuthenticator>(MockBehavior.Strict);
 
         _handler = new PasswordGrantHandler(
-            _parameterValidator.Object,
             _credentialsAuthenticator.Object);
+    }
+
+    /// <summary>
+    /// RFC 6749 §5.2: a token request without the required username or password parameter is the
+    /// caller's protocol error and yields invalid_request — previously it threw and surfaced as
+    /// HTTP 500.
+    /// </summary>
+    [Theory]
+    [InlineData(null, Password)]
+    [InlineData(UserName, null)]
+    public async Task AuthorizeAsync_MissingCredentialParameter_ReturnsInvalidRequest(
+        string? userName, string? password)
+    {
+        var tokenRequest = new TokenRequest { UserName = userName, Password = password };
+
+        var result = await _handler.AuthorizeAsync(tokenRequest, new ClientInfo(ClientId));
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
     }
 
     /// <summary>
@@ -77,9 +93,6 @@ public class PasswordGrantHandlerTests
             Password = Password,
             Scope = [Scopes.OpenId]
         };
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession("user123", "session1", DateTimeOffset.UtcNow, "192.168.1.1"),
@@ -115,9 +128,6 @@ public class PasswordGrantHandlerTests
             Scope = [Scopes.OpenId]
         };
 
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
-
         var authError = new OidcError(ErrorCodes.InvalidGrant, "Invalid username or password");
         _credentialsAuthenticator
             .Setup(a => a.ValidateAsync(UserName, "wrongpassword", It.IsAny<AuthorizationContext>()))
@@ -146,9 +156,6 @@ public class PasswordGrantHandlerTests
             Password = Password,
             Scope = [Scopes.OpenId]
         };
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
 
         var authError = new OidcError(ErrorCodes.InvalidGrant, "Account is locked");
         _credentialsAuthenticator
@@ -180,9 +187,6 @@ public class PasswordGrantHandlerTests
             Password = specialPassword,
             Scope = [Scopes.OpenId]
         };
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession("user123", "session1", DateTimeOffset.UtcNow, "192.168.1.1"),
@@ -216,9 +220,6 @@ public class PasswordGrantHandlerTests
             Scope = scopes
         };
 
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession("user123", "session1", DateTimeOffset.UtcNow, "192.168.1.1"),
             Context: new AuthorizationContext(ClientId, scopes, null));
@@ -250,9 +251,6 @@ public class PasswordGrantHandlerTests
             Password = Password,
             Scope = null!
         };
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
 
         var expectedGrant = new AuthorizedGrant(
             new AuthSession("user123", "session1", DateTimeOffset.UtcNow, "192.168.1.1"),
@@ -300,9 +298,6 @@ public class PasswordGrantHandlerTests
             Scope = [Scopes.OpenId]
         };
 
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
-
         var expectedGrant = new AuthorizedGrant(
             new AuthSession("user123", "session1", DateTimeOffset.UtcNow, "192.168.1.1"),
             Context: new AuthorizationContext(ClientId, tokenRequest.Scope, null));
@@ -341,9 +336,6 @@ public class PasswordGrantHandlerTests
             Scope = [Scopes.OpenId],
             Resources = resources,
         };
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.UserName, nameof(tokenRequest.UserName)));
-        _parameterValidator.Setup(v => v.Required(tokenRequest.Password, nameof(tokenRequest.Password)));
 
         var fixedTime = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var expectedGrant = new AuthorizedGrant(

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/RefreshTokenGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/RefreshTokenGrantHandlerTests.cs
@@ -50,21 +50,31 @@ public class RefreshTokenGrantHandlerTests
     private const string DifferentClientId = "different_client_456";
     private const string ValidRefreshToken = "valid.refresh.token";
 
-    private readonly Mock<IParameterValidator> _parameterValidator;
     private readonly Mock<IAuthServiceJwtValidator> _jwtValidator;
     private readonly Mock<IRefreshTokenService> _refreshTokenService;
     private readonly RefreshTokenGrantHandler _handler;
 
     public RefreshTokenGrantHandlerTests()
     {
-        _parameterValidator = new Mock<IParameterValidator>(MockBehavior.Strict);
         _jwtValidator = new Mock<IAuthServiceJwtValidator>(MockBehavior.Strict);
         _refreshTokenService = new Mock<IRefreshTokenService>(MockBehavior.Strict);
 
         _handler = new RefreshTokenGrantHandler(
-            _parameterValidator.Object,
             _jwtValidator.Object,
             _refreshTokenService.Object);
+    }
+
+    /// <summary>
+    /// RFC 6749 §5.2: a token request without the required refresh_token parameter is the caller's
+    /// protocol error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+    /// </summary>
+    [Fact]
+    public async Task AuthorizeAsync_MissingRefreshToken_ReturnsInvalidRequest()
+    {
+        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId));
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
     }
 
     /// <summary>
@@ -78,8 +88,6 @@ public class RefreshTokenGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { RefreshToken = ValidRefreshToken };
         var refreshToken = CreateValidRefreshToken(ClientId);
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
 
         _jwtValidator
             .Setup(v => v.ValidateAsync(ValidRefreshToken, ValidationOptions.Default))
@@ -113,8 +121,6 @@ public class RefreshTokenGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { RefreshToken = ValidRefreshToken };
         var refreshToken = CreateValidRefreshToken(ClientId);
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
 
         _jwtValidator
             .Setup(v => v.ValidateAsync(ValidRefreshToken, ValidationOptions.Default))
@@ -150,8 +156,6 @@ public class RefreshTokenGrantHandlerTests
         var tokenRequest = new TokenRequest { RefreshToken = ValidRefreshToken };
         var accessToken = CreateTokenWithType(JwtTypes.AccessToken);
 
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
-
         _jwtValidator
             .Setup(v => v.ValidateAsync(ValidRefreshToken, ValidationOptions.Default))
             .ReturnsAsync(accessToken);
@@ -176,8 +180,6 @@ public class RefreshTokenGrantHandlerTests
         var tokenRequest = new TokenRequest { RefreshToken = ValidRefreshToken };
         var idToken = CreateTokenWithType("JWT");
 
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
-
         _jwtValidator
             .Setup(v => v.ValidateAsync(ValidRefreshToken, ValidationOptions.Default))
             .ReturnsAsync(idToken);
@@ -201,8 +203,6 @@ public class RefreshTokenGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { RefreshToken = "malformed.jwt" };
 
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
-
         _jwtValidator
             .Setup(v => v.ValidateAsync("malformed.jwt", ValidationOptions.Default))
             .ReturnsAsync(new JwtValidationError(JwtError.InvalidToken, "Token is malformed"));
@@ -225,8 +225,6 @@ public class RefreshTokenGrantHandlerTests
         // Arrange
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { RefreshToken = ValidRefreshToken };
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
 
         _jwtValidator
             .Setup(v => v.ValidateAsync(ValidRefreshToken, ValidationOptions.Default))
@@ -252,8 +250,6 @@ public class RefreshTokenGrantHandlerTests
         var clientInfo = new ClientInfo(ClientId);
         var tokenRequest = new TokenRequest { RefreshToken = ValidRefreshToken };
         var refreshToken = CreateValidRefreshToken(ClientId);
-
-        _parameterValidator.Setup(v => v.Required(tokenRequest.RefreshToken, nameof(tokenRequest.RefreshToken)));
 
         _jwtValidator
             .Setup(v => v.ValidateAsync(ValidRefreshToken, ValidationOptions.Default))

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenAuthorizationContextEvaluatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenAuthorizationContextEvaluatorTests.cs
@@ -144,9 +144,52 @@ public class TokenAuthorizationContextEvaluatorTests
             Array.ConvertAll(requestedResources, resource => new ResourceDefinition(resource)));
     }
 
+    /// <summary>
+    /// RFC 8705 §3.4: tls_client_certificate_bound_access_tokens binds the issued token to the
+    /// presented certificate even when the client authenticates with a non-mTLS method — the
+    /// metadata decouples binding from authentication.
+    /// </summary>
+    [Fact]
+    public void InitialIssuance_NonMtlsAuthWithBindingFlag_BindsToPresentedCertificate()
+    {
+        using var certificate = CreateCertificate();
+        var expectedThumbprint = Base64Url.EncodeToString(SHA256.HashData(certificate.RawData));
+        var request = CreateRefreshRequest(
+            boundThumbprint: null,
+            clientCertificate: certificate,
+            authMethod: ClientAuthenticationMethods.PrivateKeyJwt,
+            certificateBoundAccessTokens: true);
+
+        var result = Evaluator.EvaluateAuthorizationContext(request);
+
+        Assert.Equal(expectedThumbprint, result.CertificateSha256Thumbprint);
+    }
+
+    /// <summary>
+    /// Without the RFC 8705 §3.4 flag a non-mTLS-authenticated client gets no certificate binding
+    /// even when a certificate happens to be present on the connection — pins the pre-existing
+    /// behavior the new flag deliberately does not change.
+    /// </summary>
+    [Fact]
+    public void InitialIssuance_NonMtlsAuthWithoutBindingFlag_DoesNotBind()
+    {
+        using var certificate = CreateCertificate();
+        var request = CreateRefreshRequest(
+            boundThumbprint: null,
+            clientCertificate: certificate,
+            authMethod: ClientAuthenticationMethods.PrivateKeyJwt,
+            certificateBoundAccessTokens: false);
+
+        var result = Evaluator.EvaluateAuthorizationContext(request);
+
+        Assert.Null(result.CertificateSha256Thumbprint);
+    }
+
     private static ValidTokenRequest CreateRefreshRequest(
         string? boundThumbprint,
-        X509Certificate2? clientCertificate)
+        X509Certificate2? clientCertificate,
+        string authMethod = ClientAuthenticationMethods.TlsClientAuth,
+        bool certificateBoundAccessTokens = false)
     {
         var fixedTime = DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture);
         var session = new AuthSession("user-123", "session-456", fixedTime, "local");
@@ -157,7 +200,8 @@ public class TokenAuthorizationContextEvaluatorTests
         var grant = new AuthorizedGrant(session, context);
         var clientInfo = new ClientInfo("test-client")
         {
-            TokenEndpointAuthMethod = ClientAuthenticationMethods.TlsClientAuth,
+            TokenEndpointAuthMethod = authMethod,
+            TlsClientCertificateBoundAccessTokens = certificateBoundAccessTokens,
         };
 
         return new ValidTokenRequest(

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -496,8 +496,9 @@ public class TokenExchangeGrantHandlerTests
         clientInfo.TokenExchangeAllowedAudiences = ["https://api1.example.com"];
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
         {
-            // One allowlisted, one not — the whole request must be rejected.
-            Audiences = ["https://api1.example.com", "https://api2.example.com"],
+            // One allowlisted, two not — the whole request must be rejected and EVERY disallowed
+            // audience reported, so the client can fix them all in one round-trip.
+            Audiences = ["https://api1.example.com", "https://api2.example.com", "https://api3.example.com"],
         };
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
@@ -505,6 +506,8 @@ public class TokenExchangeGrantHandlerTests
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
         Assert.Contains("api2.example.com", error.ErrorDescription);
+        Assert.Contains("api3.example.com", error.ErrorDescription);
+        Assert.DoesNotContain("api1.example.com", error.ErrorDescription);
     }
 
     [Fact]

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -53,13 +53,37 @@ public class TokenExchangeGrantHandlerTests
     private const string TestSubject = "user-7";
     private const string TestSessionId = "test-session";
 
-    private readonly Mock<IParameterValidator> _parameterValidator = new(MockBehavior.Strict);
     private readonly Mock<ISessionIdGenerator> _sessionIdGenerator = new(MockBehavior.Strict);
     private readonly FakeTimeProvider _timeProvider = new();
 
     public TokenExchangeGrantHandlerTests()
     {
         _sessionIdGenerator.Setup(g => g.GenerateSessionId()).Returns(TestSessionId);
+    }
+
+    /// <summary>
+    /// RFC 8693 §2.1 / RFC 6749 §5.2: a request without subject_token or subject_token_type is the
+    /// caller's protocol error and yields invalid_request — previously it threw and surfaced as
+    /// HTTP 500.
+    /// </summary>
+    [Theory]
+    [InlineData(null, TokenExchangeTokenTypes.AccessToken)]
+    [InlineData(SubjectTokenWire, null)]
+    public async Task AuthorizeAsync_MissingRequiredParameter_ReturnsInvalidRequest(
+        string? subjectToken, string? subjectTokenType)
+    {
+        var handler = CreateHandlerWithoutResolvers();
+        var request = new TokenRequest
+        {
+            GrantType = GrantTypes.TokenExchange,
+            SubjectToken = subjectToken,
+            SubjectTokenType = subjectTokenType,
+        };
+
+        var result = await handler.AuthorizeAsync(request, ClientWithAllowlist(null));
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
     }
 
     [Fact]
@@ -70,8 +94,6 @@ public class TokenExchangeGrantHandlerTests
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -91,8 +113,6 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetSuccess(out var grant));
@@ -109,8 +129,6 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(null);
         var request = ExchangeRequest("urn:ietf:params:oauth:token-type:saml2");
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -126,8 +144,6 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist();  // empty -> deny-all
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -141,8 +157,6 @@ public class TokenExchangeGrantHandlerTests
         var handler = CreateHandlerWithoutResolvers();
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.IdToken);  // only id_token allowed
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -168,8 +182,6 @@ public class TokenExchangeGrantHandlerTests
             ActorToken = actorWire,
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,
         };
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -200,8 +212,6 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetSuccess(out var grant));
@@ -221,8 +231,6 @@ public class TokenExchangeGrantHandlerTests
             ActorToken = "actor.jwt",  // type missing
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -239,8 +247,6 @@ public class TokenExchangeGrantHandlerTests
         {
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,  // value missing
         };
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -268,8 +274,6 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -292,8 +296,6 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -309,8 +311,6 @@ public class TokenExchangeGrantHandlerTests
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.IdToken, ctx);
         var clientInfo = ClientWithAllowlist(null);  // tri-state: no constraint
         var request = ExchangeRequest(TokenExchangeTokenTypes.IdToken);
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -328,8 +328,6 @@ public class TokenExchangeGrantHandlerTests
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = requestScope };
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -361,8 +359,6 @@ public class TokenExchangeGrantHandlerTests
         var requestingClient = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken); // ClientId = "test-client"
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, requestingClient);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -386,8 +382,6 @@ public class TokenExchangeGrantHandlerTests
         };
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, brokerClient);
 
         Assert.True(result.TryGetSuccess(out var grant));
@@ -407,8 +401,6 @@ public class TokenExchangeGrantHandlerTests
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         var requestingClient = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, requestingClient);
 
@@ -437,8 +429,6 @@ public class TokenExchangeGrantHandlerTests
         };
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientWithDifferentAllowlist);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -462,8 +452,6 @@ public class TokenExchangeGrantHandlerTests
         {
             Audiences = ["https://api1.example.com", "https://api2.example.com"],
         };
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -489,8 +477,6 @@ public class TokenExchangeGrantHandlerTests
             Audiences = ["https://victim.example.com"],
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -514,8 +500,6 @@ public class TokenExchangeGrantHandlerTests
             Audiences = ["https://api1.example.com", "https://api2.example.com"],
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -537,8 +521,6 @@ public class TokenExchangeGrantHandlerTests
         {
             Resources = [new Uri("https://api.example.com")],
         };
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -566,8 +548,6 @@ public class TokenExchangeGrantHandlerTests
             RequestedTokenType = TokenExchangeTokenTypes.IdToken,
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -589,8 +569,6 @@ public class TokenExchangeGrantHandlerTests
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
-
-        SetupRequiredOnly(request);
 
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
@@ -632,8 +610,6 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,  // not in allowlist
         };
 
-        SetupRequiredOnly(request);
-
         var result = await handler.AuthorizeAsync(request, clientInfo);
 
         Assert.True(result.TryGetFailure(out var error));
@@ -662,22 +638,14 @@ public class TokenExchangeGrantHandlerTests
         services.AddKeyedSingleton(tokenType, resolverMock.Object);
         var sp = services.BuildServiceProvider();
 
-        var handler = new TokenExchangeGrantHandler(
-            _parameterValidator.Object, sp, _sessionIdGenerator.Object, _timeProvider);
+        var handler = new TokenExchangeGrantHandler(sp, _sessionIdGenerator.Object, _timeProvider);
         return (handler, resolverMock);
     }
 
     private TokenExchangeGrantHandler CreateHandlerWithoutResolvers()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        return new TokenExchangeGrantHandler(
-            _parameterValidator.Object, sp, _sessionIdGenerator.Object, _timeProvider);
-    }
-
-    private void SetupRequiredOnly(TokenRequest request)
-    {
-        _parameterValidator.Setup(v => v.Required(request.SubjectToken, nameof(request.SubjectToken)));
-        _parameterValidator.Setup(v => v.Required(request.SubjectTokenType, nameof(request.SubjectTokenType)));
+        return new TokenExchangeGrantHandler(sp, _sessionIdGenerator.Object, _timeProvider);
     }
 
     private static ClientInfo ClientWithAllowlist(params string[]? allowlist) =>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -447,7 +447,7 @@ public class TokenExchangeGrantHandlerTests
     }
 
     [Fact]
-    public async Task S2_Audience_parameter_propagates_to_AuthorizationContext()
+    public async Task S2_Audience_parameter_propagates_when_allowlisted()
     {
         var subject = new SubjectTokenContext("alice", null, ["openid"], null)
         {
@@ -456,6 +456,8 @@ public class TokenExchangeGrantHandlerTests
         };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
+        // Default-deny: the requested audiences must be on the client's audience allowlist.
+        clientInfo.TokenExchangeAllowedAudiences = ["https://api1.example.com", "https://api2.example.com"];
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
         {
             Audiences = ["https://api1.example.com", "https://api2.example.com"],
@@ -467,6 +469,58 @@ public class TokenExchangeGrantHandlerTests
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(request.Audiences, grant.Context.Audiences);
+    }
+
+    [Fact]
+    public async Task Audience_rejected_when_client_has_no_allowlist()
+    {
+        // Default-deny: a client that requests an audience without an explicit
+        // TokenExchangeAllowedAudiences allowlist is rejected with invalid_target. Otherwise the
+        // client could mint a token for any target service it names in the issued token's aud.
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null)
+        {
+            OriginalClientId = ClientId,
+            JwtTokenType = JwtTypes.AccessToken,
+        };
+        var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
+        var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken); // no audience allowlist
+        var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
+        {
+            Audiences = ["https://victim.example.com"],
+        };
+
+        SetupRequiredOnly(request);
+
+        var result = await handler.AuthorizeAsync(request, clientInfo);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
+    }
+
+    [Fact]
+    public async Task Audience_rejected_when_not_in_allowlist()
+    {
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null)
+        {
+            OriginalClientId = ClientId,
+            JwtTokenType = JwtTypes.AccessToken,
+        };
+        var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
+        var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
+        clientInfo.TokenExchangeAllowedAudiences = ["https://api1.example.com"];
+        var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
+        {
+            // One allowlisted, one not — the whole request must be rejected.
+            Audiences = ["https://api1.example.com", "https://api2.example.com"],
+        };
+
+        SetupRequiredOnly(request);
+
+        var result = await handler.AuthorizeAsync(request, clientInfo);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
+        Assert.Contains("api2.example.com", error.ErrorDescription);
     }
 
     [Fact]

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
@@ -30,8 +30,7 @@ using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Utils;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
-using Abblix.Oidc.Server.Features.Storages;
-using Abblix.Oidc.Server.Features.Tokens.Revocation;
+using Abblix.Oidc.Server.Features.ReplayPrevention;
 using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
@@ -58,7 +57,7 @@ public class ClientSecretJwtAuthenticatorTests
     private readonly Mock<IClientInfoProvider> _clientInfoProvider;
     private readonly Mock<IRequestInfoProvider> _requestInfoProvider;
     private readonly FakeTimeProvider _clock;
-    private readonly Mock<ITokenRegistry> _tokenRegistry;
+    private readonly Mock<IJwtReplayCache> _replayCache;
     private readonly ClientSecretJwtAuthenticator _authenticator;
 
     public ClientSecretJwtAuthenticatorTests()
@@ -68,7 +67,7 @@ public class ClientSecretJwtAuthenticatorTests
         _clientInfoProvider = new Mock<IClientInfoProvider>(MockBehavior.Strict);
         _requestInfoProvider = new Mock<IRequestInfoProvider>(MockBehavior.Strict);
         _clock = new FakeTimeProvider();
-        _tokenRegistry = new Mock<ITokenRegistry>(MockBehavior.Strict);
+        _replayCache = new Mock<IJwtReplayCache>(MockBehavior.Strict);
 
         _requestInfoProvider
             .Setup(p => p.RequestUri)
@@ -80,7 +79,7 @@ public class ClientSecretJwtAuthenticatorTests
             _clientInfoProvider.Object,
             _requestInfoProvider.Object,
             _clock,
-            _tokenRegistry.Object);
+            _replayCache.Object);
     }
 
     /// <summary>
@@ -209,9 +208,9 @@ public class ClientSecretJwtAuthenticatorTests
             .Setup(p => p.TryFindClientAsync(ClientId))
             .ReturnsAsync(clientInfo);
 
-        _tokenRegistry
-            .Setup(r => r.SetStatusAsync(jwtId, JsonWebTokenStatus.Used, It.IsAny<DateTimeOffset>()))
-            .Returns(Task.CompletedTask);
+        _replayCache
+            .Setup(r => r.TryAddAsync(jwtId, It.IsAny<DateTimeOffset?>()))
+            .ReturnsAsync(true);
 
         var request = new ClientRequest
         {
@@ -226,7 +225,7 @@ public class ClientSecretJwtAuthenticatorTests
         Assert.NotNull(result);
         Assert.Equal(ClientId, result.ClientId);
 
-        _tokenRegistry.Verify(r => r.SetStatusAsync(jwtId, JsonWebTokenStatus.Used, It.IsAny<DateTimeOffset>()), Times.Once);
+        _replayCache.Verify(r => r.TryAddAsync(jwtId, It.IsAny<DateTimeOffset?>()), Times.Once);
     }
 
     /// <summary>
@@ -276,8 +275,8 @@ public class ClientSecretJwtAuthenticatorTests
 
         // Assert
         Assert.Null(result);
-        _tokenRegistry.Verify(
-            r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()),
+        _replayCache.Verify(
+            r => r.TryAddAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>()),
             Times.Never);
     }
 
@@ -316,9 +315,9 @@ public class ClientSecretJwtAuthenticatorTests
             .Setup(p => p.TryFindClientAsync(ClientId))
             .ReturnsAsync(clientInfo);
 
-        _tokenRegistry
-            .Setup(r => r.SetStatusAsync(jwtId, JsonWebTokenStatus.Used, It.IsAny<DateTimeOffset>()))
-            .Returns(Task.CompletedTask);
+        _replayCache
+            .Setup(r => r.TryAddAsync(jwtId, It.IsAny<DateTimeOffset?>()))
+            .ReturnsAsync(true);
 
         var request = new ClientRequest
         {
@@ -520,8 +519,8 @@ public class ClientSecretJwtAuthenticatorTests
         // Assert
         Assert.Null(result);
 
-        // A rejected assertion is never recorded in the replay registry.
-        _tokenRegistry.Verify(r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()), Times.Never);
+        // A rejected assertion is never recorded in the replay cache.
+        _replayCache.Verify(r => r.TryAddAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>()), Times.Never);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
@@ -28,8 +28,7 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
-using Abblix.Oidc.Server.Features.Storages;
-using Abblix.Oidc.Server.Features.Tokens.Revocation;
+using Abblix.Oidc.Server.Features.ReplayPrevention;
 using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.DependencyInjection;
@@ -303,18 +302,19 @@ public class PrivateKeyJwtAuthenticatorTests
     }
 
     /// <summary>
-    /// Verifies that the JWT ID (jti) and expiration time (exp) are registered in the token registry.
+    /// Verifies that the JWT ID (jti) and expiration time (exp) are recorded in the replay cache.
     /// This prevents replay attacks by ensuring tokens can only be used once.
     /// </summary>
     [Fact]
-    public async Task ValidJwtWithJtiAndExp_ShouldRegisterInTokenRegistry()
+    public async Task ValidJwtWithJtiAndExp_ShouldRecordInReplayCache()
     {
         // Arrange
         var (authenticator, mocks) = CreateAuthenticator();
 
         var clientInfo = CreateClientInfo(ClientId);
         var jti = "unique_jwt_id_123";
-        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        var expiresAt = DateTimeOffset.Parse(
+            "2027-01-01T00:05:00Z", System.Globalization.CultureInfo.InvariantCulture);
 
         var validToken = CreateValidJwtTokenWithJtiAndExp(ClientId, ClientId, jti, expiresAt);
 
@@ -333,12 +333,49 @@ public class PrivateKeyJwtAuthenticatorTests
 
         // Assert
         Assert.NotNull(result);
-        mocks.TokenRegistry.Verify(
-            r => r.SetStatusAsync(
+        mocks.ReplayCache.Verify(
+            r => r.TryAddAsync(
                 It.Is<string>(id => id == jti),
-                It.Is<JsonWebTokenStatus>(s => s == JsonWebTokenStatus.Used),
-                It.Is<DateTimeOffset>(exp => Math.Abs((exp - expiresAt).TotalSeconds) < 1)),
+                It.Is<DateTimeOffset?>(exp =>
+                    exp.HasValue && Math.Abs((exp.Value - expiresAt).TotalSeconds) < 1)),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a replayed assertion is rejected: the replay cache reports the jti as
+    /// already present, and the single TryAddAsync call makes the reserve-and-check atomic —
+    /// two concurrent presenters of the same assertion cannot both pass.
+    /// </summary>
+    [Fact]
+    public async Task ReplayedAssertion_ShouldReturnNull()
+    {
+        // Arrange
+        var (authenticator, mocks) = CreateAuthenticator();
+
+        var clientInfo = CreateClientInfo(ClientId);
+        var validToken = CreateValidJwtTokenWithJtiAndExp(
+            ClientId, ClientId, "replayed-jti",
+            DateTimeOffset.Parse("2027-01-01T00:05:00Z", System.Globalization.CultureInfo.InvariantCulture));
+
+        mocks.ClientJwtValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(validToken, clientInfo));
+
+        mocks.ReplayCache
+            .Setup(r => r.TryAddAsync("replayed-jti", It.IsAny<DateTimeOffset?>()))
+            .ReturnsAsync(false);
+
+        var request = new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion
+        };
+
+        // Act
+        var result = await authenticator.TryAuthenticateClientAsync(request);
+
+        // Assert
+        Assert.Null(result);
     }
 
     /// <summary>
@@ -371,10 +408,42 @@ public class PrivateKeyJwtAuthenticatorTests
 
         // Assert
         Assert.Null(result);
-        // A rejected assertion is never recorded in the replay registry.
-        mocks.TokenRegistry.Verify(
-            r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()),
+        // A rejected assertion is never recorded in the replay cache.
+        mocks.ReplayCache.Verify(
+            r => r.TryAddAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that an assertion without an exp claim is rejected. RFC 7523 §3 makes exp REQUIRED
+    /// ("The JWT MUST contain an 'exp' (expiration time) claim that limits the time window during
+    /// which the JWT can be used"); without it the replay-registry entry has no TTL to key off,
+    /// so the assertion would be replayable indefinitely.
+    /// </summary>
+    [Fact]
+    public async Task AssertionWithoutExp_ShouldReturnNull()
+    {
+        // Arrange
+        var (authenticator, mocks) = CreateAuthenticator();
+
+        var clientInfo = CreateClientInfo(ClientId);
+        var tokenWithoutExp = CreateValidJwtTokenWithJti(ClientId, ClientId, "jti-without-exp");
+
+        mocks.ClientJwtValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(tokenWithoutExp, clientInfo));
+
+        var request = new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion
+        };
+
+        // Act
+        var result = await authenticator.TryAuthenticateClientAsync(request);
+
+        // Assert
+        Assert.Null(result);
     }
 
     /// <summary>
@@ -422,13 +491,13 @@ public class PrivateKeyJwtAuthenticatorTests
     private (PrivateKeyJwtAuthenticator authenticator, Mocks mocks) CreateAuthenticator()
     {
         var logger = new Mock<ILogger<PrivateKeyJwtAuthenticator>>();
-        var tokenRegistry = new Mock<ITokenRegistry>(MockBehavior.Strict);
+        var replayCache = new Mock<IJwtReplayCache>(MockBehavior.Strict);
         var clientJwtValidator = new Mock<IClientJwtValidator>(MockBehavior.Strict);
 
-        // Setup default behavior for token registry
-        tokenRegistry
-            .Setup(r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()))
-            .Returns(Task.CompletedTask);
+        // Setup default behavior for the replay cache: every jti is fresh
+        replayCache
+            .Setup(r => r.TryAddAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>()))
+            .ReturnsAsync(true);
 
         // Create service provider with scoped services
         var services = new ServiceCollection();
@@ -437,13 +506,13 @@ public class PrivateKeyJwtAuthenticatorTests
 
         var authenticator = new PrivateKeyJwtAuthenticator(
             logger.Object,
-            tokenRegistry.Object,
+            replayCache.Object,
             serviceProvider);
 
         var mocks = new Mocks
         {
             Logger = logger,
-            TokenRegistry = tokenRegistry,
+            ReplayCache = replayCache,
             ClientJwtValidator = clientJwtValidator,
         };
 
@@ -477,6 +546,36 @@ public class PrivateKeyJwtAuthenticatorTests
             payloadJson[JwtClaimTypes.Issuer] = issuer;
         if (subject != null)
             payloadJson[JwtClaimTypes.Subject] = subject;
+
+        var headerJson = new JsonObject
+        {
+            [JwtClaimTypes.Algorithm] = "RS256",
+            [JwtClaimTypes.Type] = "JWT"
+        };
+
+        return new JsonWebToken
+        {
+            Header = new JsonWebTokenHeader(headerJson),
+            Payload = new JsonWebTokenPayload(payloadJson)
+        };
+    }
+
+    /// <summary>
+    /// Creates a JWT token with a jti claim but no exp claim, for testing the RFC 7523 §3
+    /// expiration requirement. Uses real JsonObject instances for JWT payload - NOT mocked!
+    /// </summary>
+    /// <param name="issuer">The issuer claim (iss).</param>
+    /// <param name="subject">The subject claim (sub).</param>
+    /// <param name="jwtId">The JWT ID claim (jti).</param>
+    /// <returns>A JsonWebToken with the specified claims and no expiration.</returns>
+    private JsonWebToken CreateValidJwtTokenWithJti(string issuer, string subject, string jwtId)
+    {
+        var payloadJson = new JsonObject
+        {
+            [JwtClaimTypes.Issuer] = issuer,
+            [JwtClaimTypes.Subject] = subject,
+            [JwtClaimTypes.JwtId] = jwtId
+        };
 
         var headerJson = new JsonObject
         {
@@ -533,7 +632,7 @@ public class PrivateKeyJwtAuthenticatorTests
     private sealed class Mocks
     {
         public Mock<ILogger<PrivateKeyJwtAuthenticator>> Logger { get; init; } = null!;
-        public Mock<ITokenRegistry> TokenRegistry { get; init; } = null!;
+        public Mock<IJwtReplayCache> ReplayCache { get; init; } = null!;
         public Mock<IClientJwtValidator> ClientJwtValidator { get; init; } = null!;
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/RequestObject/RequestObjectFetcherTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/RequestObject/RequestObjectFetcherTests.cs
@@ -793,4 +793,79 @@ public class RequestObjectFetcherTests
                 It.Is<ValidationOptions>(opts => opts.HasFlag(ValidationOptions.RequireSignedTokens))),
             Times.Once);
     }
+
+    /// <summary>
+    /// RFC 9101 §10.5: a client registered with require_signed_request_object committed to SIGNED
+    /// request objects — an unsigned (alg=none) object passes structural validation but must be
+    /// rejected by the per-client commitment even when the server-wide requirement is off.
+    /// </summary>
+    [Fact]
+    public async Task FetchAsync_UnsignedObjectFromCommittedClient_ShouldFail()
+    {
+        // Arrange — server-wide RequireSignedRequestObject stays off.
+        var fetcher = CreateFetcher();
+        var request = new TestRequest(TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri.OriginalString, null);
+        var jwt = "eyJhbGciOiJub25lIn0.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.";
+        var token = new JsonWebToken
+        {
+            Header = new JsonWebTokenHeader(new JsonObject()) { Algorithm = SigningAlgorithms.None },
+            Payload = new JsonWebTokenPayload(new JsonObject()),
+        };
+        var committedClient = new ClientInfo("test-client") { RequireSignedRequestObject = true };
+
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, committedClient));
+
+        // Act
+        var result = await fetcher.FetchAsync(request, jwt);
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequestObject, error.Error);
+    }
+
+    /// <summary>
+    /// RFC 9101 §5 strict mode: the payload binds onto a fresh model instead of merging over the
+    /// outer request, so parameters passed outside the request object are ignored.
+    /// </summary>
+    [Fact]
+    public async Task FetchAsync_StrictMode_BindsPayloadOntoFreshModel()
+    {
+        // Arrange
+        _oidcOptions.IgnoreParametersOutsideRequestObject = true;
+        var fetcher = CreateFetcher();
+        var outerRequest = new Abblix.Oidc.Server.Model.AuthorizationRequest { State = "outer-state" };
+        var jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjbGllbnQxIn0.signature";
+        var payload = new JsonObject { ["client_id"] = TestConstants.DefaultClientId };
+        var token = new JsonWebToken
+        {
+            Header = new JsonWebTokenHeader(new JsonObject()) { Algorithm = SigningAlgorithms.RS256 },
+            Payload = new JsonWebTokenPayload(payload),
+        };
+        var boundRequest = new Abblix.Oidc.Server.Model.AuthorizationRequest
+        {
+            ClientId = TestConstants.DefaultClientId,
+        };
+
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, new ClientInfo("test-client")));
+
+        // The binder must receive a FRESH target, not the outer request — that is what makes the
+        // outer parameters invisible to the merged result.
+        _jsonObjectBinder
+            .Setup(b => b.BindModelAsync(
+                payload,
+                It.Is<Abblix.Oidc.Server.Model.AuthorizationRequest>(t => !ReferenceEquals(t, outerRequest))))
+            .ReturnsAsync(boundRequest);
+
+        // Act
+        var result = await fetcher.FetchAsync(outerRequest, jwt);
+
+        // Assert
+        Assert.True(result.TryGetSuccess(out var value));
+        Assert.Same(boundRequest, value);
+        Assert.Null(value.State);
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -438,30 +438,58 @@ public class AuthorizationCodeServiceTests
     }
 
     /// <summary>
-    /// Verifies that RemoveAuthorizationCodeAsync calls storage.RemoveAsync.
-    /// Per OAuth 2.0, authorization codes should be removed after use to prevent replay.
+    /// Verifies that RemoveAuthorizationCodeAsync performs an atomic get-and-remove
+    /// (removeOnRetrieval: true) and returns the claimed grant. The atomic claim is what enforces
+    /// single-use against two concurrent redemptions of the same code — exactly one caller wins.
     /// </summary>
     [Fact]
-    public async Task RemoveAuthorizationCodeAsync_ShouldCallStorageRemove()
+    public async Task RemoveAuthorizationCodeAsync_ShouldGetAndRemoveAtomically()
     {
         // Arrange
         var code = "code_to_remove";
+        var grant = CreateGrant();
+        bool? capturedRemoveOnRetrieval = null;
 
         _storage
-            .Setup(s => s.RemoveAsync(
+            .Setup(s => s.GetAsync<AuthorizedGrant>(
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<System.Threading.CancellationToken?>()))
-            .Returns(Task.CompletedTask);
+            .Callback<string, bool, System.Threading.CancellationToken?>(
+                (_, remove, _) => capturedRemoveOnRetrieval = remove)
+            .ReturnsAsync(grant);
 
         // Act
-        await _service.RemoveAuthorizationCodeAsync(code);
+        var result = await _service.RemoveAuthorizationCodeAsync(code);
 
         // Assert
-        _storage.Verify(
-            s => s.RemoveAsync(
-                $"Abblix.Oidc.Server:Grant:{code}",
-                It.IsAny<System.Threading.CancellationToken?>()),
-            Times.Once);
+        Assert.True(capturedRemoveOnRetrieval);
+        Assert.True(result.TryGetSuccess(out var claimed));
+        Assert.Same(grant, claimed);
+    }
+
+    /// <summary>
+    /// Verifies that RemoveAuthorizationCodeAsync returns an invalid_grant failure when the code is
+    /// absent — already claimed by a concurrent request, already consumed, or never issued.
+    /// </summary>
+    [Fact]
+    public async Task RemoveAuthorizationCodeAsync_WithAbsentCode_ReturnsFailure()
+    {
+        // Arrange
+        var code = "missing_code";
+        _storage
+            .Setup(s => s.GetAsync<AuthorizedGrant>(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<System.Threading.CancellationToken?>()))
+            .ReturnsAsync((AuthorizedGrant?)null);
+
+        // Act
+        var result = await _service.RemoveAuthorizationCodeAsync(code);
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
     }
 
     /// <summary>
@@ -476,12 +504,13 @@ public class AuthorizationCodeServiceTests
         string? capturedKey = null;
 
         _storage
-            .Setup(s => s.RemoveAsync(
+            .Setup(s => s.GetAsync<AuthorizedGrant>(
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<System.Threading.CancellationToken?>()))
-            .Callback<string, System.Threading.CancellationToken?>(
-                (key, _) => capturedKey = key)
-            .Returns(Task.CompletedTask);
+            .Callback<string, bool, System.Threading.CancellationToken?>(
+                (key, _, _) => capturedKey = key)
+            .ReturnsAsync(CreateGrant());
 
         // Act
         await _service.RemoveAuthorizationCodeAsync(code);
@@ -640,29 +669,30 @@ public class AuthorizationCodeServiceTests
                 It.IsAny<System.Threading.CancellationToken?>()))
             .Returns(Task.CompletedTask);
 
+        // Both the read-only validation lookup (removeOnRetrieval: false) and the atomic claim
+        // (removeOnRetrieval: true) go through GetAsync; return the grant for either.
         _storage
             .Setup(s => s.GetAsync<AuthorizedGrant>(
                 $"Abblix.Oidc.Server:Grant:{code}",
-                false,
+                It.IsAny<bool>(),
                 It.IsAny<System.Threading.CancellationToken?>()))
             .ReturnsAsync(grant);
-
-        _storage
-            .Setup(s => s.RemoveAsync(
-                $"Abblix.Oidc.Server:Grant:{code}",
-                It.IsAny<System.Threading.CancellationToken?>()))
-            .Returns(Task.CompletedTask);
 
         // Act
         var generatedCode = await _service.GenerateAuthorizationCodeAsync(grant, expiresIn);
         var authorizeResult = await _service.AuthorizeByCodeAsync(generatedCode);
-        await _service.RemoveAuthorizationCodeAsync(generatedCode);
+        var removeResult = await _service.RemoveAuthorizationCodeAsync(generatedCode);
 
         // Assert
         Assert.Equal(code, generatedCode);
         Assert.True(authorizeResult.TryGetSuccess(out var retrievedGrant));
         Assert.Same(grant, retrievedGrant);
-        _storage.Verify(s => s.RemoveAsync($"Abblix.Oidc.Server:Grant:{code}", It.IsAny<System.Threading.CancellationToken?>()), Times.Once);
+        Assert.True(removeResult.TryGetSuccess(out var claimedGrant));
+        Assert.Same(grant, claimedGrant);
+        _storage.Verify(
+            s => s.GetAsync<AuthorizedGrant>(
+                $"Abblix.Oidc.Server:Grant:{code}", true, It.IsAny<System.Threading.CancellationToken?>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
@@ -477,6 +478,49 @@ public class IdentityTokenServiceTests
     }
 
     /// <summary>
+    /// Verifies c_hash/at_hash are produced for non-RS256 signing algorithms, using the hash
+    /// matching the algorithm's digest size (OIDC Core §3.1.3.6 / §3.3.2.11): SHA-256 for *256,
+    /// SHA-384 for *384, SHA-512 for *512. The claim is base64url of the left half of the digest,
+    /// so its decoded length is half the digest size (16 / 24 / 32 bytes). Before the fix only
+    /// RS256 was handled and these algorithms silently omitted the hashes, breaking hybrid flows.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.ES256, 16)] // SHA-256: 32-byte digest, left half 16
+    [InlineData(SigningAlgorithms.PS384, 24)] // SHA-384: 48-byte digest, left half 24
+    [InlineData(SigningAlgorithms.ES512, 32)] // SHA-512: 64-byte digest, left half 32
+    public async Task CreateIdentityToken_NonRs256Algorithm_ProducesHashesOfCorrectSize(
+        string signingAlgorithm, int expectedHalfDigestBytes)
+    {
+        // Arrange
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo(signingAlgorithm: signingAlgorithm);
+        var userClaims = CreateUserClaims();
+
+        _userClaimsProvider
+            .Setup(p => p.GetUserClaimsAsync(authSession, authContext.Scope, null, clientInfo))
+            .ReturnsAsync(userClaims);
+
+        JsonWebToken? capturedToken = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
+            .ReturnsAsync(EncodedToken);
+
+        // Act
+        await _service.CreateIdentityTokenAsync(authSession, authContext, clientInfo, true, AuthCode, AccessToken);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        var cHash = capturedToken!.Payload[JwtClaimTypes.CodeHash]?.GetValue<string>();
+        var atHash = capturedToken.Payload[JwtClaimTypes.AccessTokenHash]?.GetValue<string>();
+        Assert.NotNull(cHash);
+        Assert.NotNull(atHash);
+        Assert.Equal(expectedHalfDigestBytes, Base64Url.DecodeFromChars(cHash).Length);
+        Assert.Equal(expectedHalfDigestBytes, Base64Url.DecodeFromChars(atHash).Length);
+    }
+
+    /// <summary>
     /// Verifies that when authorization code is null or empty, c_hash is not included.
     /// </summary>
     [Fact]
@@ -626,11 +670,13 @@ public class IdentityTokenServiceTests
     private static AuthorizationContext CreateAuthorizationContext() =>
         new(ClientId, [Scopes.OpenId, Scopes.Profile], null);
 
-    private static ClientInfo CreateClientInfo(TimeSpan? identityTokenExpiresIn = null)
+    private static ClientInfo CreateClientInfo(
+        TimeSpan? identityTokenExpiresIn = null,
+        string signingAlgorithm = SigningAlgorithms.RS256)
     {
         var clientInfo = new ClientInfo(ClientId)
         {
-            IdentityTokenSignedResponseAlgorithm = SigningAlgorithms.RS256
+            IdentityTokenSignedResponseAlgorithm = signingAlgorithm
         };
 
         if (identityTokenExpiresIn.HasValue)

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
@@ -108,7 +108,58 @@ public class LogoutTokenServiceTests
         // Assert
         Assert.NotNull(capturedToken);
         Assert.Equal(JwtTypes.LogoutToken, capturedToken!.Header.Type);
+        // The default ClientInfo registers RS256 for ID Token signing, and §2.4 signs the logout
+        // token in the same manner as the ID Token.
         Assert.Equal(SigningAlgorithms.RS256, capturedToken.Header.Algorithm);
+    }
+
+    /// <summary>
+    /// Back-Channel Logout §2.4: the logout token is signed in the same manner as the ID Token —
+    /// by default the client's registered ID Token signing algorithm applies, not a hardcoded RS256.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.ES256)]
+    [InlineData(SigningAlgorithms.PS384)]
+    public async Task CreateLogoutTokenAsync_ShouldFallBackToIdTokenAlgorithm(string algorithm)
+    {
+        // Arrange
+        var clientInfo = CreateClientInfo();
+        clientInfo.IdentityTokenSignedResponseAlgorithm = algorithm;
+        var logoutContext = CreateLogoutContext();
+
+        JsonWebToken? capturedToken = null;
+        SetupMocks(clientInfo, logoutContext, token => capturedToken = token);
+
+        // Act
+        await _service.CreateLogoutTokenAsync(clientInfo, logoutContext);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.Equal(algorithm, capturedToken!.Header.Algorithm);
+    }
+
+    /// <summary>
+    /// The explicit per-client logout token algorithm overrides the §2.4 default coupling with
+    /// the ID Token signing algorithm.
+    /// </summary>
+    [Fact]
+    public async Task CreateLogoutTokenAsync_ExplicitLogoutAlgorithm_OverridesIdTokenAlgorithm()
+    {
+        // Arrange
+        var clientInfo = CreateClientInfo();
+        clientInfo.IdentityTokenSignedResponseAlgorithm = SigningAlgorithms.ES256;
+        clientInfo.LogoutTokenSignedResponseAlgorithm = SigningAlgorithms.PS512;
+        var logoutContext = CreateLogoutContext();
+
+        JsonWebToken? capturedToken = null;
+        SetupMocks(clientInfo, logoutContext, token => capturedToken = token);
+
+        // Act
+        await _service.CreateLogoutTokenAsync(clientInfo, logoutContext);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.Equal(SigningAlgorithms.PS512, capturedToken!.Header.Algorithm);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -412,9 +412,9 @@ public class RefreshTokenServiceTests
 
     /// <summary>
     /// Verifies sliding expiration calculation when shorter than absolute expiration.
-    /// Sliding expiration resets on each token use, but is capped by absolute expiration.
-    /// When SlidingExpiresIn results in earlier expiry, it takes precedence.
-    /// This limits token lifetime based on inactivity while respecting the absolute maximum.
+    /// The sliding window is anchored to the moment of the refresh (now), not the original issuance,
+    /// so each use extends the lifetime; it is capped by the absolute ceiling from the original
+    /// issuance. When the sliding window yields the earlier expiry, it takes precedence.
     /// </summary>
     [Fact]
     public async Task CreateRefreshToken_WithSlidingExpirationShorter_ShouldUseSlidingExpiry()
@@ -422,14 +422,14 @@ public class RefreshTokenServiceTests
         // Arrange
         var authSession = CreateAuthSession();
         var authContext = CreateAuthorizationContext();
-        var originalIssuedAt = _currentTime.AddMinutes(-30);  // Only 30 mins ago
-        var slidingExpiry = TimeSpan.FromHours(2);  // 2 hours from IssuedAt = 1.5h from now
+        var originalIssuedAt = _currentTime.AddMinutes(-30);  // First login, 30 mins ago
+        var slidingExpiry = TimeSpan.FromHours(2);
         var absoluteExpiry = TimeSpan.FromDays(30);  // 30 days from IssuedAt
 
         var clientInfo = CreateClientInfo(refreshTokenOptions: new RefreshTokenOptions
         {
-            AbsoluteExpiresIn = absoluteExpiry, // 30 days from IssuedAt
-            SlidingExpiresIn = slidingExpiry,   // 2 hours from IssuedAt
+            AbsoluteExpiresIn = absoluteExpiry,
+            SlidingExpiresIn = slidingExpiry,
         });
 
         var oldToken = new JsonWebToken
@@ -454,11 +454,12 @@ public class RefreshTokenServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.NotNull(capturedToken);
-        // Sliding: originalIssuedAt + 2h = -30min + 2h = +1.5h from now
-        // Absolute: originalIssuedAt + 30days = -30min + 30days
-        // Since +1.5h < +30days, sliding wins
-        var expectedExpiry = originalIssuedAt + slidingExpiry;
+        // Sliding window slides to now: now + 2h. Absolute ceiling: originalIssuedAt + 30days.
+        // now + 2h < originalIssuedAt + 30days, so the slid window wins — and it is LATER than the
+        // old token's expiry (originalIssuedAt + 2h), proving the window actually extended.
+        var expectedExpiry = _currentTime + slidingExpiry;
         Assert.Equal(expectedExpiry, capturedToken!.Payload.ExpiresAt);
+        Assert.True(capturedToken.Payload.ExpiresAt > oldToken.Payload.ExpiresAt);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/UserInfo/SubjectTypeConverterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/UserInfo/SubjectTypeConverterTests.cs
@@ -1,0 +1,99 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.UserInfo;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.UserInfo;
+
+/// <summary>
+/// Unit tests for <see cref="SubjectTypeConverter"/> verifying pairwise subject derivation per
+/// OIDC Core §8.1, in particular the sector identifier fallback chain for statically configured
+/// clients without an explicit sector identifier.
+/// </summary>
+public class SubjectTypeConverterTests
+{
+    private const string Subject = "user_123";
+
+    // Test-only salt: 32 zero bytes, base64-encoded.
+    private static readonly string TestSalt = Convert.ToBase64String(new byte[32]);
+
+    private static SubjectTypeConverter CreateConverter() => new(new PairwiseSubjectSettings { Salt = TestSalt });
+
+    private static ClientInfo CreatePairwiseClient(
+        string clientId,
+        string? sectorIdentifier = null,
+        Uri[]? redirectUris = null) => new(clientId)
+    {
+        SubjectType = SubjectTypes.Pairwise,
+        SectorIdentifier = sectorIdentifier,
+        RedirectUris = redirectUris,
+    };
+
+    /// <summary>
+    /// OIDC Core §8.1: without an explicit sector identifier the sector is the host component of
+    /// the registered redirect_uri — two statically configured clients of the same sector must
+    /// derive the same pairwise subject. The previous client_id fallback broke exactly this.
+    /// </summary>
+    [Fact]
+    public void Convert_NoSectorIdentifier_DerivesSectorFromRedirectUriHost()
+    {
+        var converter = CreateConverter();
+        var clientA = CreatePairwiseClient("client-a", redirectUris: [new Uri("https://app.example.com/cb1")]);
+        var clientB = CreatePairwiseClient("client-b", redirectUris: [new Uri("https://app.example.com/cb2")]);
+
+        Assert.Equal(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
+    }
+
+    /// <summary>
+    /// An explicit sector identifier takes precedence over the redirect_uri host fallback.
+    /// </summary>
+    [Fact]
+    public void Convert_ExplicitSectorIdentifier_OverridesRedirectUriHost()
+    {
+        var converter = CreateConverter();
+        var withSector = CreatePairwiseClient(
+            "client-a", sectorIdentifier: "sector.example.com",
+            redirectUris: [new Uri("https://app.example.com/cb")]);
+        var hostDerived = CreatePairwiseClient(
+            "client-b", redirectUris: [new Uri("https://app.example.com/cb")]);
+
+        Assert.NotEqual(converter.Convert(Subject, withSector), converter.Convert(Subject, hostDerived));
+    }
+
+    /// <summary>
+    /// Different sectors must produce unlinkable identifiers for the same subject — the core
+    /// privacy property of pairwise subject types.
+    /// </summary>
+    [Fact]
+    public void Convert_DifferentSectors_ProduceDifferentSubjects()
+    {
+        var converter = CreateConverter();
+        var sectorOne = CreatePairwiseClient("client-a", redirectUris: [new Uri("https://one.example.com/cb")]);
+        var sectorTwo = CreatePairwiseClient("client-b", redirectUris: [new Uri("https://two.example.com/cb")]);
+
+        Assert.NotEqual(converter.Convert(Subject, sectorOne), converter.Convert(Subject, sectorTwo));
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -85,6 +85,14 @@ public record OidcOptions
 	public Uri? LoginUri { get; set; }
 
 	/// <summary>
+	/// The URL of the account-creation (registration) UI the user is redirected to when a client requests
+	/// user registration via <c>prompt=create</c> (Initiating User Registration via OpenID Connect 1.0).
+	/// When not set, <see cref="LoginUri"/> is used instead, so hosts whose login page also offers
+	/// registration need no extra configuration.
+	/// </summary>
+	public Uri? RegistrationUri { get; set; }
+
+	/// <summary>
 	/// The name of the parameter used by the OIDC server to pass the authorization request identifier. This parameter
 	/// name is used in URLs and requests to reference specific authorization requests, especially in advanced features
 	/// like Pushed Authorization Requests (PAR). Customizing this parameter name can help align with specific client
@@ -228,6 +236,15 @@ public record OidcOptions
 	/// enhancing security for certain sensitive operations.
 	/// </summary>
 	public bool RequireSignedRequestObject { get; set; } = false;
+
+	/// <summary>
+	/// Switches request-object processing to the strict RFC 9101 §5 semantics: when a request
+	/// object is used, the authorization request is exactly the content of the object and any
+	/// parameter passed outside it is ignored instead of merged. The default (off) keeps the
+	/// OpenID Connect Core §6.1 merge semantics, where parameters outside the object complement
+	/// the ones inside. FAPI-style OAuth-only deployments enable this switch.
+	/// </summary>
+	public bool IgnoreParametersOutsideRequestObject { get; set; } = false;
 
 	/// <summary>
 	/// Determines whether the client registration endpoint requires an initial access token

--- a/Abblix.Oidc.Server/Common/MissingAuthenticationError.cs
+++ b/Abblix.Oidc.Server/Common/MissingAuthenticationError.cs
@@ -1,0 +1,36 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Constants;
+
+namespace Abblix.Oidc.Server.Common;
+
+/// <summary>
+/// Subtype of <see cref="OidcError"/> tagging a request to a protected endpoint that carried no
+/// authentication information at all. RFC 6750 §3.1: in that case the challenge SHOULD NOT include
+/// an error code or other error attributes — a bare <c>WWW-Authenticate</c> header simply tells
+/// the client that authentication is required. The error code still drives the internal 401
+/// status-code mapping; only the challenge attributes are suppressed by the builder. Mirrors
+/// <see cref="InvalidDPoPProofError"/> as a typed marker for deterministic pattern matching.
+/// </summary>
+public sealed record MissingAuthenticationError(string Description)
+    : OidcError(ErrorCodes.InvalidToken, Description);

--- a/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
+++ b/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
@@ -52,12 +52,27 @@ public static class WwwAuthenticateBuilder
     {
         var challenge = new Challenge(TokenTypes.Bearer);
         challenge.Append("realm", realm);
-        if (includeError)
+
+        // RFC 6750 §3.1: when the request carried no authentication information at all, the
+        // challenge must stay bare — no error code or description, just the scheme (and realm).
+        if (includeError && error is not MissingAuthenticationError)
         {
             challenge.Append("error", error.Error);
             challenge.Append("error_description", error.ErrorDescription);
         }
 
+        return challenge.ToString();
+    }
+
+    /// <summary>
+    /// Builds a <c>WWW-Authenticate: Basic</c> challenge per RFC 7617 §2 for client-authentication
+    /// failures (RFC 6749 §5.2). Only the realm parameter is emitted: unlike Bearer (RFC 6750 §3),
+    /// the Basic scheme defines no error attributes, so the error itself stays in the JSON body.
+    /// </summary>
+    public static string BuildBasicChallenge(string? realm)
+    {
+        var challenge = new Challenge(TokenTypes.Basic);
+        challenge.Append("realm", realm);
         return challenge.ToString();
     }
 
@@ -69,8 +84,15 @@ public static class WwwAuthenticateBuilder
     {
         var challenge = new Challenge(TokenTypes.DPoP);
         challenge.Append("realm", realm);
-        challenge.Append("error", error.Error);
-        challenge.Append("error_description", error.ErrorDescription);
+
+        // RFC 6750 §3.1 applies to the DPoP line too: an unauthenticated request gets a bare
+        // challenge advertising the scheme, without error attributes.
+        if (error is not MissingAuthenticationError)
+        {
+            challenge.Append("error", error.Error);
+            challenge.Append("error_description", error.ErrorDescription);
+        }
+
         challenge.Append("algs", string.Join(' ', algs));
         return challenge.ToString();
     }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -46,7 +46,8 @@ public class AuthorizationRequestProcessor(
 	IAuthSessionService authSessionService,
 	IUserConsentsProvider consentsProvider,
 	TimeProvider clock,
-	IEnumerable<IAuthorizationResponseBuilder> responseProcessors) : IAuthorizationRequestProcessor
+	IEnumerable<IAuthorizationResponseBuilder> responseProcessors,
+	IConsentConstraintEnforcer consentConstraintEnforcer) : IAuthorizationRequestProcessor
 {
 	/// <summary>
 	/// Orchestrates the flow for handling a valid authorization request, considering the user's session state,
@@ -158,6 +159,14 @@ public class AuthorizationRequestProcessor(
 				request.ResponseMode,
 				model.RedirectUri);
 		}
+
+		// Defense-in-depth backstop: the IUserConsentsProvider contract permits a NARROWER grant
+		// than the request, never a broader one. Assert that invariant before the granted set
+		// reaches the issued token. A violation is a host-side defect (a buggy consent provider, or
+		// browser tampering it failed to intersect against the request), so it surfaces as an
+		// exception rather than an escalated grant. Symmetric with the strictly narrowing-only
+		// TokenAuthorizationContextEvaluator at the token endpoint.
+		await consentConstraintEnforcer.EnforceAsync(request, userConsents.Granted, CancellationToken.None);
 
 		// C2 (PR #135 review): the JsonArray reference passed to the consent provider and the
 		// one placed on AuthorizationContext travel through System.Text.Json on the way to the

--- a/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -71,6 +71,13 @@ public class AuthorizationRequestProcessor(
 		AuthSession authSession;
 		switch (authSessions.Count, model.Prompt)
 		{
+			// Initiating User Registration via OpenID Connect 1.0: prompt=create takes the user to
+			// the account-creation experience regardless of whether a session exists. An OP that
+			// advertises create in prompt_values_supported must act on it — previously the value
+			// fell through to the generic branches and the registration intent was silently lost.
+			case (_, Prompts.Create):
+				return new RegistrationRequired(model);
+
 			// If no sessions exist and the prompt forbids user interaction,
 			// respond that login is required without allowing user interaction.
 			case (0, Prompts.None):

--- a/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -1,0 +1,144 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+using Abblix.Oidc.Server.Features.Consents;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+
+namespace Abblix.Oidc.Server.Endpoints.Authorization;
+
+/// <summary>
+/// Default <see cref="IConsentConstraintEnforcer"/>. Asserts <c>granted ⊆ requested</c> for scopes,
+/// resources (including their nested scopes) and RFC 9396 <c>authorization_details</c>, throwing
+/// when the consent provider returned anything outside the request.
+/// </summary>
+/// <param name="authorizationDetailsPolicy">Re-runs granted <c>authorization_details</c> through the
+/// per-type validators and per-client allowlist; the per-type validator owns the "is B a narrowing
+/// of A" decision for intra-entry content (RFC 9396 has no universal comparator).</param>
+public class ConsentConstraintEnforcer(
+    IAuthorizationDetailsPolicy authorizationDetailsPolicy) : IConsentConstraintEnforcer
+{
+    /// <inheritdoc />
+    public async Task EnforceAsync(
+        ValidAuthorizationRequest request,
+        ConsentDefinition granted,
+        CancellationToken cancellationToken)
+    {
+        EnforceScopes(request, granted);
+        EnforceResources(request, granted);
+        await EnforceAuthorizationDetailsAsync(request, granted, cancellationToken);
+    }
+
+    private static void EnforceScopes(ValidAuthorizationRequest request, ConsentDefinition granted)
+    {
+        var requested = request.Scope.Select(s => s.Scope).ToHashSet(StringComparer.Ordinal);
+
+        var escaped = granted.Scopes
+            .Select(s => s.Scope)
+            .Where(scope => !requested.Contains(scope))
+            .ToArray();
+
+        if (escaped.Length > 0)
+            throw Violation("scopes", escaped);
+    }
+
+    private static void EnforceResources(ValidAuthorizationRequest request, ConsentDefinition granted)
+    {
+        // Map each requested resource URI to the set of scopes requested for it. Built defensively
+        // against duplicate resource entries (scopes merged) so a malformed request can't crash the
+        // guard before it does its job.
+        var requested = new Dictionary<Uri, HashSet<string>>();
+        foreach (var resource in request.Resources)
+        {
+            if (!requested.TryGetValue(resource.Resource, out var scopes))
+                requested[resource.Resource] = scopes = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var scope in resource.Scopes)
+                scopes.Add(scope.Scope);
+        }
+
+        foreach (var grantedResource in granted.Resources)
+        {
+            if (!requested.TryGetValue(grantedResource.Resource, out var requestedScopes))
+                throw Violation("resources", [grantedResource.Resource.OriginalString]);
+
+            // RFC 8707: a resource indicator scopes down. The granted resource's nested scopes must
+            // not exceed what was requested for that same resource.
+            var escapedScopes = grantedResource.Scopes
+                .Select(s => s.Scope)
+                .Where(scope => !requestedScopes.Contains(scope))
+                .ToArray();
+
+            if (escapedScopes.Length > 0)
+                throw Violation($"scopes for resource '{grantedResource.Resource}'", escapedScopes);
+        }
+    }
+
+    private async Task EnforceAuthorizationDetailsAsync(
+        ValidAuthorizationRequest request,
+        ConsentDefinition granted,
+        CancellationToken cancellationToken)
+    {
+        if (granted.AuthorizationDetails is not { Count: > 0 } grantedAuthorizationDetails)
+            return;
+
+        // Type-level subset: every granted entry's type must appear among the requested types. The
+        // per-client allowlist (re-checked below) is not enough on its own — a client allowed types
+        // {A, B} that requested only {A} must not have a {B} entry injected by the consent decision.
+        var requestedTypes = (request.AuthorizationDetails?.ToTypedArray() ?? [])
+            .Select(detail => detail.Type)
+            .Where(type => type is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var escapedTypes = (grantedAuthorizationDetails.ToTypedArray() ?? [])
+            .Select(detail => detail.Type)
+            .Where(type => type is not null && !requestedTypes.Contains(type))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (escapedTypes.Length > 0)
+            throw Violation("authorization_details types", escapedTypes!);
+
+        // Intra-entry narrowing: RFC 9396 defines no universal comparator for "is B a narrowing of
+        // A" (an amount, a locations list within one entry), so re-run the granted entries through
+        // the per-type validators and per-client allowlist and let the per-type validator own that
+        // decision. A rejection means a granted entry's content escalated beyond what the validator
+        // permits for this client.
+        var revalidation = await authorizationDetailsPolicy.ApplyAsync(
+            grantedAuthorizationDetails, request.ClientInfo, cancellationToken);
+
+        if (revalidation.TryGetFailure(out var error))
+        {
+            throw new InvalidOperationException(
+                "The IUserConsentsProvider granted authorization_details that fail per-type re-validation, " +
+                "so the granted set is not a valid narrowing of the request " +
+                $"(the consent provider violated the granted ⊆ requested contract): {error.ErrorDescription}");
+        }
+    }
+
+    private static InvalidOperationException Violation(string category, string[] escaped) =>
+        new($"The IUserConsentsProvider granted {category} absent from the authorization request: " +
+            $"{string.Join(", ", escaped)}. The granted set must be a subset of what the request carried " +
+            "(granted ⊆ requested); returning a broader set violates the IUserConsentsProvider " +
+            "contract documented on ConsentDefinition and would let the end-user escalate their own grant.");
+}

--- a/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
@@ -1,0 +1,63 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+using Abblix.Oidc.Server.Features.Consents;
+
+namespace Abblix.Oidc.Server.Endpoints.Authorization;
+
+/// <summary>
+/// Defense-in-depth backstop that asserts the anti-escalation invariant on the consent decision:
+/// the set granted by <see cref="IUserConsentsProvider"/> MUST be a subset of what the
+/// authorization request carried. This mirrors the strictly narrowing-only
+/// <see cref="Token.ITokenAuthorizationContextEvaluator"/> at the token endpoint (RFC 8707 §2.2),
+/// giving the authorize-time consent path the same guarantee.
+/// </summary>
+/// <remarks>
+/// Violating <c>granted ⊆ requested</c> is never a protocol-level condition: the consent decision
+/// frequently originates across the browser trust boundary, and a host whose
+/// <see cref="IUserConsentsProvider"/> echoes browser-supplied scopes / resources /
+/// <c>authorization_details</c> without intersecting against the request would let a user escalate
+/// their own grant. The provider returning anything outside the request is a defect in the host's
+/// code (or browser tampering its provider failed to defend against), so the enforcer fails loud
+/// with an exception rather than masking it as a recoverable OAuth error — it surfaces in the
+/// debugger, fails the host's tests, and is logged as a server error in production while no
+/// escalated grant is issued.
+/// </remarks>
+public interface IConsentConstraintEnforcer
+{
+    /// <summary>
+    /// Asserts that the granted consent does not exceed the request. The granted set is left
+    /// unchanged on success.
+    /// </summary>
+    /// <param name="request">The validated authorization request carrying the requested scopes,
+    /// resources and <c>authorization_details</c>.</param>
+    /// <param name="granted">The consent decision produced by <see cref="IUserConsentsProvider"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the granted set contains a scope,
+    /// resource, resource scope or <c>authorization_details</c> entry absent from — or broader than —
+    /// the request.</exception>
+    Task EnforceAsync(
+        ValidAuthorizationRequest request,
+        ConsentDefinition granted,
+        CancellationToken cancellationToken);
+}

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Interfaces/AuthorizationEndpointMetadata.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Interfaces/AuthorizationEndpointMetadata.cs
@@ -86,10 +86,13 @@ public record AuthorizationEndpointMetadata
 
     /// <summary>
     /// The code challenge methods supported for PKCE (Proof Key for Code Exchange).
+    /// Only the methods registered in the IANA "PKCE Code Challenge Methods" registry (plain,
+    /// S256 — verified 2026-06-11) are advertised: announcing an unregistered wire value in
+    /// discovery is a false conformance claim. The S512 transformation itself stays accepted at
+    /// runtime as an undocumented extension, so existing clients using it keep working.
     /// </summary>
     public List<string> CodeChallengeMethodsSupported { get; init; } =
     [
-        CodeChallengeMethods.S512,
         CodeChallengeMethods.S256,
         CodeChallengeMethods.Plain
     ];

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Interfaces/RegistrationRequired.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Interfaces/RegistrationRequired.cs
@@ -1,0 +1,34 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Model;
+
+namespace Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+
+/// <summary>
+/// Outcome signalling that the host must surface its account-creation UI: the client requested
+/// user registration via <c>prompt=create</c> (Initiating User Registration via OpenID Connect 1.0).
+/// Per that specification the registration experience is shown regardless of whether the user
+/// currently has an authenticated session.
+/// </summary>
+public record RegistrationRequired(AuthorizationRequest Model)
+    : AuthorizationResponse(Model);

--- a/Abblix.Oidc.Server/Endpoints/Authorization/RequestFetching/PushedRequestFetcher.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/RequestFetching/PushedRequestFetcher.cs
@@ -25,6 +25,8 @@ using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.Options;
@@ -38,9 +40,12 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization.RequestFetching;
 /// Provides configuration options for the OIDC server, such as whether PAR is required.</param>
 /// <param name="authorizationRequestStorage">
 /// The storage system used to retrieve pushed authorization request objects.</param>
+/// <param name="clientInfoProvider">
+/// Resolves the requesting client's registration to enforce the per-client PAR requirement.</param>
 public class PushedRequestFetcher(
     IOptionsSnapshot<OidcOptions> options,
-    IAuthorizationRequestStorage authorizationRequestStorage) : IAuthorizationRequestFetcher
+    IAuthorizationRequestStorage authorizationRequestStorage,
+    IClientInfoProvider clientInfoProvider) : IAuthorizationRequestFetcher
 {
     /// <summary>
     /// Asynchronously retrieves the pushed authorization request object associated with the specified URN.
@@ -90,6 +95,19 @@ public class PushedRequestFetcher(
         if (options.Value.RequirePushedAuthorizationRequests)
         {
             return ErrorFactory.InvalidRequestObject("The Pushed Authorization Request (PAR) is required");
+        }
+
+        // RFC 9126 §6: the per-client require_pushed_authorization_requests metadata makes PAR the
+        // only way for this client to start an authorization flow, independent of the server-wide
+        // flag. Enforced here (not in the shared context-validator pipeline) because this fetcher
+        // participates only in the authorization endpoint's chain — the PAR endpoint itself runs a
+        // different fetcher set and must not trip over the requirement it is there to satisfy.
+        if (request.ClientId is { } clientId &&
+            await clientInfoProvider.TryFindClientAsync(clientId).WithLicenseCheck() is
+                { RequirePushedAuthorizationRequests: true })
+        {
+            return ErrorFactory.InvalidRequestObject(
+                "The client is required to use Pushed Authorization Requests (PAR)");
         }
 
         // If no URN is provided and PAR is not required, return the original request

--- a/Abblix.Oidc.Server/Endpoints/Authorization/RequestFetching/RequestObjectFetchAdapter.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/RequestFetching/RequestObjectFetchAdapter.cs
@@ -21,6 +21,8 @@
 // info@abblix.com
 
 using Abblix.Utils;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 using Abblix.Oidc.Server.Features.RequestObject;
@@ -53,6 +55,40 @@ public class RequestObjectFetchAdapter(IRequestObjectFetcher requestObjectFetche
     {
         var fetchResult = await requestObjectFetcher.FetchAsync(
             request, request.Request, client => client.RequestObjectSigningAlgorithm);
-        return fetchResult.MapFailure(error => ErrorFactory.ValidationError(error.Error, error.ErrorDescription));
+
+        return fetchResult
+            .Bind(merged => ValidateMergedParameters(request, merged))
+            .MapFailure(error => ErrorFactory.ValidationError(error.Error, error.ErrorDescription));
+    }
+
+    /// <summary>
+    /// OIDC Core §6.1: the response_type and client_id values passed in the OAuth request syntax
+    /// MUST match the ones inside the request object when the object carries them. The merge gives
+    /// the request object's values precedence, so a mismatch surfaces as the merged value differing
+    /// from the outer one — without this check an attacker-supplied object could silently swap the
+    /// flow or the client identity relative to what the plain OAuth parameters declared.
+    /// </summary>
+    private static Result<AuthorizationRequest, OidcError> ValidateMergedParameters(
+        AuthorizationRequest outer,
+        AuthorizationRequest merged)
+    {
+        if (outer.ClientId != null && merged.ClientId != outer.ClientId)
+        {
+            return new OidcError(
+                ErrorCodes.InvalidRequestObject,
+                $"The {AuthorizationRequest.Parameters.ClientId} inside the request object " +
+                "does not match the one outside of it");
+        }
+
+        if (outer.ResponseType != null && merged.ResponseType != null &&
+            !outer.ResponseType.ToHashSet(StringComparer.Ordinal).SetEquals(merged.ResponseType))
+        {
+            return new OidcError(
+                ErrorCodes.InvalidRequestObject,
+                $"The {AuthorizationRequest.Parameters.ResponseType} inside the request object " +
+                "does not match the one outside of it");
+        }
+
+        return merged;
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
@@ -59,40 +59,63 @@ public partial class FlowTypeValidator(
     {
         var responseType = context.Request.ResponseType;
 
+        // RFC 6749 §4.1.2.1: response_type is REQUIRED, and a missing required parameter is
+        // invalid_request — not unsupported_response_type (no method was named at all) and not
+        // unauthorized_client (no client policy was consulted).
+        if (responseType is not { Length: > 0 })
+        {
+            LogResponseTypeInvalid(responseType);
+            return Error(ErrorCodes.InvalidRequest, "The response type is required");
+        }
+
         // Server-level support: every part of response_type must have a registered processor. This
         // is the gate that turns Implicit Flow opt-in: when EnableImplicitFlow() is not called,
         // the token / id_token processors are absent from DI and the corresponding parts get
         // rejected here regardless of client-level AllowedResponseTypes configuration.
-        if (responseType != null)
+        var unsupportedPart = responseType.FirstOrDefault(part => !_supportedResponseTypeParts.Contains(part));
+        if (unsupportedPart != null)
         {
-            var unsupportedPart = responseType.FirstOrDefault(part => !_supportedResponseTypeParts.Contains(part));
-            if (unsupportedPart != null)
-            {
-                LogResponseTypePartUnsupported(unsupportedPart);
-                return UnsupportedResponseType($"The response type '{unsupportedPart}' is not supported by this server");
-            }
+            LogResponseTypePartUnsupported(unsupportedPart);
+            return Error(
+                ErrorCodes.UnsupportedResponseType,
+                $"The response type '{unsupportedPart}' is not supported by this server");
         }
 
         if (!ResponseTypeAllowed(context))
         {
             LogResponseTypeNotAllowed(responseType);
-            return UnsupportedResponseType("The response type is not allowed for the client");
+            // RFC 6749 §4.1.2.1 / §4.2.2.1: the server supports this response_type (the gate above
+            // passed), but this particular client is not registered to use it — that is
+            // unauthorized_client. unsupported_response_type (returned before) is reserved for
+            // methods the server itself cannot produce.
+            return Error(ErrorCodes.UnauthorizedClient, "The response type is not allowed for the client");
         }
 
         if (!TryDetectFlowType(responseType, out var flowType, out var responseMode))
         {
             LogResponseTypeInvalid(responseType);
-            return UnsupportedResponseType("The response type is not supported");
+            return Error(ErrorCodes.UnsupportedResponseType, "The response type is not supported");
         }
 
         context.FlowType = flowType;
         context.ResponseMode = responseMode;
         return null;
 
-        AuthorizationRequestValidationError UnsupportedResponseType(string message)
+        AuthorizationRequestValidationError Error(string errorCode, string message)
         {
-            context.ResponseMode = context.Request.ResponseMode ?? ResponseModes.Query;
-            return context.Error(ErrorCodes.UnsupportedResponseType, message);
+            // OAuth 2.0 Multiple Response Types §5: when the requested response_type contains a
+            // value that requires fragment encoding (token / id_token), the error response MUST be
+            // returned in the fragment as well. The previous unconditional query default delivered
+            // the error to a channel the client never reads and exposed it to the server hosting
+            // the redirect URI via the query string.
+            var defaultResponseMode =
+                responseType != null &&
+                (responseType.HasFlag(ResponseTypes.Token) || responseType.HasFlag(ResponseTypes.IdToken))
+                    ? ResponseModes.Fragment
+                    : ResponseModes.Query;
+
+            context.ResponseMode = context.Request.ResponseMode ?? defaultResponseMode;
+            return context.Error(errorCode, message);
         }
     }
 

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/NonceValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/NonceValidator.cs
@@ -49,13 +49,20 @@ public class NonceValidator : SyncAuthorizationContextValidatorBase
     protected override AuthorizationRequestValidationError? Validate(AuthorizationValidationContext context)
     {
         var request = context.Request;
-        var responseType = request.ResponseType;
+        var responseType = request.ResponseType.NotNull(nameof(request.ResponseType));
 
-        // Validate nonce as per OpenID Connect Core 1.0 requirements
-        if (responseType.NotNull(nameof(responseType)).Contains(ResponseTypes.IdToken) &&
-            string.IsNullOrEmpty(request.Nonce))
+        // OIDC Core 1.0: the nonce is REQUIRED whenever an ID token is delivered from the
+        // authorization endpoint (§3.2.2.1, response_type contains id_token) and in EVERY Hybrid
+        // Flow combination (§3.3.2.11) — including "code token", where no id_token is returned
+        // directly but the one minted later from the code must still carry the nonce binding.
+        var idTokenRequested = responseType.Contains(ResponseTypes.IdToken);
+        var hybridCodeToken = responseType.Contains(ResponseTypes.Code) &&
+                              responseType.Contains(ResponseTypes.Token);
+
+        if ((idTokenRequested || hybridCodeToken) && string.IsNullOrEmpty(request.Nonce))
         {
-            return context.InvalidRequest($"Nonce is when {Parameters.ResponseType} includes '{ResponseTypes.IdToken}', as specified in OpenID Connect Core 1.0.");
+            return context.InvalidRequest(
+                $"Nonce is required for the requested {Parameters.ResponseType}, as specified in OpenID Connect Core 1.0.");
         }
 
         return null;

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/SignedRequestObjectRequirementValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/SignedRequestObjectRequirementValidator.cs
@@ -1,0 +1,49 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+
+namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
+
+/// <summary>
+/// Enforces the RFC 9101 §10.5 <c>require_signed_request_object</c> client metadata: a client that
+/// committed to it must deliver its authorization parameters as a signed request object. A request
+/// that came neither from a request object nor from a PAR-stored request is plain parameters and is
+/// rejected. The PAR push itself runs through the same validator pipeline, so a flagged client
+/// cannot smuggle plain parameters in via PAR either; the signature itself (rejecting the
+/// <c>none</c> algorithm) is enforced by the request-object fetcher where the JWT is validated.
+/// </summary>
+public class SignedRequestObjectRequirementValidator : SyncAuthorizationContextValidatorBase
+{
+    /// <inheritdoc />
+    protected override AuthorizationRequestValidationError? Validate(AuthorizationValidationContext context)
+    {
+        if (context.ClientInfo.RequireSignedRequestObject &&
+            context.Request is { Request: null, PushedRequestUri: null })
+        {
+            return context.InvalidRequest(
+                "The client is required to pass authorization request parameters as a signed request object");
+        }
+
+        return null;
+    }
+}

--- a/Abblix.Oidc.Server/Endpoints/Configuration/JwtAlgorithmsProvider.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/JwtAlgorithmsProvider.cs
@@ -33,8 +33,23 @@ public sealed class JwtAlgorithmsProvider(
 	IJsonWebTokenCreator jwtCreator,
 	IJsonWebTokenValidator jwtValidator) : IJwtAlgorithmsProvider
 {
+	/// <summary>
+	/// HMAC algorithms are excluded from every client-addressed response-signing list: per
+	/// OIDC Core §10.1 an HS* signature uses the client_secret as the key, but this server
+	/// persists client secrets as SHA-512 hashes (except the client_secret_jwt case), so it
+	/// cannot derive the HMAC key at signing time. Advertising HS* let a client register it
+	/// via DCR and then fail with a server error on the first issued token. The JWT layer
+	/// itself still supports HMAC signers — the constraint is about key availability here,
+	/// not signing capability.
+	/// </summary>
+	private static readonly string[] HmacAlgorithms =
+		[SigningAlgorithms.HS256, SigningAlgorithms.HS384, SigningAlgorithms.HS512];
+
+	private IEnumerable<string> ClientAddressedSigningAlgorithms
+		=> jwtCreator.SignedResponseAlgorithmsSupported.Where(alg => !HmacAlgorithms.Contains(alg));
+
 	/// <inheritdoc />
-	public IEnumerable<string> SignedResponseAlgorithmsSupported => jwtCreator.SignedResponseAlgorithmsSupported;
+	public IEnumerable<string> SignedResponseAlgorithmsSupported => ClientAddressedSigningAlgorithms;
 
 	/// <inheritdoc />
 	public IEnumerable<string> SigningAlgorithmsSupported => jwtValidator.SigningAlgorithmsSupported;
@@ -50,7 +65,7 @@ public sealed class JwtAlgorithmsProvider(
 	public IEnumerable<string> RequestObjectEncryptionEncValuesSupported => jwtValidator.EncryptionMethodsSupported;
 
 	/// <inheritdoc />
-	public IEnumerable<string> AuthorizationSigningAlgValuesSupported => jwtCreator.SignedResponseAlgorithmsSupported;
+	public IEnumerable<string> AuthorizationSigningAlgValuesSupported => ClientAddressedSigningAlgorithms;
 
 	/// <inheritdoc />
 	public IEnumerable<string> AuthorizationEncryptionAlgValuesSupported => jwtValidator.EncryptionAlgorithmsSupported;
@@ -59,7 +74,7 @@ public sealed class JwtAlgorithmsProvider(
 	public IEnumerable<string> AuthorizationEncryptionEncValuesSupported => jwtValidator.EncryptionMethodsSupported;
 
 	/// <inheritdoc />
-	public IEnumerable<string> IntrospectionSigningAlgValuesSupported => jwtCreator.SignedResponseAlgorithmsSupported;
+	public IEnumerable<string> IntrospectionSigningAlgValuesSupported => ClientAddressedSigningAlgorithms;
 
 	/// <inheritdoc />
 	public IEnumerable<string> IntrospectionEncryptionAlgValuesSupported => jwtValidator.EncryptionAlgorithmsSupported;

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ClientRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ClientRequestValidator.cs
@@ -38,21 +38,30 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 /// </summary>
 /// <param name="clientInfoProvider">Store consulted for the addressed client.</param>
 /// <param name="registrationAccessTokenValidator">Validator for the bearer registration access token.</param>
+/// <param name="registrationAccessTokenStore">Store holding the jti of each client's current token.</param>
 public class ClientRequestValidator(
     IClientInfoProvider clientInfoProvider,
-    IRegistrationAccessTokenValidator registrationAccessTokenValidator) : IClientRequestValidator
+    IRegistrationAccessTokenValidator registrationAccessTokenValidator,
+    IRegistrationAccessTokenStore registrationAccessTokenStore) : IClientRequestValidator
 {
     /// <inheritdoc />
     public async Task<Result<ValidClientRequest, OidcError>> ValidateAsync(ClientRequest request)
     {
+        var clientId = request.ClientId.NotNull(nameof(request.ClientId));
+
+        // The expected jti is the value recorded when this client's current registration access
+        // token was issued; it binds the token so a rotated token invalidates its predecessors.
+        var expectedTokenId = await registrationAccessTokenStore.GetTokenIdAsync(clientId);
+
         var headerErrorDescription = await registrationAccessTokenValidator.ValidateAsync(
             request.AuthorizationHeader,
-            request.ClientId.NotNull(nameof(request.ClientId)));
+            clientId,
+            expectedTokenId);
 
         if (headerErrorDescription != null)
             return new OidcError(ErrorCodes.InvalidToken, headerErrorDescription);
 
-        var clientInfo = await clientInfoProvider.TryFindClientAsync(request.ClientId).WithLicenseCheck();
+        var clientInfo = await clientInfoProvider.TryFindClientAsync(clientId).WithLicenseCheck();
         if (clientInfo == null)
             return new OidcError(ErrorCodes.InvalidClient, "Client does not exist on this server");
 

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ClientRegistrationSuccessResponse.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ClientRegistrationSuccessResponse.cs
@@ -241,6 +241,14 @@ public record ClientRegistrationSuccessResponse(
     public string[]? TokenExchangeSubjectTokenTypes { get; init; }
 
     /// <summary>
+    /// Non-standard extension: default-deny per-client allowlist of RFC 8693 <c>audience</c> values
+    /// this client may request when exchanging a token. Echoes
+    /// <c>ClientInfo.TokenExchangeAllowedAudiences</c>.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.TokenExchangeAudiences)]
+    public string[]? TokenExchangeAudiences { get; init; }
+
+    /// <summary>
     /// JSON property names per RFC 7591/7592, OpenID Connect Core, RFC 8705, and RFC 9449.
     /// </summary>
     private static class ResponseParameters
@@ -270,5 +278,6 @@ public record ClientRegistrationSuccessResponse(
         public const string DpopBoundAccessTokens = "dpop_bound_access_tokens";
         public const string AuthorizationDetailsTypes = "authorization_details_types";
         public const string TokenExchangeSubjectTokenTypes = "token_exchange_subject_token_types";
+        public const string TokenExchangeAudiences = "token_exchange_audiences";
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ClientRegistrationSuccessResponse.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ClientRegistrationSuccessResponse.cs
@@ -22,6 +22,7 @@
 
 using System.Text.Json.Serialization;
 using Abblix.Oidc.Server.DeclarativeValidation;
+using Abblix.Utils.Json;
 
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 
@@ -94,6 +95,30 @@ public record ClientRegistrationSuccessResponse(
     /// </summary>
     [JsonPropertyName(ResponseParameters.RedirectUris)]
     public Uri[]? RedirectUris { get; init; }
+
+    /// <summary>
+    /// The grant types the client is registered to use at the token endpoint, including the
+    /// server-assigned default when the request omitted them. Per RFC 7591 §2/§3.2.1.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.GrantTypes)]
+    public string[]? GrantTypes { get; init; }
+
+    /// <summary>
+    /// The response type combinations the client is registered to use at the authorization endpoint,
+    /// including the server-assigned default when the request omitted them. Each entry is a
+    /// space-separated combination, mirroring the request shape. Per RFC 7591 §2/§3.2.1.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.ResponseTypes)]
+    [JsonConverter(typeof(ArrayConverter<string[], SpaceSeparatedValuesConverter>))]
+    public string[][]? ResponseTypes { get; init; }
+
+    /// <summary>
+    /// The scope values the client is registered to request, serialized as a space-separated string.
+    /// Per RFC 7591 §2/§3.2.1.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.Scope)]
+    [JsonConverter(typeof(SpaceSeparatedValuesConverter))]
+    public string[]? Scope { get; init; }
 
     /// <summary>
     /// The human-readable name of the client. Optional client metadata. Per RFC 7591 §2.
@@ -224,6 +249,27 @@ public record ClientRegistrationSuccessResponse(
     public bool? DpopBoundAccessTokens { get; init; }
 
     /// <summary>
+    /// Whether PAR is the only way this client may start an authorization flow per RFC 9126 §6.
+    /// Echoes <c>ClientInfo.RequirePushedAuthorizationRequests</c>.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.RequirePushedAuthorizationRequests)]
+    public bool? RequirePushedAuthorizationRequests { get; init; }
+
+    /// <summary>
+    /// Whether this client must deliver authorization parameters as a signed request object per
+    /// RFC 9101 §10.5. Echoes <c>ClientInfo.RequireSignedRequestObject</c>.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.RequireSignedRequestObject)]
+    public bool? RequireSignedRequestObject { get; init; }
+
+    /// <summary>
+    /// Whether access tokens are certificate-bound whenever the token request arrives over mutual
+    /// TLS per RFC 8705 §3.4. Echoes <c>ClientInfo.TlsClientCertificateBoundAccessTokens</c>.
+    /// </summary>
+    [JsonPropertyName(ResponseParameters.TlsClientCertificateBoundAccessTokens)]
+    public bool? TlsClientCertificateBoundAccessTokens { get; init; }
+
+    /// <summary>
     /// The per-client allowlist of authorization-detail <c>type</c> values this client may
     /// use in RFC 9396 Rich Authorization Requests (<c>authorization_details_types</c>,
     /// RFC 9396 §5.1). Echoes the registered value of
@@ -257,6 +303,9 @@ public record ClientRegistrationSuccessResponse(
         public const string TokenEndpointAuthMethod = "token_endpoint_auth_method";
         public const string ApplicationType = "application_type";
         public const string RedirectUris = "redirect_uris";
+        public const string GrantTypes = "grant_types";
+        public const string ResponseTypes = "response_types";
+        public const string Scope = "scope";
         public const string ClientName = "client_name";
         public const string LogoUri = "logo_uri";
         public const string SubjectType = "subject_type";
@@ -276,6 +325,9 @@ public record ClientRegistrationSuccessResponse(
         public const string TlsClientAuthSanIp = "tls_client_auth_san_ip";
         public const string TlsClientAuthSanEmail = "tls_client_auth_san_email";
         public const string DpopBoundAccessTokens = "dpop_bound_access_tokens";
+        public const string RequirePushedAuthorizationRequests = "require_pushed_authorization_requests";
+        public const string RequireSignedRequestObject = "require_signed_request_object";
+        public const string TlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens";
         public const string AuthorizationDetailsTypes = "authorization_details_types";
         public const string TokenExchangeSubjectTokenTypes = "token_exchange_subject_token_types";
         public const string TokenExchangeAudiences = "token_exchange_audiences";

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/IRegistrationAccessTokenService.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/IRegistrationAccessTokenService.cs
@@ -35,10 +35,16 @@ public interface IRegistrationAccessTokenService
     /// <param name="clientId">The unique identifier of the registered client.</param>
     /// <param name="issuedAt">The timestamp when the token is issued.</param>
     /// <param name="expiresIn">The optional duration after which the token expires.</param>
+    /// <param name="tokenId">
+    /// The identifier (jti) to embed in the token. The caller records this value via the
+    /// registration-access-token store so the validator can bind the token to the client: issuing
+    /// with a fresh id invalidates earlier tokens, reusing the stored id keeps them valid
+    /// (idempotent read).
+    /// </param>
     /// <returns>A task that results in the encoded registration access token.</returns>
     /// <remarks>
     /// The registration access token is a bearer token that authenticates the client when
     /// performing read, update, or delete operations on its configuration.
     /// </remarks>
-    Task<string> IssueTokenAsync(string clientId, DateTimeOffset issuedAt, TimeSpan? expiresIn);
+    Task<string> IssueTokenAsync(string clientId, DateTimeOffset issuedAt, TimeSpan? expiresIn, string tokenId);
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/IRegistrationAccessTokenStore.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/IRegistrationAccessTokenStore.cs
@@ -1,0 +1,63 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
+
+/// <summary>
+/// Records, for each registered client, the identifier (jti) of the registration access token
+/// currently authorized to manage it via the RFC 7592 client configuration endpoint. The token
+/// validator accepts only a token whose jti matches the stored value, so rotating the token on
+/// update (storing a fresh jti) invalidates every previously issued token (RFC 7592 §5).
+/// </summary>
+/// <remarks>
+/// The binding outlives any single request and must be shared across all server replicas, so the
+/// default implementation persists it in the distributed entity storage rather than in process
+/// memory. The binding has no expiration — it lives as long as the client is registered — and is
+/// removed when the client is deregistered.
+/// </remarks>
+public interface IRegistrationAccessTokenStore
+{
+    /// <summary>
+    /// Records <paramref name="tokenId"/> as the jti of the client's current registration access
+    /// token, replacing any previously stored value (which thereby becomes invalid).
+    /// </summary>
+    /// <param name="clientId">The identifier of the client the token manages.</param>
+    /// <param name="tokenId">The jti embedded in the newly issued registration access token.</param>
+    Task SetTokenIdAsync(string clientId, string tokenId);
+
+    /// <summary>
+    /// Retrieves the jti of the client's current registration access token.
+    /// </summary>
+    /// <param name="clientId">The identifier of the client.</param>
+    /// <returns>
+    /// The stored jti, or <c>null</c> when no binding is recorded (a statically configured client,
+    /// or one registered before the binding existed) — in which case the validator does not enforce
+    /// the binding.
+    /// </returns>
+    Task<string?> GetTokenIdAsync(string clientId);
+
+    /// <summary>
+    /// Removes the binding for a deregistered client.
+    /// </summary>
+    /// <param name="clientId">The identifier of the client being removed.</param>
+    Task RemoveAsync(string clientId);
+}

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/IRegistrationAccessTokenValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/IRegistrationAccessTokenValidator.cs
@@ -37,9 +37,15 @@ public interface IRegistrationAccessTokenValidator
     /// </summary>
     /// <param name="header">The HTTP <c>Authorization</c> header carrying the bearer token.</param>
     /// <param name="clientId">The <c>client_id</c> targeted by the management request.</param>
+    /// <param name="expectedTokenId">
+    /// The jti the token must carry to be accepted — the value stored on the client when its
+    /// current registration access token was issued. When <c>null</c> the binding is not enforced
+    /// (statically configured client, or a record predating the stored id) and only signature,
+    /// type and audience are checked.
+    /// </param>
     /// <returns>
     /// <c>null</c> when the token is valid for the client; otherwise a human-readable description
     /// of the validation failure.
     /// </returns>
-    Task<string?> ValidateAsync(AuthenticationHeaderValue? header, string clientId);
+    Task<string?> ValidateAsync(AuthenticationHeaderValue? header, string clientId, string? expectedTokenId);
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ReadClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ReadClientRequestProcessor.cs
@@ -65,6 +65,14 @@ public class ReadClientRequestProcessor(
             TokenEndpointAuthMethod = client.TokenEndpointAuthMethod,
             ApplicationType = client.ApplicationType,
             RedirectUris = client.RedirectUris,
+            // RFC 7592 §3: the read response carries the full registered metadata, including the
+            // grant/response types the server assigned by default when registration omitted them.
+            GrantTypes = client.AllowedGrantTypes,
+            ResponseTypes = client.AllowedResponseTypes,
+            Scope = client.AllowedScopes,
+            RequirePushedAuthorizationRequests = client.RequirePushedAuthorizationRequests,
+            RequireSignedRequestObject = client.RequireSignedRequestObject,
+            TlsClientCertificateBoundAccessTokens = client.TlsClientCertificateBoundAccessTokens,
             ClientName = client.ClientName,
             LogoUri = client.LogoUri,
             SubjectType = client.SubjectType,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ReadClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ReadClientRequestProcessor.cs
@@ -23,6 +23,7 @@
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 
@@ -31,11 +32,14 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 /// <summary>
 /// Builds the RFC 7592 §2.1 read-client response from stored client metadata. The
 /// <c>client_secret</c> is intentionally omitted because secrets are persisted only as
-/// hashes; a fresh <c>registration_access_token</c> is issued so the client can keep using
-/// the management endpoint after the read.
+/// hashes; a registration access token bearing the client's current jti is re-issued so the
+/// client can keep using the management endpoint after the read, without invalidating the token
+/// it presented (read stays idempotent — only update rotates the jti).
 /// </summary>
 public class ReadClientRequestProcessor(
     IRegistrationAccessTokenService registrationAccessTokenService,
+    IRegistrationAccessTokenStore registrationAccessTokenStore,
+    ITokenIdGenerator tokenIdGenerator,
     TimeProvider clock) : IReadClientRequestProcessor
 {
     /// <inheritdoc />
@@ -44,7 +48,13 @@ public class ReadClientRequestProcessor(
         var client = request.ClientInfo;
 
         var issuedAt = clock.GetUtcNow();
-        var registrationAccessToken = await registrationAccessTokenService.IssueTokenAsync(client.ClientId, issuedAt, null);
+        // Reuse the stored jti so the token the client just presented stays valid; only update
+        // rotates it (read is idempotent). A legacy client with no recorded jti gets a transient
+        // one — it is not persisted here, so the binding stays unenforced for that client.
+        var registrationAccessTokenId =
+            await registrationAccessTokenStore.GetTokenIdAsync(client.ClientId) ?? tokenIdGenerator.GenerateTokenId();
+        var registrationAccessToken = await registrationAccessTokenService.IssueTokenAsync(
+            client.ClientId, issuedAt, null, registrationAccessTokenId);
 
         return new ReadClientSuccessfulResponse
         {

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -90,6 +90,12 @@ public class RegisterClientRequestProcessor(
             TokenEndpointAuthMethod = clientInfo.TokenEndpointAuthMethod,
             ApplicationType = clientInfo.ApplicationType,
             RedirectUris = clientInfo.RedirectUris,
+            // RFC 7591 §3.2.1: grant_types/response_types/scope are read back from the stored
+            // ClientInfo, not from the request — this is what makes server-assigned defaults
+            // (authorization_code / code when omitted) visible to the client.
+            GrantTypes = clientInfo.AllowedGrantTypes,
+            ResponseTypes = clientInfo.AllowedResponseTypes,
+            Scope = clientInfo.AllowedScopes,
             ClientName = clientInfo.ClientName,
             LogoUri = clientInfo.LogoUri,
             SubjectType = clientInfo.SubjectType,
@@ -117,6 +123,9 @@ public class RegisterClientRequestProcessor(
             TlsClientAuthSanIp = clientInfo.TlsClientAuth?.SanIps,
             TlsClientAuthSanEmail = clientInfo.TlsClientAuth?.SanEmails,
             DpopBoundAccessTokens = clientInfo.RequireDPoP,
+            RequirePushedAuthorizationRequests = clientInfo.RequirePushedAuthorizationRequests,
+            RequireSignedRequestObject = clientInfo.RequireSignedRequestObject,
+            TlsClientCertificateBoundAccessTokens = clientInfo.TlsClientCertificateBoundAccessTokens,
             AuthorizationDetailsTypes = clientInfo.AuthorizationDetailsTypes,
             TokenExchangeSubjectTokenTypes = clientInfo.TokenExchangeAllowedSubjectTokenTypes,
             TokenExchangeAudiences = clientInfo.TokenExchangeAllowedAudiences,
@@ -145,6 +154,11 @@ public class RegisterClientRequestProcessor(
             OfflineAccessAllowed = model.OfflineAccessAllowed,
             // RFC 9449 §5.2: dpop_bound_access_tokens — when omitted, defaults to false.
             RequireDPoP = model.DpopBoundAccessTokens ?? false,
+            // RFC 9126 §6 / RFC 9101 §10.5 / RFC 8705 §3.4: per-client FAPI-grade enforcement
+            // flags — when omitted, default to false.
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests ?? false,
+            RequireSignedRequestObject = model.RequireSignedRequestObject ?? false,
+            TlsClientCertificateBoundAccessTokens = model.TlsClientCertificateBoundAccessTokens ?? false,
             // RFC 9396 §5.1: authorization_details_types per-client allowlist.
             AuthorizationDetailsTypes = model.AuthorizationDetailsTypes,
             // Non-standard extension: RFC 8693 Token Exchange per-client subject-token-type allowlist.

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -119,6 +119,7 @@ public class RegisterClientRequestProcessor(
             DpopBoundAccessTokens = clientInfo.RequireDPoP,
             AuthorizationDetailsTypes = clientInfo.AuthorizationDetailsTypes,
             TokenExchangeSubjectTokenTypes = clientInfo.TokenExchangeAllowedSubjectTokenTypes,
+            TokenExchangeAudiences = clientInfo.TokenExchangeAllowedAudiences,
         };
 
         return response;
@@ -148,6 +149,8 @@ public class RegisterClientRequestProcessor(
             AuthorizationDetailsTypes = model.AuthorizationDetailsTypes,
             // Non-standard extension: RFC 8693 Token Exchange per-client subject-token-type allowlist.
             TokenExchangeAllowedSubjectTokenTypes = model.TokenExchangeSubjectTokenTypes,
+            // Non-standard extension: RFC 8693 Token Exchange per-client audience allowlist (default-deny).
+            TokenExchangeAllowedAudiences = model.TokenExchangeAudiences,
             LogoUri = model.LogoUri,
             PolicyUri = model.PolicyUri,
             TermsOfServiceUri = model.TermsOfServiceUri,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -25,6 +25,7 @@ using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 
@@ -38,7 +39,9 @@ public class RegisterClientRequestProcessor(
     IClientCredentialFactory credentialFactory,
     IClientInfoManager clientInfoManager,
     TimeProvider clock,
-    IRegistrationAccessTokenService registrationAccessTokenService) : IRegisterClientRequestProcessor
+    ITokenIdGenerator tokenIdGenerator,
+    IRegistrationAccessTokenService registrationAccessTokenService,
+    IRegistrationAccessTokenStore registrationAccessTokenStore) : IRegisterClientRequestProcessor
 {
     /// <summary>
     /// Processes a valid client registration request, generating and storing the client's credentials and configuration.
@@ -64,10 +67,16 @@ public class RegisterClientRequestProcessor(
 
         await clientInfoManager.AddClientAsync(clientInfo);
 
+        // Record the jti of the issued registration access token so the management endpoint can
+        // bind the token to this client (RFC 7592 §5).
+        var registrationAccessTokenId = tokenIdGenerator.GenerateTokenId();
+        await registrationAccessTokenStore.SetTokenIdAsync(credentials.ClientId, registrationAccessTokenId);
+
         var registrationAccessToken = await registrationAccessTokenService.IssueTokenAsync(
             credentials.ClientId,
             issuedAt,
-            clientInfo.ExpiresAfter);
+            clientInfo.ExpiresAfter,
+            registrationAccessTokenId);
 
         var response = new ClientRegistrationSuccessResponse(
             credentials.ClientId,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenService.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenService.cs
@@ -42,8 +42,9 @@ public class RegistrationAccessTokenService(
     /// <param name="clientId">The unique identifier of the registered client.</param>
     /// <param name="issuedAt">The timestamp when the token is issued.</param>
     /// <param name="expiresIn">The optional duration after which the token expires.</param>
+    /// <param name="tokenId">The identifier (jti) embedded in the token and bound to the client.</param>
     /// <returns>A task that results in the encoded registration access token.</returns>
-    public Task<string> IssueTokenAsync(string clientId, DateTimeOffset issuedAt, TimeSpan? expiresIn)
+    public Task<string> IssueTokenAsync(string clientId, DateTimeOffset issuedAt, TimeSpan? expiresIn, string tokenId)
     {
         var token = new JsonWebToken
         {
@@ -54,6 +55,10 @@ public class RegistrationAccessTokenService(
             },
             Payload =
             {
+                // The jti binds the token to the client: the validator accepts only the token whose
+                // jti matches the value stored on the client, so a rotated token invalidates its
+                // predecessors (RFC 7592 §5).
+                JwtId = tokenId,
                 IssuedAt = issuedAt,
                 NotBefore = issuedAt,
                 ExpiresAt = issuedAt + expiresIn,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenStore.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenStore.cs
@@ -1,0 +1,55 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
+using Abblix.Oidc.Server.Features.Storages;
+
+namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
+
+/// <summary>
+/// Default <see cref="IRegistrationAccessTokenStore"/> backed by the distributed
+/// <see cref="IEntityStorage"/>, so the client-to-token-jti binding is shared across all server
+/// replicas. The entry is stored without expiration — it lives as long as the client is registered
+/// — and is removed when the client is deregistered.
+/// </summary>
+/// <param name="storage">The distributed entity storage holding the bindings.</param>
+/// <param name="keyFactory">The factory that builds the storage key for each client.</param>
+public class RegistrationAccessTokenStore(
+    IEntityStorage storage,
+    IEntityStorageKeyFactory keyFactory) : IRegistrationAccessTokenStore
+{
+    // No expiration: the registration access token does not expire while the client is registered
+    // (RFC 7592 §5), so neither does its binding. RemoveAsync drops it on deregistration.
+    private static readonly StorageOptions NonExpiring = new();
+
+    /// <inheritdoc />
+    public Task SetTokenIdAsync(string clientId, string tokenId)
+        => storage.SetAsync(keyFactory.RegistrationAccessTokenKey(clientId), tokenId, NonExpiring);
+
+    /// <inheritdoc />
+    public Task<string?> GetTokenIdAsync(string clientId)
+        => storage.GetAsync<string>(keyFactory.RegistrationAccessTokenKey(clientId), removeOnRetrieval: false);
+
+    /// <inheritdoc />
+    public Task RemoveAsync(string clientId)
+        => storage.RemoveAsync(keyFactory.RegistrationAccessTokenKey(clientId));
+}

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenValidator.cs
@@ -41,7 +41,7 @@ public class RegistrationAccessTokenValidator(IAuthServiceJwtValidator jwtValida
     : IRegistrationAccessTokenValidator
 {
     /// <inheritdoc />
-    public async Task<string?> ValidateAsync(AuthenticationHeaderValue? header, string clientId)
+    public async Task<string?> ValidateAsync(AuthenticationHeaderValue? header, string clientId, string? expectedTokenId)
     {
         if (header?.Parameter == null)
             return $"The access token must be specified via '{HttpRequestHeaders.Authorization}' header";
@@ -66,6 +66,12 @@ public class RegistrationAccessTokenValidator(IAuthServiceJwtValidator jwtValida
             return $"Invalid token type: {tokenType}";
 
         if (subject != clientId || !audiences.Contains(clientId))
+            return "The access token unauthorized";
+
+        // RFC 7592 §5: bind the token to the client so a rotated token invalidates its
+        // predecessors. Enforced only when the client records the current jti — a null expectation
+        // keeps statically configured clients and pre-existing records working unchanged.
+        if (expectedTokenId != null && token.Payload.JwtId != expectedTokenId)
             return "The access token unauthorized";
 
         return null;

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RemoveClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RemoveClientRequestProcessor.cs
@@ -32,9 +32,11 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 /// <see cref="IClientInfoManager"/> per RFC 7592 §2.3.
 /// </summary>
 /// <param name="clientInfoManager">Store used to remove the client record.</param>
+/// <param name="registrationAccessTokenStore">Store holding the client's registration-token binding.</param>
 /// <param name="clock">Source for the deletion timestamp recorded in the response.</param>
 public class RemoveClientRequestProcessor(
     IClientInfoManager clientInfoManager,
+    IRegistrationAccessTokenStore registrationAccessTokenStore,
     TimeProvider clock) : IRemoveClientRequestProcessor
 {
     /// <summary>
@@ -45,6 +47,9 @@ public class RemoveClientRequestProcessor(
     {
         var clientId = request.ClientInfo.ClientId;
         await clientInfoManager.RemoveClientAsync(clientId);
+
+        // Drop the registration access token binding so it does not outlive the client.
+        await registrationAccessTokenStore.RemoveAsync(clientId);
 
         return new RemoveClientSuccessfulResponse(
             ClientId: clientId,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -79,6 +79,8 @@ public class UpdateClientRequestProcessor(
             AuthorizationDetailsTypes = model.AuthorizationDetailsTypes,
             // Non-standard extension: RFC 8693 Token Exchange per-client subject-token-type allowlist.
             TokenExchangeAllowedSubjectTokenTypes = model.TokenExchangeSubjectTokenTypes,
+            // Non-standard extension: RFC 8693 Token Exchange per-client audience allowlist (default-deny).
+            TokenExchangeAllowedAudiences = model.TokenExchangeAudiences,
             LogoUri = model.LogoUri,
             PolicyUri = model.PolicyUri,
             TermsOfServiceUri = model.TermsOfServiceUri,
@@ -198,6 +200,8 @@ public class UpdateClientRequestProcessor(
             AuthorizationDetailsTypes = updatedClient.AuthorizationDetailsTypes,
             // Non-standard extension: echo token_exchange_subject_token_types.
             TokenExchangeSubjectTokenTypes = updatedClient.TokenExchangeAllowedSubjectTokenTypes,
+            // Non-standard extension: echo token_exchange_audiences.
+            TokenExchangeAudiences = updatedClient.TokenExchangeAllowedAudiences,
         };
     }
 

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -24,6 +24,7 @@ using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 
@@ -36,6 +37,8 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 public class UpdateClientRequestProcessor(
     IClientInfoManager clientInfoManager,
     IRegistrationAccessTokenService registrationAccessTokenService,
+    IRegistrationAccessTokenStore registrationAccessTokenStore,
+    ITokenIdGenerator tokenIdGenerator,
     TimeProvider clock) : IUpdateClientRequestProcessor
 {
     /// <summary>
@@ -149,12 +152,19 @@ public class UpdateClientRequestProcessor(
         // Update client in storage
         await clientInfoManager.UpdateClientAsync(updatedClient);
 
-        // Generate response with new registration_access_token
+        // RFC 7592 §5: rotate the registration access token on update. Recording a fresh jti
+        // invalidates every token issued before this update, limiting the exposure window of a
+        // leaked token to the period between rotations.
+        var registrationAccessTokenId = tokenIdGenerator.GenerateTokenId();
+        await registrationAccessTokenStore.SetTokenIdAsync(updatedClient.ClientId, registrationAccessTokenId);
+
+        // Generate response with new registration_access_token, embedding the freshly rotated jti.
         var issuedAt = clock.GetUtcNow();
         var registrationAccessToken = await registrationAccessTokenService.IssueTokenAsync(
             updatedClient.ClientId,
             issuedAt,
-            null);
+            null,
+            registrationAccessTokenId);
 
         return new ReadClientSuccessfulResponse
         {

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -75,6 +75,11 @@ public class UpdateClientRequestProcessor(
             OfflineAccessAllowed = model.OfflineAccessAllowed,
             // RFC 9449 §5.2: dpop_bound_access_tokens — when omitted, defaults to false.
             RequireDPoP = model.DpopBoundAccessTokens ?? false,
+            // RFC 9126 §6 / RFC 9101 §10.5 / RFC 8705 §3.4: per-client FAPI-grade enforcement
+            // flags — RFC 7592 update is a full replacement, so omission resets them to false.
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests ?? false,
+            RequireSignedRequestObject = model.RequireSignedRequestObject ?? false,
+            TlsClientCertificateBoundAccessTokens = model.TlsClientCertificateBoundAccessTokens ?? false,
             // RFC 9396 §5.1: authorization_details_types per-client allowlist.
             AuthorizationDetailsTypes = model.AuthorizationDetailsTypes,
             // Non-standard extension: RFC 8693 Token Exchange per-client subject-token-type allowlist.
@@ -177,6 +182,14 @@ public class UpdateClientRequestProcessor(
             TokenEndpointAuthMethod = updatedClient.TokenEndpointAuthMethod,
             ApplicationType = updatedClient.ApplicationType,
             RedirectUris = updatedClient.RedirectUris,
+            // RFC 7592 §3: echo the post-update registered state so the client can verify the
+            // full replacement took effect (grant/response types and scope included).
+            GrantTypes = updatedClient.AllowedGrantTypes,
+            ResponseTypes = updatedClient.AllowedResponseTypes,
+            Scope = updatedClient.AllowedScopes,
+            RequirePushedAuthorizationRequests = updatedClient.RequirePushedAuthorizationRequests,
+            RequireSignedRequestObject = updatedClient.RequireSignedRequestObject,
+            TlsClientCertificateBoundAccessTokens = updatedClient.TlsClientCertificateBoundAccessTokens,
             ClientName = updatedClient.ClientName,
             LogoUri = updatedClient.LogoUri,
             SubjectType = updatedClient.SubjectType,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SignedResponseAlgorithmsValidator.cs
@@ -23,6 +23,7 @@
 using Abblix.Oidc.Server.Common;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using static Abblix.Oidc.Server.Model.ClientRegistrationRequest;
 
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
@@ -33,8 +34,11 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 /// <c>authorization_signed_response_alg</c> (JARM §3). Each must appear in the server's set of supported
 /// signing algorithms; in addition, JARM §3 forbids <c>none</c> for the authorization response.
 /// </summary>
-/// <param name="jwtCreator">Source of supported signing algorithms for outbound tokens.</param>
-public class SignedResponseAlgorithmsValidator(IJsonWebTokenCreator jwtCreator) : SyncClientRegistrationContextValidator
+/// <param name="jwtAlgorithms">Source of supported signing algorithms for outbound tokens. The same
+/// provider feeds the discovery document, so DCR accepts exactly what the server advertises —
+/// in particular HS* stays rejected here for the same key-availability reason it is not
+/// advertised (client secrets are stored hashed and cannot serve as HMAC keys).</param>
+public class SignedResponseAlgorithmsValidator(IJwtAlgorithmsProvider jwtAlgorithms) : SyncClientRegistrationContextValidator
 {
     /// <summary>
     /// Validates the signing algorithms specified for ID tokens, user info and JARM authorization responses.
@@ -48,10 +52,30 @@ public class SignedResponseAlgorithmsValidator(IJsonWebTokenCreator jwtCreator) 
     protected override OidcError? Validate(ClientRegistrationValidationContext context)
     {
         var request = context.Request;
-        return Validate(request.IdTokenSignedResponseAlg, Parameters.IdTokenSignedResponseAlg) ??
+        return ValidateIdTokenSignedResponseAlg(request) ??
                Validate(request.UserInfoSignedResponseAlg, Parameters.UserInfoSignedResponseAlg) ??
                Validate(request.IntrospectionSignedResponseAlg, Parameters.IntrospectionSignedResponseAlg) ??
                ValidateAuthorizationSignedResponseAlg(request.AuthorizationSignedResponseAlg);
+    }
+
+    /// <summary>
+    /// Validates <c>id_token_signed_response_alg</c>. OIDC Registration 1.0 §2: the value none MUST
+    /// NOT be used unless the client uses only response types that return no ID Token from the
+    /// authorization endpoint — an unsigned ID Token delivered through the browser would be
+    /// modifiable in transit.
+    /// </summary>
+    private OidcError? ValidateIdTokenSignedResponseAlg(Model.ClientRegistrationRequest request)
+    {
+        if (string.Equals(request.IdTokenSignedResponseAlg, SigningAlgorithms.None, StringComparison.Ordinal) &&
+            Array.Exists(request.ResponseTypes, responseType => responseType.Contains(ResponseTypes.IdToken)))
+        {
+            return new OidcError(
+                ErrorCodes.InvalidClientMetadata,
+                $"The algorithm '{SigningAlgorithms.None}' is not allowed for {Parameters.IdTokenSignedResponseAlg} " +
+                $"when the registered response types return an ID Token from the authorization endpoint");
+        }
+
+        return Validate(request.IdTokenSignedResponseAlg, Parameters.IdTokenSignedResponseAlg);
     }
 
     /// <summary>
@@ -82,7 +106,7 @@ public class SignedResponseAlgorithmsValidator(IJsonWebTokenCreator jwtCreator) 
     /// </returns>
     private OidcError? Validate(string? alg, string description)
     {
-        if (alg is not null && !jwtCreator.SignedResponseAlgorithmsSupported.Contains(alg, StringComparer.Ordinal))
+        if (alg is not null && !jwtAlgorithms.SignedResponseAlgorithmsSupported.Contains(alg, StringComparer.Ordinal))
         {
             return new OidcError(
                 ErrorCodes.InvalidRequest,

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.Logging.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.Logging.cs
@@ -30,6 +30,6 @@ partial class SubjectTypeValidator
     [LoggerMessage(
         EventId = LogEvents.DynamicClientManagement.SubjectTypeValidator.SectorIdentifierMissingUris,
         Level = LogLevel.Warning,
-        Message = "The following URIs are present in the {SectorIdentifierUri}, but missing from the Redirect URIs: {@MissingUris}")]
+        Message = "The following registered redirect URIs are missing from the document at {SectorIdentifierUri}: {@MissingUris}")]
     private partial void LogSectorIdentifierMissingUris(Sanitized SectorIdentifierUri, Uri[] MissingUris);
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -68,7 +68,6 @@ public partial class SubjectTypeValidator(
 
         // SSRF protection is handled by the SsrfValidatingHttpFetcher decorator
         var contentResult = await secureHttpFetcher.FetchAsync<Uri[]>(sectorIdentifierUri);
-
         if (contentResult.TryGetFailure(out var contentError))
             return contentError;
 
@@ -117,13 +116,20 @@ public partial class SubjectTypeValidator(
             return ErrorFactory.InvalidClientMetadata("All schemes in the redirect URIs must be https");
         }
 
-        var missingUris = sectorIdentifierContent.Except(redirectUris).ToArray();
+        // OIDC Core §8.1 / OIDC Registration §5: the values of the registered redirect_uris MUST be
+        // included in the elements of the sector identifier document — the subset check goes from the
+        // registration towards the document, not the other way around. The document is intentionally
+        // shareable across several clients of the same sector, so it may list URIs this client did not
+        // register. The inverted check (document minus registration) both rejected such legitimate
+        // shared documents and let a client register a redirect URI absent from the document — i.e.
+        // claim a sector it does not belong to, breaking pairwise subject isolation.
+        var missingUris = redirectUris.Except(sectorIdentifierContent).ToArray();
         if (missingUris.Length > 0)
         {
             LogSectorIdentifierMissingUris(sectorIdentifierUri, missingUris);
 
             return ErrorFactory.InvalidClientMetadata(
-                $"The content received from the {Parameters.SectorIdentifierUri} contains one or more URIs that are not in the registered list of redirect URIs");
+                $"One or more registered redirect URIs are not listed in the document fetched from the {Parameters.SectorIdentifierUri}");
         }
 
         return null;

--- a/Abblix.Oidc.Server/Endpoints/Introspection/Interfaces/IntrospectionSuccess.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/Interfaces/IntrospectionSuccess.cs
@@ -35,6 +35,15 @@ namespace Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
 public record IntrospectionSuccess(bool Active, JsonObject? Claims, ClientInfo ClientInfo)
 {
     /// <summary>
+    /// Wire-level member names of the introspection response, as registered in the IANA
+    /// "OAuth Token Introspection Response" registry (RFC 7662 §3.1).
+    /// </summary>
+    public static class Parameters
+    {
+        public const string Active = "active";
+    }
+
+    /// <summary>
     /// RFC 7662 <c>active</c> field: <c>true</c> only if the token is currently valid and the
     /// caller is permitted to introspect it. <c>false</c> covers all other cases (expired,
     /// revoked, unknown, or not allowed) and per §2.2 is returned without disclosing why.

--- a/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestValidator.Logging.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestValidator.Logging.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Abblix.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Abblix.Oidc.Server.Endpoints.Introspection;
@@ -32,4 +33,10 @@ partial class IntrospectionRequestValidator
 		Level = LogLevel.Warning,
 		Message = "The incoming JWT token is invalid: {@JwtValidationError}")]
 	private partial void LogInvalidJwt(JwtValidationError JwtValidationError);
+
+	[LoggerMessage(
+		EventId = LogEvents.Endpoints.IntrospectionRequestValidator.PublicClientRejected,
+		Level = LogLevel.Warning,
+		Message = "Introspection rejected for public client {ClientId}: 'none' authentication does not satisfy RFC 7662 §2.1")]
+	private partial void LogPublicClientRejected(Sanitized ClientId);
 }

--- a/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestValidator.cs
@@ -68,6 +68,15 @@ public partial class IntrospectionRequestValidator(
 			return new OidcError(ErrorCodes.InvalidClient, "The client is not authorized");
 		}
 
+		// RFC 7662 §2.1: the introspection endpoint MUST require some form of authorization to
+		// prevent token scanning. A public client (auth method "none") presents only its client_id,
+		// which is not a credential — reject it even though "none" is valid at the token endpoint.
+		if (clientInfo.TokenEndpointAuthMethod == ClientAuthenticationMethods.None)
+		{
+			LogPublicClientRejected(clientInfo.ClientId);
+			return new OidcError(ErrorCodes.InvalidClient, "The client is not authorized");
+		}
+
 		var result = await jwtValidator.ValidateAsync(introspectionRequest.Token);
 
 		return result.Match(

--- a/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.Logging.cs
+++ b/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.Logging.cs
@@ -39,4 +39,10 @@ partial class RevocationRequestValidator
 		Level = LogLevel.Warning,
 		Message = "The token validation failed: {@Error}")]
 	private partial void LogTokenValidationFailed(JwtValidationError Error);
+
+	[LoggerMessage(
+		EventId = LogEvents.Endpoints.RevocationRequestValidator.PublicClientRejected,
+		Level = LogLevel.Warning,
+		Message = "Revocation rejected for public client {ClientId}: 'none' authentication does not satisfy RFC 7009 §2.1")]
+	private partial void LogPublicClientRejected(Sanitized ClientId);
 }

--- a/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.cs
@@ -77,11 +77,22 @@ public partial class RevocationRequestValidator(
 	{
 		// Authenticate the client making the revocation request.
 		var clientInfo = await clientAuthenticator.TryAuthenticateClientAsync(clientRequest);
-		if (clientInfo == null)
+		switch (clientInfo)
 		{
-			return new OidcError(
-				ErrorCodes.InvalidClient,
-				"The client is not authorized");
+			case null:
+				return new OidcError(
+					ErrorCodes.InvalidClient,
+					"The client is not authorized");
+
+			// RFC 7009 §2.1 (referencing the OAuth 2.0 client-authentication requirements): the
+			// revocation endpoint must authenticate the client. A public client (auth method "none")
+			// presents only its client_id, which is not a credential — reject it even though "none" is
+			// valid at the token endpoint.
+			case { TokenEndpointAuthMethod: ClientAuthenticationMethods.None}:
+				LogPublicClientRejected(clientInfo.ClientId);
+				return new OidcError(
+					ErrorCodes.InvalidClient,
+					"The client is not authorized");
 		}
 
 		var result = await jwtValidator.ValidateAsync(revocationRequest.Token);

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -182,6 +182,9 @@ public static class ServiceCollectionExtensions
         // compose AuthorizationContext validation as a pipeline of several IAuthorizationContextValidator
         services.TryAddEnumerable([
             ServiceDescriptor.Singleton<IAuthorizationContextValidator, Authorization.Validation.ClientValidator>(),
+            // Right after ClientValidator: needs the resolved ClientInfo and must reject plain
+            // parameters from a require_signed_request_object client before further processing.
+            ServiceDescriptor.Singleton<IAuthorizationContextValidator, SignedRequestObjectRequirementValidator>(),
             ServiceDescriptor.Singleton<IAuthorizationContextValidator, RedirectUriValidator>(),
             // Scoped: FlowTypeValidator consumes IEnumerable<IAuthorizationResponseBuilder>, which
             // includes the scoped IdTokenResponseBuilder once EnableImplicitFlow() is called.

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -535,6 +535,7 @@ public static class ServiceCollectionExtensions
             .AddDefaultInitialAccessTokenRevocationProvider();
 
         services.TryAddSingleton<IRegistrationAccessTokenValidator, RegistrationAccessTokenValidator>();
+        services.TryAddScoped<IRegistrationAccessTokenStore, RegistrationAccessTokenStore>();
         services.TryAddTransient(newClientOptionsFactory);
 
         services.TryAddScoped<IClientCredentialFactory, ClientCredentialFactory>();

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -116,6 +116,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddScoped<AuthorizationHandler>();
         services.TryAddScoped<IAuthorizationRequestValidator, AuthorizationRequestValidator>();
+        services.TryAddSingleton<IConsentConstraintEnforcer, ConsentConstraintEnforcer>();
         services.TryAddScoped<IAuthorizationRequestProcessor, AuthorizationRequestProcessor>();
 
         // Single-use PAR (RFC 9126 §6): decorate the processor so a pushed request_uri is consumed once a

--- a/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -59,19 +59,30 @@ public class AuthorizationCodeReusePreventingDecorator(
     /// </returns>
     public async Task<Result<TokenIssued, OidcError>> ProcessAsync(ValidTokenRequest request)
     {
-        if (request is not {
-                Model: { GrantType: GrantTypes.AuthorizationCode, Code: {} code },
-                AuthorizedGrant.IssuedTokens: var issuedTokens })
+        if (request is not { Model: { GrantType: GrantTypes.AuthorizationCode, Code: {} code } })
         {
             return await processor.ProcessAsync(request);
         }
 
-        // Handle revocation for used authorization codes and their associated tokens
-        if (issuedTokens is { Length: > 0 })
-        {
-            // code was already used to issue some tokens, so we have to revoke all these tokens for security reason
-            await authorizationCodeService.RemoveAuthorizationCodeAsync(code);
+        // Atomically claim the code by removing it (get-and-remove). This happens AFTER the grant
+        // validators have already checked client binding and PKCE, so a failed validation never
+        // reaches here and never burns the code — but two concurrent redemptions of a valid code
+        // now contend for a single claim instead of both passing a stale "not yet used" check.
+        var claim = await authorizationCodeService.RemoveAuthorizationCodeAsync(code);
 
+        // The code is gone: a concurrent request already claimed it, or it was already consumed.
+        // Either way this redemption loses — reject without issuing a second set of tokens.
+        if (!claim.TryGetSuccess(out var claimedGrant))
+        {
+            return new OidcError(
+                ErrorCodes.InvalidGrant,
+                "The authorization code was already used");
+        }
+
+        // The claimed grant carries tokens from a prior successful redemption — a sequential reuse.
+        // Revoke those tokens (OAuth 2.0 Security BCP §4.13) and reject.
+        if (claimedGrant.IssuedTokens is { Length: > 0 } issuedTokens)
+        {
             foreach (var (jwtId, expiresAt) in issuedTokens)
             {
                 await tokenRegistry.SetStatusAsync(jwtId, JsonWebTokenStatus.Revoked, expiresAt);
@@ -82,7 +93,7 @@ public class AuthorizationCodeReusePreventingDecorator(
                 "The authorization code was already used");
         }
 
-        // Proceed with processing the request using the decorated processor
+        // We won the claim — proceed with processing the request using the decorated processor.
         var result = await processor.ProcessAsync(request);
 
         // Register issued tokens as part of the authorization code grant

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/AuthorizationCodeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/AuthorizationCodeGrantHandler.cs
@@ -42,10 +42,8 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// request, runs the RFC 7636 §4.6 verification by transforming the submitted <c>code_verifier</c> with
 /// the recorded <c>plain</c> / <c>S256</c> / <c>S512</c> method.
 /// </summary>
-/// <param name="parameterValidator">Asserts that required wire parameters (<c>code</c>) are present.</param>
 /// <param name="authorizationCodeService">Persists, looks up and removes authorization codes.</param>
 public class AuthorizationCodeGrantHandler(
-    IParameterValidator parameterValidator,
     IAuthorizationCodeService authorizationCodeService) : IAuthorizationGrantHandler
 {
     /// <summary>
@@ -72,8 +70,12 @@ public class AuthorizationCodeGrantHandler(
     /// The result is either an authorized grant or an error indicating why the request failed.</returns>
     public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
     {
-        // Ensures the authorization code is provided in the request.
-        parameterValidator.Required(request.Code, nameof(request.Code));
+        // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
+        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        if (!request.Code.HasValue())
+        {
+            return ErrorFactory.MissingParameter(TokenRequest.Parameters.Code);
+        }
 
         // Validates the authorization code and retrieves the authorization context associated with the code.
         var result = await authorizationCodeService.AuthorizeByCodeAsync(request.Code);
@@ -85,10 +87,13 @@ public class AuthorizationCodeGrantHandler(
         var grant = result.GetSuccess();
 
         // Verifies that the authorization code was issued for the requesting client.
+        // RFC 6749 §5.2 lists "authorization code ... issued to another client" explicitly under
+        // invalid_grant; unauthorized_client (used before) means the client is barred from the
+        // grant type as such, which is a different failure.
         if (grant.Context.ClientId != clientInfo.ClientId)
         {
             return new OidcError(
-                ErrorCodes.UnauthorizedClient,
+                ErrorCodes.InvalidGrant,
                 "Code was issued for another client");
         }
 

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -44,7 +44,6 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// Supports both short-polling (immediate response) and long-polling (holds connection until auth completes).
 /// </summary>
 /// <param name="storage">Service for storing and retrieving backchannel authentication requests.</param>
-/// <param name="parameterValidator">The service to validate request parameters.</param>
 /// <param name="timeProvider">Provides access to the current time.</param>
 /// <param name="options">Configuration options for backchannel authentication including long-polling settings.</param>
 /// <param name="serviceProvider">Service provider for resolving mode-specific grant processors.</param>
@@ -52,7 +51,6 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// <param name="httpContextAccessor">Accessor for HTTP context to retrieve cancellation token.</param>
 public class BackChannelAuthenticationGrantHandler(
     IBackChannelRequestStorage storage,
-    IParameterValidator parameterValidator,
     TimeProvider timeProvider,
     IOptions<OidcOptions> options,
     IServiceProvider serviceProvider,
@@ -99,8 +97,12 @@ public class BackChannelAuthenticationGrantHandler(
     /// </returns>
     public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
     {
-        // Check if the request contains a valid authentication request ID
-        parameterValidator.Required(request.AuthenticationRequestId, nameof(request.AuthenticationRequestId));
+        // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
+        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        if (!request.AuthenticationRequestId.HasValue())
+        {
+            return ErrorFactory.MissingParameter(TokenRequest.Parameters.AuthenticationRequestId);
+        }
 
         // Try to retrieve the corresponding backchannel authentication request from storage
         var authenticationRequest = await storage.TryGetAsync(request.AuthenticationRequestId);

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -40,12 +40,10 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// checking the device code status and returning tokens when authorized.
 /// </summary>
 /// <param name="storage">Service for storing and retrieving device authorization requests.</param>
-/// <param name="parameterValidator">Service to validate request parameters.</param>
 /// <param name="timeProvider">Provides access to the current time.</param>
 /// <param name="options">Configuration options containing polling interval settings.</param>
 public class DeviceCodeGrantHandler(
     IDeviceAuthorizationStorage storage,
-    IParameterValidator parameterValidator,
     TimeProvider timeProvider,
     IOptions<OidcOptions> options) : IAuthorizationGrantHandler
 {
@@ -60,7 +58,12 @@ public class DeviceCodeGrantHandler(
         TokenRequest request,
         ClientInfo clientInfo)
     {
-        parameterValidator.Required(request.DeviceCode, nameof(request.DeviceCode));
+        // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
+        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        if (!request.DeviceCode.HasValue())
+        {
+            return ErrorFactory.MissingParameter(TokenRequest.Parameters.DeviceCode);
+        }
 
         var deviceRequest = await storage.TryGetByDeviceCodeAsync(request.DeviceCode);
 

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/ErrorFactory.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/ErrorFactory.cs
@@ -1,0 +1,54 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+
+namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
+
+/// <summary>
+/// Builds <see cref="OidcError"/> instances using the error codes RFC 6749 §5.2 defines for
+/// the token endpoint. Mirrors the sibling per-area factories (authorization validation,
+/// dynamic client registration, secure HTTP fetch): each area exposes only the error codes
+/// its specification legitimately uses, so codes from one protocol surface do not leak into
+/// another.
+/// </summary>
+public static class ErrorFactory
+{
+    /// <summary>
+    /// Creates an error for a malformed token request — a missing, repeated, or otherwise
+    /// invalid parameter (RFC 6749 §5.2, <c>invalid_request</c>).
+    /// </summary>
+    /// <param name="description">The description of the error.</param>
+    /// <returns>An error instance with the error code and description.</returns>
+    public static OidcError InvalidRequest(string description)
+        => new(ErrorCodes.InvalidRequest, description);
+
+    /// <summary>
+    /// Creates an error for a token request whose required parameter is absent
+    /// (RFC 6749 §5.2, <c>invalid_request</c>).
+    /// </summary>
+    /// <param name="parameterName">The wire-level name of the missing parameter.</param>
+    /// <returns>An error instance with the error code and description.</returns>
+    public static OidcError MissingParameter(string parameterName)
+        => InvalidRequest($"The {parameterName} parameter is required");
+}

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/PasswordGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/PasswordGrantHandler.cs
@@ -37,10 +37,8 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// The password grant type allows clients to directly exchange a user's credentials (username and password)
 /// for an access token, typically for trusted clients.
 /// </summary>
-/// <param name="parameterValidator">A service for validating required request parameters.</param>
 /// <param name="userCredentialsAuthenticator">A service for authenticating the user's credentials.</param>
 public class PasswordGrantHandler(
-    IParameterValidator parameterValidator,
     IUserCredentialsAuthenticator userCredentialsAuthenticator) : IAuthorizationGrantHandler
 {
     /// <summary>
@@ -66,9 +64,19 @@ public class PasswordGrantHandler(
     /// </returns>
     public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
     {
-        // Ensure that the request contains the required username and password parameters.
-        parameterValidator.Required(request.UserName, nameof(request.UserName));
-        parameterValidator.Required(request.Password, nameof(request.Password));
+        // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
+        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        if (!request.UserName.HasValue())
+        {
+            return Task.FromResult<Result<AuthorizedGrant, OidcError>>(
+                ErrorFactory.MissingParameter(TokenRequest.Parameters.Username));
+        }
+
+        if (!request.Password.HasValue())
+        {
+            return Task.FromResult<Result<AuthorizedGrant, OidcError>>(
+                ErrorFactory.MissingParameter(TokenRequest.Parameters.Password));
+        }
 
         // Extract relevant details from the request and prepare the authorization context.
         var userName = request.UserName;

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/RefreshTokenGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/RefreshTokenGrantHandler.cs
@@ -38,12 +38,10 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// <c>rt+jwt</c>, recovers the original <see cref="AuthorizedGrant"/>, and rejects the request with
 /// <c>invalid_grant</c> when the refreshing client differs from the client that received the token.
 /// </summary>
-/// <param name="parameterValidator">Asserts that the <c>refresh_token</c> parameter is present.</param>
 /// <param name="jwtValidator">Validates the refresh-token JWT issued by this server.</param>
 /// <param name="refreshTokenService">Resolves the refresh-token JWT to an <see cref="AuthorizedGrant"/>
 /// and enforces single-use / rotation semantics.</param>
 public class RefreshTokenGrantHandler(
-	IParameterValidator parameterValidator,
 	IAuthServiceJwtValidator jwtValidator,
 	IRefreshTokenService refreshTokenService) : IAuthorizationGrantHandler
 {
@@ -70,8 +68,12 @@ public class RefreshTokenGrantHandler(
 	/// </returns>
 	public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
 	{
-		// Validate that the refresh token parameter is present in the request, throwing an error if missing.
-		parameterValidator.Required(request.RefreshToken, nameof(request.RefreshToken));
+		// RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
+		// not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+		if (!request.RefreshToken.HasValue())
+		{
+			return ErrorFactory.MissingParameter(TokenRequest.Parameters.RefreshToken);
+		}
 
 		// Validate the refresh token's JWT structure and authenticity using the JWT validator service.
 		var jwtValidationResult = await jwtValidator.ValidateAsync(request.RefreshToken);

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -355,14 +355,17 @@ public class TokenExchangeGrantHandler(
         }
 
         var allowed = new HashSet<string>(allowlist, StringComparer.Ordinal);
-        foreach (var audience in audiences)
+        var disallowed = audiences
+            .Where(audience => !allowed.Contains(audience))
+            .ToArray();
+
+        if (disallowed.Length > 0)
         {
-            if (!allowed.Contains(audience))
-            {
-                return new OidcError(
-                    ErrorCodes.InvalidTarget,
-                    $"audience '{audience}' is not in the client's allow list.");
-            }
+            // Report every disallowed audience, not just the first: a client fixing its request
+            // should not have to re-submit and rediscover the rejected values one round-trip at a time.
+            return new OidcError(
+                ErrorCodes.InvalidTarget,
+                $"The following audiences are not in the client's allow list: {string.Join(", ", disallowed)}.");
         }
 
         return ctx;

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -96,6 +96,7 @@ public class TokenExchangeGrantHandler(
             .Bind(ValidateForwardedAuthorizationDetails)
             .BindAsync(ResolveActorTokenAsync)
             .Bind(ValidateActorTokenOriginAndType)
+            .Bind(ValidateAudiences)
             .MapSuccessAsync(ctx => Task.FromResult(BuildAuthorizedGrant(ctx)));
     }
 
@@ -318,6 +319,41 @@ public class TokenExchangeGrantHandler(
         return CheckTokenOriginAndType(actor, ctx.Request.ActorTokenType, ctx.ClientInfo) is { } error
             ? new OidcError(ErrorCodes.InvalidRequest, $"actor_token: {error.ErrorDescription}")
             : ctx;
+    }
+
+    /// <summary>
+    /// Enforces the per-client <c>audience</c> allowlist (RFC 8693 §2.1). The requested audience is
+    /// written into the issued token's <c>aud</c> claim, so it must be constrained — otherwise a
+    /// client could mint a token for any target service it names. The allowlist is default-deny: an
+    /// <c>audience</c> is accepted only when the client declares a non-empty
+    /// <see cref="ClientInfo.TokenExchangeAllowedAudiences"/> that contains every requested value.
+    /// A request without <c>audience</c> passes through. Rejections use <c>invalid_target</c>
+    /// (RFC 8693 §2.2.1: the AS is unwilling to issue a token for the requested target service).
+    /// </summary>
+    private static Result<ValidationContext, OidcError> ValidateAudiences(ValidationContext ctx)
+    {
+        if (ctx.Request.Audiences is not { Length: > 0 } audiences)
+            return ctx;
+
+        if (ctx.ClientInfo.TokenExchangeAllowedAudiences is not { Length: > 0 } allowlist)
+        {
+            return new OidcError(
+                ErrorCodes.InvalidTarget,
+                "The client is not permitted to request an audience for token exchange.");
+        }
+
+        var allowed = new HashSet<string>(allowlist, StringComparer.Ordinal);
+        foreach (var audience in audiences)
+        {
+            if (!allowed.Contains(audience))
+            {
+                return new OidcError(
+                    ErrorCodes.InvalidTarget,
+                    $"audience '{audience}' is not in the client's allow list.");
+            }
+        }
+
+        return ctx;
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -66,7 +66,6 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// </para>
 /// </remarks>
 public class TokenExchangeGrantHandler(
-    IParameterValidator parameterValidator,
     IServiceProvider serviceProvider,
     ISessionIdGenerator sessionIdGenerator,
     TimeProvider timeProvider) : IAuthorizationGrantHandler
@@ -82,11 +81,10 @@ public class TokenExchangeGrantHandler(
         TokenRequest request,
         ClientInfo clientInfo)
     {
-        ValidateRequiredParameters(request);
-
         Result<ValidationContext, OidcError> initial = new ValidationContext(request, clientInfo);
 
         return initial
+            .Bind(ValidateRequiredParameters)
             .Bind(ValidateSubjectTokenType)
             .Bind(ValidateActorTokenPair)
             .Bind(ValidateActorTokenType)
@@ -111,10 +109,24 @@ public class TokenExchangeGrantHandler(
         SubjectTokenContext? Subject = null,
         SubjectTokenContext? Actor = null);
 
-    private void ValidateRequiredParameters(TokenRequest request)
+    /// <summary>
+    /// RFC 8693 §2.1: <c>subject_token</c> and <c>subject_token_type</c> are REQUIRED. A missing one
+    /// is the caller's protocol error (<c>invalid_request</c> per RFC 6749 §5.2), not a server
+    /// fault — the previous throw-on-access surfaced it as HTTP 500.
+    /// </summary>
+    private static Result<ValidationContext, OidcError> ValidateRequiredParameters(ValidationContext ctx)
     {
-        parameterValidator.Required(request.SubjectToken, nameof(request.SubjectToken));
-        parameterValidator.Required(request.SubjectTokenType, nameof(request.SubjectTokenType));
+        if (!ctx.Request.SubjectToken.HasValue())
+        {
+            return ErrorFactory.MissingParameter(TokenRequest.Parameters.SubjectToken);
+        }
+
+        if (!ctx.Request.SubjectTokenType.HasValue())
+        {
+            return ErrorFactory.MissingParameter(TokenRequest.Parameters.SubjectTokenType);
+        }
+
+        return ctx;
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Endpoints/Token/TokenAuthorizationContextEvaluator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/TokenAuthorizationContextEvaluator.cs
@@ -70,9 +70,14 @@ public class TokenAuthorizationContextEvaluator : ITokenAuthorizationContextEval
         var thumbprint = authContext.CertificateSha256Thumbprint;
         if (thumbprint == null && request.ClientCertificate != null)
         {
+            // RFC 8705 §3.4: tls_client_certificate_bound_access_tokens decouples certificate
+            // binding from the authentication method — a client may authenticate with, say,
+            // private_key_jwt over a mutual-TLS connection and still receive certificate-bound
+            // tokens. The mTLS authentication methods keep their implicit binding.
             var authMethod = request.ClientInfo.TokenEndpointAuthMethod;
             if (authMethod == ClientAuthenticationMethods.SelfSignedTlsClientAuth
-                || authMethod == ClientAuthenticationMethods.TlsClientAuth)
+                || authMethod == ClientAuthenticationMethods.TlsClientAuth
+                || request.ClientInfo.TlsClientCertificateBoundAccessTokens)
             {
                 thumbprint = Base64Url.EncodeToString(SHA256.HashData(request.ClientCertificate.RawData));
             }

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
@@ -102,8 +102,10 @@ public class UserInfoRequestValidator(
 		}
 		else if (userInfoRequest.AccessToken == null)
 		{
-			return new OidcError(
-				ErrorCodes.InvalidToken,
+			// RFC 6750 §3.1: a request with no authentication information at all gets a bare
+			// WWW-Authenticate challenge — the typed marker tells the challenge builder to omit
+			// the error attributes the other invalid_token cases carry.
+			return new MissingAuthenticationError(
 				$"The access token must be passed via '{HttpRequestHeaders.Authorization}' header " +
 				$"or '{Parameters.AccessToken}' parameter, but none of them specified");
 		}

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
@@ -26,7 +26,7 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Licensing;
-using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.Features.ReplayPrevention;
 using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Utils;
 using Microsoft.Extensions.Logging;
@@ -43,14 +43,14 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// <param name="clientInfoProvider">Provider for retrieving client information.</param>
 /// <param name="requestInfoProvider">Provider for retrieving request information.</param>
 /// <param name="clock">Time provider for checking secret expiration.</param>
-/// <param name="tokenRegistry">Registry for managing the status of JWTs, such as marking them as used or invalid.</param>
+/// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
 public partial class ClientSecretJwtAuthenticator(
     ILogger<ClientSecretJwtAuthenticator> logger,
     IJsonWebTokenValidator tokenValidator,
     IClientInfoProvider clientInfoProvider,
     IRequestInfoProvider requestInfoProvider,
     TimeProvider clock,
-    ITokenRegistry tokenRegistry) : JwtAssertionAuthenticatorBase(logger, tokenRegistry)
+    IJwtReplayCache replayCache) : JwtAssertionAuthenticatorBase(logger, replayCache)
 {
     /// <summary>
     /// Specifies the client authentication method this authenticator supports, which is 'client_secret_jwt'.

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
@@ -74,4 +74,16 @@ partial class JwtAssertionAuthenticatorBase
         Level = LogLevel.Warning,
         Message = "The client assertion for {ClientId} uses algorithm {Algorithm}, but the client registered token_endpoint_auth_signing_alg {RequiredAlgorithm}")]
     private partial void LogSigningAlgorithmNotAllowed(string ClientId, string? Algorithm, string RequiredAlgorithm);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.MissingExpiration,
+        Level = LogLevel.Warning,
+        Message = "The client assertion for {ClientId} has no exp claim, which RFC 7523 §3 requires to bound the assertion's usage window")]
+    private partial void LogMissingExpiration(string ClientId);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.ReplayDetected,
+        Level = LogLevel.Warning,
+        Message = "The client assertion jti {Jti} for {ClientId} has already been used; possible replay attack")]
+    private partial void LogReplayDetected(string Jti, string ClientId);
 }

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -23,8 +23,7 @@
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
-using Abblix.Oidc.Server.Features.Storages;
-using Abblix.Oidc.Server.Features.Tokens.Revocation;
+using Abblix.Oidc.Server.Features.ReplayPrevention;
 using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
@@ -37,10 +36,10 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// for both private_key_jwt and client_secret_jwt authentication methods.
 /// </summary>
 /// <param name="logger">logger for recording the authentication process and any issues encountered.</param>
-/// <param name="tokenRegistry">Registry for managing the status of JWTs, such as marking them as used or invalid.</param>
+/// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
 public abstract partial class JwtAssertionAuthenticatorBase(
     ILogger logger,
-    ITokenRegistry tokenRegistry) : IClientAuthenticator
+    IJwtReplayCache replayCache) : IClientAuthenticator
 {
     /// <summary>
     /// Specifies the client authentication methods supported by this authenticator.
@@ -124,16 +123,30 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         // identifier for the token, which can be used to prevent reuse of the token". Reject an
         // assertion without it: single-use replay protection is impossible without a unique id,
         // and accepting it would leave the assertion replayable within its expiry window (the
-        // replay registry below, and the validation decorator, both key off jti).
+        // replay cache below keys off jti).
         if (token.Payload.JwtId is not { } jwtId)
         {
             LogMissingJti(clientInfo.ClientId);
             return null;
         }
 
-        if (token.Payload.ExpiresAt is { } expiresAt)
+        // RFC 7523 §3: the assertion MUST contain an 'exp' claim that limits the window during
+        // which it can be used; the generic lifetime check treats a token with neither 'nbf' nor
+        // 'exp' as valid, so this enforces the assertion-specific MUST and is also what bounds
+        // the replay-cache entry's TTL.
+        if (token.Payload.ExpiresAt is not { } expiresAt)
         {
-            await tokenRegistry.SetStatusAsync(jwtId, JsonWebTokenStatus.Used, expiresAt);
+            LogMissingExpiration(clientInfo.ClientId);
+            return null;
+        }
+
+        // Single atomic reserve-and-check: record the jti and treat "already present" as a replay.
+        // One call avoids the read-then-write race a separate status check + mark step would leave
+        // between two concurrent presenters of the same assertion.
+        if (!await replayCache.TryAddAsync(jwtId, expiresAt))
+        {
+            LogReplayDetected(jwtId, clientInfo.ClientId);
+            return null;
         }
 
         return clientInfo;

--- a/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
+++ b/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
@@ -22,7 +22,7 @@
 
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
-using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.Features.ReplayPrevention;
 using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,12 +35,12 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// that the client provides. This method is suitable for clients that can securely store and use private keys.
 /// </summary>
 /// <param name="logger">Logger for recording the authentication process and any issues encountered.</param>
-/// <param name="tokenRegistry">Registry for managing the status of JWTs, such as marking them as used or invalid.</param>
+/// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
 /// <param name="serviceProvider">Service provider used to resolve scoped dependencies.</param>
 public class PrivateKeyJwtAuthenticator(
     ILogger<PrivateKeyJwtAuthenticator> logger,
-    ITokenRegistry tokenRegistry,
-    IServiceProvider serviceProvider) : JwtAssertionAuthenticatorBase(logger, tokenRegistry)
+    IJwtReplayCache replayCache,
+    IServiceProvider serviceProvider) : JwtAssertionAuthenticatorBase(logger, replayCache)
 {
     /// <summary>
     /// Indicates the client authentication method supported by this authenticator.

--- a/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -148,8 +148,20 @@ public record ClientInfo(string ClientId)
 
     /// <summary>
     /// Specifies the algorithm that must be used for signing identity token responses issued to this client.
+    /// Per Back-Channel Logout 1.0 §2.4 logout tokens are signed in the same manner as ID Tokens, so this
+    /// value also serves as the default signing algorithm for back-channel logout tokens unless
+    /// <see cref="LogoutTokenSignedResponseAlgorithm"/> overrides it.
     /// </summary>
     public string IdentityTokenSignedResponseAlgorithm { get; set; } = SigningAlgorithms.RS256;
+
+    /// <summary>
+    /// The algorithm used to sign back-channel logout tokens issued to this client. When null
+    /// (the default), the value of <see cref="IdentityTokenSignedResponseAlgorithm"/> applies —
+    /// Back-Channel Logout 1.0 §2.4 signs logout tokens in the same manner as ID Tokens, and this
+    /// property makes that otherwise implicit coupling visible and overridable per client. There is
+    /// no registered DCR metadata parameter for it, so the override is host-side configuration only.
+    /// </summary>
+    public string? LogoutTokenSignedResponseAlgorithm { get; set; }
 
     /// <summary>
     /// Controls whether claims about the authenticated user are included directly in the identity token
@@ -250,6 +262,32 @@ public record ClientInfo(string ClientId)
     /// issued.
     /// </summary>
     public bool RequireDPoP { get; set; } = false;
+
+    /// <summary>
+    /// RFC 9126 §6 client metadata (<c>require_pushed_authorization_requests</c>): when <c>true</c>,
+    /// a pushed authorization request is the only way this client may start an authorization flow —
+    /// a request arriving at the authorization endpoint without a PAR-issued request URI is rejected
+    /// even when the server-wide requirement is off. FAPI-grade clients set this so a granular
+    /// server-side toggle cannot silently weaken them.
+    /// </summary>
+    public bool RequirePushedAuthorizationRequests { get; set; } = false;
+
+    /// <summary>
+    /// RFC 9101 §10.5 client metadata (<c>require_signed_request_object</c>): when <c>true</c>,
+    /// this client must deliver its authorization request parameters as a signed request object
+    /// (via the request parameter or a pushed authorization request) — plain-parameter requests and
+    /// unsigned request objects are rejected.
+    /// </summary>
+    public bool RequireSignedRequestObject { get; set; } = false;
+
+    /// <summary>
+    /// RFC 8705 §3.4 client metadata (<c>tls_client_certificate_bound_access_tokens</c>): when
+    /// <c>true</c>, access tokens issued to this client are certificate-bound whenever the token
+    /// request arrives over mutual TLS — independently of the client authentication method, which
+    /// is what distinguishes this flag from the implicit binding the mTLS authentication methods
+    /// already get.
+    /// </summary>
+    public bool TlsClientCertificateBoundAccessTokens { get; set; } = false;
 
     /// <summary>
     /// Determines the algorithm used for signing responses from the UserInfo endpoint.

--- a/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -204,6 +204,22 @@ public record ClientInfo(string ClientId)
     public string[]? TokenExchangeAllowedSubjectTokenTypes { get; set; }
 
     /// <summary>
+    /// RFC 8693 §2.1 per-client allowlist of <c>audience</c> values this client may request when
+    /// exchanging a token. The requested audience is written into the issued token's <c>aud</c>
+    /// claim, so without a constraint a client could mint a token for any target service it names.
+    /// This allowlist is therefore <b>default-deny</b>, unlike the unconstrained-by-default
+    /// <see cref="TokenExchangeAllowedSubjectTokenTypes"/>:
+    /// <list type="bullet">
+    /// <item><description><c>null</c> or empty array: the client may not request any <c>audience</c>
+    /// -- a Token Exchange request carrying one is rejected with <c>invalid_target</c>.</description></item>
+    /// <item><description>Non-empty array: allowlist -- only the listed audience values are accepted;
+    /// any other is rejected with <c>invalid_target</c>.</description></item>
+    /// </list>
+    /// A request that omits <c>audience</c> is unaffected.
+    /// </summary>
+    public string[]? TokenExchangeAllowedAudiences { get; set; }
+
+    /// <summary>
     /// RFC 8693 §1.3: by default this AS rejects a Token Exchange request where the
     /// <c>subject_token</c> was originally issued to a different client than the one presenting
     /// it -- the "confused deputy" anti-pattern. When this client is intended to operate as an

--- a/Abblix.Oidc.Server/Features/RequestObject/RequestObjectFetcher.cs
+++ b/Abblix.Oidc.Server/Features/RequestObject/RequestObjectFetcher.cs
@@ -77,7 +77,17 @@ public partial class RequestObjectFetcher(
         return await validationResult.BindAsync<T>(
             async payload =>
             {
-                var updatedRequest = await jsonObjectBinder.BindModelAsync(payload, request);
+                // RFC 9101 §5 strict mode: the authorization request is exactly the request object,
+                // so the payload binds onto a fresh model and parameters passed outside the object
+                // are ignored (the OAuth-syntax client_id/response_type duplicates are still
+                // cross-checked against the result by the authorization-endpoint adapter). The
+                // default keeps the OIDC Core §6.1 merge semantics, binding the payload over the
+                // outer request.
+                var target = options.Value.IgnoreParametersOutsideRequestObject
+                    ? Activator.CreateInstance<T>()
+                    : request;
+
+                var updatedRequest = await jsonObjectBinder.BindModelAsync(payload, target);
                 if (updatedRequest == null)
                     return InvalidRequestObject("Unable to bind request object");
 
@@ -106,10 +116,14 @@ public partial class RequestObjectFetcher(
         // Always validate issuer when present (but accept missing issuer)
         // Always validate signatures when present (ValidateIssuerSigningKey)
         // Always validate lifetime (exp/nbf claims) if present
+        // RFC 9101 §4 / OIDC Core §6.1: the aud of a request object SHOULD be the OP — when the
+        // object carries an audience, reject values addressed to another server (a request object
+        // minted for a different OP must not be replayable here); an absent aud stays accepted.
         // Only require signed tokens when RequireSignedRequestObject is true
         var validationOptions = ValidationOptions.ValidateIssuer |
                                 ValidationOptions.ValidateIssuerSigningKey |
-                                ValidationOptions.ValidateLifetime;
+                                ValidationOptions.ValidateLifetime |
+                                ValidationOptions.ValidateAudience;
 
         if (options.Value.RequireSignedRequestObject)
             validationOptions |= ValidationOptions.RequireSignedTokens;
@@ -121,6 +135,17 @@ public partial class RequestObjectFetcher(
         return result.Match<Result<JsonObject, OidcError>>(
             validJwt =>
             {
+                // RFC 9101 §10.5: a client registered with require_signed_request_object committed
+                // to SIGNED request objects — an unsigned (alg=none) object satisfies the
+                // structural check but not the commitment.
+                if (validJwt.Client.RequireSignedRequestObject &&
+                    string.Equals(validJwt.Token.Header.Algorithm, SigningAlgorithms.None, StringComparison.Ordinal))
+                {
+                    return new OidcError(
+                        ErrorCodes.InvalidRequestObject,
+                        "The client is required to sign its request objects");
+                }
+
                 // Pin the request object's alg to what the resolved client registered for this
                 // request-object kind. The signature is already verified; this rejects a request
                 // object signed with a different (e.g. weaker) algorithm than the client registered.

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -104,6 +104,14 @@ public static class ServiceCollectionExtensions
             // mTLS metadata-driven subject/SAN matching (tls_client_auth)
             ServiceDescriptor.Singleton<IClientAuthenticator, TlsMetadataClientAuthenticator>()
         ]);
+
+        // JWT assertion authenticators (client_secret_jwt / private_key_jwt) record assertion jti
+        // values in the replay cache; defensive TryAdd so deployments that never call AddDPoP or
+        // enable JWT Bearer still resolve the dependency.
+        services.TryAddSingleton<
+            ReplayPrevention.IJwtReplayCache,
+            ReplayPrevention.DistributedJwtReplayCache>();
+
         return services.Compose<IClientAuthenticator, CompositeClientAuthenticator>();
     }
 

--- a/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -80,13 +80,22 @@ public class AuthorizationCodeService(
 		return result;
 	}
 
-	/// <summary>
-	/// Removes an authorization code from storage, ensuring that it cannot be reused.
-	/// </summary>
-	/// <param name="authorizationCode">The authorization code to remove.</param>
-	/// <returns>A task representing the asynchronous operation to remove the code.</returns>
-	public Task RemoveAuthorizationCodeAsync(string authorizationCode)
-		=> storage.RemoveAsync(keyFactory.AuthorizedGrantKey(authorizationCode));
+	/// <inheritdoc />
+	public async Task<Result<AuthorizedGrant, OidcError>> RemoveAuthorizationCodeAsync(string authorizationCode)
+	{
+		// removeOnRetrieval: true performs an atomic get-and-remove, so two concurrent redemptions
+		// of the same code cannot both observe the grant — exactly one wins the claim; every other
+		// caller finds the code already gone and is rejected.
+		var grant = await storage.GetAsync<AuthorizedGrant>(
+			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);
+
+		if (grant == null)
+		{
+			return new OidcError(ErrorCodes.InvalidGrant, "Authorization code is invalid");
+		}
+
+		return grant;
+	}
 
 	/// <summary>
 	/// Updates the authorization grant result based on a specific authorization code and client information.

--- a/Abblix.Oidc.Server/Features/Storages/EntityStorageKeyFactory.cs
+++ b/Abblix.Oidc.Server/Features/Storages/EntityStorageKeyFactory.cs
@@ -91,4 +91,12 @@ public class EntityStorageKeyFactory : IEntityStorageKeyFactory
     /// <returns>A formatted storage key for the IP rate limit state.</returns>
     public string IpRateLimitKey(string clientIdentifier)
         => $"Abblix.Oidc.Server:RateLimit:IP:{clientIdentifier}";
+
+    /// <summary>
+    /// Generates a storage key for the registration access token binding of a client (RFC 7592).
+    /// </summary>
+    /// <param name="clientId">The identifier of the registered client.</param>
+    /// <returns>A formatted storage key for the client's current registration-access-token jti.</returns>
+    public string RegistrationAccessTokenKey(string clientId)
+        => $"Abblix.Oidc.Server:RegistrationAccessToken:{clientId}";
 }

--- a/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -60,13 +60,24 @@ public interface IAuthorizationCodeService
     Task<Result<AuthorizedGrant, OidcError>> AuthorizeByCodeAsync(string authorizationCode);
 
     /// <summary>
-    /// Asynchronously removes an authorization code from the system. This method is typically called once
-    /// an authorization code has been exchanged for an access token, or when it expires, ensuring that the code
-    /// cannot be reused.
+    /// Atomically removes an authorization code from storage and returns the grant it held, in a
+    /// single get-and-remove operation. This is how a code is claimed for redemption: it enforces
+    /// the single-use guarantee against a race between two simultaneous redemptions of the same
+    /// code (RFC 6749 §4.1.2) — exactly one caller wins and receives the grant, every other caller
+    /// finds the code already gone and receives an <c>invalid_grant</c> failure.
     /// </summary>
-    /// <param name="authorizationCode">The authorization code to be removed.</param>
-    /// <returns>A task representing the asynchronous operation of removing the authorization code.</returns>
-    Task RemoveAuthorizationCodeAsync(string authorizationCode);
+    /// <param name="authorizationCode">The authorization code to remove and claim.</param>
+    /// <returns>
+    /// The grant on success when this caller won the claim; an <c>invalid_grant</c>
+    /// <see cref="OidcError"/> when the code is absent — already claimed by a concurrent request,
+    /// already consumed, expired, or never issued.
+    /// </returns>
+    /// <remarks>
+    /// A successfully claimed grant whose <c>IssuedTokens</c> is non-empty indicates the code was
+    /// already used to issue tokens (a sequential reuse), which the caller treats as a reuse to be
+    /// rejected and whose tokens are revoked.
+    /// </remarks>
+    Task<Result<AuthorizedGrant, OidcError>> RemoveAuthorizationCodeAsync(string authorizationCode);
 
     /// <summary>
     /// Updates the authorization grant result based on a specific authorization code and expiration time.

--- a/Abblix.Oidc.Server/Features/Storages/IEntityStorageKeyFactory.cs
+++ b/Abblix.Oidc.Server/Features/Storages/IEntityStorageKeyFactory.cs
@@ -83,4 +83,11 @@ public interface IEntityStorageKeyFactory
     /// <param name="clientIdentifier">The client identifier (typically IP address).</param>
     /// <returns>A formatted storage key for the IP rate limit state.</returns>
     string IpRateLimitKey(string clientIdentifier);
+
+    /// <summary>
+    /// Generates a storage key for the registration access token binding of a client (RFC 7592).
+    /// </summary>
+    /// <param name="clientId">The identifier of the registered client.</param>
+    /// <returns>A formatted storage key for the client's current registration-access-token jti.</returns>
+    string RegistrationAccessTokenKey(string clientId);
 }

--- a/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -161,11 +161,29 @@ internal class IdentityTokenService(
 		string? authorizationCode,
 		string? accessToken)
 	{
+		// OIDC Core §3.1.3.6 (at_hash) and §3.3.2.11 (c_hash): the hash is computed with the hash
+		// algorithm used in the id_token's signature 'alg'. Every JWS family encodes the digest size
+		// in the last three characters of the alg name, so the mapping is by size, not by family:
+		//   *256 (RS256/PS256/ES256/HS256) -> SHA-256
+		//   *384 (RS384/PS384/ES384/HS384) -> SHA-384
+		//   *512 (RS512/PS512/ES512/HS512) -> SHA-512   (ES512 signs with SHA-512)
+		// Previously only RS256 was handled, so an id_token signed with any other algorithm silently
+		// omitted c_hash/at_hash — breaking hybrid/implicit flows (c_hash is REQUIRED for
+		// response_type "code id_token", at_hash for "id_token token"). 'none' (unsigned) and any
+		// unrecognised alg have no associated hash, so no hash claim is produced.
 		Func<byte[], byte[]> hashFunc;
 		switch (identityToken.Header.Algorithm)
 		{
-			case SigningAlgorithms.RS256:
+			case SigningAlgorithms.RS256 or SigningAlgorithms.PS256 or SigningAlgorithms.ES256 or SigningAlgorithms.HS256:
 				hashFunc = SHA256.HashData;
+				break;
+
+			case SigningAlgorithms.RS384 or SigningAlgorithms.PS384 or SigningAlgorithms.ES384 or SigningAlgorithms.HS384:
+				hashFunc = SHA384.HashData;
+				break;
+
+			case SigningAlgorithms.RS512 or SigningAlgorithms.PS512 or SigningAlgorithms.ES512 or SigningAlgorithms.HS512:
+				hashFunc = SHA512.HashData;
 				break;
 
 			default:

--- a/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
@@ -87,7 +87,13 @@ public partial class LogoutTokenService(
             Header =
             {
                 Type = JwtTypes.LogoutToken,
-                Algorithm = SigningAlgorithms.RS256,
+                // Back-Channel Logout §2.4: the logout token is signed in the same manner as the
+                // ID Token, so the client's ID Token signing algorithm is the default; a host may
+                // diverge per client via the explicit LogoutTokenSignedResponseAlgorithm override.
+                // The previous hardcoded RS256 produced tokens an ES256/PS256-registered client
+                // would reject on signature-algorithm verification.
+                Algorithm = clientInfo.LogoutTokenSignedResponseAlgorithm
+                            ?? clientInfo.IdentityTokenSignedResponseAlgorithm,
             },
             Payload =
             {

--- a/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -85,7 +85,7 @@ public class RefreshTokenService(
 
 		var now = clock.GetUtcNow();
 		var issuedAt = refreshToken?.Payload.IssuedAt ?? now;
-		expiresAt = CalculateExpiresAt(issuedAt, clientInfo.RefreshToken);
+		expiresAt = CalculateExpiresAt(issuedAt, now, clientInfo.RefreshToken);
 		if (expiresAt < now)
 			return null;
 
@@ -112,18 +112,27 @@ public class RefreshTokenService(
 		return new EncodedJsonWebToken(newToken, await jwtFormatter.FormatAsync(newToken));
 	}
 
-	private static DateTimeOffset CalculateExpiresAt(DateTimeOffset issuedAt, RefreshTokenOptions options)
+	private static DateTimeOffset CalculateExpiresAt(
+		DateTimeOffset issuedAt,
+		DateTimeOffset now,
+		RefreshTokenOptions options)
 	{
-		var expiresAt = issuedAt + options.AbsoluteExpiresIn;
+		// The absolute ceiling is anchored to the original issuance (the first login), so the
+		// session can never outlive AbsoluteExpiresIn no matter how often it is refreshed.
+		var absoluteExpiresAt = issuedAt + options.AbsoluteExpiresIn;
 
-		if (options.SlidingExpiresIn.HasValue)
+		if (options.SlidingExpiresIn is { } slidingExpiresIn)
 		{
-			var sliding = issuedAt + options.SlidingExpiresIn.Value;
-			if (sliding < expiresAt)
-				return sliding;
+			// The sliding window is anchored to NOW (the moment of this refresh), so each use
+			// extends the lifetime — that is what makes it "sliding". Anchoring it to issuedAt (as
+			// before) produced a fixed value that never moved, making the window a hard limit. The
+			// extended expiry is still capped by the absolute ceiling.
+			var slidingExpiresAt = now + slidingExpiresIn;
+			if (slidingExpiresAt < absoluteExpiresAt)
+				return slidingExpiresAt;
 		}
 
-		return expiresAt;
+		return absoluteExpiresAt;
 	}
 
 	/// <summary>

--- a/Abblix.Oidc.Server/Features/UserInfo/SubjectTypeConverter.cs
+++ b/Abblix.Oidc.Server/Features/UserInfo/SubjectTypeConverter.cs
@@ -72,7 +72,16 @@ public class SubjectTypeConverter(PairwiseSubjectSettings? settings = null) : IS
                 $"(client '{clientInfo.ClientId}' has {nameof(clientInfo.SubjectType)}={clientInfo.SubjectType})");
         }
 
-        var sector = clientInfo.SectorIdentifier ?? clientInfo.ClientId;
+        // OIDC Core §8.1: when no sector_identifier_uri was provided, the sector identifier is the
+        // host component of the registered redirect_uri. The previous client_id fallback produced
+        // identifiers that silently change when the same application is re-registered under a new
+        // client id — defeating the stability pairwise identifiers are supposed to give a sector.
+        // Affects only statically configured clients: DCR-registered pairwise clients always get
+        // SectorIdentifier computed at registration time. client_id remains the last resort for
+        // clients with no redirect URIs at all (e.g. pure client_credentials configurations).
+        var sector = clientInfo.SectorIdentifier
+            ?? clientInfo.RedirectUris?.FirstOrDefault()?.Host
+            ?? clientInfo.ClientId;
         var data = Encoding.UTF8.GetBytes($"{HttpUtility.UrlEncode(sector)}&{HttpUtility.UrlEncode(subject)}");
         var algorithm = settings.HashAlgorithm;
         var salt = System.Convert.FromBase64String(settings.Salt);

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -205,6 +205,8 @@ internal static class LogEvents
             public const int IssuerSubjectMismatch = Base + 6;
             public const int MissingJti = Base + 7;
             public const int SigningAlgorithmNotAllowed = Base + 8;
+            public const int MissingExpiration = Base + 9;
+            public const int ReplayDetected = Base + 10;
         }
 
         /// <summary>

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -168,6 +168,7 @@ internal static class LogEvents
             private const int Base = 2085;
 
             public const int InvalidJwt = Base + 1;
+            public const int PublicClientRejected = Base + 2;
         }
 
         /// <summary>
@@ -180,6 +181,7 @@ internal static class LogEvents
 
             public const int TokenIssuedToAnotherClient = Base + 1;
             public const int TokenValidationFailed = Base + 2;
+            public const int PublicClientRejected = Base + 3;
         }
     }
 

--- a/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -384,6 +384,36 @@ public record ClientRegistrationRequest
     public bool? DpopBoundAccessTokens { get; init; }
 
     /// <summary>
+    /// The <c>require_pushed_authorization_requests</c> client metadata per RFC 9126 §6: when
+    /// <c>true</c>, pushed authorization requests are the only way this client may start an
+    /// authorization flow. Maps to
+    /// <see cref="Features.ClientInformation.ClientInfo.RequirePushedAuthorizationRequests"/>.
+    /// When omitted, treated as <c>false</c>.
+    /// </summary>
+    [JsonPropertyName(Parameters.RequirePushedAuthorizationRequests)]
+    public bool? RequirePushedAuthorizationRequests { get; init; }
+
+    /// <summary>
+    /// The <c>require_signed_request_object</c> client metadata per RFC 9101 §10.5: when
+    /// <c>true</c>, the client must deliver its authorization request parameters as a signed
+    /// request object. Maps to
+    /// <see cref="Features.ClientInformation.ClientInfo.RequireSignedRequestObject"/>.
+    /// When omitted, treated as <c>false</c>.
+    /// </summary>
+    [JsonPropertyName(Parameters.RequireSignedRequestObject)]
+    public bool? RequireSignedRequestObject { get; init; }
+
+    /// <summary>
+    /// The <c>tls_client_certificate_bound_access_tokens</c> client metadata per RFC 8705 §3.4:
+    /// when <c>true</c>, access tokens issued to this client are certificate-bound whenever the
+    /// token request arrives over mutual TLS, independently of the authentication method. Maps to
+    /// <see cref="Features.ClientInformation.ClientInfo.TlsClientCertificateBoundAccessTokens"/>.
+    /// When omitted, treated as <c>false</c>.
+    /// </summary>
+    [JsonPropertyName(Parameters.TlsClientCertificateBoundAccessTokens)]
+    public bool? TlsClientCertificateBoundAccessTokens { get; init; }
+
+    /// <summary>
     /// The <c>authorization_details_types</c> client metadata per RFC 9396 §5.1: the per-client
     /// allowlist of authorization-detail <c>type</c> values this client may use in RAR requests.
     /// Maps to <see cref="Features.ClientInformation.ClientInfo.AuthorizationDetailsTypes"/>.
@@ -700,6 +730,19 @@ public record ClientRegistrationRequest
         /// <summary>The <c>dpop_bound_access_tokens</c> registration parameter (RFC 9449 §5.2) requiring
         /// DPoP-bound access tokens for this client.</summary>
         public const string DpopBoundAccessTokens = "dpop_bound_access_tokens";
+
+        /// <summary>The <c>require_pushed_authorization_requests</c> registration parameter (RFC 9126 §6)
+        /// making PAR the only way this client may start an authorization flow.</summary>
+        public const string RequirePushedAuthorizationRequests = "require_pushed_authorization_requests";
+
+        /// <summary>The <c>require_signed_request_object</c> registration parameter (RFC 9101 §10.5)
+        /// committing this client to signed request objects.</summary>
+        public const string RequireSignedRequestObject = "require_signed_request_object";
+
+        /// <summary>The <c>tls_client_certificate_bound_access_tokens</c> registration parameter
+        /// (RFC 8705 §3.4) requesting certificate-bound access tokens independently of the
+        /// authentication method.</summary>
+        public const string TlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens";
 
         /// <summary>The <c>authorization_details_types</c> registration parameter (RFC 9396 §5.1):
         /// per-client allowlist of authorization-detail <c>type</c> values this client may use in

--- a/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -405,6 +405,18 @@ public record ClientRegistrationRequest
     public string[]? TokenExchangeSubjectTokenTypes { get; init; }
 
     /// <summary>
+    /// Non-standard extension: the per-client allowlist of RFC 8693 <c>audience</c> values this
+    /// client may request when exchanging a token. RFC 8693 does not standardise a registration
+    /// parameter for this, so the property is exposed under the non-standard
+    /// <c>token_exchange_audiences</c> name. Maps to
+    /// <see cref="Features.ClientInformation.ClientInfo.TokenExchangeAllowedAudiences"/>.
+    /// Default-deny: <c>null</c> or empty means the client may not request any <c>audience</c>;
+    /// a non-empty array is the allowlist of accepted values.
+    /// </summary>
+    [JsonPropertyName(Parameters.TokenExchangeAudiences)]
+    public string[]? TokenExchangeAudiences { get; init; }
+
+    /// <summary>
     /// The <c>backchannel_logout_uri</c> (OIDC Back-Channel Logout 1.0): an absolute URL at the client
     /// that the OP calls server-to-server with a logout token to terminate the user's session at the client.
     /// </summary>
@@ -698,6 +710,11 @@ public record ClientRegistrationRequest
         /// (non-standard extension; RFC 8693 does not standardise it): per-client allowlist of
         /// <c>subject_token_type</c> URIs this client may submit to the Token Exchange grant.</summary>
         public const string TokenExchangeSubjectTokenTypes = "token_exchange_subject_token_types";
+
+        /// <summary>The <c>token_exchange_audiences</c> registration parameter
+        /// (non-standard extension; RFC 8693 does not standardise it): default-deny per-client
+        /// allowlist of <c>audience</c> values this client may request when exchanging a token.</summary>
+        public const string TokenExchangeAudiences = "token_exchange_audiences";
 
         /// <summary>The <c>backchannel_logout_uri</c> registration parameter pointing to the client's
         /// back-channel logout endpoint.</summary>

--- a/Abblix.Oidc.Server/Model/ClientRegistrationResponse.cs
+++ b/Abblix.Oidc.Server/Model/ClientRegistrationResponse.cs
@@ -245,6 +245,14 @@ public record ClientRegistrationResponse
     [JsonPropertyName(Parameters.TokenExchangeSubjectTokenTypes)]
     public string[]? TokenExchangeSubjectTokenTypes { get; init; }
 
+    /// <summary>
+    /// Non-standard extension: default-deny per-client allowlist of RFC 8693 <c>audience</c> values
+    /// this client may request when exchanging a token. Echoes
+    /// <see cref="Features.ClientInformation.ClientInfo.TokenExchangeAllowedAudiences"/>.
+    /// </summary>
+    [JsonPropertyName(Parameters.TokenExchangeAudiences)]
+    public string[]? TokenExchangeAudiences { get; init; }
+
     private static class Parameters
     {
         public const string ClientId = "client_id";
@@ -277,5 +285,6 @@ public record ClientRegistrationResponse
         public const string DpopBoundAccessTokens = "dpop_bound_access_tokens";
         public const string AuthorizationDetailsTypes = "authorization_details_types";
         public const string TokenExchangeSubjectTokenTypes = "token_exchange_subject_token_types";
+        public const string TokenExchangeAudiences = "token_exchange_audiences";
     }
 }

--- a/Abblix.Oidc.Server/Model/ClientRegistrationResponse.cs
+++ b/Abblix.Oidc.Server/Model/ClientRegistrationResponse.cs
@@ -130,6 +130,20 @@ public record ClientRegistrationResponse
     public Uri[]? RedirectUris { get; init; }
 
     /// <summary>
+    /// The registered grant types, including server-assigned defaults. Per RFC 7591 §2/§3.2.1.
+    /// </summary>
+    [JsonPropertyName(ClientRegistrationRequest.Parameters.GrantTypes)]
+    public string[]? GrantTypes { get; init; }
+
+    /// <summary>
+    /// The registered response type combinations (each entry space-separated), including
+    /// server-assigned defaults. Per RFC 7591 §2/§3.2.1.
+    /// </summary>
+    [JsonPropertyName(ClientRegistrationRequest.Parameters.ResponseTypes)]
+    [JsonConverter(typeof(ArrayConverter<string[], SpaceSeparatedValuesConverter>))]
+    public string[][]? ResponseTypes { get; init; }
+
+    /// <summary>
     /// The human-readable name of the client. Optional client metadata. Per RFC 7591 §2.
     /// </summary>
     [JsonPropertyName(Parameters.ClientName)]
@@ -227,6 +241,27 @@ public record ClientRegistrationResponse
     /// </summary>
     [JsonPropertyName(Parameters.DpopBoundAccessTokens)]
     public bool? DpopBoundAccessTokens { get; init; }
+
+    /// <summary>
+    /// Whether PAR is the only way this client may start an authorization flow per RFC 9126 §6.
+    /// Echoes <c>ClientInfo.RequirePushedAuthorizationRequests</c>.
+    /// </summary>
+    [JsonPropertyName(ClientRegistrationRequest.Parameters.RequirePushedAuthorizationRequests)]
+    public bool? RequirePushedAuthorizationRequests { get; init; }
+
+    /// <summary>
+    /// Whether this client must deliver authorization parameters as a signed request object per
+    /// RFC 9101 §10.5. Echoes <c>ClientInfo.RequireSignedRequestObject</c>.
+    /// </summary>
+    [JsonPropertyName(ClientRegistrationRequest.Parameters.RequireSignedRequestObject)]
+    public bool? RequireSignedRequestObject { get; init; }
+
+    /// <summary>
+    /// Whether access tokens are certificate-bound whenever the token request arrives over mutual
+    /// TLS per RFC 8705 §3.4. Echoes <c>ClientInfo.TlsClientCertificateBoundAccessTokens</c>.
+    /// </summary>
+    [JsonPropertyName(ClientRegistrationRequest.Parameters.TlsClientCertificateBoundAccessTokens)]
+    public bool? TlsClientCertificateBoundAccessTokens { get; init; }
 
     /// <summary>
     /// The per-client allowlist of authorization-detail <c>type</c> values this client may

--- a/Abblix.Oidc.Server/Model/ReadClientSuccessfulResponse.cs
+++ b/Abblix.Oidc.Server/Model/ReadClientSuccessfulResponse.cs
@@ -245,6 +245,15 @@ public record ReadClientSuccessfulResponse
     public string[]? TokenExchangeSubjectTokenTypes { get; init; }
 
     /// <summary>
+    /// Non-standard extension: default-deny per-client allowlist of RFC 8693 <c>audience</c> values
+    /// this client may request when exchanging a token. Echoes
+    /// <see cref="Features.ClientInformation.ClientInfo.TokenExchangeAllowedAudiences"/>.
+    /// </summary>
+    [JsonPropertyOrder(27)]
+    [JsonPropertyName(Parameters.TokenExchangeAudiences)]
+    public string[]? TokenExchangeAudiences { get; init; }
+
+    /// <summary>
     /// Contains constants for parameter names per RFC 7591/7592 and OpenID Connect specifications.
     /// </summary>
     private static class Parameters
@@ -276,5 +285,6 @@ public record ReadClientSuccessfulResponse
         public const string DpopBoundAccessTokens = "dpop_bound_access_tokens";
         public const string AuthorizationDetailsTypes = "authorization_details_types";
         public const string TokenExchangeSubjectTokenTypes = "token_exchange_subject_token_types";
+        public const string TokenExchangeAudiences = "token_exchange_audiences";
     }
 }

--- a/Abblix.Oidc.Server/Model/ReadClientSuccessfulResponse.cs
+++ b/Abblix.Oidc.Server/Model/ReadClientSuccessfulResponse.cs
@@ -22,6 +22,7 @@
 
 using System.Text.Json.Serialization;
 using Abblix.Oidc.Server.DeclarativeValidation;
+using Abblix.Utils.Json;
 
 namespace Abblix.Oidc.Server.Model;
 
@@ -254,6 +255,57 @@ public record ReadClientSuccessfulResponse
     public string[]? TokenExchangeAudiences { get; init; }
 
     /// <summary>
+    /// The registered grant types, including server-assigned defaults. Per RFC 7591 §2 / RFC 7592 §3.
+    /// </summary>
+    [JsonPropertyOrder(28)]
+    [JsonPropertyName(Parameters.GrantTypes)]
+    public string[]? GrantTypes { get; init; }
+
+    /// <summary>
+    /// The registered response type combinations (each entry space-separated), including
+    /// server-assigned defaults. Per RFC 7591 §2 / RFC 7592 §3.
+    /// </summary>
+    [JsonPropertyOrder(29)]
+    [JsonPropertyName(Parameters.ResponseTypes)]
+    [JsonConverter(typeof(ArrayConverter<string[], SpaceSeparatedValuesConverter>))]
+    public string[][]? ResponseTypes { get; init; }
+
+    /// <summary>
+    /// The registered scope values, serialized as a space-separated string.
+    /// Per RFC 7591 §2 / RFC 7592 §3.
+    /// </summary>
+    [JsonPropertyOrder(30)]
+    [JsonPropertyName(Parameters.Scope)]
+    [JsonConverter(typeof(SpaceSeparatedValuesConverter))]
+    public string[]? Scope { get; init; }
+
+    /// <summary>
+    /// Whether PAR is the only way this client may start an authorization flow per RFC 9126 §6.
+    /// Echoes <see cref="Features.ClientInformation.ClientInfo.RequirePushedAuthorizationRequests"/>.
+    /// </summary>
+    [JsonPropertyOrder(31)]
+    [JsonPropertyName(Parameters.RequirePushedAuthorizationRequests)]
+    public bool? RequirePushedAuthorizationRequests { get; init; }
+
+    /// <summary>
+    /// Whether this client must deliver authorization parameters as a signed request object per
+    /// RFC 9101 §10.5. Echoes
+    /// <see cref="Features.ClientInformation.ClientInfo.RequireSignedRequestObject"/>.
+    /// </summary>
+    [JsonPropertyOrder(32)]
+    [JsonPropertyName(Parameters.RequireSignedRequestObject)]
+    public bool? RequireSignedRequestObject { get; init; }
+
+    /// <summary>
+    /// Whether access tokens are certificate-bound whenever the token request arrives over mutual
+    /// TLS per RFC 8705 §3.4. Echoes
+    /// <see cref="Features.ClientInformation.ClientInfo.TlsClientCertificateBoundAccessTokens"/>.
+    /// </summary>
+    [JsonPropertyOrder(33)]
+    [JsonPropertyName(Parameters.TlsClientCertificateBoundAccessTokens)]
+    public bool? TlsClientCertificateBoundAccessTokens { get; init; }
+
+    /// <summary>
     /// Contains constants for parameter names per RFC 7591/7592 and OpenID Connect specifications.
     /// </summary>
     private static class Parameters
@@ -286,5 +338,11 @@ public record ReadClientSuccessfulResponse
         public const string AuthorizationDetailsTypes = "authorization_details_types";
         public const string TokenExchangeSubjectTokenTypes = "token_exchange_subject_token_types";
         public const string TokenExchangeAudiences = "token_exchange_audiences";
+        public const string GrantTypes = "grant_types";
+        public const string ResponseTypes = "response_types";
+        public const string Scope = "scope";
+        public const string RequirePushedAuthorizationRequests = "require_pushed_authorization_requests";
+        public const string RequireSignedRequestObject = "require_signed_request_object";
+        public const string TlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens";
     }
 }

--- a/Abblix.Utils.UnitTests/SingleOrArrayConverterTests.cs
+++ b/Abblix.Utils.UnitTests/SingleOrArrayConverterTests.cs
@@ -22,6 +22,7 @@
 
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Abblix.Utils.Json;
 
 namespace Abblix.Utils.UnitTests;
@@ -29,6 +30,42 @@ namespace Abblix.Utils.UnitTests;
 public class SingleOrArrayConverterTests
 {
     private readonly SingleOrArrayConverter<string> _converter = new();
+
+    /// <summary>
+    /// A DTO whose single-or-array value is a property inside an object, with another property
+    /// after it. This is the real-world shape (e.g. a "resource" array in a JWT request object) that
+    /// exposed the over-read bug: the top-level-array tests below cannot, because at end of stream
+    /// the stray read past EndArray simply returns false.
+    /// </summary>
+    private sealed class Dto
+    {
+        [JsonPropertyName("values")]
+        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
+        public string[]? Values { get; set; }
+
+        [JsonPropertyName("other")]
+        public string? Other { get; set; }
+    }
+
+    [Theory]
+    // Array value followed by another property — the read past EndArray would land on the next
+    // property name and throw before the fix.
+    [InlineData("{\"values\":[\"a\",\"b\"],\"other\":\"x\"}", new[] { "a", "b" }, "x")]
+    // Array value as the last property — the read past EndArray would land on the object's EndObject.
+    [InlineData("{\"other\":\"x\",\"values\":[\"a\",\"b\"]}", new[] { "a", "b" }, "x")]
+    // Single scalar form inside an object still works.
+    [InlineData("{\"values\":\"a\",\"other\":\"x\"}", new[] { "a" }, "x")]
+    // Single-element array inside an object.
+    [InlineData("{\"values\":[\"a\"],\"other\":\"x\"}", new[] { "a" }, "x")]
+    public void Read_ArrayInsideObject_DeserializesWithoutOverReading(
+        string json, string[] expectedValues, string expectedOther)
+    {
+        var dto = JsonSerializer.Deserialize<Dto>(json);
+
+        Assert.NotNull(dto);
+        Assert.Equal(expectedValues, dto.Values);
+        Assert.Equal(expectedOther, dto.Other);
+    }
 
     [Theory]
     [InlineData("\"singleString\"", new[] { "singleString" })]

--- a/Abblix.Utils/Json/SingleOrArrayConverter.cs
+++ b/Abblix.Utils/Json/SingleOrArrayConverter.cs
@@ -73,8 +73,13 @@ public class SingleOrArrayConverter<T> : JsonConverter<T[]>
         {
             switch (reader.TokenType)
             {
+                // Return on EndArray rather than break: a bare break exits only the switch, so the
+                // enclosing while would then read the token AFTER the array. When the array is a
+                // property value inside an object that next token is EndObject (or the next property
+                // name), which the default case rejects — corrupting deserialization of any
+                // single-or-array value that appears as an array (e.g. a multi-valued "resource").
                 case JsonTokenType.EndArray:
-                    break;
+                    return values.ToArray();
 
                 case JsonTokenType.String:
                     values.Add(ReadFrom(ref reader, elementType, converter, options));


### PR DESCRIPTION
Fixes from the June 2026 security and conformance review of the library: every finding is addressed with a regression test, grouped one commit per finding (or per theme where changes share files).

## Security hardening

- Client assertion replay protection: a JWT assertion now requires an expiration claim, and its identifier is consumed atomically, closing the race between concurrent presentations of the same assertion (RFC 7523 §3).
- Registration access tokens are bound to the client record through a server-side store, expire, and are rotated on every management update (RFC 7592 §5).
- Authorization codes are redeemed atomically: get-and-remove in one storage operation, so two concurrent redemptions can no longer both succeed; reuse revokes the issued grant.
- JWE decryption applies the RFC 7516 §11.5 random-CEK mitigation, removing the padding-oracle distinguisher while keeping RSA1_5 available for legacy clients.
- Token exchange validates the requested audience against a default-deny per-client allow list (RFC 8693).
- The token endpoint accepts POST only (RFC 6749 §3.2), and introspection/revocation reject public clients (RFC 7662/7009).

## Conformance

- ID token hash claims are computed for every supported signing algorithm, not only the RSA default (OIDC Core §3.1.3.6/§3.3.2.11).
- Sector identifier documents are validated in the spec-defined direction (OIDC Registration §5), restoring shared-document support and closing a pairwise-sector takeover gap.
- Introspection reports token activity as a JSON boolean (RFC 7662 §2.2).
- Registration, read and update responses echo the full registered metadata, including grant types, response types and scope with server-applied defaults (RFC 7591 §3.2.1 / RFC 7592 §3).
- Client authentication failures return 401 with a Basic challenge (RFC 6749 §5.2); unauthenticated protected-resource requests get a bare challenge (RFC 6750 §3.1).
- Missing grant parameters produce invalid_request instead of HTTP 500; wrong-client codes produce invalid_grant; authorization-endpoint error codes and fragment-encoding of errors follow RFC 6749 §4.1.2.1/§4.2.2.1 and OAuth 2.0 Multiple Response Types §5.
- Back-channel logout tokens follow the client's registered ID token signing algorithm with an optional per-client override (Back-Channel Logout §2.4).
- Discovery advertises only what the server can actually do: symmetric response-signing algorithms are excluded (client secrets are stored hashed, so the signing key cannot be derived) and the unregistered SHA-512 PKCE method is no longer announced (IANA registry verified 2026-06-11); dynamic registration accepts exactly the advertised set.
- A request to initiate user registration (prompt value "create") redirects to a configurable registration UI instead of degrading to a plain login.
- Device authorization responses include the complete verification URI variant (RFC 8628 §3.2).
- Smaller OIDC Core gaps: nonce required in every hybrid combination, pairwise sector falls back to the redirect URI host, request objects are cross-checked against the outer parameters and their audience is validated, fragment responses report the access token lifetime.

## FAPI-grade per-client enforcement

New client metadata, registrable via dynamic registration: require pushed authorization requests (RFC 9126 §6), require signed request objects (RFC 9101 §10.5), and certificate-bound access tokens independent of the authentication method (RFC 8705 §3.4); plus an opt-in strict request-object mode (RFC 9101 §5). These are the granular building blocks for the per-client FAPI 2.0 profile tracked in #150.

## Compatibility notes

- Pairwise subject identifiers of statically configured clients without an explicit sector identifier change after upgrade (the sector is now derived from the redirect URI host per OIDC Core §8.1).
- Grant handler constructors no longer take the parameter validator dependency; the public validator types remain.
