### PR TITLE
feat(mvc): render model-validation failures as OAuth errors

### DIFF
--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/ModelValidationErrorResponseTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/ModelValidationErrorResponseTests.cs
@@ -1,0 +1,59 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end guard for the OAuth-shaped rendering of model-layer validation failures on the OIDC
+/// endpoints. A value that breaks a declarative <c>[AllowedValues]</c> constraint (here <c>prompt</c>) is
+/// rejected by <c>[ApiController]</c> model validation before the handler runs. The response must be the
+/// OAuth error envelope <c>{ "error": "invalid_request", ... }</c> served as <c>application/json</c>, not
+/// the framework-default <c>ValidationProblemDetails</c> (<c>application/problem+json</c>) that omits the
+/// <c>error</c> code OAuth/OIDC clients read. Without the <c>[ReturnsOidcInvalidRequest]</c> attribute on the
+/// controller this test fails: the problem+json body carries no <c>error</c> key and the wrong media type.
+/// </summary>
+public class ModelValidationErrorResponseTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task Authorize_WithInvalidPromptValue_ReturnsOAuthInvalidRequestJson()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var (_, challenge) = GeneratePkcePair();
+        var authorizeUri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+
+            // Not one of the spec-fixed prompt values, so the generated model's [AllowedValues] rejects it
+            // at the model-binding layer, before redirect_uri is validated — hence a direct response, not a
+            // redirect with an error.
+            [AuthorizationRequest.Parameters.Prompt] = "bogus",
+        });
+
+        var response = await client.GetAsync(authorizeUri, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        // The decisive check: OAuth JSON, not the [ApiController] default ValidationProblemDetails, whose
+        // media type is application/problem+json and whose body carries no OAuth error code.
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var body = JsonNode.Parse(raw)!.AsObject();
+        Assert.Equal(ErrorCodes.InvalidRequest, body["error"]!.GetValue<string>());
+        Assert.False(string.IsNullOrWhiteSpace(body["error_description"]?.GetValue<string>()));
+    }
+}

--- a/Abblix.Oidc.Server.Mvc.UnitTests/Filters/ReturnsOidcInvalidRequestTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/Filters/ReturnsOidcInvalidRequestTests.cs
@@ -1,0 +1,109 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Reflection;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.Mvc.Controllers;
+using Abblix.Oidc.Server.Mvc.Filters;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+
+namespace Abblix.Oidc.Server.Mvc.UnitTests.Filters;
+
+/// <summary>
+/// Covers the OAuth invalid_request rendering of a failed model-validation pass, the ordering that lets it
+/// pre-empt the <c>[ApiController]</c> automatic 400, and the requirement that every OIDC controller carries
+/// the attribute (placement is what scopes the behaviour to this library's endpoints).
+/// </summary>
+public class ReturnsOidcInvalidRequestTests
+{
+    [Fact]
+    public void OnActionExecuting_InvalidModelState_ShortCircuitsWithOAuthError()
+    {
+        var context = BuildContext(modelStateValid: false);
+
+        new ReturnsOidcInvalidRequestAttribute().OnActionExecuting(context);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(context.Result);
+        var body = Assert.IsType<ErrorResponse>(badRequest.Value);
+        Assert.Equal(ErrorCodes.InvalidRequest, body.Error);
+        Assert.Contains("bogus", body.ErrorDescription);
+    }
+
+    [Fact]
+    public void OnActionExecuting_ValidModelState_DoesNotShortCircuit()
+    {
+        var context = BuildContext(modelStateValid: true);
+
+        new ReturnsOidcInvalidRequestAttribute().OnActionExecuting(context);
+
+        Assert.Null(context.Result);
+    }
+
+    [Fact]
+    public void Order_SortsBeforeApiControllerModelStateValidation()
+    {
+        // The framework's ModelStateInvalidFilter (the [ApiController] auto-400) runs at -2000; this filter
+        // must sort before it to pre-empt the automatic ProblemDetails response.
+        Assert.True(new ReturnsOidcInvalidRequestAttribute().Order < -2000);
+    }
+
+    [Fact]
+    public void Attribute_IsAppliedToEveryOidcController()
+    {
+        // Placement is the scoping mechanism, so a new controller without the attribute would silently fall
+        // back to ProblemDetails. Guard every controller in the adapter assembly against that omission.
+        var controllers = typeof(TokenController).Assembly.GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type) && !type.IsAbstract)
+            .ToArray();
+
+        Assert.NotEmpty(controllers);
+        foreach (var controller in controllers)
+            Assert.True(
+                controller.GetCustomAttribute<ReturnsOidcInvalidRequestAttribute>(inherit: true) is not null,
+                $"{controller.Name} is missing [ReturnsOidcInvalidRequest]");
+    }
+
+    private static ActionExecutingContext BuildContext(bool modelStateValid)
+    {
+        var modelState = new ModelStateDictionary();
+        if (!modelStateValid)
+            modelState.AddModelError("response_mode", "The value 'bogus' is invalid");
+
+        var actionContext = new ActionContext(
+            new DefaultHttpContext(),
+            new RouteData(),
+            new ControllerActionDescriptor(),
+            modelState);
+
+        return new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            controller: new object());
+    }
+}

--- a/Abblix.Oidc.Server.Mvc.UnitTests/ModelValidationErrorTests.cs
+++ b/Abblix.Oidc.Server.Mvc.UnitTests/ModelValidationErrorTests.cs
@@ -1,0 +1,70 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Mvc.ActionResults;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Abblix.Oidc.Server.Mvc.UnitTests;
+
+/// <summary>
+/// Covers the framework-neutral mapping of validation messages onto the OAuth <c>invalid_request</c>
+/// error. The scoping and short-circuit behaviour is covered by
+/// <see cref="Filters.ReturnsOidcInvalidRequestTests"/>.
+/// </summary>
+public class ModelValidationErrorTests
+{
+    [Fact]
+    public void InvalidRequest_FromMessages_JoinsAndSetsInvalidRequestCode()
+    {
+        var error = ModelValidationError.InvalidRequest(["first problem", "second problem"]);
+
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+        Assert.Equal("first problem second problem", error.ErrorDescription);
+    }
+
+    [Fact]
+    public void InvalidRequest_FromBlankOrNoMessages_FallsBackToGenericDescription()
+    {
+        string[][] blankCases = [[], [""], ["   "], ["", "   "]];
+
+        foreach (var messages in blankCases)
+        {
+            var error = ModelValidationError.InvalidRequest(messages);
+
+            Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+            Assert.False(string.IsNullOrWhiteSpace(error.ErrorDescription));
+        }
+    }
+
+    [Fact]
+    public void InvalidRequest_FromModelState_AggregatesErrorMessages()
+    {
+        var modelState = new ModelStateDictionary();
+        modelState.AddModelError("response_mode", "The value 'bogus' is invalid");
+
+        var error = ModelValidationError.InvalidRequest(modelState);
+
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+        Assert.Contains("bogus", error.ErrorDescription);
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/ActionResults/ModelValidationError.cs
+++ b/Abblix.Oidc.Server.Mvc/ActionResults/ModelValidationError.cs
@@ -1,0 +1,74 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.ComponentModel.DataAnnotations;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Abblix.Oidc.Server.Mvc.ActionResults;
+
+/// <summary>
+/// Maps a model-layer validation failure onto the OAuth <c>invalid_request</c> error. The few checks the
+/// declarative validation attributes enforce at binding time (an out-of-range <c>prompt</c>,
+/// <c>response_mode</c>, <c>display</c>, ...) thereby surface in the same
+/// <c>{ "error": "invalid_request", "error_description": ... }</c> envelope as every other rejection on
+/// these endpoints, rather than as the <c>[ApiController]</c> default
+/// <see cref="Microsoft.AspNetCore.Mvc.ValidationProblemDetails"/> 400 that OAuth/OIDC clients do not
+/// understand. The result is rendered through <see cref="ActionResultExtensions.Format(OidcError, int, string)"/>,
+/// the single place that turns an <see cref="OidcError"/> into an HTTP response.
+/// </summary>
+internal static class ModelValidationError
+{
+	private const string FallbackDescription =
+		"The request is missing a required parameter, includes an invalid parameter value, " +
+		"includes a parameter more than once, or is otherwise malformed";
+
+	/// <summary>
+	/// Builds an <see cref="OidcError"/> carrying the <see cref="ErrorCodes.InvalidRequest"/> code from a flat
+	/// sequence of validation messages. The input is a plain message sequence on purpose, so a different
+	/// transport adapter can feed it the output of
+	/// <see cref="Validator.TryValidateObject(object, ValidationContext, ICollection{ValidationResult}, bool)"/>
+	/// and share one source of truth for "a malformed request becomes invalid_request".
+	/// </summary>
+	/// <param name="messages">The human-readable validation messages collected for the rejected request.</param>
+	/// <returns>An <see cref="OidcError"/> describing the failure in OAuth terms.</returns>
+	public static OidcError InvalidRequest(IEnumerable<string> messages)
+	{
+		var description = string.Join(' ', messages.Where(message => !string.IsNullOrWhiteSpace(message)));
+
+		// error_description is optional per RFC 6749 §5.2, so an empty join means the caller had no concrete
+		// message and the generic fallback stands in for it.
+		return new OidcError(
+			ErrorCodes.InvalidRequest,
+			description.Length > 0 ? description : FallbackDescription);
+	}
+
+	/// <summary>
+	/// Aggregates the messages held in <paramref name="modelState"/> after a failed <c>[ApiController]</c>
+	/// model-binding pass and maps them through <see cref="InvalidRequest(IEnumerable{string})"/>.
+	/// </summary>
+	/// <param name="modelState">The model state populated by MVC when binding or validation failed.</param>
+	/// <returns>An <see cref="OidcError"/> describing the failure in OAuth terms.</returns>
+	public static OidcError InvalidRequest(ModelStateDictionary modelState)
+		=> InvalidRequest(modelState.SelectMany(entry => entry.Value!.Errors.Select(error => error.ErrorMessage)));
+}

--- a/Abblix.Oidc.Server.Mvc/Controllers/AuthenticationController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/AuthenticationController.cs
@@ -54,6 +54,7 @@ namespace Abblix.Oidc.Server.Mvc.Controllers;
 /// of user sessions for OIDC compliance.
 /// </remarks>
 [ApiController]
+[ReturnsOidcInvalidRequest]
 [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [SkipStatusCodePages]
 [RequireHttps]

--- a/Abblix.Oidc.Server.Mvc/Controllers/ClientManagementController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/ClientManagementController.cs
@@ -45,6 +45,7 @@ namespace Abblix.Oidc.Server.Mvc.Controllers;
 /// For detailed protocol specifications, refer to <see href="https://openid.net/specs/openid-connect-registration-1_0.html"/>.
 /// </remarks>
 [ApiController]
+[ReturnsOidcInvalidRequest]
 [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [SkipStatusCodePages]
 [RequireHttps]

--- a/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
@@ -50,6 +50,7 @@ namespace Abblix.Oidc.Server.Mvc.Controllers;
 /// <see href="https://openid.net/specs/openid-connect-discovery-1_0.html"/>.
 /// </remarks>
 [ApiController]
+[ReturnsOidcInvalidRequest]
 [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [SkipStatusCodePages]
 [EnableCors(OidcConstants.CorsPolicyName)]

--- a/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
@@ -43,6 +43,7 @@ namespace Abblix.Oidc.Server.Mvc.Controllers;
 /// Serves as the primary interface between clients and the authorization server for managing tokens' lifecycle.
 /// </summary>
 [ApiController]
+[ReturnsOidcInvalidRequest]
 [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [SkipStatusCodePages]
 [RequireHttps]

--- a/Abblix.Oidc.Server.Mvc/Filters/ReturnsOidcInvalidRequestAttribute.cs
+++ b/Abblix.Oidc.Server.Mvc/Filters/ReturnsOidcInvalidRequestAttribute.cs
@@ -1,0 +1,69 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Mvc.ActionResults;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Abblix.Oidc.Server.Mvc.Filters;
+
+/// <summary>
+/// Renders a failed model-validation pass as the OAuth <c>invalid_request</c> error instead of the
+/// <c>[ApiController]</c> default <see cref="Microsoft.AspNetCore.Mvc.ValidationProblemDetails"/> 400, so the
+/// rejection joins the JSON error envelope every other rejection on these endpoints uses. Applied to this
+/// library's own OIDC controllers, which confines the OAuth shape to them and leaves a host's own controllers
+/// on their default validation response.
+/// </summary>
+/// <remarks>
+/// Implemented as a controller attribute rather than a globally registered filter so it is pure controller
+/// metadata: it mutates no global option (notably not
+/// <c>ApiBehaviorOptions.InvalidModelStateResponseFactory</c>), so a host cannot clobber it by reconfiguring
+/// its own MVC pipeline and the OIDC endpoints cannot affect the host's. It is ordered just before the
+/// framework's <c>ModelStateInvalidFilter</c> (Order -2000) and short-circuits with the OAuth result, so the
+/// automatic ProblemDetails response is never produced here.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, Inherited = true)]
+internal sealed class ReturnsOidcInvalidRequestAttribute : Attribute, IActionFilter, IOrderedFilter
+{
+	// The framework's ModelStateInvalidFilter (the [ApiController] auto-400) runs at Order -2000; one step
+	// earlier lets this filter emit the OAuth error before that automatic ProblemDetails is set.
+	private const int OrderBeforeApiControllerValidation = -2001;
+
+	/// <inheritdoc />
+	public int Order => OrderBeforeApiControllerValidation;
+
+	/// <inheritdoc />
+	public void OnActionExecuting(ActionExecutingContext context)
+	{
+		if (context.ModelState.IsValid)
+			return;
+
+		context.Result = ModelValidationError
+			.InvalidRequest(context.ModelState)
+			.Format(StatusCodes.Status400BadRequest);
+	}
+
+	/// <inheritdoc />
+	public void OnActionExecuted(ActionExecutedContext context)
+	{
+	}
+}


### PR DESCRIPTION
## Problem

The OIDC controllers carry `[ApiController]`, so an invalid `ModelState` short-circuits with the framework-default `ValidationProblemDetails` 400 (`application/problem+json`) before the controller runs. On the OAuth/OIDC endpoints that is the wrong shape: a request with e.g. `prompt=bogus` or `response_mode=bogus` returned ProblemDetails, while every other rejection on the same endpoints returns the `{ "error": "invalid_request", ... }` JSON envelope OAuth/OIDC clients expect.

## Change

`ReturnsOidcInvalidRequestAttribute` is applied to each OIDC controller. It is an action filter ordered just before the framework's `ModelStateInvalidFilter` (Order `-2000`), so on an invalid `ModelState` it short-circuits first with the OAuth `invalid_request` result — mapped by the new `ModelValidationError` helper and rendered through the existing `OidcError` → `ActionResultExtensions.Format` path. The automatic ProblemDetails is therefore never produced for these endpoints.

As a controller attribute it touches **no global option**: it does not set `ApiBehaviorOptions.InvalidModelStateResponseFactory`, so a host stays free to shape its own controllers' validation responses and cannot clobber, or be clobbered by, the OIDC endpoints. Placement is the scoping mechanism; a reflection test guards that every controller in the adapter assembly carries the attribute.

## Behaviour change

Model-validation rejections on the OIDC endpoints now return OAuth-error JSON (`application/json`) instead of `ValidationProblemDetails` (`application/problem+json`) — a move toward OAuth/OIDC compliance, but a visible change worth a release-notes entry. On `/authorize` the failure is a direct 400 (not a redirect), matching today's delivery; only the body shape changes.

No public signatures change; the mapper and the attribute are `internal`.