### PR TITLE
feat(discovery): serve Authorization Server Metadata at the oauth-authorization-server suffix (RFC 8414)

### DIFF
--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/OAuthMetadataEndpointTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/OAuthMetadataEndpointTests.cs
@@ -1,0 +1,39 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// RFC 8414 §3 lets the Authorization Server Metadata be published under the oauth-authorization-server
+/// well-known suffix in addition to openid-configuration. The MVC adapter serves the identical document at
+/// both, so a client that queries only oauth-authorization-server still resolves the provider's metadata.
+/// </summary>
+public class OAuthMetadataEndpointTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task Oauth_authorization_server_suffix_serves_the_same_metadata_as_openid_configuration()
+    {
+        var client = CreateClient();
+        var token = TestContext.Current.CancellationToken;
+
+        var oidc = JsonNode.Parse(
+            await client.GetStringAsync("/.well-known/openid-configuration", token))!.AsObject();
+
+        var response = await client.GetAsync("/.well-known/oauth-authorization-server", token);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var oauth = JsonNode.Parse(await response.Content.ReadAsStringAsync(token))!.AsObject();
+        Assert.Equal(
+            oidc[ConfigurationResponse.Parameters.Issuer]!.GetValue<string>(),
+            oauth[ConfigurationResponse.Parameters.Issuer]!.GetValue<string>());
+        Assert.Equal(
+            oidc[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>(),
+            oauth[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>());
+    }
+}

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
@@ -215,6 +215,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
 
     [Theory]
     [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
     [InlineData("/.well-known/jwks")]
     public async Task Discovery_and_jwks_are_cors_enabled_like_the_mvc_discovery_controller(string path)
     {
@@ -238,6 +239,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
 
     [Theory]
     [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
     [InlineData("/.well-known/jwks")]
     public async Task Every_oidc_response_is_no_store_like_the_mvc_controllers(string path)
     {
@@ -303,6 +305,31 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
         var response = await httpClient.PostAsync("/connect/token", content, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Oauth_authorization_server_suffix_serves_the_same_metadata_as_openid_configuration()
+    {
+        var client = ClientOf(factory);
+
+        // RFC 8414 §3 lets the Authorization Server Metadata be published under the oauth-authorization-server
+        // suffix as well as openid-configuration. Abblix serves the identical document at both, so a client that
+        // queries only oauth-authorization-server resolves the same issuer and endpoints.
+        var oidc = JsonNode.Parse(await client.GetStringAsync(
+            "/.well-known/openid-configuration", TestContext.Current.CancellationToken))!.AsObject();
+
+        var response = await client.GetAsync(
+            "/.well-known/oauth-authorization-server", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var oauth = JsonNode.Parse(
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+        Assert.Equal(
+            oidc[ConfigurationResponse.Parameters.Issuer]!.GetValue<string>(),
+            oauth[ConfigurationResponse.Parameters.Issuer]!.GetValue<string>());
+        Assert.Equal(
+            oidc[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>(),
+            oauth[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>());
     }
 
     /// <summary>A stand-in discovery formatter a host registers to prove its registration wins over the adapter's.</summary>

--- a/Abblix.Oidc.Server.MinimalApi/EndpointNames.cs
+++ b/Abblix.Oidc.Server.MinimalApi/EndpointNames.cs
@@ -48,5 +48,6 @@ internal static class EndpointNames
     public const string Register = Prefix + nameof(Register);
     public const string RegisterClient = Prefix + nameof(RegisterClient);
     public const string Configuration = Prefix + nameof(Configuration);
+    public const string OAuthAuthorizationServer = Prefix + nameof(OAuthAuthorizationServer);
     public const string Keys = Prefix + nameof(Keys);
 }

--- a/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -96,6 +96,13 @@ public static class EndpointRouteBuilderExtensions
                 .MapGet(routes.Configuration, ConfigurationAsync)
                 .WithName(EndpointNames.Configuration)
                 .RequireCors(OidcConstants.CorsPolicyName);
+
+            // RFC 8414 §3: the same Authorization Server Metadata document, also served at the
+            // oauth-authorization-server suffix so a client that queries only that suffix still resolves it.
+            oidcGroup
+                .MapGet(routes.OAuthAuthorizationServer, ConfigurationAsync)
+                .WithName(EndpointNames.OAuthAuthorizationServer)
+                .RequireCors(OidcConstants.CorsPolicyName);
         }
 
         if (options.EnabledEndpoints.HasFlag(OidcEndpoints.Keys))

--- a/Abblix.Oidc.Server.MinimalApi/OidcRouteOptions.cs
+++ b/Abblix.Oidc.Server.MinimalApi/OidcRouteOptions.cs
@@ -79,4 +79,10 @@ public sealed class OidcRouteOptions
 
     /// <summary>The JSON Web Key Set endpoint (OpenID Connect Discovery 4).</summary>
     public string Keys { get; set; } = "/.well-known/jwks";
+
+    /// <summary>
+    /// The OAuth 2.0 Authorization Server Metadata document (RFC 8414 §3) — the same metadata served at
+    /// <see cref="Configuration"/>, also exposed at the oauth-authorization-server suffix.
+    /// </summary>
+    public string OAuthAuthorizationServer { get; set; } = "/.well-known/oauth-authorization-server";
 }

--- a/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
@@ -73,6 +73,7 @@ public sealed class DiscoveryController : ControllerBase
 	/// <returns>A task that results in an action result containing the provider's configuration details
 	/// in JSON format.</returns>
 	[HttpGet(Path.Configuration)]
+	[HttpGet(Path.OAuthAuthorizationServer)]
 	[Produces(MediaTypeNames.Application.Json)]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	[EnabledBy(OidcEndpoints.Configuration)]

--- a/Abblix.Oidc.Server.Mvc/Path.cs
+++ b/Abblix.Oidc.Server.Mvc/Path.cs
@@ -116,6 +116,13 @@ public static class Path
     public const string Configuration = "[" + RoutePrefix + ":configuration?" + WellKnown + "/openid-configuration]";
 
     /// <summary>
+    /// Path for the OAuth 2.0 Authorization Server Metadata document per RFC 8414 Section 3.
+    /// Serves the same metadata as <see cref="Configuration"/> at the oauth-authorization-server well-known suffix,
+    /// so a client that queries only that suffix still resolves the provider's metadata.
+    /// </summary>
+    public const string OAuthAuthorizationServer = "[" + RoutePrefix + ":oauth_authorization_server?" + WellKnown + "/oauth-authorization-server]";
+
+    /// <summary>
     /// Path for the JSON Web Key Set (JWKS) endpoint per OpenID Connect Discovery Section 4.
     /// </summary>
     public const string Keys = "[" + RoutePrefix + ":jwks?" + WellKnown + "/jwks]";


### PR DESCRIPTION
## Summary

Discovery now serves the OAuth 2.0 Authorization Server Metadata document (RFC 8414 §3) at `/.well-known/oauth-authorization-server` in addition to `/.well-known/openid-configuration`, in both the MVC and Minimal API adapters.

RFC 8414 §3 permits publishing the Authorization Server Metadata under either the `oauth-authorization-server` or the `openid-configuration` well-known suffix. Until now the server served it only at `openid-configuration`, so a client that queried only the `oauth-authorization-server` suffix (as some OAuth-only clients do) got a 404. Both Duende and OpenIddict expose the suffix by default; this closes that gap.

## Design

- The same metadata document is served at both suffixes — no separate handler, formatter, or transport change. The MVC action gains a second route attribute; the Minimal API adapter maps a second route to the same delegate.
- Gated by the existing `OidcEndpoints.Configuration` flag (part of the default `Base` set): the alias is available whenever discovery is enabled, with no new opt-in. The RFC 8414 metadata is the same document, so a separate flag would be redundant.
- Paths stay host-overridable like every other endpoint: a `[route:oauth_authorization_server?…]` tokenized template in the MVC adapter, an `OidcRouteOptions.OAuthAuthorizationServer` property in the Minimal API adapter, and discovery reflects the resolved paths.
