### PR TITLE
docs(codeql): correct the README to the actual scanning state

### DIFF
--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -1,6 +1,14 @@
 # CodeQL — Abblix policy (Oidc.Server)
 
-**Current state: ENABLED via custom workflow** at `.github/workflows/codeql.yml`.
+**Current state: no verifiable CodeQL results on `develop`.** The custom workflow at
+`.github/workflows/codeql.yml` is **manual-only** (its push-to-`develop` auto-trigger was removed — see
+Trigger policy). While it was enabled, `autobuild` of the multi-target (net8/9/10) solution timed out at
+the 5-minute step cap on every run, so every analysis it produced carried `rules=0` (nothing extracted). A
+GitHub **"Code Quality: Push on develop"** run (`dynamic/github-code-scanning/codeql`) still fires on each
+develop push and finishes green in ~3 min, but uploads no code-scanning analysis while Default Setup is
+`not-configured` — treat it as a green no-op, not coverage. To restore verifiable scanning, raise the
+custom workflow's autobuild `timeout-minutes` (compile + analyze needs ~10-15m) or switch it to
+`build-mode: none`, then re-add a trigger.
 
 GitHub-managed Default Setup remains `not-configured` (verify via `gh api repos/Abblix/Oidc.Server/code-scanning/default-setup --jq .state`). The custom workflow is used because Default Setup cannot disable the weekly schedule or PR-trigger via API — `state=configured` always pairs with hardcoded triggers that drove the May 2026 burn.
 
@@ -16,7 +24,7 @@ The custom workflow fires only on:
 
 No `push`, no `pull_request`, no `schedule`. The `push`-to-`develop` auto-trigger was **removed (2026-07)**: autobuild of the multi-target (net8/9/10) solution consistently exceeded the autobuild step's 5-minute cap and failed with `analyze` skipped — ~5 min burned per develop push for no result. Before re-enabling any trigger, first raise the autobuild step `timeout-minutes` (compile + analyze needs ~10-15m) or switch to `build-mode: none`. `concurrency: cancel-in-progress: true` still cancels stale manual runs.
 
-Billing footprint: **~0 min/month** while manual-only (was ~50-225 min/month on push; the unbounded ~180m/month of Default Setup is still avoided).
+Billing footprint of the custom workflow: **~0 min/month** while manual-only (was ~50-225 min/month on push). Note the Default Setup `"Code Quality: Push on develop"` run still fires ~3 min per develop push (a green no-op — see Current state), so per-push CodeQL cost is ~3 min, not zero.
 
 ## Background
 


### PR DESCRIPTION
## What
Correct `.github/codeql/README.md` to describe the actual CodeQL state on `develop`.

## Why
The README claimed "ENABLED via custom workflow" and implied coverage. Verified reality:
- The custom `codeql.yml` autobuild timed out at the 5-min step cap every run → analyses carried `rules=0` (no results). Now manual-only (auto-trigger removed in #197).
- A GitHub "Code Quality: Push on develop" run (`dynamic/github-code-scanning/codeql`) still fires ~3 min per push but uploads no analysis while Default Setup is `not-configured` — a green no-op.
- Net: `develop` has no verifiable CodeQL results. The README now says so and records how to restore them (raise autobuild timeout or `build-mode: none`).

Docs-only; no workflow or code change.
