### PR TITLE
fix: close resource-parameter allowlist bypass and RFC 7592 challenge-scheme mismatch

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/ClientRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/ClientRequestValidatorTests.cs
@@ -1,0 +1,121 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement;
+
+/// <summary>
+/// Unit tests for <see cref="ClientRequestValidator"/> — the RFC 7592 client configuration
+/// endpoint authentication gate. The endpoint authenticates with a Bearer registration access
+/// token, so every failure must speak the Bearer vocabulary of RFC 6750.
+/// </summary>
+public class ClientRequestValidatorTests
+{
+    // Reuse the suite-wide client id: LicenseChecker counts distinct client ids in a static set,
+    // so a fresh id here would push parallel-running tests over the free-license client limit.
+    private const string ClientId = TestConstants.DefaultClientId;
+    private const string TokenId = "jti-current";
+
+    private readonly Mock<IClientInfoProvider> _clientInfoProvider = new(MockBehavior.Strict);
+    private readonly Mock<IRegistrationAccessTokenValidator> _tokenValidator = new(MockBehavior.Strict);
+    private readonly Mock<IRegistrationAccessTokenStore> _tokenStore = new(MockBehavior.Strict);
+    private readonly ClientRequestValidator _validator;
+
+    public ClientRequestValidatorTests()
+    {
+        _validator = new ClientRequestValidator(
+            _clientInfoProvider.Object,
+            _tokenValidator.Object,
+            _tokenStore.Object);
+    }
+
+    private static ClientRequest Request() => new()
+    {
+        ClientId = ClientId,
+        AuthorizationHeader = new AuthenticationHeaderValue("Bearer", "registration.access.token"),
+    };
+
+    [Fact]
+    public async Task ValidateAsync_TokenBoundToExistingClient_ReturnsValidRequest()
+    {
+        var clientInfo = new ClientInfo(ClientId);
+        _tokenStore.Setup(s => s.GetTokenIdAsync(ClientId)).ReturnsAsync(TokenId);
+        _tokenValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<AuthenticationHeaderValue?>(), ClientId, TokenId))
+            .ReturnsAsync((string?)null);
+        _clientInfoProvider.Setup(p => p.TryFindClientAsync(ClientId)).ReturnsAsync(clientInfo);
+
+        var result = await _validator.ValidateAsync(Request());
+
+        Assert.True(result.TryGetSuccess(out var validRequest));
+        Assert.Equal(clientInfo, validRequest.ClientInfo);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_InvalidToken_ReturnsInvalidTokenError()
+    {
+        _tokenStore.Setup(s => s.GetTokenIdAsync(ClientId)).ReturnsAsync(TokenId);
+        _tokenValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<AuthenticationHeaderValue?>(), ClientId, TokenId))
+            .ReturnsAsync("The token is expired");
+
+        var result = await _validator.ValidateAsync(Request());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
+        _clientInfoProvider.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// RFC 7592 §2.3: when the addressed client does not exist, the server responds
+    /// 401 Unauthorized and the registration access token MUST be immediately revoked.
+    /// The error therefore has to be <c>invalid_token</c> (RFC 6750, Bearer challenge) —
+    /// <c>invalid_client</c> would produce a Basic challenge that names an authentication
+    /// scheme this Bearer-authenticated endpoint never accepts.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ClientVanished_ReturnsInvalidTokenAndRevokesBinding()
+    {
+        _tokenStore.Setup(s => s.GetTokenIdAsync(ClientId)).ReturnsAsync(TokenId);
+        _tokenValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<AuthenticationHeaderValue?>(), ClientId, TokenId))
+            .ReturnsAsync((string?)null);
+        _clientInfoProvider.Setup(p => p.TryFindClientAsync(ClientId)).ReturnsAsync((ClientInfo?)null);
+        _tokenStore.Setup(s => s.RemoveAsync(ClientId)).Returns(Task.CompletedTask);
+
+        var result = await _validator.ValidateAsync(Request());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
+        _tokenStore.Verify(s => s.RemoveAsync(ClientId), Times.Once);
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -602,6 +602,56 @@ public class TokenExchangeGrantHandlerTests
     }
 
     [Fact]
+    public async Task Resource_rejected_when_not_in_declared_audience_allowlist()
+    {
+        // RFC 8707 resource values land in the issued token's aud claim exactly like RFC 8693
+        // audience values do, so a client restricted to api1 must not escape to api2 simply by
+        // renaming the parameter from audience to resource.
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null)
+        {
+            OriginalClientId = ClientId,
+            JwtTokenType = JwtTypes.AccessToken,
+        };
+        var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
+        var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
+        clientInfo.TokenExchangeAllowedAudiences = ["https://api1.example.com"];
+        var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
+        {
+            Resources = [new Uri("https://api2.example.com")],
+        };
+
+        var result = await handler.AuthorizeAsync(request, clientInfo);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
+        Assert.Contains("api2.example.com", error.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task Resource_and_audience_propagate_when_both_in_declared_allowlist()
+    {
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null)
+        {
+            OriginalClientId = ClientId,
+            JwtTokenType = JwtTypes.AccessToken,
+        };
+        var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
+        var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
+        clientInfo.TokenExchangeAllowedAudiences = ["https://api1.example.com", "https://api2.example.com"];
+        var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
+        {
+            Audiences = ["https://api1.example.com"],
+            Resources = [new Uri("https://api2.example.com")],
+        };
+
+        var result = await handler.AuthorizeAsync(request, clientInfo);
+
+        Assert.True(result.TryGetSuccess(out var grant));
+        Assert.Equal(request.Audiences, grant.Context.Audiences);
+        Assert.Equal(request.Resources, grant.Context.Resources);
+    }
+
+    [Fact]
     public async Task S2_Resource_parameter_propagates_to_AuthorizationContext()
     {
         var subject = new SubjectTokenContext("alice", null, ["openid"], null)

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ClientRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ClientRequestValidator.cs
@@ -63,7 +63,15 @@ public class ClientRequestValidator(
 
         var clientInfo = await clientInfoProvider.TryFindClientAsync(clientId).WithLicenseCheck();
         if (clientInfo == null)
-            return new OidcError(ErrorCodes.InvalidClient, "Client does not exist on this server");
+        {
+            // RFC 7592 §2.3: when the addressed client does not exist, the server responds
+            // 401 Unauthorized and the registration access token MUST be immediately revoked.
+            // The error is invalid_token, not invalid_client: this endpoint authenticates with a
+            // Bearer token (RFC 6750), and invalid_client would be formatted as a Basic challenge —
+            // an authentication scheme the configuration endpoint never accepts.
+            await registrationAccessTokenStore.RemoveAsync(clientId);
+            return new OidcError(ErrorCodes.InvalidToken, "Client does not exist on this server");
+        }
 
         return new ValidClientRequest(request, clientInfo);
     }

--- a/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -338,16 +338,29 @@ public class TokenExchangeGrantHandler(
     /// client could mint a token for any target service it names. The allowlist is default-deny: an
     /// <c>audience</c> is accepted only when the client declares a non-empty
     /// <see cref="ClientInfo.TokenExchangeAllowedAudiences"/> that contains every requested value.
-    /// A request without <c>audience</c> passes through. Rejections use <c>invalid_target</c>
-    /// (RFC 8693 §2.2.1: the AS is unwilling to issue a token for the requested target service).
+    /// RFC 8707 <c>resource</c> values reach the <c>aud</c> claim through the exact same path
+    /// (see <c>AuthorizationContextExtensions.ApplyTo</c>), so a declared allowlist gates them too —
+    /// otherwise renaming <c>audience</c> to <c>resource</c> would bypass the constraint entirely.
+    /// A client without a declared allowlist keeps the asymmetric defaults: <c>audience</c> is
+    /// default-deny because no other gate exists for logical service names, while <c>resource</c>
+    /// stays subject to the global resource registry (<c>ResourceValidator</c> has already checked
+    /// it earlier in the token pipeline). A request without either parameter passes through.
+    /// Rejections use <c>invalid_target</c> (RFC 8693 §2.2.1: the AS is unwilling to issue a token
+    /// for the requested target service).
     /// </summary>
     private static Result<ValidationContext, OidcError> ValidateAudiences(ValidationContext ctx)
     {
-        if (ctx.Request.Audiences is not { Length: > 0 } audiences)
+        var audiences = ctx.Request.Audiences ?? [];
+        var resources = ctx.Request.Resources ?? [];
+
+        if (audiences.Length == 0 && resources.Length == 0)
             return ctx;
 
         if (ctx.ClientInfo.TokenExchangeAllowedAudiences is not { Length: > 0 } allowlist)
         {
+            if (audiences.Length == 0)
+                return ctx;
+
             return new OidcError(
                 ErrorCodes.InvalidTarget,
                 "The client is not permitted to request an audience for token exchange.");
@@ -355,16 +368,17 @@ public class TokenExchangeGrantHandler(
 
         var allowed = new HashSet<string>(allowlist, StringComparer.Ordinal);
         var disallowed = audiences
-            .Where(audience => !allowed.Contains(audience))
+            .Concat(Array.ConvertAll(resources, resource => resource.OriginalString))
+            .Where(target => !allowed.Contains(target))
             .ToArray();
 
         if (disallowed.Length > 0)
         {
-            // Report every disallowed audience, not just the first: a client fixing its request
+            // Report every disallowed target, not just the first: a client fixing its request
             // should not have to re-submit and rediscover the rejected values one round-trip at a time.
             return new OidcError(
                 ErrorCodes.InvalidTarget,
-                $"The following audiences are not in the client's allow list: {string.Join(", ", disallowed)}.");
+                $"The following target services are not in the client's allow list: {string.Join(", ", disallowed)}.");
         }
 
         return ctx;


### PR DESCRIPTION
Closes the two follow-up gaps documented in the PR #187 spec review (#204). Both fixes are red-first: each reproducing test failed against the old code and passes now. Full suite green: UnitTests 2365, E2E 59, MinimalApi E2E 32, Mvc 76, AspNetCore 18.

## fix(token-exchange): gate RFC 8707 `resource` values through the audience allowlist

RFC 8707 `resource` values land in the issued token's `aud` claim exactly like RFC 8693 `audience` values (`AuthorizationContextExtensions.ApplyTo`), so a client whose `TokenExchangeAllowedAudiences` restricts it to `api1` could escape to `api2` by renaming the parameter from `audience` to `resource`. With a declared allowlist, every requested target — audience or resource — must now be on it (`invalid_target` otherwise, all offending values reported at once).

Without a declared allowlist the defaults stay asymmetric on purpose: `audience` is default-deny because logical service names have no other gate, while `resource` remains under the global resource registry that `ResourceValidator` already enforces earlier in the token pipeline — the pre-existing RFC 8707 behavior for such clients is unchanged.

## fix(dcm): answer a vanished client with `invalid_token` and revoke its binding

RFC 7592 §2.3: when the addressed client does not exist, the server responds 401 Unauthorized and the registration access token MUST be immediately revoked. The validator returned `invalid_client`, which the MVC layer formats as a 401 with a **Basic** challenge — a scheme the Bearer-only configuration endpoint never accepts. It now returns `invalid_token` (Bearer challenge per RFC 6750) and removes the stored token binding, implementing the mandatory revocation.

Side note: the new test initially surfaced the shared-state license counter (`LicenseChecker._knownClientIds` is static, suite-wide); the test reuses the suite-wide client id to stay under the free-license client limit.
