### PR TITLE
fix(authorize): nonce is optional for the code token combination

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/NonceValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/NonceValidatorTests.cs
@@ -111,13 +111,15 @@ public class NonceValidatorTests
     }
 
     /// <summary>
-    /// OIDC Core 1.0 §3.3.2.11: nonce is REQUIRED for every Hybrid Flow combination, including
-    /// code token — no id_token is returned from the authorization endpoint, but the one minted
-    /// later from the code must carry the nonce binding. Previously only response types containing
-    /// id_token were checked.
+    /// Verifies that ValidateAsync accepts the code token hybrid combination without nonce.
+    /// Nonce is REQUIRED only when the response_type delivers an id_token from the authorization
+    /// endpoint (OIDC Core 1.0 errata, Nonce Implementation Notes). code token returns no id_token
+    /// there, so nonce stays optional exactly as in pure code flow. The certification module
+    /// oidcc-ensure-request-without-nonce-succeeds-for-code-flow sends this very combination
+    /// without nonce and requires the authorization to succeed.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_CodeTokenResponseTypeWithoutNonce_ShouldReturnError()
+    public async Task ValidateAsync_CodeTokenResponseTypeWithoutNonce_ShouldSucceed()
     {
         // Arrange
         var context = CreateContext([ResponseTypes.Code, ResponseTypes.Token], nonce: null);
@@ -126,8 +128,7 @@ public class NonceValidatorTests
         var result = await _validator.ValidateAsync(context);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Null(result);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/NonceValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/NonceValidator.cs
@@ -51,15 +51,17 @@ public class NonceValidator : SyncAuthorizationContextValidatorBase
         var request = context.Request;
         var responseType = request.ResponseType.NotNull(nameof(request.ResponseType));
 
-        // OIDC Core 1.0: the nonce is REQUIRED whenever an ID token is delivered from the
-        // authorization endpoint (§3.2.2.1, response_type contains id_token) and in EVERY Hybrid
-        // Flow combination (§3.3.2.11) — including "code token", where no id_token is returned
-        // directly but the one minted later from the code must still carry the nonce binding.
-        var idTokenRequested = responseType.Contains(ResponseTypes.IdToken);
-        var hybridCodeToken = responseType.Contains(ResponseTypes.Code) &&
-                              responseType.Contains(ResponseTypes.Token);
-
-        if ((idTokenRequested || hybridCodeToken) && string.IsNullOrEmpty(request.Nonce))
+        // The nonce is REQUIRED exactly when the response_type delivers an id_token from the
+        // authorization endpoint, i.e. when it contains id_token (OIDC Core 1.0 §3.2.2.1 for
+        // implicit, §3.3.2.11 for hybrid, as clarified by the Core errata "Nonce Implementation
+        // Notes" and OIDC issues 972 and 1052): the nonce binds the front-channel id_token to the
+        // client session. The "code token" combination is nominally a hybrid flow, yet it returns
+        // NO id_token from the authorization endpoint, so the nonce stays OPTIONAL for it exactly
+        // as in pure code flow (§3.1.2.1). Do not re-add a blanket "every hybrid combination
+        // requires nonce" clause: that reading slipped in once and breaks OIDF certification,
+        // whose module oidcc-ensure-request-without-nonce-succeeds-for-code-flow sends
+        // response_type=code token without a nonce and requires the authorization to succeed.
+        if (responseType.Contains(ResponseTypes.IdToken) && string.IsNullOrEmpty(request.Nonce))
         {
             return context.InvalidRequest(
                 $"Nonce is required for the requested {Parameters.ResponseType}, as specified in OpenID Connect Core 1.0.");


### PR DESCRIPTION
## Problem

Since `7954fe7` (June 11, develop only — **not** in the v2.3 release), the authorization endpoint rejects `response_type=code token` without a `nonce` with `invalid_request`. That reading ("every hybrid combination requires nonce") is stricter than the specification and fails OIDF certification.

## Spec basis

Per OIDC Core 1.0 as clarified by the errata **Nonce Implementation Notes** (`openid-connect-core-1_0-27.html#NonceNotes`, tracking OIDC issues 972/1052), the nonce is REQUIRED exactly when the `response_type` delivers an `id_token` **from the authorization endpoint** — i.e. when it contains `id_token`. `code token` returns no id_token there, so nonce stays OPTIONAL, exactly as in pure code flow (§3.1.2.1).

The official conformance suite encodes this: `oidcc-ensure-request-without-nonce-succeeds-for-code-flow` is `@VariantNotApplicable` for the four id_token-bearing response types, and the Hybrid OP plan assigns it to the **`code token`** variant with the comment "a request without nonce should succeed for code token" — the module strips the nonce and requires the authorization to succeed.

## Fix

Restore the pre-`7954fe7` rule (`nonce required ⟺ response_type contains id_token`) and document the exact rule inline in `NonceValidator`, including an explicit warning not to re-add a blanket hybrid clause, so the mistaken reading cannot slip back in.

The unit test asserting the wrong behavior is flipped to the spec-correct expectation (red-first: it failed against the old validator, passes now). Full unit suite green (2357/2357).

## Impact

Caught by the AuthenticationService conformance suite: `oidcc-hybrid-code-token` and `oidcc-formpost-hybrid-code-token` were rejected with `invalid_request` against `2.4.0-dev.*`. With this fix they pass again. The published v2.3 predates the regression and is unaffected.
