### PR TITLE
ci: publish-dev-builds — cancel-in-progress: false (state-mutating publish)

### DIFF
--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -37,10 +37,11 @@ permissions:
   contents: read
 
 concurrency:
-  # Only the latest develop commit needs to land in the feed; cancel an
-  # in-progress run if a newer commit arrives.
+  # Publishing mutates the package feed — never cancel a run mid-push, or the
+  # feed is left with a partial package set; queue the newer commit's run
+  # instead (--skip-duplicate keeps the re-push idempotent).
   group: publish-dev-builds-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pack-and-publish:


### PR DESCRIPTION
## What

`publish-dev-builds.yml`: `concurrency.cancel-in-progress` flipped from `true` to `false`, comment updated to state the actual rationale.

## Why

This workflow publishes packages (`dotnet nuget push` to the GitHub feed), i.e. it mutates external state. Cancelling a run mid-push leaves the feed with a partial package set for that commit. Per the [GHA security checklist concurrency rule](https://github.com/Abblix/Docs/blob/master/wiki/github-actions-security-checklist.md#concurrency-and-integrity), the discriminator is idempotent-vs-state-mutating: publish/release/deploy workflows keep a stable group with `cancel-in-progress: false` (as `enhanced-release.yml` already does). Newer commits queue instead of killing the in-flight publish; `--skip-duplicate` keeps any re-push idempotent.

Found by the 2026-07-02 GHA audit across all Abblix repos (see the checklist findings log).

Checked: Concurrency (stable group + false). N/A: Inputs, Permissions, Pinning, Secrets (unchanged).
