### PR TITLE
fix(minimal-api): register the default IAuthSessionService like the MVC transport

### DIFF
--- a/Abblix.Oidc.Server.MinimalApi/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server.MinimalApi/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ using Abblix.DependencyInjection;
 using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.MinimalApi.Features.SessionManagement;
 using Abblix.Oidc.Server.MinimalApi.Formatters;
 using Abblix.Utils.Json;
@@ -82,6 +83,10 @@ public static class ServiceCollectionExtensions
         // The core resolves request details (base URL, scheme, client IP) through this contract; the adapter
         // supplies the ASP.NET Core HttpContext-backed implementation.
         services.TryAddSingleton<IRequestInfoProvider, HttpRequestInfoProvider>();
+
+        // The default authentication-session bridge over the host's cookie authentication scheme,
+        // mirroring the MVC transport. TryAdd lets a host supply its own session service instead.
+        services.TryAddScoped<IAuthSessionService, AuthenticationSchemeAdapter>();
 
         // Flattens a response DTO into name/value pairs for query/fragment/form_post delivery.
         services.TryAddSingleton<IParametersProvider, Abblix.Oidc.Server.Common.ParametersProvider>();

--- a/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -28,6 +28,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Abblix.Oidc.Server\Abblix.Oidc.Server.csproj" />
     <ProjectReference Include="..\Abblix.Oidc.Server.Mvc\Abblix.Oidc.Server.Mvc.csproj" />
+    <ProjectReference Include="..\Abblix.Oidc.Server.MinimalApi\Abblix.Oidc.Server.MinimalApi.csproj" />
+    <!-- Direct reference: the transports reference this project with PrivateAssets="all",
+         so AuthenticationSchemeAdapter does not flow transitively -->
+    <ProjectReference Include="..\Abblix.Oidc.Server.AspNetCore\Abblix.Oidc.Server.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
@@ -24,12 +24,17 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.DPoP;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.Tokens.Validation;
+using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Oidc.Server.Features.UserInfo;
+using Abblix.Oidc.Server.MinimalApi;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -136,5 +141,63 @@ public class ServiceCollectionOverrideTests
         var resolved = provider.GetRequiredService<IAuthServiceKeysProvider>();
 
         Assert.Same(stub, resolved);
+    }
+
+    [Fact]
+    public void AddOidcMinimalApi_RegistersDefaultAuthSessionService()
+    {
+        // The MVC transport registers AuthenticationSchemeAdapter as the default IAuthSessionService;
+        // the Minimal API transport must mirror it, or a host without its own implementation fails
+        // at request time on every endpoint that touches the authentication session.
+        var services = new ServiceCollection();
+
+        services.AddOidcMinimalApi();
+
+        var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IAuthSessionService));
+        Assert.Equal(typeof(AuthenticationSchemeAdapter), descriptor.ImplementationType);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddOidcMinimalApi_HostPreregisteredAuthSessionService_Wins()
+    {
+        var services = new ServiceCollection();
+        var stub = new Mock<IAuthSessionService>().Object;
+        services.AddSingleton(stub);
+
+        services.AddOidcMinimalApi();
+
+        var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IAuthSessionService));
+        Assert.Same(stub, descriptor.ImplementationInstance);
+    }
+
+    [Fact]
+    public void AddOidcMinimalApi_EveryEndpointOptedIn_GraphValidates()
+    {
+        // The full-surface host: every optional endpoint enabled, and the only contract the host
+        // itself implements is IUserInfoProvider. ValidateOnBuild constructs every registered
+        // descriptor, so a missing default registration anywhere in the adapter or the core
+        // fails here instead of surfacing as an HTTP 500 at request time.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRouting();
+        services.AddMemoryCache();
+        services.AddDistributedMemoryCache();
+        services.AddAuthentication().AddCookie();
+        services.AddSingleton(new Mock<IUserInfoProvider>().Object);
+
+        // Grant-bearing opt-ins precede AddOidcMinimalApi so AddOidcCore composes their grant handlers
+        services.AddDeviceAuthorization();
+        services.AddBackChannelAuthentication();
+        services.AddRevocation();
+        services.AddIntrospection();
+        services.AddCheckSession();
+        services.AddDynamicClientRegistration();
+
+        services.AddOidcMinimalApi(_ => { });
+        services.AddRichAuthorizationRequests();
+
+        using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
     }
 }


### PR DESCRIPTION
## Problem

`AddOidcMvc` supplies `AuthenticationSchemeAdapter` as the default `IAuthSessionService`; `AddOidcMinimalApi` did not. A Minimal API host without its own registration failed at request time on every endpoint touching the authentication session: a bare 500 at `/connect/token` in Production, a DI validation error naming `EndSessionRequestProcessor` and `IIdentityTokenService` in Development.

The E2E TestHost masked the gap because `Replace()` adds its stub even when nothing was registered. Found while building the first external host on the adapter (the upcoming GettingStarted sample).

## Fix

One registration in the Minimal API transport, mirroring the MVC transport line:

- `TryAddScoped<IAuthSessionService, AuthenticationSchemeAdapter>()` - `TryAdd` keeps host pre-registrations winning.

## Regression coverage

Three cases added to `ServiceCollectionOverrideTests`:

- the default registration is present after `AddOidcMinimalApi()`;
- a host pre-registered `IAuthSessionService` wins;
- a full-surface guard: every optional endpoint opted in, the only host-implemented contract is `IUserInfoProvider`, and `BuildServiceProvider(ValidateOnBuild)` constructs the entire graph - any future missing default registration in the adapter or the core fails the suite instead of surfacing as a runtime 500.
