### PR TITLE
fix: three spec-conformance defects from the June security-review batch

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Revocation/RevocationRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Revocation/RevocationRequestValidatorTests.cs
@@ -142,12 +142,14 @@ public class RevocationRequestValidatorTests
     }
 
     /// <summary>
-    /// Verifies that a public client (token_endpoint_auth_method = none) is rejected. The revocation
-    /// endpoint must authenticate the client (RFC 7009 §2.1); a client_id alone is not a credential,
-    /// so the token is never even validated.
+    /// RFC 7009 §5: "a client's request must contain a valid client_id, in the case of a public
+    /// client, or valid client credentials, in the case of a confidential client" — a public
+    /// client revoking its own token is protocol-legal, and the token-ownership check is the
+    /// protection the spec actually mandates. Rejecting public clients here would leave SPA and
+    /// native clients unable to revoke their refresh tokens on logout.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_WithPublicClient_ShouldReturnInvalidClientError()
+    public async Task ValidateAsync_WithPublicClient_ShouldValidateToken()
     {
         // Arrange
         var revocationRequest = CreateRevocationRequest();
@@ -156,18 +158,22 @@ public class RevocationRequestValidatorTests
         {
             TokenEndpointAuthMethod = ClientAuthenticationMethods.None,
         };
+        var token = CreateValidJsonWebToken();
 
         _clientAuthenticator
             .Setup(a => a.TryAuthenticateClientAsync(It.IsAny<ClientRequest>()))
             .Returns(Task.FromResult<ClientInfo?>(publicClient));
 
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(token);
+
         // Act
         var result = await _validator.ValidateAsync(revocationRequest, clientRequest);
 
         // Assert
-        Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(ErrorCodes.InvalidClient, error.Error);
-        _jwtValidator.VerifyNoOtherCalls();
+        Assert.True(result.TryGetSuccess(out var validRequest));
+        Assert.Equal(token, validRequest.Token);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/LogoutTokenServiceTests.cs
@@ -163,6 +163,31 @@ public class LogoutTokenServiceTests
     }
 
     /// <summary>
+    /// Back-Channel Logout §2.4: "A Logout Token MUST be signed" and none "MUST NOT be used" —
+    /// even when the client legally registered id_token_signed_response_alg=none (allowed for
+    /// response types that return no ID Token from the authorization endpoint), the logout token
+    /// must fall back to RS256, the algorithm every OIDC client is required to support.
+    /// </summary>
+    [Fact]
+    public async Task CreateLogoutTokenAsync_NoneIdTokenAlgorithm_FallsBackToRs256()
+    {
+        // Arrange
+        var clientInfo = CreateClientInfo();
+        clientInfo.IdentityTokenSignedResponseAlgorithm = SigningAlgorithms.None;
+        var logoutContext = CreateLogoutContext();
+
+        JsonWebToken? capturedToken = null;
+        SetupMocks(clientInfo, logoutContext, token => capturedToken = token);
+
+        // Act
+        await _service.CreateLogoutTokenAsync(clientInfo, logoutContext);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.Equal(SigningAlgorithms.RS256, capturedToken!.Header.Algorithm);
+    }
+
+    /// <summary>
     /// Verifies that CreateLogoutTokenAsync sets correct issuer claim.
     /// Per OpenID Connect Back-Channel Logout Section 2.4, issuer must match authorization server issuer.
     /// </summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/UserInfo/SubjectTypeConverterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/UserInfo/SubjectTypeConverterTests.cs
@@ -84,6 +84,25 @@ public class SubjectTypeConverterTests
     }
 
     /// <summary>
+    /// Custom-scheme redirect URIs of native clients (RFC 8252 §7.1) carry no meaningful host:
+    /// the single-slash form parses with an empty Host, and the authority form puts an arbitrary
+    /// path-like segment there — either would merge unrelated clients into one shared sector,
+    /// giving them identical pairwise subjects and defeating the isolation pairwise subject
+    /// types exist to provide (OIDC Core §8.1). The client_id fallback applies instead.
+    /// </summary>
+    [Theory]
+    [InlineData("com.example.one:/oauth2redirect", "com.example.two:/oauth2redirect")]
+    [InlineData("app-one://callback", "app-two://callback")]
+    public void Convert_CustomSchemeRedirectUri_FallsBackToClientId(string redirectUriA, string redirectUriB)
+    {
+        var converter = CreateConverter();
+        var clientA = CreatePairwiseClient("client-a", redirectUris: [new Uri(redirectUriA)]);
+        var clientB = CreatePairwiseClient("client-b", redirectUris: [new Uri(redirectUriB)]);
+
+        Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
+    }
+
+    /// <summary>
     /// Different sectors must produce unlinkable identifiers for the same subject — the core
     /// privacy property of pairwise subject types.
     /// </summary>

--- a/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.Logging.cs
+++ b/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.Logging.cs
@@ -39,10 +39,4 @@ partial class RevocationRequestValidator
 		Level = LogLevel.Warning,
 		Message = "The token validation failed: {@Error}")]
 	private partial void LogTokenValidationFailed(JwtValidationError Error);
-
-	[LoggerMessage(
-		EventId = LogEvents.Endpoints.RevocationRequestValidator.PublicClientRejected,
-		Level = LogLevel.Warning,
-		Message = "Revocation rejected for public client {ClientId}: 'none' authentication does not satisfy RFC 7009 §2.1")]
-	private partial void LogPublicClientRejected(Sanitized ClientId);
 }

--- a/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Revocation/RevocationRequestValidator.cs
@@ -75,24 +75,20 @@ public partial class RevocationRequestValidator(
 		RevocationRequest revocationRequest,
 		ClientRequest clientRequest)
 	{
-		// Authenticate the client making the revocation request.
+		// Authenticate the client making the revocation request. Public clients (auth method
+		// "none") are deliberately allowed through: RFC 7009 §5 states a revocation request
+		// "must contain a valid client_id, in the case of a public client, or valid client
+		// credentials, in the case of a confidential client", and the spec's own security
+		// analysis dismisses the guessed-client_id threat — a guessed token is worth far more
+		// used than revoked. The protection the spec actually mandates is the token-ownership
+		// check below. Do not re-add a public-client rejection here: it slipped in once and
+		// left every SPA and native client unable to revoke its own refresh token on logout.
 		var clientInfo = await clientAuthenticator.TryAuthenticateClientAsync(clientRequest);
-		switch (clientInfo)
+		if (clientInfo == null)
 		{
-			case null:
-				return new OidcError(
-					ErrorCodes.InvalidClient,
-					"The client is not authorized");
-
-			// RFC 7009 §2.1 (referencing the OAuth 2.0 client-authentication requirements): the
-			// revocation endpoint must authenticate the client. A public client (auth method "none")
-			// presents only its client_id, which is not a credential — reject it even though "none" is
-			// valid at the token endpoint.
-			case { TokenEndpointAuthMethod: ClientAuthenticationMethods.None}:
-				LogPublicClientRejected(clientInfo.ClientId);
-				return new OidcError(
-					ErrorCodes.InvalidClient,
-					"The client is not authorized");
+			return new OidcError(
+				ErrorCodes.InvalidClient,
+				"The client is not authorized");
 		}
 
 		var result = await jwtValidator.ValidateAsync(revocationRequest.Token);

--- a/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/LogoutTokenService.cs
@@ -91,9 +91,12 @@ public partial class LogoutTokenService(
                 // ID Token, so the client's ID Token signing algorithm is the default; a host may
                 // diverge per client via the explicit LogoutTokenSignedResponseAlgorithm override.
                 // The previous hardcoded RS256 produced tokens an ES256/PS256-registered client
-                // would reject on signature-algorithm verification.
-                Algorithm = clientInfo.LogoutTokenSignedResponseAlgorithm
-                            ?? clientInfo.IdentityTokenSignedResponseAlgorithm,
+                // would reject on signature-algorithm verification. The same §2.4 also demands
+                // "A Logout Token MUST be signed" and that none "MUST NOT be used": a client whose
+                // response types return no ID Token from the authorization endpoint may legally
+                // register id_token_signed_response_alg=none, so that value cannot be inherited
+                // here — fall back to RS256, which every OIDC client is required to support.
+                Algorithm = ResolveSigningAlgorithm(clientInfo),
             },
             Payload =
             {
@@ -128,4 +131,11 @@ public partial class LogoutTokenService(
 
         return new EncodedJsonWebToken(logoutToken, jwt);
     }
+
+    private static string ResolveSigningAlgorithm(ClientInfo clientInfo)
+        => (clientInfo.LogoutTokenSignedResponseAlgorithm ?? clientInfo.IdentityTokenSignedResponseAlgorithm) switch
+        {
+            SigningAlgorithms.None => SigningAlgorithms.RS256,
+            var algorithm => algorithm,
+        };
 }

--- a/Abblix.Oidc.Server/Features/UserInfo/SubjectTypeConverter.cs
+++ b/Abblix.Oidc.Server/Features/UserInfo/SubjectTypeConverter.cs
@@ -79,9 +79,20 @@ public class SubjectTypeConverter(PairwiseSubjectSettings? settings = null) : IS
         // Affects only statically configured clients: DCR-registered pairwise clients always get
         // SectorIdentifier computed at registration time. client_id remains the last resort for
         // clients with no redirect URIs at all (e.g. pure client_credentials configurations).
-        var sector = clientInfo.SectorIdentifier
-            ?? clientInfo.RedirectUris?.FirstOrDefault()?.Host
-            ?? clientInfo.ClientId;
+        // The host is meaningful only for http(s) redirect URIs — the web clients Core §8.1 had
+        // in mind. Native custom-scheme redirects (RFC 8252 §7.1) must not reach the host branch:
+        // the single-slash form (com.example.app:/oauth2redirect) parses with an EMPTY host, and
+        // the authority form (app-one://callback) puts an arbitrary path-like segment into Host —
+        // either way unrelated clients would silently share one sector and derive identical
+        // pairwise subjects for the same user, defeating the isolation this subject type exists
+        // to provide. Such clients keep per-client isolation via the client_id fallback.
+        var redirectUri = clientInfo.RedirectUris?.FirstOrDefault();
+        var redirectHost =
+            redirectUri != null &&
+            (redirectUri.Scheme == Uri.UriSchemeHttp || redirectUri.Scheme == Uri.UriSchemeHttps)
+                ? redirectUri.Host
+                : null;
+        var sector = clientInfo.SectorIdentifier ?? redirectHost ?? clientInfo.ClientId;
         var data = Encoding.UTF8.GetBytes($"{HttpUtility.UrlEncode(sector)}&{HttpUtility.UrlEncode(subject)}");
         var algorithm = settings.HashAlgorithm;
         var salt = System.Convert.FromBase64String(settings.Salt);

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -181,7 +181,6 @@ internal static class LogEvents
 
             public const int TokenIssuedToAnotherClient = Base + 1;
             public const int TokenValidationFailed = Base + 2;
-            public const int PublicClientRejected = Base + 3;
         }
     }
 


### PR DESCRIPTION
Fixes three defects found by an adversarial spec review of the `fix/security-review-2026-06` batch (PR #187). Each fix is red-first: the reproducing test failed against the old code and passes now. Full unit suite green (2360/2360). None of the three ships in v2.3 — all are develop-only.

## fix(revocation): allow public clients to revoke their own tokens

RFC 7009 §5: *"a client's request must contain a valid client_id, **in the case of a public client**, or valid client credentials, in the case of a confidential client."* The spec's own security analysis dismisses the guessed-client_id threat, and the protection it actually mandates — the token-ownership check — already runs after authentication. The removed rejection left every SPA/native client unable to revoke its refresh token on logout (401 + Basic challenge to a client with no secret). Introspection keeps rejecting public clients: RFC 7662 §2.1 requires real authorization.

## fix(backchannel-logout): never sign logout tokens with `none`

Back-Channel Logout §2.4: *"A Logout Token MUST be signed"*, `none` *"MUST NOT be used"*. The algorithm falls back to the client's `id_token_signed_response_alg`, which a code-flow-only client may legally register as `none` — yielding an unsigned logout token. The resolver now replaces `none` with RS256.

## fix(userinfo): pairwise sector only from http(s) redirect URI hosts

Core §8.1's sector-from-redirect-host rule assumes web clients. Native custom-scheme redirects (RFC 8252 §7.1) have no meaningful host — the single-slash form parses with an empty `Uri.Host`, the authority form puts a path-like segment there — so unrelated clients silently shared one sector and derived **identical pairwise subjects** for the same user. The host branch is now restricted to http(s); custom-scheme clients keep per-client isolation via the client_id fallback.
