### PR TITLE
fix(authorization): render non-string response parameters instead of 500

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Common/ParametersProviderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/ParametersProviderTests.cs
@@ -1,0 +1,68 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Linq;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common;
+
+public class ParametersProviderTests
+{
+    private readonly ParametersProvider _provider = new();
+
+    // Regression: an authorization response carrying expires_in (any response_type that delivers an access token
+    // from the authorization endpoint) serializes expires_in as a JSON number. GetParameters must render that
+    // numeric value rather than throw. The earlier implementation called JsonElement.GetString() on every property
+    // and raised InvalidOperationException on the numeric element, turning every implicit/hybrid token response into
+    // an HTTP 500.
+    [Fact]
+    public void GetParameters_RendersNumericExpiresIn()
+    {
+        var response = new AuthorizationResponse { ExpiresIn = TimeSpan.FromSeconds(3600) };
+
+        var parameters = _provider.GetParameters(response);
+
+        Assert.Contains(("expires_in", "3600"), parameters);
+    }
+
+    // Every JSON value kind maps to its wire form: strings keep their value, numbers and booleans render via their
+    // raw JSON text, and JSON nulls become a null value that downstream query/fragment/form encoders drop.
+    [Fact]
+    public void GetParameters_RendersEachValueKind()
+    {
+        var parameters = _provider.GetParameters(new
+        {
+            text = "hello",
+            number = 42,
+            flag = true,
+            missing = (string?)null,
+        }).ToArray();
+
+        Assert.Contains(("text", "hello"), parameters);
+        Assert.Contains(("number", "42"), parameters);
+        Assert.Contains(("flag", "true"), parameters);
+        Assert.Contains(("missing", (string?)null), parameters);
+    }
+}

--- a/Abblix.Oidc.Server/Common/ParametersProvider.cs
+++ b/Abblix.Oidc.Server/Common/ParametersProvider.cs
@@ -34,6 +34,18 @@ public class ParametersProvider : IParametersProvider
     /// <inheritdoc />
     public IEnumerable<(string name, string? value)> GetParameters(object obj)
         => JsonSerializer.SerializeToElement(obj).EnumerateObject()
-            .Select(property => (property.Name, property.Value.GetString()))
+            .Select(property => (property.Name, ToParameterValue(property.Value)))
             .ToArray();
+
+    // A parameter value is a string on the wire, but a property may serialize to any JSON kind — for example
+    // expires_in serializes as a number. JsonElement.GetString() only accepts String and Null and throws on every
+    // other kind, so non-string values render through their raw JSON text instead (a number as its digits, a boolean
+    // as true/false). JSON null maps to a null value that downstream query/fragment/form encoders drop.
+    private static string? ToParameterValue(JsonElement value)
+        => value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Null => null,
+            _ => value.GetRawText(),
+        };
 }


### PR DESCRIPTION
## Problem

`/connect/authorize` returns HTTP 500 for every `response_type` that delivers an access token from the authorization endpoint (`token`, `id_token token`, `code token`, `code id_token token`) — the whole implicit and hybrid token family, on both the MVC and Minimal API transports.

`ParametersProvider.GetParameters` calls `JsonElement.GetString()` on every serialized property. `expires_in` serializes as a JSON **number** (via `TimeSpanSecondsConverter`), and `GetString()` throws `InvalidOperationException` on any non-string element, so the response encoder never completes.

## Fix

Render each property by its JSON kind: strings keep their value, JSON `null` stays `null` (downstream query/fragment/form encoders drop it), and every other kind renders via `GetRawText()` — so `expires_in` emits its seconds. This is the single extraction path shared by the MVC and Minimal API transports, so one change covers both.

## Impact

Surfaced by the Abblix Authentication Service OIDC conformance suite, where 146 token-bearing tests were failing against `2.3.0-dev.*` with this HTTP 500. Full Oidc.Server unit suite stays green (2357/2357) with two added regression tests for the numeric `expires_in` case and each JSON value kind. No public contract change.
