### PR TITLE
refactor(endpoints): make niche endpoints opt-in; add OidcEndpoints.Base

### DIFF
--- a/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -28,10 +28,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllersWithViews();
 
-// Opt into device authorization BEFORE AddOidcServices: the device-code grant handler must be registered
-// before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or it lands beside the composite
-// and the token endpoint resolves the wrong single IAuthorizationGrantHandler.
+// Opt into the endpoints that are no longer on by default (EnabledEndpoints now defaults to OidcEndpoints.Base).
+// The grant-bearing features — device authorization and CIBA — MUST be registered BEFORE AddOidcServices: their
+// grant handlers must exist before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or a
+// handler lands beside the composite and the token endpoint resolves the wrong single IAuthorizationGrantHandler.
+// The endpoint-only opt-ins have no ordering constraint but are grouped here so the host mirrors the previous
+// every-endpoint-on server the E2E suite expects.
 builder.Services.AddDeviceAuthorization();
+builder.Services.AddBackChannelAuthentication();
+builder.Services.AddRevocation();
+builder.Services.AddIntrospection();
+builder.Services.AddCheckSession();
+builder.Services.AddDynamicClientRegistration();
 
 builder.Services.AddOidcServices(options =>
 {

--- a/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Program.cs
@@ -27,10 +27,18 @@ await LoadEmbeddedTestLicenseAsync();
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Opt into device authorization BEFORE AddOidcMinimalApi: the device-code grant handler must be registered
-// before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or it lands beside the composite
-// and the token endpoint resolves the wrong single IAuthorizationGrantHandler.
+// Opt into the endpoints that are no longer on by default (EnabledEndpoints now defaults to OidcEndpoints.Base).
+// The grant-bearing features — device authorization and CIBA — MUST be registered BEFORE AddOidcMinimalApi: their
+// grant handlers must exist before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or a
+// handler lands beside the composite and the token endpoint resolves the wrong single IAuthorizationGrantHandler.
+// The endpoint-only opt-ins have no ordering constraint but are grouped here so the host mirrors the previous
+// every-endpoint-on server the E2E suite expects.
 builder.Services.AddDeviceAuthorization();
+builder.Services.AddBackChannelAuthentication();
+builder.Services.AddRevocation();
+builder.Services.AddIntrospection();
+builder.Services.AddCheckSession();
+builder.Services.AddDynamicClientRegistration();
 
 // AddOidcMinimalApi = AddOidcCore + the Minimal API transport, the exact counterpart of the MVC
 // host's AddOidcServices (= AddOidcCore + AddOidcMvc). The options block below is identical to the

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
@@ -87,6 +87,36 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
     }
 
     [Fact]
+    public async Task Base_configuration_advertises_and_maps_no_opt_in_endpoint()
+    {
+        // The full host advertises introspection; capture the path it maps so we can prove the Base host 404s it.
+        var introspectPath = new Uri((await ClientOf(factory).FetchDiscoveryAsync())
+            [ConfigurationResponse.Parameters.IntrospectionEndpoint]!.GetValue<string>()).AbsolutePath;
+
+        // Reset the host to the default OidcEndpoints.Base set — the state of a server that opts into nothing.
+        using var baseHost = factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
+                    new PostConfigureOptions<OidcOptions>(
+                        Options.DefaultName,
+                        options => options.EnabledEndpoints = OidcEndpoints.Base))));
+        var client = ClientOf(baseHost);
+        var baseDiscovery = await client.FetchDiscoveryAsync();
+
+        // A base endpoint stays advertised; every opt-in endpoint drops out of the discovery document.
+        Assert.NotNull(baseDiscovery[ConfigurationResponse.Parameters.TokenEndpoint]);
+        Assert.Null(baseDiscovery[ConfigurationResponse.Parameters.IntrospectionEndpoint]);
+        Assert.Null(baseDiscovery[ConfigurationResponse.Parameters.RevocationEndpoint]);
+        Assert.Null(baseDiscovery[ConfigurationResponse.Parameters.RegistrationEndpoint]);
+
+        // And the path the full host mapped for introspection is unmapped here.
+        var response = await client.PostAsync(introspectPath, new FormUrlEncodedContent(
+            new Dictionary<string, string> { [IntrospectionRequest.Parameters.Token] = "irrelevant" }),
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Model_validation_failure_is_rendered_as_oauth_invalid_request_json()
     {
         var client = ClientOf(factory);

--- a/Abblix.Oidc.Server.UnitTests/Common/Configuration/OidcEndpointsTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/Configuration/OidcEndpointsTests.cs
@@ -1,0 +1,74 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Pins the composition of <see cref="OidcEndpoints.Base"/> — the default value of
+/// <see cref="OidcOptions.EnabledEndpoints"/>. Base is the always-on interactive OIDC core plus PAR and
+/// RP-initiated logout; the six niche or security-sensitive endpoints are opt-in and must stay out of it. Locking
+/// the set here makes any accidental widening (e.g. adding a new flag to Base) a failing test rather than a
+/// silent change to what a default server exposes.
+/// </summary>
+public class OidcEndpointsTests
+{
+    private const OidcEndpoints OptInEndpoints =
+        OidcEndpoints.CheckSession | OidcEndpoints.Revocation | OidcEndpoints.Introspection |
+        OidcEndpoints.RegisterClient | OidcEndpoints.BackChannelAuthentication | OidcEndpoints.DeviceAuthorization;
+
+    [Fact]
+    public void Base_is_the_always_on_core_set()
+    {
+        var expected = OidcEndpoints.Configuration | OidcEndpoints.Keys | OidcEndpoints.Authorize |
+                       OidcEndpoints.Token | OidcEndpoints.UserInfo | OidcEndpoints.EndSession |
+                       OidcEndpoints.PushedAuthorizationRequest;
+
+        Assert.Equal(expected, OidcEndpoints.Base);
+    }
+
+    [Fact]
+    public void Base_equals_All_minus_the_six_opt_in_endpoints()
+    {
+        Assert.Equal(OidcEndpoints.All & ~OptInEndpoints, OidcEndpoints.Base);
+    }
+
+    [Theory]
+    [InlineData(OidcEndpoints.CheckSession)]
+    [InlineData(OidcEndpoints.Revocation)]
+    [InlineData(OidcEndpoints.Introspection)]
+    [InlineData(OidcEndpoints.RegisterClient)]
+    [InlineData(OidcEndpoints.BackChannelAuthentication)]
+    [InlineData(OidcEndpoints.DeviceAuthorization)]
+    public void Base_excludes_every_opt_in_endpoint(OidcEndpoints optIn)
+    {
+        Assert.False(OidcEndpoints.Base.HasFlag(optIn));
+    }
+
+    [Fact]
+    public void EnabledEndpoints_defaults_to_Base()
+    {
+        Assert.Equal(OidcEndpoints.Base, new OidcOptions().EnabledEndpoints);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
@@ -8,6 +8,7 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
+using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.UserInfo;
 using Abblix.Oidc.Server.Mvc;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -68,16 +69,15 @@ public class PushModeValidatorRegistrationTests
         services.AddSingleton(Mock.Of<IUserCredentialsAuthenticator>());
         services.AddSingleton(Mock.Of<IUserInfoProvider>());
 
+        // CIBA is opt-in (off in the OidcEndpoints.Base set) and carries a grant handler, so it must be
+        // registered before AddOidcServices composes the grant handlers. This test inspects its validator pipeline.
+        services.AddBackChannelAuthentication();
+
         services.AddOidcServices(options =>
         {
             options.Issuer = TestConstants.DefaultIssuer.OriginalString;
             options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)];
             options.RequireInitialAccessToken = false;
-
-            // This test inspects the CIBA validator pipeline, not the device flow, so drop the default-enabled
-            // device endpoint rather than configure it (the startup validator requires DeviceAuthorization settings
-            // whenever that endpoint is enabled).
-            options.EnabledEndpoints &= ~OidcEndpoints.DeviceAuthorization;
         });
 
         return services.BuildServiceProvider();

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -28,6 +28,7 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
+using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ImplicitFlow;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Abblix.Oidc.Server.Features.UserInfo;
@@ -67,6 +68,10 @@ public class RegisterClientHandlerIntegrationTests
         services.AddSingleton(Mock.Of<IUserCredentialsAuthenticator>());
         services.AddSingleton(Mock.Of<IUserInfoProvider>());
 
+        // Dynamic client registration is opt-in (off in the OidcEndpoints.Base set); register it explicitly
+        // so this suite's DCR handlers and validators resolve.
+        services.AddDynamicClientRegistration();
+
         services.AddOidcServices(opts =>
         {
             opts.Issuer = TestConstants.DefaultIssuer.OriginalString;
@@ -84,10 +89,6 @@ public class RegisterClientHandlerIntegrationTests
             // sees the request — masking the very behaviour we want to verify.
             opts.RequireInitialAccessToken = false;
 
-            // This suite exercises dynamic client registration, not the device flow, so drop the
-            // default-enabled device endpoint rather than configure it (the startup validator requires
-            // DeviceAuthorization settings whenever that endpoint is enabled).
-            opts.EnabledEndpoints &= ~OidcEndpoints.DeviceAuthorization;
         });
         configure?.Invoke(services);
         return services.BuildServiceProvider();

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/EndpointOptInTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/EndpointOptInTests.cs
@@ -93,15 +93,20 @@ public class EndpointOptInTests
     }
 
     [Fact]
-    public void Opting_into_one_endpoint_leaves_the_others_off()
+    public void Each_opt_in_enables_exactly_its_own_endpoint_on_top_of_Base()
     {
-        var enabled = EnabledAfter(s => s.AddRevocation());
-
-        Assert.True(enabled.HasFlag(OidcEndpoints.Revocation));
-        Assert.False(enabled.HasFlag(OidcEndpoints.Introspection));
-        Assert.False(enabled.HasFlag(OidcEndpoints.RegisterClient));
-        Assert.False(enabled.HasFlag(OidcEndpoints.CheckSession));
-        Assert.False(enabled.HasFlag(OidcEndpoints.BackChannelAuthentication));
+        // The result is Base plus exactly the one opted-in flag — no other opt-in endpoint leaks on.
+        // (Device is covered separately because its options validator requires configured settings.)
+        Assert.Equal(OidcEndpoints.Base | OidcEndpoints.CheckSession,
+            EnabledAfter(s => s.AddCheckSession()));
+        Assert.Equal(OidcEndpoints.Base | OidcEndpoints.Revocation,
+            EnabledAfter(s => s.AddRevocation()));
+        Assert.Equal(OidcEndpoints.Base | OidcEndpoints.Introspection,
+            EnabledAfter(s => s.AddIntrospection()));
+        Assert.Equal(OidcEndpoints.Base | OidcEndpoints.RegisterClient,
+            EnabledAfter(s => s.AddDynamicClientRegistration()));
+        Assert.Equal(OidcEndpoints.Base | OidcEndpoints.BackChannelAuthentication,
+            EnabledAfter(s => s.AddBackChannelAuthentication()));
     }
 
     [Fact]
@@ -126,5 +131,31 @@ public class EndpointOptInTests
         var services = new ServiceCollection();
         services.AddDynamicClientRegistration();
         Assert.Contains(services, d => d.ServiceType == typeof(IRegisterClientHandler));
+    }
+
+    [Fact]
+    public void All_opt_ins_together_enable_the_full_All_set()
+    {
+        // Base plus all six opt-in endpoints reconstitutes the complete OidcEndpoints.All set — the previous
+        // every-endpoint-on default is exactly Base with every AddX() applied.
+        var enabled = EnabledAfter(s =>
+        {
+            s.AddCheckSession();
+            s.AddRevocation();
+            s.AddIntrospection();
+            s.AddDynamicClientRegistration();
+            s.AddBackChannelAuthentication();
+            s.AddDeviceAuthorization();
+            s.Configure<OidcOptions>(o => o.DeviceAuthorization = new DeviceAuthorizationOptions
+            {
+                VerificationUri = new Uri("https://provider.example/device"),
+                CodeLifetime = TimeSpan.FromMinutes(15),
+                PollingInterval = TimeSpan.FromSeconds(5),
+                DeviceCodeLength = 32,
+                UserCodeLength = 8,
+            });
+        });
+
+        Assert.Equal(OidcEndpoints.All, enabled);
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/EndpointOptInTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/EndpointOptInTests.cs
@@ -1,0 +1,130 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Introspection.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Revocation.Interfaces;
+using Abblix.Oidc.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.DependencyInjection;
+
+/// <summary>
+/// Verifies the opt-in contract of the six niche endpoints. Each is off in the default
+/// <see cref="OidcEndpoints.Base"/> set and turned on solely by its dedicated <c>AddX()</c> feature method,
+/// which re-enables the corresponding flag via a <c>PostConfigure&lt;OidcOptions&gt;</c> and registers the endpoint
+/// services. These tests lock that the flag flip happens, that it is isolated (one opt-in does not enable another),
+/// and that the endpoint handler descriptors are registered.
+/// </summary>
+public class EndpointOptInTests
+{
+    private static OidcEndpoints EnabledAfter(Action<IServiceCollection> optIn)
+    {
+        var services = new ServiceCollection();
+        optIn(services);
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<OidcOptions>>().Value.EnabledEndpoints;
+    }
+
+    [Fact]
+    public void AddCheckSession_enables_the_CheckSession_flag()
+        => Assert.True(EnabledAfter(s => s.AddCheckSession()).HasFlag(OidcEndpoints.CheckSession));
+
+    [Fact]
+    public void AddRevocation_enables_the_Revocation_flag()
+        => Assert.True(EnabledAfter(s => s.AddRevocation()).HasFlag(OidcEndpoints.Revocation));
+
+    [Fact]
+    public void AddIntrospection_enables_the_Introspection_flag()
+        => Assert.True(EnabledAfter(s => s.AddIntrospection()).HasFlag(OidcEndpoints.Introspection));
+
+    [Fact]
+    public void AddDynamicClientRegistration_enables_the_RegisterClient_flag()
+        => Assert.True(EnabledAfter(s => s.AddDynamicClientRegistration()).HasFlag(OidcEndpoints.RegisterClient));
+
+    [Fact]
+    public void AddBackChannelAuthentication_enables_the_BackChannelAuthentication_flag()
+        => Assert.True(EnabledAfter(s => s.AddBackChannelAuthentication())
+            .HasFlag(OidcEndpoints.BackChannelAuthentication));
+
+    [Fact]
+    public void AddDeviceAuthorization_enables_the_DeviceAuthorization_flag()
+    {
+        var enabled = EnabledAfter(s =>
+        {
+            s.AddDeviceAuthorization();
+
+            // The device options validator (registered by the opt-in) rejects an enabled device endpoint with no
+            // settings, so supply a valid configuration; this test asserts the flag flip, not the validator.
+            s.Configure<OidcOptions>(o => o.DeviceAuthorization = new DeviceAuthorizationOptions
+            {
+                VerificationUri = new Uri("https://provider.example/device"),
+                CodeLifetime = TimeSpan.FromMinutes(15),
+                PollingInterval = TimeSpan.FromSeconds(5),
+                DeviceCodeLength = 32,
+                UserCodeLength = 8,
+            });
+        });
+
+        Assert.True(enabled.HasFlag(OidcEndpoints.DeviceAuthorization));
+    }
+
+    [Fact]
+    public void Opting_into_one_endpoint_leaves_the_others_off()
+    {
+        var enabled = EnabledAfter(s => s.AddRevocation());
+
+        Assert.True(enabled.HasFlag(OidcEndpoints.Revocation));
+        Assert.False(enabled.HasFlag(OidcEndpoints.Introspection));
+        Assert.False(enabled.HasFlag(OidcEndpoints.RegisterClient));
+        Assert.False(enabled.HasFlag(OidcEndpoints.CheckSession));
+        Assert.False(enabled.HasFlag(OidcEndpoints.BackChannelAuthentication));
+    }
+
+    [Fact]
+    public void AddRevocation_registers_the_revocation_handler()
+    {
+        var services = new ServiceCollection();
+        services.AddRevocation();
+        Assert.Contains(services, d => d.ServiceType == typeof(IRevocationHandler));
+    }
+
+    [Fact]
+    public void AddIntrospection_registers_the_introspection_handler()
+    {
+        var services = new ServiceCollection();
+        services.AddIntrospection();
+        Assert.Contains(services, d => d.ServiceType == typeof(IIntrospectionHandler));
+    }
+
+    [Fact]
+    public void AddDynamicClientRegistration_registers_the_register_client_handler()
+    {
+        var services = new ServiceCollection();
+        services.AddDynamicClientRegistration();
+        Assert.Contains(services, d => d.ServiceType == typeof(IRegisterClientHandler));
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/OidcEndpoints.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcEndpoints.cs
@@ -36,6 +36,19 @@ public enum OidcEndpoints
 	      Introspection | RegisterClient | PushedAuthorizationRequest | BackChannelAuthentication | DeviceAuthorization,
 
 	/// <summary>
+	/// The base set of endpoints for a typical OpenID Provider: discovery, JWKS, the interactive authorization and
+	/// token core, PAR, UserInfo and RP-initiated logout. This is the default value of
+	/// <see cref="OidcOptions.EnabledEndpoints"/> — the minimal functional provider on top of which the opt-in
+	/// endpoints are added. It deliberately excludes the six opt-in endpoints — <see cref="CheckSession"/>,
+	/// <see cref="Revocation"/>, <see cref="Introspection"/>, <see cref="RegisterClient"/>,
+	/// <see cref="BackChannelAuthentication"/> and <see cref="DeviceAuthorization"/> — each of which is niche,
+	/// security-sensitive or carries its own grant, and is enabled by a dedicated <c>AddX()</c> call that both
+	/// registers the feature and re-enables its flag. A server that opts into none of them exposes exactly this set
+	/// and neither advertises nor validates an endpoint it was never asked to serve.
+	/// </summary>
+	Base = Configuration | Keys | Authorize | Token | UserInfo | EndSession | PushedAuthorizationRequest,
+
+	/// <summary>
 	/// The configuration endpoint, used by clients to dynamically discover information about the OpenID Provider.
 	/// This typically provides metadata such as available endpoints, supported grant types, and signing algorithms.
 	/// </summary>

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -103,13 +103,15 @@ public record OidcOptions
 	/// <summary>
 	/// Specifies which OIDC endpoints are enabled on the server. This property allows for fine-grained control over
 	/// the available functionality, enabling or disabling specific endpoints based on the server's role, security
-	/// considerations, or operational requirements. By default every endpoint is enabled except
-	/// <see cref="OidcEndpoints.DeviceAuthorization"/>: device authorization is opt-in via
-	/// <c>AddDeviceAuthorization()</c>, which registers the feature and re-enables the flag. The device
-	/// endpoint requires a configured <see cref="DeviceAuthorization"/>, so leaving it off by default keeps
-	/// a server that never opts in from advertising — or validating — an endpoint it cannot serve.
+	/// considerations, or operational requirements. Defaults to <see cref="OidcEndpoints.Base"/> — the core
+	/// interactive OIDC set plus PAR and RP-initiated logout. The six niche or security-sensitive endpoints
+	/// (CheckSession, Revocation, Introspection, dynamic client registration, CIBA and device authorization) are
+	/// off by default and each turned on by its dedicated <c>AddX()</c> opt-in, which registers the feature and
+	/// re-enables the corresponding flag. Leaving them off keeps a server that never opts in from advertising — or
+	/// validating — an endpoint it was never asked to serve. Set this explicitly to <see cref="OidcEndpoints.All"/>
+	/// to restore the previous every-endpoint-on behaviour.
 	/// </summary>
-	public OidcEndpoints EnabledEndpoints { get; set; } = OidcEndpoints.All & ~OidcEndpoints.DeviceAuthorization;
+	public OidcEndpoints EnabledEndpoints { get; set; } = OidcEndpoints.Base;
 
 	/// <summary>
 	/// The collection of JSON Web Keys (JWK) used for signing tokens issued by the OIDC server.

--- a/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Configuration/ConfigurationHandler.cs
@@ -49,10 +49,16 @@ public sealed class ConfigurationHandler(
 	IAuthorizationMetadataProvider authorizationMetadata,
 	IScopesAndClaimsProvider scopesAndClaims,
 	IJwtAlgorithmsProvider jwtAlgorithms,
-	IAuthenticationCompletionHandler cibaCompletionHandler,
+	IEnumerable<IAuthenticationCompletionHandler> cibaCompletionHandlers,
 	IAcrMetadataProvider acrMetadata,
 	Features.RichAuthorizationRequests.IAuthorizationDetailsMetadataProvider authorizationDetailsMetadata) : IConfigurationHandler
 {
+	// CIBA metadata is advertised only when the CIBA feature is opted in (AddBackChannelAuthentication), the sole
+	// registrar of IAuthenticationCompletionHandler. Resolved from a collection so discovery — an always-on
+	// endpoint — still constructs under ValidateOnBuild when CIBA is off; null means CIBA is disabled, so the
+	// backchannel discovery fields are omitted rather than advertised.
+	private readonly IAuthenticationCompletionHandler? cibaCompletionHandler = cibaCompletionHandlers.FirstOrDefault();
+
 	/// <summary>
 	/// Handles the configuration request by building discovery metadata.
 	/// </summary>
@@ -119,9 +125,11 @@ public sealed class ConfigurationHandler(
 		UserInfoSigningAlgValuesSupported = jwtAlgorithms.SignedResponseAlgorithmsSupported,
 		DpopSigningAlgValuesSupported = jwtAlgorithms.DpopSigningAlgorithmsSupported,
 
-		BackChannelAuthenticationRequestSigningAlgValuesSupported = jwtAlgorithms.SigningAlgorithmsSupported,
-		BackChannelTokenDeliveryModesSupported = cibaCompletionHandler.TokenDeliveryModesSupported,
-		BackChannelUserCodeParameterSupported = options.Value.BackChannelAuthentication.UserCodeParameterSupported,
+		BackChannelAuthenticationRequestSigningAlgValuesSupported =
+			cibaCompletionHandler is null ? null : jwtAlgorithms.SigningAlgorithmsSupported,
+		BackChannelTokenDeliveryModesSupported = cibaCompletionHandler?.TokenDeliveryModesSupported,
+		BackChannelUserCodeParameterSupported =
+			cibaCompletionHandler is null ? null : options.Value.BackChannelAuthentication.UserCodeParameterSupported,
 
 		AcrValuesSupported = acrMetadata.AcrValuesSupported,
 

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -458,7 +458,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
-    public static IServiceCollection AddRevocationEndpoint(this IServiceCollection services)
+    internal static IServiceCollection AddRevocationEndpoint(this IServiceCollection services)
     {
         services.TryAddScoped<IRevocationHandler, RevocationHandler>();
         services.TryAddScoped<IRevocationRequestValidator, RevocationRequestValidator>();
@@ -473,7 +473,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
-    public static IServiceCollection AddIntrospectionEndpoint(this IServiceCollection services)
+    internal static IServiceCollection AddIntrospectionEndpoint(this IServiceCollection services)
     {
         services.TryAddScoped<IIntrospectionHandler, IntrospectionHandler>();
         services.TryAddScoped<IIntrospectionRequestValidator, IntrospectionRequestValidator>();
@@ -494,7 +494,7 @@ public static class ServiceCollectionExtensions
     /// </remarks>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure with check session endpoint support.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>, enabling further chaining of service registrations.</returns>
-    public static IServiceCollection AddCheckSessionEndpoint(this IServiceCollection services)
+    internal static IServiceCollection AddCheckSessionEndpoint(this IServiceCollection services)
     {
         services.TryAddScoped<ICheckSessionHandler, CheckSessionHandler>();
         return services;
@@ -534,7 +534,7 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     /// <param name="newClientOptionsFactory">A factory function to setup options for new client registrations.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
-    public static IServiceCollection AddDynamicClientEndpoints(
+    internal static IServiceCollection AddDynamicClientEndpoints(
         this IServiceCollection services,
         Func<IServiceProvider, NewClientOptions> newClientOptionsFactory)
     {
@@ -655,7 +655,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
-    public static IServiceCollection AddBackChannelAuthenticationEndpoint(this IServiceCollection services)
+    internal static IServiceCollection AddBackChannelAuthenticationEndpoint(this IServiceCollection services)
     {
         services.AddBackChannelAuthenticationContextValidators();
 

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -485,9 +485,18 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Configures services for handling back-channel authentication requests, enabling secure server-to-server
-    /// authentication flows and registers the CIBA grant handler.
+    /// Opts the server into Client-Initiated Backchannel Authentication (CIBA). This single call registers the
+    /// CIBA feature services, the CIBA grant handler, the backchannel endpoint services and re-enables the
+    /// <see cref="OidcEndpoints.BackChannelAuthentication"/> flag, which is off in the default
+    /// <see cref="OidcOptions.EnabledEndpoints"/>. A server that never calls this method exposes no backchannel
+    /// endpoint and runs no CIBA grant.
     /// </summary>
+    /// <remarks>
+    /// Call this <b>before</b> <c>AddOidcCore</c>/<c>AddOidcServices</c>: the CIBA grant handler must be
+    /// registered before <c>AddAuthorizationGrants()</c> composes the grant handlers at the end of
+    /// <c>AddOidcCore</c>, otherwise it is registered beside the composite and the token endpoint resolves the
+    /// wrong single <c>IAuthorizationGrantHandler</c>.
+    /// </remarks>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddBackChannelAuthentication(this IServiceCollection services)
@@ -543,6 +552,12 @@ public static class ServiceCollectionExtensions
         // Register CIBA grant handler (dual: IAuthorizationGrantHandler + IGrantTypeInformer).
         services.AddAuthorizationGrant<BackChannelAuthenticationGrantHandler>();
 
+        // Single opt-in: registering the feature also brings in the backchannel endpoint services and turns the
+        // endpoint on. EnabledEndpoints defaults to OidcEndpoints.Base (CIBA off), so a server that never calls this
+        // method neither registers the CIBA types nor advertises/validates the endpoint.
+        services.AddBackChannelAuthenticationEndpoint();
+        services.PostConfigure<OidcOptions>(options => options.EnabledEndpoints |= OidcEndpoints.BackChannelAuthentication);
+
         return services;
     }
 
@@ -580,6 +595,73 @@ public static class ServiceCollectionExtensions
         services.AddDeviceAuthorizationEndpoint();
         services.PostConfigure<OidcOptions>(options => options.EnabledEndpoints |= OidcEndpoints.DeviceAuthorization);
 
+        return services;
+    }
+
+    /// <summary>
+    /// Opts the server into the OpenID Connect Session Management check-session endpoint. This single call
+    /// registers the check-session handler and re-enables the <see cref="OidcEndpoints.CheckSession"/> flag,
+    /// which is off in the default <see cref="OidcOptions.EnabledEndpoints"/>. Many SPAs do not use the
+    /// session-management iframe, so it is opt-in: a server that never calls this method exposes no check-session
+    /// endpoint and does not advertise it in discovery.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
+    /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddCheckSession(this IServiceCollection services)
+    {
+        services.AddCheckSessionEndpoint();
+        services.PostConfigure<OidcOptions>(options => options.EnabledEndpoints |= OidcEndpoints.CheckSession);
+        return services;
+    }
+
+    /// <summary>
+    /// Opts the server into the OAuth 2.0 Token Revocation endpoint (RFC 7009). This single call registers the
+    /// revocation handler, validator and processor and re-enables the <see cref="OidcEndpoints.Revocation"/>
+    /// flag, which is off in the default <see cref="OidcOptions.EnabledEndpoints"/>. This governs only the public
+    /// <c>/revoke</c> endpoint; the internal token-revocation machinery that refresh-token rotation, logout and
+    /// initial-access-token invalidation depend on is always registered and is unaffected. A server that never
+    /// calls this method exposes no revocation endpoint and does not advertise it in discovery.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
+    /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddRevocation(this IServiceCollection services)
+    {
+        services.AddRevocationEndpoint();
+        services.PostConfigure<OidcOptions>(options => options.EnabledEndpoints |= OidcEndpoints.Revocation);
+        return services;
+    }
+
+    /// <summary>
+    /// Opts the server into the OAuth 2.0 Token Introspection endpoint (RFC 7662). This single call registers the
+    /// introspection handler, validator and processor and re-enables the <see cref="OidcEndpoints.Introspection"/>
+    /// flag, which is off in the default <see cref="OidcOptions.EnabledEndpoints"/>. Introspection is chiefly
+    /// needed by resource servers validating opaque tokens; a server issuing self-contained JWTs often does not
+    /// need it, so it is opt-in. A server that never calls this method exposes no introspection endpoint and does
+    /// not advertise it in discovery.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
+    /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddIntrospection(this IServiceCollection services)
+    {
+        services.AddIntrospectionEndpoint();
+        services.PostConfigure<OidcOptions>(options => options.EnabledEndpoints |= OidcEndpoints.Introspection);
+        return services;
+    }
+
+    /// <summary>
+    /// Opts the server into Dynamic Client Registration (RFC 7591 / RFC 7592). This single call registers the
+    /// registration, read, update and remove handlers and their validators, and re-enables the
+    /// <see cref="OidcEndpoints.RegisterClient"/> flag, which is off in the default
+    /// <see cref="OidcOptions.EnabledEndpoints"/>. Open registration widens the attack surface, so it is opt-in:
+    /// a server that never calls this method exposes no registration endpoint and does not advertise it in
+    /// discovery. New-client defaults are taken from <see cref="OidcOptions.NewClientOptions"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
+    /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddDynamicClientRegistration(this IServiceCollection services)
+    {
+        services.AddDynamicClientEndpoints(sp => sp.GetRequiredService<IOptions<OidcOptions>>().Value.NewClientOptions);
+        services.PostConfigure<OidcOptions>(options => options.EnabledEndpoints |= OidcEndpoints.RegisterClient);
         return services;
     }
 

--- a/Abblix.Oidc.Server/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/ServiceCollectionExtensions.cs
@@ -25,7 +25,6 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Endpoints;
 using Abblix.Oidc.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server;
 
@@ -116,33 +115,31 @@ public static class ServiceCollectionExtensions
 			.AddStorages()
 			.AddUserInfo()
 			.AddRequestObject()
-			.AddBackChannelAuthentication()
 			.AddDPoP()
 			.AddRichAuthorizationRequests();
 			// AddSecureHttpFetch() moved to AddOidcCore() to run before AddEndpoints()
 	}
 
 	/// <summary>
-	/// Configures the service collection with a comprehensive suite of endpoints necessary for handling various
-	/// OAuth 2.0 and OpenID Connect flows, including authorization, token issuance, revocation, introspection,
-	/// user information, session management and dynamic client registration.
+	/// Configures the service collection with the always-on OAuth 2.0 and OpenID Connect endpoints — the set
+	/// mounted unconditionally regardless of <see cref="OidcOptions.EnabledEndpoints"/>: discovery, authorization,
+	/// PAR, token, UserInfo and end session.
 	/// </summary>
 	/// <remarks>
 	/// By calling this method, the application integrates support for:
 	///
+	/// - The Configuration (discovery) Endpoint for publishing provider metadata.
 	/// - The Authorization Endpoint for initiating user authentication and consent.
 	/// - Pushed Authorization Request (PAR) Endpoint for pre-registering authorization requests.
 	/// - Token Endpoint for issuing tokens following successful authentication.
-	/// - Revocation Endpoint for token revocation by clients.
-	/// - Introspection Endpoint for token validation by resource servers.
 	/// - User Info Endpoint for accessing authenticated user information.
 	/// - End Session Endpoint for managing user logout processes.
-	/// - Back Channel Authentication Endpoint for supporting CIBA (Client Initiated Backchannel Authentication).
-	/// - Check Session Endpoint for session state management in browser clients.
-	/// - Dynamic Client Registration Endpoint for runtime registration of new clients.
 	///
-	/// This setup ensures the application is equipped to support a wide range of authentication, authorization
-	/// and session management scenarios in a secure and standards-compliant manner.
+	/// The niche or security-sensitive endpoints — Revocation, Introspection, CIBA, Check Session and Dynamic
+	/// Client Registration — are not wired here. Each is opt-in through its dedicated <c>AddX()</c> feature method
+	/// (<c>AddRevocation</c>, <c>AddIntrospection</c>, <c>AddBackChannelAuthentication</c>, <c>AddCheckSession</c>,
+	/// <c>AddDynamicClientRegistration</c>), which registers the endpoint services and re-enables its flag in
+	/// <see cref="OidcOptions.EnabledEndpoints"/> (defaulting to <see cref="OidcEndpoints.Base"/>).
 	/// </remarks>
 	/// <param name="services">The <see cref="IServiceCollection"/> to configure with necessary endpoints.</param>
 	/// <returns>The configured <see cref="IServiceCollection"/>, enabling further service registration chaining.</returns>
@@ -153,12 +150,7 @@ public static class ServiceCollectionExtensions
 			.AddAuthorizationEndpoint()
 			.AddPushedAuthorizationEndpoint()
 			.AddTokenEndpoint()
-			.AddRevocationEndpoint()
-			.AddIntrospectionEndpoint()
 			.AddUserInfoEndpoint()
-			.AddEndSessionEndpoint()
-			.AddBackChannelAuthenticationEndpoint()
-			.AddCheckSessionEndpoint()
-			.AddDynamicClientEndpoints(sp => sp.GetRequiredService<IOptions<OidcOptions>>().Value.NewClientOptions);
+			.AddEndSessionEndpoint();
 	}
 }


### PR DESCRIPTION
Changes the default `OidcOptions.EnabledEndpoints` from `All` to the new public `OidcEndpoints.Base` set — the minimal functional OpenID Provider: discovery, JWKS, authorization, token, UserInfo, PAR and end session.

The six niche or security-sensitive endpoints become opt-in, each enabled by a dedicated feature method that registers the endpoint services and re-enables its flag:

- `AddDeviceAuthorization` — device authorization ([RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628))
- `AddBackChannelAuthentication` — CIBA
- `AddCheckSession` — session-management check-session iframe
- `AddRevocation` — token revocation ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009))
- `AddIntrospection` — token introspection ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662))
- `AddDynamicClientRegistration` — dynamic client registration ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) / [RFC 7592](https://datatracker.ietf.org/doc/html/rfc7592))

The endpoint registration methods become `internal` — a feature method now owns each opt-in endpoint's registration.

Also decouples the always-on discovery handler from CIBA: `ConfigurationHandler` resolved `IAuthenticationCompletionHandler` directly, so a server with CIBA disabled could not construct its discovery handler under `ValidateOnBuild`. It now takes the handler as a collection and advertises the backchannel metadata (`backchannel_token_delivery_modes_supported`, `backchannel_authentication_request_signing_alg_values_supported`, `backchannel_user_code_parameter_supported`) only when CIBA is opted in.

**Breaking:** hosts relying on default-on dynamic client registration, CIBA, check session, revocation or introspection must call the corresponding `AddX()`. Set `EnabledEndpoints` to `OidcEndpoints.All` to restore the previous every-endpoint-on behaviour.
