### PR TITLE
ci(codeql): disable the push-to-develop auto-trigger (manual-only)

### DIFF
--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -12,12 +12,11 @@ GitHub-managed Default Setup remains `not-configured` (verify via `gh api repos/
 
 The custom workflow fires only on:
 
-- `push` to `develop` (default branch)
 - `workflow_dispatch` (manual)
 
-No `pull_request`, no `schedule`. `concurrency: cancel-in-progress: true` cancels stale runs when commits land in quick succession.
+No `push`, no `pull_request`, no `schedule`. The `push`-to-`develop` auto-trigger was **removed (2026-07)**: autobuild of the multi-target (net8/9/10) solution consistently exceeded the autobuild step's 5-minute cap and failed with `analyze` skipped — ~5 min burned per develop push for no result. Before re-enabling any trigger, first raise the autobuild step `timeout-minutes` (compile + analyze needs ~10-15m) or switch to `build-mode: none`. `concurrency: cancel-in-progress: true` still cancels stale manual runs.
 
-Expected billing footprint: ~5-15 minutes per push to `develop`, ~10-15 develops/month historically → **~50-225 min/month**, vs the unbounded ~180m/month under Default Setup.
+Billing footprint: **~0 min/month** while manual-only (was ~50-225 min/month on push; the unbounded ~180m/month of Default Setup is still avoided).
 
 ## Background
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,12 @@ name: CodeQL
 # weekly schedule or PR triggers via API; only a custom workflow gives
 # full control. See .github/codeql/README.md for the policy and the
 # May 2026 incident that led to the restrictions.
+#
+# The push-to-develop auto-trigger is disabled: autobuild of the
+# multi-target (net8/9/10) solution exceeded the 5-minute step cap and
+# burned ~5m on every develop push with no result. Run on demand via
+# workflow_dispatch (raise the autobuild timeout first — see README).
 on:
-  push:
-    branches: [develop]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
Disable the push-to-`develop` auto-trigger of the custom CodeQL workflow; keep `workflow_dispatch` (manual).

## Why
`autobuild` builds the full multi-target (net8/9/10) solution, which consistently hits the autobuild step's 5-minute cap and fails with `analyze` skipped — confirmed on two runs, both exactly 5:00. Every develop push burned ~5 min for no scan result.

## Coverage note
Default Setup is `not-configured`, so `develop` now has no automatic CodeQL. Manual runs (`workflow_dispatch`) remain, but they need the autobuild `timeout-minutes` raised (or `build-mode: none`) to actually complete — recorded in `.github/codeql/README.md`.

## Review evidence (GitHub Actions security checklist)
- `actionlint`: clean.
- Triggers narrowed (only `workflow_dispatch`), not widened.
- No `run:` scripts, no `${{ }}` in `run:`; permissions unchanged (`contents: read` + per-job `security-events: write` on analyze); all `uses:` remain SHA-pinned; `persist-credentials: false` intact.
