### PR TITLE
fix(grants): fail loud when a grant handler is registered after AddOidcCore

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -72,6 +72,10 @@ public class RegisterClientHandlerIntegrationTests
         // so this suite's DCR handlers and validators resolve.
         services.AddDynamicClientRegistration();
 
+        // Apply per-test opt-ins (e.g. EnablePasswordGrant) BEFORE AddOidcServices: a grant handler must be
+        // registered before AddOidcCore composes the handlers, otherwise the ordering guard rejects it.
+        configure?.Invoke(services);
+
         services.AddOidcServices(opts =>
         {
             opts.Issuer = TestConstants.DefaultIssuer.OriginalString;
@@ -90,7 +94,7 @@ public class RegisterClientHandlerIntegrationTests
             opts.RequireInitialAccessToken = false;
 
         });
-        configure?.Invoke(services);
+
         return services.BuildServiceProvider();
     }
 

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/AddAuthorizationGrantTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/AddAuthorizationGrantTests.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -289,18 +290,19 @@ public class AddAuthorizationGrantTests
     }
 
     /// <summary>
-    /// When the host opts into ROPC via <c>EnablePasswordGrant()</c> on top of
-    /// <c>AddOidcServices</c>, <see cref="PasswordGrantHandler"/> appears in the
-    /// <see cref="IGrantTypeInformer"/> descriptor list — proving the opt-in surfaces in the
-    /// same registry discovery and the registration validator read.
+    /// When the host opts into ROPC via <c>EnablePasswordGrant()</c> BEFORE <c>AddOidcServices</c>,
+    /// <see cref="PasswordGrantHandler"/> appears in the <see cref="IGrantTypeInformer"/> descriptor list — proving
+    /// the opt-in surfaces in the same registry discovery and the registration validator read. The opt-in must
+    /// precede <c>AddOidcCore</c> so the handler is included in the composite the token endpoint dispatches on;
+    /// registering it after is rejected by the ordering guard (see below).
     /// </summary>
     [Fact]
     public void AddOidcServices_WithPasswordOptIn_IncludesPasswordGrantInInformer()
     {
         var services = new ServiceCollection();
         services
-            .AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString)
-            .EnablePasswordGrant();
+            .EnablePasswordGrant()
+            .AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString);
 
         var informerImpls = services
             .Where(d => d.ServiceType == typeof(IGrantTypeInformer))
@@ -308,5 +310,58 @@ public class AddAuthorizationGrantTests
             .ToList();
 
         Assert.Contains(typeof(PasswordGrantHandler), informerImpls);
+    }
+
+    /// <summary>
+    /// A grant handler registered AFTER the grant handlers were composed by <c>AddOidcCore</c> would land beside the
+    /// composite rather than inside it, so the token endpoint would silently not dispatch its grant type. The
+    /// ordering guard turns that latent misconfiguration into a loud startup error naming the offending handler and
+    /// pointing at the fix — call the opt-in before <c>AddOidcCore</c>.
+    /// </summary>
+    [Fact]
+    public void AddAuthorizationGrant_AfterOidcCore_ThrowsWithOrderingGuidance()
+    {
+        var services = new ServiceCollection();
+        services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddAuthorizationGrant<StubGrantHandler>());
+
+        Assert.Contains(nameof(StubGrantHandler), exception.Message);
+        Assert.Contains("AddOidcCore", exception.Message);
+    }
+
+    /// <summary>
+    /// The mirror of the guard: a grant handler registered BEFORE <c>AddOidcCore</c> — the correct order — is
+    /// accepted, and the subsequent composition does not throw. This is the path every opt-in feature method takes.
+    /// </summary>
+    [Fact]
+    public void AddAuthorizationGrant_BeforeOidcCore_IsAccepted()
+    {
+        var services = new ServiceCollection();
+        services.AddAuthorizationGrant<StubGrantHandler>();
+
+        var exception = Record.Exception(
+            () => services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString));
+
+        Assert.Null(exception);
+    }
+
+    /// <summary>
+    /// The guard fires through a real opt-in feature method, not only the low-level helper: calling
+    /// <c>EnablePasswordGrant()</c> after <c>AddOidcServices</c> — the exact misuse a host might commit — is rejected
+    /// with the grant handler named and the fix pointed at. This is the consumer-facing shape of the ordering
+    /// contract, and the regression that would return if the sentinel check were removed.
+    /// </summary>
+    [Fact]
+    public void EnablePasswordGrant_AfterOidcCore_IsRejectedByTheOrderingGuard()
+    {
+        var services = new ServiceCollection();
+        services.AddOidcServices(opts => opts.Issuer = TestConstants.DefaultIssuer.OriginalString);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => services.EnablePasswordGrant());
+
+        Assert.Contains(nameof(PasswordGrantHandler), exception.Message);
+        Assert.Contains("AddOidcCore", exception.Message);
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -284,7 +284,9 @@ public static class ServiceCollectionExtensions
     /// user credentials directly, which can increase the risk of credential exposure and related security issues.
     /// By isolating this method, we ensure that developers make a deliberate decision to enable this feature, being
     /// fully aware of its security implications. It's recommended to use more secure grant types like authorization
-    /// code or client credentials whenever possible.
+    /// code or client credentials whenever possible. Call this before <c>AddOidcCore</c>/<c>AddOidcServices</c>:
+    /// the password grant handler must be registered before the grant handlers are composed, otherwise the
+    /// registration is rejected at startup.
     /// </remarks>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the password grant handler to.</param>
     /// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained.</returns>
@@ -416,6 +418,21 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAuthorizationGrant<TImpl>(this IServiceCollection services)
         where TImpl : class, IAuthorizationGrantHandler
     {
+        // Fail loud when a grant handler is registered after AddOidcCore has composed the handlers. Compose registers
+        // CompositeAuthorizationGrantHandler as a concrete service and removes the individual
+        // IAuthorizationGrantHandler registrations, so its presence marks that composition already happened: a handler
+        // added now lands beside the composite rather than inside it, and the token endpoint would silently not
+        // dispatch its grant type. The opt-in that registers the handler must run before AddOidcCore.
+        if (services.Any(descriptor => descriptor.ServiceType == typeof(CompositeAuthorizationGrantHandler)))
+        {
+            throw new InvalidOperationException(
+                $"The authorization grant handler '{typeof(TImpl).Name}' is registered after the grant handlers were " +
+                "composed by AddOidcCore/AddOidcServices. Registered this late it lands beside the composite the token " +
+                "endpoint dispatches on rather than inside it, so its grant type would be silently unavailable. Call " +
+                "the opt-in that registers this handler (for example AddDeviceAuthorization, " +
+                "AddBackChannelAuthentication or EnablePasswordGrant) BEFORE AddOidcCore/AddOidcServices.");
+        }
+
         services.TryAddSingleton<TImpl>();
         services.TryAddEnumerableAlias<IAuthorizationGrantHandler, TImpl>();
         services.TryAddEnumerableAlias<IGrantTypeInformer, TImpl>();
@@ -731,7 +748,7 @@ public static class ServiceCollectionExtensions
             ServiceDescriptor.Singleton<IDeviceAuthorizationContextValidator, DeviceAuthorization.Validation.ScopeValidator>(),
             ServiceDescriptor.Singleton<IDeviceAuthorizationContextValidator, DeviceAuthorization.Validation.ResourceValidator>(),
             // RFC 9396 §3 authorization_details on device authorization requests.
-            ServiceDescriptor.Singleton<IDeviceAuthorizationContextValidator, DeviceAuthorization.Validation.DeviceAuthorizationDetailsValidator>(),
+            ServiceDescriptor.Singleton<IDeviceAuthorizationContextValidator, DeviceAuthorizationDetailsValidator>(),
         ]);
         return services.Compose<IDeviceAuthorizationContextValidator, DeviceAuthorizationValidatorComposite>();
     }


### PR DESCRIPTION
## Problem

`AddOidcCore` composes the registered `IAuthorizationGrantHandler` set into a single `CompositeAuthorizationGrantHandler` via an **eager snapshot** (`Compose<>` takes `.ToArray()` of the current registrations and removes the individual ones). A grant handler registered *after* that — an opt-in feature method (`AddDeviceAuthorization`, `AddBackChannelAuthentication`, `EnablePasswordGrant`) called after `AddOidcCore`/`AddOidcServices` — lands *beside* the composite rather than inside it. The token endpoint's singular resolve then picks the wrong handler, and the late grant type is silently not dispatched.

The ordering requirement was documented on the feature methods but nothing enforced it: a misordered call produced a working-looking server whose token endpoint quietly rejected a grant type it advertised.

## Fix (fail-loud)

`AddAuthorizationGrant<T>` now detects that composition already happened — `Compose` registers `CompositeAuthorizationGrantHandler` as a concrete service, so its presence marks that the handlers were composed — and throws a clear `InvalidOperationException` naming the offending handler and pointing at the fix (call the opt-in before `AddOidcCore`). This is additive: `Compose`, `AddAuthorizationGrant` registration and the token-endpoint dispatch are unchanged; only a guard is added.

## Surfaced latent bugs

The guard immediately caught **two** existing tests that relied on the ordering bug — both called `EnablePasswordGrant` *after* `AddOidcServices` and were green only because they asserted the `IGrantTypeInformer` registry (which `Compose` leaves intact for discovery), not actual token-endpoint dispatch. Both are corrected to opt in before `AddOidcCore`.

## Coverage

Three guard tests: a handler registered after the core throws with ordering guidance; a handler registered before the core is accepted; and the real consumer path (`EnablePasswordGrant` after `AddOidcServices`) is rejected with the handler named.
