### PR TITLE
Rotate refresh tokens by default with token-family revocation (RFC 9700 §4.14.2)

### DIFF
--- a/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -182,18 +182,19 @@ public class JsonWebTokenPayload(JsonObject json)
 	}
 
 	/// <summary>
-	/// Binds this refresh token to the lineage of every refresh token derived from one authorization grant.
-	/// A first-issued token starts a new family; each rotation carries the value forward, so a detected replay
-	/// can revoke the whole family in one registry write (RFC 9700 Section 4.14.2).
+	/// Identifies the authorization grant this refresh token belongs to, binding it to the lineage of every
+	/// refresh token derived from the same grant. A first-issued token starts a new grant; each rotation
+	/// carries the value forward, so a detected replay can revoke the whole family in one registry write
+	/// (RFC 9700 Section 4.14.2).
 	/// </summary>
 	/// <remarks>
 	/// Present only on refresh tokens (<c>rt+jwt</c>); absent (null) on all other token types, which leaves
 	/// the family cascade in the token-status validator inert for them.
 	/// </remarks>
-	public string? RefreshTokenFamily
+	public string? GrantId
 	{
-		get => Json.GetProperty<string>(JwtClaimTypes.RefreshTokenFamily);
-		set => Json.SetProperty(JwtClaimTypes.RefreshTokenFamily, value);
+		get => Json.GetProperty<string>(JwtClaimTypes.GrantId);
+		set => Json.SetProperty(JwtClaimTypes.GrantId, value);
 	}
 
 	/// <summary>

--- a/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -182,6 +182,21 @@ public class JsonWebTokenPayload(JsonObject json)
 	}
 
 	/// <summary>
+	/// Binds this refresh token to the lineage of every refresh token derived from one authorization grant.
+	/// A first-issued token starts a new family; each rotation carries the value forward, so a detected replay
+	/// can revoke the whole family in one registry write (RFC 9700 Section 4.14.2).
+	/// </summary>
+	/// <remarks>
+	/// Present only on refresh tokens (<c>rt+jwt</c>); absent (null) on all other token types, which leaves
+	/// the family cascade in the token-status validator inert for them.
+	/// </remarks>
+	public string? RefreshTokenFamily
+	{
+		get => Json.GetProperty<string>(JwtClaimTypes.RefreshTokenFamily);
+		set => Json.SetProperty(JwtClaimTypes.RefreshTokenFamily, value);
+	}
+
+	/// <summary>
 	/// Represents the time when the authentication occurred, facilitating checks against token freshness
 	/// and replay attacks.
 	/// </summary>

--- a/Abblix.Jwt/JwtClaimTypes.cs
+++ b/Abblix.Jwt/JwtClaimTypes.cs
@@ -268,11 +268,12 @@ public static class JwtClaimTypes
     public const string AuthenticationMethodReferences = IanaClaimTypes.Amr;
 
     /// <summary>
-    /// "rt_family" — Abblix private claim (RFC 7519 Section 4.3) binding every refresh token derived from one
-    /// authorization grant into a single lineage: a first-issued token starts a new family, and each rotation
-    /// carries the same value forward. It lets a detected replay revoke the whole family in one registry write.
-    /// No IANA-registered claim captures per-grant refresh-token lineage, and this token is self-issued and
-    /// self-validated, never shown to third parties. See RFC 9700 Section 4.14.2.
+    /// "grant_id" — Abblix private claim (RFC 7519 Section 4.3) identifying the authorization grant a refresh
+    /// token belongs to. It binds every refresh token derived from one grant into a single lineage (a "token
+    /// family" in RFC 9700 terms): a first-issued token starts a new grant, and each rotation carries the same
+    /// value forward. It lets a detected replay revoke the whole family in one registry write. No IANA-registered
+    /// claim captures per-grant refresh-token lineage, and this token is self-issued and self-validated, never
+    /// shown to third parties. See RFC 9700 Section 4.14.2.
     /// </summary>
-    public const string RefreshTokenFamily = "rt_family";
+    public const string GrantId = "grant_id";
 }

--- a/Abblix.Jwt/JwtClaimTypes.cs
+++ b/Abblix.Jwt/JwtClaimTypes.cs
@@ -266,4 +266,13 @@ public static class JwtClaimTypes
     /// and can help relying parties understand the strength and nature of the authentication.
     /// </summary>
     public const string AuthenticationMethodReferences = IanaClaimTypes.Amr;
+
+    /// <summary>
+    /// "rt_family" — Abblix private claim (RFC 7519 Section 4.3) binding every refresh token derived from one
+    /// authorization grant into a single lineage: a first-issued token starts a new family, and each rotation
+    /// carries the same value forward. It lets a detected replay revoke the whole family in one registry write.
+    /// No IANA-registered claim captures per-grant refresh-token lineage, and this token is self-issued and
+    /// self-validated, never shown to third parties. See RFC 9700 Section 4.14.2.
+    /// </summary>
+    public const string RefreshTokenFamily = "rt_family";
 }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenFamilyRevocationTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenFamilyRevocationTests.cs
@@ -1,0 +1,125 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end proof of the OAuth 2.0 Security BCP refresh-token rotation model (RFC 9700 Section 4.14.2)
+/// against the real token endpoint and the real token registry: a replay of a superseded refresh token
+/// revokes the entire token family, so the currently active token of the same authorization grant dies
+/// with it. This is the reuse-detection behaviour that contains a stolen refresh token — a leaked token is
+/// directly replayable for a public client, which is exactly why RFC 9700 Section 2.2.2 mandates rotation
+/// there. The mechanism is client-type independent; the confidential client is used here as the most
+/// heavily-exercised transport path.
+/// </summary>
+public class RefreshTokenFamilyRevocationTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task Replayed_superseded_refresh_token_revokes_the_whole_family()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        // A legitimate auth-code flow with offline_access issues the first refresh token of a new family
+        // (rt1). The test client does not set AllowReuse, so it rotates by default (the secure default).
+        var initial = await ObtainRefreshTokenAsync(client, discovery);
+        var rt1 = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        // A normal refresh rotates rt1 -> rt2: rt1 becomes superseded (marked Used) and rt2 is now the
+        // legitimately active token of the family. This also proves rotation works end-to-end.
+        var rotated = await RefreshAsync(client, discovery, rt1);
+        var rotatedBody = await ReadJsonAsync(rotated);
+        Assert.True(rotated.IsSuccessStatusCode, $"first refresh should rotate, got {(int)rotated.StatusCode}: {rotatedBody}");
+        var rt2 = rotatedBody[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        Assert.NotEqual(rt1, rt2); // rotation actually minted a new token
+
+        // THEFT: the stolen rt1 is replayed after it was rotated. The AS cannot tell an attacker from a
+        // lagging client, so it rejects the reuse AND revokes the whole family (RFC 9700 Section 4.14.2).
+        var replay = await RefreshAsync(client, discovery, rt1);
+        await AssertInvalidGrantAsync(replay);
+
+        // FAMILY CASCADE: rt2 was valid a moment ago, but the reuse of its sibling revoked the lineage, so
+        // rt2 is now rejected too. The active token an attacker would be holding dies with the family.
+        var afterCascade = await RefreshAsync(client, discovery, rt2);
+        await AssertInvalidGrantAsync(afterCascade);
+    }
+
+    /// <summary>
+    /// Drives a plain (non-PAR) auth-code flow with <c>offline_access</c> for the confidential client and
+    /// returns the token response, whose <c>refresh_token</c> is the first member of a fresh family.
+    /// </summary>
+    private static async Task<JsonObject> ObtainRefreshTokenAsync(HttpClient client, DiscoveryDocument discovery)
+    {
+        var (verifier, challenge) = GeneratePkcePair();
+
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = $"{Scopes.OpenId} {Scopes.OfflineAccess}",
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+
+        return await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+    }
+
+    private static async Task<HttpResponseMessage> RefreshAsync(
+        HttpClient client, DiscoveryDocument discovery, string refreshToken) =>
+        await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
+            [TokenRequest.Parameters.RefreshToken] = refreshToken,
+            [ClientRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+    private static async Task<JsonObject> ReadJsonAsync(HttpResponseMessage response) =>
+        JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+
+    private static async Task AssertInvalidGrantAsync(HttpResponseMessage response)
+    {
+        var body = await ReadJsonAsync(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(ErrorCodes.InvalidGrant, body["error"]!.GetValue<string>());
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -54,6 +54,7 @@ public class RefreshTokenServiceTests
     private const string UserId = "user_456";
     private const string SessionId = "session_789";
     private const string TokenId = "token_abc123";
+    private const string GrantId = "grant_xyz789";
     private const string OldTokenId = "old_token_xyz";
     private const string EncodedToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6InJ0K2p3dCJ9.eyJzdWIiOiJ1c2VyXzQ1NiJ9.signature";
 
@@ -72,6 +73,9 @@ public class RefreshTokenServiceTests
         var tokenIdGenerator = new Mock<ITokenIdGenerator>(MockBehavior.Strict);
         tokenIdGenerator.Setup(g => g.GenerateTokenId()).Returns(TokenId);
 
+        var grantIdGenerator = new Mock<IGrantIdGenerator>(MockBehavior.Strict);
+        grantIdGenerator.Setup(g => g.GenerateGrantId()).Returns(GrantId);
+
         _jwtFormatter = new Mock<IAuthServiceJwtFormatter>(MockBehavior.Strict);
 
         _tokenRegistry = new Mock<ITokenRegistry>(MockBehavior.Strict);
@@ -80,6 +84,7 @@ public class RefreshTokenServiceTests
             issuerProvider.Object,
             timeProvider,
             tokenIdGenerator.Object,
+            grantIdGenerator.Object,
             _jwtFormatter.Object,
             _tokenRegistry.Object);
     }
@@ -296,7 +301,7 @@ public class RefreshTokenServiceTests
 
     /// <summary>
     /// Verifies that a first-issued refresh token starts a new token family: the
-    /// <c>rt_family</c> claim (<see cref="JsonWebTokenPayload.RefreshTokenFamily"/>) is populated so that
+    /// <c>grant_id</c> claim (<see cref="JsonWebTokenPayload.GrantId"/>) is populated so that
     /// every token later rotated from it shares one lineage a detected replay can revoke whole
     /// (RFC 9700 Section 4.14.2).
     /// </summary>
@@ -319,19 +324,19 @@ public class RefreshTokenServiceTests
 
         // Assert
         Assert.NotNull(capturedToken);
-        Assert.False(string.IsNullOrEmpty(capturedToken!.Payload.RefreshTokenFamily));
+        Assert.Equal(GrantId, capturedToken!.Payload.GrantId);
     }
 
     /// <summary>
     /// Verifies that rotation carries the existing token family forward: the new token inherits the previous
-    /// token's <c>rt_family</c> value instead of starting a fresh lineage. This is what lets a replay detected
+    /// token's <c>grant_id</c> value instead of starting a fresh lineage. This is what lets a replay detected
     /// on any single token cascade to the whole grant per the RFC 9700 Section 4.14.2 implementation note.
     /// </summary>
     [Fact]
     public async Task CreateRefreshToken_WithRenewal_ShouldCarryFamilyForward()
     {
         // Arrange
-        const string familyId = "family_root_001";
+        const string grantId = "grant_root_001";
         var authSession = CreateAuthSession();
         var authContext = CreateAuthorizationContext();
         var clientInfo = CreateClientInfo(refreshTokenOptions: new RefreshTokenOptions
@@ -347,7 +352,7 @@ public class RefreshTokenServiceTests
                 JwtId = OldTokenId,
                 IssuedAt = _currentTime.AddHours(-2),
                 ExpiresAt = _currentTime.AddHours(8),
-                RefreshTokenFamily = familyId,
+                GrantId = grantId,
             }
         };
 
@@ -362,7 +367,7 @@ public class RefreshTokenServiceTests
 
         // Assert
         Assert.NotNull(capturedToken);
-        Assert.Equal(familyId, capturedToken!.Payload.RefreshTokenFamily);
+        Assert.Equal(grantId, capturedToken!.Payload.GrantId);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -248,12 +248,14 @@ public class RefreshTokenServiceTests
     }
 
     /// <summary>
-    /// Verifies that when renewing a token with AllowReuse=false, the old refresh token is revoked.
-    /// Per OAuth 2.0 security best practices, refresh token rotation prevents token reuse attacks.
-    /// The old token's JwtId is registered as revoked in the token registry until its expiration.
+    /// Verifies that when rotating a token (AllowReuse=false), the previous refresh token is marked
+    /// <see cref="JsonWebTokenStatus.Used"/> — superseded, not killed. Per the RFC 9700 Section 4.14.2
+    /// rotation model, a later replay of a superseded token is the breach signal that
+    /// <see cref="TokenStatusValidatorDecorator"/> escalates into a whole-family revocation. Marking it
+    /// Revoked here would lose that signal by collapsing "superseded by rotation" into "explicitly killed".
     /// </summary>
     [Fact]
-    public async Task CreateRefreshToken_WithRenewalAndNoReuse_ShouldRevokeOldToken()
+    public async Task CreateRefreshToken_WithRenewalAndNoReuse_ShouldMarkOldTokenSuperseded()
     {
         // Arrange
         var authSession = CreateAuthSession();
@@ -276,7 +278,7 @@ public class RefreshTokenServiceTests
         };
 
         _tokenRegistry
-            .Setup(r => r.SetStatusAsync(OldTokenId, JsonWebTokenStatus.Revoked, oldTokenExpiry))
+            .Setup(r => r.SetStatusAsync(OldTokenId, JsonWebTokenStatus.Used, oldTokenExpiry))
             .Returns(Task.CompletedTask);
 
         _jwtFormatter
@@ -288,8 +290,79 @@ public class RefreshTokenServiceTests
 
         // Assert
         _tokenRegistry.Verify(
-            r => r.SetStatusAsync(OldTokenId, JsonWebTokenStatus.Revoked, oldTokenExpiry),
+            r => r.SetStatusAsync(OldTokenId, JsonWebTokenStatus.Used, oldTokenExpiry),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a first-issued refresh token starts a new token family: the
+    /// <c>rt_family</c> claim (<see cref="JsonWebTokenPayload.RefreshTokenFamily"/>) is populated so that
+    /// every token later rotated from it shares one lineage a detected replay can revoke whole
+    /// (RFC 9700 Section 4.14.2).
+    /// </summary>
+    [Fact]
+    public async Task CreateRefreshToken_NewToken_ShouldStartNewFamily()
+    {
+        // Arrange
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo();
+
+        JsonWebToken? capturedToken = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .ReturnsAsync(EncodedToken);
+
+        // Act
+        await _service.CreateRefreshTokenAsync(authSession, authContext, clientInfo, refreshToken: null);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.False(string.IsNullOrEmpty(capturedToken!.Payload.RefreshTokenFamily));
+    }
+
+    /// <summary>
+    /// Verifies that rotation carries the existing token family forward: the new token inherits the previous
+    /// token's <c>rt_family</c> value instead of starting a fresh lineage. This is what lets a replay detected
+    /// on any single token cascade to the whole grant per the RFC 9700 Section 4.14.2 implementation note.
+    /// </summary>
+    [Fact]
+    public async Task CreateRefreshToken_WithRenewal_ShouldCarryFamilyForward()
+    {
+        // Arrange
+        const string familyId = "family_root_001";
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo(refreshTokenOptions: new RefreshTokenOptions
+        {
+            AllowReuse = true, // isolate family propagation from the rotation status write
+            AbsoluteExpiresIn = TimeSpan.FromHours(10),
+        });
+
+        var oldToken = new JsonWebToken
+        {
+            Payload =
+            {
+                JwtId = OldTokenId,
+                IssuedAt = _currentTime.AddHours(-2),
+                ExpiresAt = _currentTime.AddHours(8),
+                RefreshTokenFamily = familyId,
+            }
+        };
+
+        JsonWebToken? capturedToken = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .ReturnsAsync(EncodedToken);
+
+        // Act
+        await _service.CreateRefreshTokenAsync(authSession, authContext, clientInfo, oldToken);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.Equal(familyId, capturedToken!.Payload.RefreshTokenFamily);
     }
 
     /// <summary>
@@ -430,6 +503,7 @@ public class RefreshTokenServiceTests
         {
             AbsoluteExpiresIn = absoluteExpiry,
             SlidingExpiresIn = slidingExpiry,
+            AllowReuse = true, // this test isolates expiry math from the rotation status write
         });
 
         var oldToken = new JsonWebToken
@@ -481,6 +555,7 @@ public class RefreshTokenServiceTests
         {
             AbsoluteExpiresIn = absoluteExpiry,  // 8 hours from IssuedAt
             SlidingExpiresIn = slidingExpiry,    // 10 hours from IssuedAt
+            AllowReuse = true, // this test isolates expiry math from the rotation status write
         });
 
         var oldToken = new JsonWebToken
@@ -674,6 +749,17 @@ public class RefreshTokenServiceTests
         Assert.True(result.TryGetSuccess(out var grant));
         var refreshGrant = Assert.IsType<Abblix.Oidc.Server.Endpoints.Token.Interfaces.RefreshTokenAuthorizedGrant>(grant);
         Assert.Same(refreshToken, refreshGrant.RefreshToken);
+    }
+
+    /// <summary>
+    /// Verifies the secure-by-default policy: an unconfigured <see cref="RefreshTokenOptions"/> rotates
+    /// (AllowReuse=false). A host that does not explicitly opt a client into multi-use refresh tokens gets
+    /// rotation with family revocation out of the box, satisfying RFC 9700 Section 2.2.2 for public clients.
+    /// </summary>
+    [Fact]
+    public void RefreshTokenOptions_DefaultAllowReuse_ShouldBeFalse()
+    {
+        Assert.False(new RefreshTokenOptions().AllowReuse);
     }
 
     private static AuthSession CreateAuthSession() => new(

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Revocation/TokenStatusValidatorDecoratorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Revocation/TokenStatusValidatorDecoratorTests.cs
@@ -1,0 +1,151 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.Features.Tokens.Revocation;
+using Abblix.Utils;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Revocation;
+
+/// <summary>
+/// Unit tests for <see cref="TokenStatusValidatorDecorator"/> covering refresh-token family revocation
+/// per the OAuth 2.0 Security BCP (RFC 9700 Section 4.14.2) rotation model. The decorator turns a replay of a
+/// superseded refresh token into a whole-family revocation and enforces the family kill switch on every
+/// subsequent use, so a compromised grant is shut down rather than leaving the attacker's active token working.
+/// </summary>
+public class TokenStatusValidatorDecoratorTests
+{
+    private const string ActiveJwtId = "rt_jti_active";
+    private const string FamilyId = "rt_family_001";
+    private static readonly DateTimeOffset Expiry = new(2024, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<ITokenRegistry> _registry = new(MockBehavior.Strict);
+    private readonly Mock<IJsonWebTokenValidator> _inner = new(MockBehavior.Strict);
+    private readonly TokenStatusValidatorDecorator _decorator;
+
+    public TokenStatusValidatorDecoratorTests()
+    {
+        _decorator = new TokenStatusValidatorDecorator(_registry.Object, _inner.Object);
+    }
+
+    /// <summary>
+    /// Replay of a superseded (already-rotated) refresh token: the decorator cannot tell an attacker from a
+    /// lagging client, so it revokes the whole family and reports the token as already used. This is the
+    /// breach signal of RFC 9700 Section 4.14.2 — the point at which the active token in the lineage is doomed.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ReusedRefreshToken_RevokesFamilyAndReportsAlreadyUsed()
+    {
+        SetupInnerReturns(RefreshToken(FamilyId));
+        _registry.Setup(r => r.GetStatusAsync(FamilyId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
+        _registry.Setup(r => r.GetStatusAsync(ActiveJwtId)).ReturnsAsync(JsonWebTokenStatus.Used);
+        _registry
+            .Setup(r => r.SetStatusAsync(FamilyId, JsonWebTokenStatus.Revoked, Expiry))
+            .Returns(Task.CompletedTask);
+
+        var result = await _decorator.ValidateAsync("opaque.rt.jwt", new ValidationParameters());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.TokenAlreadyUsed, error.Error);
+        _registry.Verify(r => r.SetStatusAsync(FamilyId, JsonWebTokenStatus.Revoked, Expiry), Times.Once);
+    }
+
+    /// <summary>
+    /// A structurally valid, not-yet-used refresh token whose family has already been revoked is rejected.
+    /// This is the kill switch that outlives any single token: once a replay elsewhere in the lineage revoked
+    /// the family, the currently active token dies on its next use, even though its own <c>jti</c> is still
+    /// Unknown. The per-token status is never consulted — the family check short-circuits first.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ActiveTokenOfRevokedFamily_IsRejected()
+    {
+        SetupInnerReturns(RefreshToken(FamilyId));
+        _registry.Setup(r => r.GetStatusAsync(FamilyId)).ReturnsAsync(JsonWebTokenStatus.Revoked);
+
+        var result = await _decorator.ValidateAsync("opaque.rt.jwt", new ValidationParameters());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.TokenRevoked, error.Error);
+        _registry.Verify(r => r.GetStatusAsync(ActiveJwtId), Times.Never);
+    }
+
+    /// <summary>
+    /// A fresh refresh token of a live family passes through unchanged: neither the family nor the token has a
+    /// non-neutral status, so the decorator returns the inner validator's success without any registry write.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_LiveRefreshToken_PassesThrough()
+    {
+        var token = RefreshToken(FamilyId);
+        SetupInnerReturns(token);
+        _registry.Setup(r => r.GetStatusAsync(FamilyId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
+        _registry.Setup(r => r.GetStatusAsync(ActiveJwtId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
+
+        var result = await _decorator.ValidateAsync("opaque.rt.jwt", new ValidationParameters());
+
+        Assert.True(result.TryGetSuccess(out var validated));
+        Assert.Same(token, validated);
+    }
+
+    /// <summary>
+    /// Tokens without a family claim (access tokens, ID tokens — anything that is not a rotating refresh token)
+    /// keep the pre-existing single-token behaviour: a used token is rejected, but no family cascade fires. This
+    /// proves the family logic is inert for non-refresh tokens rather than reaching for a null family key.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_UsedTokenWithoutFamily_RejectsWithoutTouchingAnyFamily()
+    {
+        SetupInnerReturns(RefreshToken(family: null));
+        _registry.Setup(r => r.GetStatusAsync(ActiveJwtId)).ReturnsAsync(JsonWebTokenStatus.Used);
+
+        var result = await _decorator.ValidateAsync("opaque.at.jwt", new ValidationParameters());
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.TokenAlreadyUsed, error.Error);
+        _registry.Verify(
+            r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()),
+            Times.Never);
+    }
+
+    private void SetupInnerReturns(JsonWebToken token)
+    {
+        Result<JsonWebToken, JwtValidationError> success = token;
+        _inner
+            .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationParameters>()))
+            .ReturnsAsync(success);
+    }
+
+    private static JsonWebToken RefreshToken(string? family) => new()
+    {
+        Payload =
+        {
+            JwtId = ActiveJwtId,
+            ExpiresAt = Expiry,
+            RefreshTokenFamily = family,
+        }
+    };
+}

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Revocation/TokenStatusValidatorDecoratorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Revocation/TokenStatusValidatorDecoratorTests.cs
@@ -40,7 +40,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Revocation;
 public class TokenStatusValidatorDecoratorTests
 {
     private const string ActiveJwtId = "rt_jti_active";
-    private const string FamilyId = "rt_family_001";
+    private const string GrantId = "grant_001";
     private static readonly DateTimeOffset Expiry = new(2024, 1, 15, 12, 0, 0, TimeSpan.Zero);
 
     private readonly Mock<ITokenRegistry> _registry = new(MockBehavior.Strict);
@@ -60,18 +60,18 @@ public class TokenStatusValidatorDecoratorTests
     [Fact]
     public async Task ValidateAsync_ReusedRefreshToken_RevokesFamilyAndReportsAlreadyUsed()
     {
-        SetupInnerReturns(RefreshToken(FamilyId));
-        _registry.Setup(r => r.GetStatusAsync(FamilyId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
+        SetupInnerReturns(RefreshToken(GrantId));
+        _registry.Setup(r => r.GetStatusAsync(GrantId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
         _registry.Setup(r => r.GetStatusAsync(ActiveJwtId)).ReturnsAsync(JsonWebTokenStatus.Used);
         _registry
-            .Setup(r => r.SetStatusAsync(FamilyId, JsonWebTokenStatus.Revoked, Expiry))
+            .Setup(r => r.SetStatusAsync(GrantId, JsonWebTokenStatus.Revoked, Expiry))
             .Returns(Task.CompletedTask);
 
         var result = await _decorator.ValidateAsync("opaque.rt.jwt", new ValidationParameters());
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(JwtError.TokenAlreadyUsed, error.Error);
-        _registry.Verify(r => r.SetStatusAsync(FamilyId, JsonWebTokenStatus.Revoked, Expiry), Times.Once);
+        _registry.Verify(r => r.SetStatusAsync(GrantId, JsonWebTokenStatus.Revoked, Expiry), Times.Once);
     }
 
     /// <summary>
@@ -83,8 +83,8 @@ public class TokenStatusValidatorDecoratorTests
     [Fact]
     public async Task ValidateAsync_ActiveTokenOfRevokedFamily_IsRejected()
     {
-        SetupInnerReturns(RefreshToken(FamilyId));
-        _registry.Setup(r => r.GetStatusAsync(FamilyId)).ReturnsAsync(JsonWebTokenStatus.Revoked);
+        SetupInnerReturns(RefreshToken(GrantId));
+        _registry.Setup(r => r.GetStatusAsync(GrantId)).ReturnsAsync(JsonWebTokenStatus.Revoked);
 
         var result = await _decorator.ValidateAsync("opaque.rt.jwt", new ValidationParameters());
 
@@ -100,9 +100,9 @@ public class TokenStatusValidatorDecoratorTests
     [Fact]
     public async Task ValidateAsync_LiveRefreshToken_PassesThrough()
     {
-        var token = RefreshToken(FamilyId);
+        var token = RefreshToken(GrantId);
         SetupInnerReturns(token);
-        _registry.Setup(r => r.GetStatusAsync(FamilyId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
+        _registry.Setup(r => r.GetStatusAsync(GrantId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
         _registry.Setup(r => r.GetStatusAsync(ActiveJwtId)).ReturnsAsync(JsonWebTokenStatus.Unknown);
 
         var result = await _decorator.ValidateAsync("opaque.rt.jwt", new ValidationParameters());
@@ -119,7 +119,7 @@ public class TokenStatusValidatorDecoratorTests
     [Fact]
     public async Task ValidateAsync_UsedTokenWithoutFamily_RejectsWithoutTouchingAnyFamily()
     {
-        SetupInnerReturns(RefreshToken(family: null));
+        SetupInnerReturns(RefreshToken(grantId: null));
         _registry.Setup(r => r.GetStatusAsync(ActiveJwtId)).ReturnsAsync(JsonWebTokenStatus.Used);
 
         var result = await _decorator.ValidateAsync("opaque.at.jwt", new ValidationParameters());
@@ -139,13 +139,13 @@ public class TokenStatusValidatorDecoratorTests
             .ReturnsAsync(success);
     }
 
-    private static JsonWebToken RefreshToken(string? family) => new()
+    private static JsonWebToken RefreshToken(string? grantId) => new()
     {
         Payload =
         {
             JwtId = ActiveJwtId,
             ExpiresAt = Expiry,
-            RefreshTokenFamily = family,
+            GrantId = grantId,
         }
     };
 }

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -237,6 +237,14 @@ public record OidcOptions
 	public int TokenIdLength { get; set; } = 64;
 
 	/// <summary>
+	/// Specifies the length, in random bytes, of the refresh-token grant identifier (the <c>grant_id</c>
+	/// claim). The grant id binds every refresh token of one authorization grant into a single lineage for
+	/// rotation and family revocation (RFC 9700 Section 4.14.2), so it must carry enough entropy to make the
+	/// identifier unguessable.
+	/// </summary>
+	public int GrantIdLength { get; set; } = 64;
+
+	/// <summary>
 	/// Determines whether the OIDC server requires Pushed Authorization Requests (PAR).
 	/// </summary>
 	public bool RequirePushedAuthorizationRequests { get; set; } = false;

--- a/Abblix.Oidc.Server/Common/Configuration/RefreshTokenOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/RefreshTokenOptions.cs
@@ -41,8 +41,11 @@ public record struct RefreshTokenOptions()
 	public TimeSpan? SlidingExpiresIn { get; init; } = TimeSpan.FromHours(1);
 
 	/// <summary>
-	/// When <c>true</c>, a refresh token may be redeemed multiple times until it expires. When <c>false</c>,
-	/// each refresh rotates the token: the previous value is invalidated as soon as a new one is issued.
+	/// When <c>false</c> (the secure default), each refresh rotates the token: the previous value is marked
+	/// superseded as soon as a new one is issued, and later reuse of a superseded token revokes the whole
+	/// token family (RFC 9700 Section 4.14.2). Set to <c>true</c> to opt a client into multi-use refresh
+	/// tokens that may be redeemed repeatedly until they expire — appropriate only for confidential clients
+	/// whose client authentication already binds the token to its identity (RFC 6749).
 	/// </summary>
-	public bool AllowReuse { get; init; } = true;
+	public bool AllowReuse { get; init; } = false;
 }

--- a/Abblix.Oidc.Server/Features/RandomGenerators/GrantIdGenerator.cs
+++ b/Abblix.Oidc.Server/Features/RandomGenerators/GrantIdGenerator.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Utils;
+using Microsoft.Extensions.Options;
+
+using System.Buffers.Text;
+
+namespace Abblix.Oidc.Server.Features.RandomGenerators;
+
+/// <summary>
+/// Default <see cref="IGrantIdGenerator"/> implementation. Draws random bytes from a cryptographically
+/// secure source (<see cref="System.Security.Cryptography.RandomNumberGenerator"/> via <c>CryptoRandom</c>)
+/// using the byte count configured in <see cref="OidcOptions.GrantIdLength"/>, then URL-safe Base64 encodes
+/// the result so the resulting <c>grant_id</c> value can travel safely through HTTP transports.
+/// </summary>
+public class GrantIdGenerator(IOptions<OidcOptions> options) : IGrantIdGenerator
+{
+	/// <summary>
+	/// Produces a new <c>grant_id</c> value from cryptographically secure random bytes, sized per
+	/// <see cref="OidcOptions.GrantIdLength"/> and URL-safe Base64 encoded.
+	/// </summary>
+	/// <returns>A URL-safe, randomly generated unique identifier for a refresh-token grant lineage.</returns>
+	public string GenerateGrantId()
+		=> Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(options.Value.GrantIdLength));
+}

--- a/Abblix.Oidc.Server/Features/RandomGenerators/IGrantIdGenerator.cs
+++ b/Abblix.Oidc.Server/Features/RandomGenerators/IGrantIdGenerator.cs
@@ -1,0 +1,38 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.RandomGenerators;
+
+/// <summary>
+/// Produces unique identifiers for refresh-token grants, used as the <c>grant_id</c> claim that binds every
+/// refresh token derived from one authorization grant into a single lineage (a "token family" in RFC 9700
+/// terms). Rotation and family revocation (RFC 9700 §4.14.2) rely on this identifier, so implementations must
+/// generate values with sufficient entropy to make collisions and guessing impractical.
+/// </summary>
+public interface IGrantIdGenerator
+{
+	/// <summary>
+	/// Generates a new unique identifier suitable for the <c>grant_id</c> claim of a refresh token.
+	/// </summary>
+	/// <returns>A unique identifier for a refresh-token grant lineage.</returns>
+	string GenerateGrantId();
+}

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -240,6 +240,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IClientIdGenerator, ClientIdGenerator>();
         services.TryAddSingleton<IClientSecretGenerator, ClientSecretGenerator>();
         services.TryAddSingleton<ITokenIdGenerator, TokenIdGenerator>();
+        services.TryAddSingleton<IGrantIdGenerator, GrantIdGenerator>();
         services.TryAddSingleton<ISessionIdGenerator, SessionIdGenerator>();
         return services;
     }

--- a/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -76,18 +76,25 @@ public class RefreshTokenService(
 		ClientInfo clientInfo,
 		JsonWebToken? refreshToken)
 	{
-		if (!clientInfo.RefreshToken.AllowReuse &&
-		    refreshToken is { Payload: { JwtId: { } jwtId, ExpiresAt: {} expiresAt }})
-		{
-			// Revokes used refresh token to prevent its reuse
-			await tokenRegistry.SetStatusAsync(jwtId, JsonWebTokenStatus.Revoked, expiresAt);
-		}
-
 		var now = clock.GetUtcNow();
 		var issuedAt = refreshToken?.Payload.IssuedAt ?? now;
-		expiresAt = CalculateExpiresAt(issuedAt, now, clientInfo.RefreshToken);
+		var expiresAt = CalculateExpiresAt(issuedAt, now, clientInfo.RefreshToken);
 		if (expiresAt < now)
 			return null;
+
+		if (!clientInfo.RefreshToken.AllowReuse &&
+		    refreshToken is { Payload: { JwtId: { } previousJwtId, ExpiresAt: { } previousExpiresAt } })
+		{
+			// Rotation marks the previous token Used ("superseded"), not Revoked ("killed"). A later
+			// presentation of a superseded token is the replay signal that TokenStatusValidatorDecorator
+			// turns into a whole-family revocation (RFC 9700 §4.14.2). Running this only after the expiry
+			// check means a refused renewal never consumes the presented token.
+			await tokenRegistry.SetStatusAsync(previousJwtId, JsonWebTokenStatus.Used, previousExpiresAt);
+		}
+
+		// A first-issued token starts a new family; a rotation carries the existing family forward. The family
+		// ties every refresh token of one authorization grant into a lineage a detected replay can revoke whole.
+		var familyId = refreshToken?.Payload.RefreshTokenFamily ?? tokenIdGenerator.GenerateTokenId();
 
 		var newToken = new JsonWebToken
 		{
@@ -108,6 +115,7 @@ public class RefreshTokenService(
 		};
 		authSession.ApplyTo(newToken.Payload);
 		authContext.ApplyTo(newToken.Payload);
+		newToken.Payload.RefreshTokenFamily = familyId;
 
 		return new EncodedJsonWebToken(newToken, await jwtFormatter.FormatAsync(newToken));
 	}

--- a/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -45,12 +45,14 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// <param name="issuerProvider">Provider for the issuer claim in tokens.</param>
 /// <param name="clock">Time provider for token timestamps.</param>
 /// <param name="tokenIdGenerator">Generator for unique token identifiers.</param>
+/// <param name="grantIdGenerator">Generator for unique refresh-token grant identifiers.</param>
 /// <param name="jwtFormatter">Formatter for encoding JWTs.</param>
 /// <param name="tokenRegistry">Registry for tracking token status.</param>
 public class RefreshTokenService(
 	IIssuerProvider issuerProvider,
 	TimeProvider clock,
 	ITokenIdGenerator tokenIdGenerator,
+	IGrantIdGenerator grantIdGenerator,
 	IAuthServiceJwtFormatter jwtFormatter,
 	ITokenRegistry tokenRegistry) : IRefreshTokenService
 {
@@ -92,9 +94,9 @@ public class RefreshTokenService(
 			await tokenRegistry.SetStatusAsync(previousJwtId, JsonWebTokenStatus.Used, previousExpiresAt);
 		}
 
-		// A first-issued token starts a new family; a rotation carries the existing family forward. The family
-		// ties every refresh token of one authorization grant into a lineage a detected replay can revoke whole.
-		var familyId = refreshToken?.Payload.RefreshTokenFamily ?? tokenIdGenerator.GenerateTokenId();
+		// A first-issued token starts a new grant lineage; a rotation carries the existing grant id forward. The
+		// grant id ties every refresh token of one authorization grant into a family a detected replay revokes whole.
+		var grantId = refreshToken?.Payload.GrantId ?? grantIdGenerator.GenerateGrantId();
 
 		var newToken = new JsonWebToken
 		{
@@ -111,11 +113,11 @@ public class RefreshTokenService(
 				ExpiresAt = expiresAt,
 				Issuer = LicenseChecker.CheckIssuer(issuerProvider.GetIssuer()),
 				Audiences = [clientInfo.ClientId],
+				GrantId = grantId,
 			},
 		};
 		authSession.ApplyTo(newToken.Payload);
 		authContext.ApplyTo(newToken.Payload);
-		newToken.Payload.RefreshTokenFamily = familyId;
 
 		return new EncodedJsonWebToken(newToken, await jwtFormatter.FormatAsync(newToken));
 	}

--- a/Abblix.Oidc.Server/Features/Tokens/Revocation/TokenStatusValidatorDecorator.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Revocation/TokenStatusValidatorDecorator.cs
@@ -75,9 +75,23 @@ public class TokenStatusValidatorDecorator(
 
 		if (result.TryGetSuccess(out var token) && token.Payload.JwtId is { } jwtId)
 		{
+			// Refresh tokens carry a family id (Payload.RefreshTokenFamily); other token types leave it null, so
+			// the family logic below is inert for them. A revoked family is a kill switch that outlives any
+			// single token: once one member's replay trips it, every member — including the currently active
+			// one — is rejected here on its next use (RFC 9700 §4.14.2).
+			var familyId = token.Payload.RefreshTokenFamily;
+
+			if (familyId is not null && await tokenRegistry.GetStatusAsync(familyId) == JsonWebTokenStatus.Revoked)
+				return new JwtValidationError(JwtError.TokenRevoked, "Refresh token family was revoked");
+
 			switch (await tokenRegistry.GetStatusAsync(jwtId))
 			{
 				case JsonWebTokenStatus.Used:
+					// Replay of a superseded (rotated) token. We cannot tell an attacker from a lagging client,
+					// so revoke the whole family; the active token dies with it on its next use.
+					if (familyId is not null && token.Payload.ExpiresAt is { } familyExpiresAt)
+						await tokenRegistry.SetStatusAsync(familyId, JsonWebTokenStatus.Revoked, familyExpiresAt);
+
 					return new JwtValidationError(JwtError.TokenAlreadyUsed, "Token was already used");
 
 				case JsonWebTokenStatus.Revoked:

--- a/Abblix.Oidc.Server/Features/Tokens/Revocation/TokenStatusValidatorDecorator.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Revocation/TokenStatusValidatorDecorator.cs
@@ -75,22 +75,22 @@ public class TokenStatusValidatorDecorator(
 
 		if (result.TryGetSuccess(out var token) && token.Payload.JwtId is { } jwtId)
 		{
-			// Refresh tokens carry a family id (Payload.RefreshTokenFamily); other token types leave it null, so
-			// the family logic below is inert for them. A revoked family is a kill switch that outlives any
-			// single token: once one member's replay trips it, every member — including the currently active
+			// Refresh tokens carry a grant id (Payload.GrantId); other token types leave it null, so the family
+			// logic below is inert for them. A revoked grant is a kill switch that outlives any single token:
+			// once one member's replay trips it, every member of the family — including the currently active
 			// one — is rejected here on its next use (RFC 9700 §4.14.2).
-			var familyId = token.Payload.RefreshTokenFamily;
+			var grantId = token.Payload.GrantId;
 
-			if (familyId is not null && await tokenRegistry.GetStatusAsync(familyId) == JsonWebTokenStatus.Revoked)
+			if (grantId is not null && await tokenRegistry.GetStatusAsync(grantId) == JsonWebTokenStatus.Revoked)
 				return new JwtValidationError(JwtError.TokenRevoked, "Refresh token family was revoked");
 
 			switch (await tokenRegistry.GetStatusAsync(jwtId))
 			{
 				case JsonWebTokenStatus.Used:
 					// Replay of a superseded (rotated) token. We cannot tell an attacker from a lagging client,
-					// so revoke the whole family; the active token dies with it on its next use.
-					if (familyId is not null && token.Payload.ExpiresAt is { } familyExpiresAt)
-						await tokenRegistry.SetStatusAsync(familyId, JsonWebTokenStatus.Revoked, familyExpiresAt);
+					// so revoke the whole grant family; the active token dies with it on its next use.
+					if (grantId is not null && token.Payload.ExpiresAt is { } grantExpiresAt)
+						await tokenRegistry.SetStatusAsync(grantId, JsonWebTokenStatus.Revoked, grantExpiresAt);
 
 					return new JwtValidationError(JwtError.TokenAlreadyUsed, "Token was already used");
 


### PR DESCRIPTION
## What

Brings refresh-token handling in line with the OAuth 2.0 Security BCP rotation model (RFC 9700 §4.14.2).

- **Rotation by default.** `RefreshTokenOptions.AllowReuse` now defaults to `false`. A client rotates its refresh tokens unless it explicitly opts into multi-use tokens — appropriate only for confidential clients whose client authentication already binds the token (RFC 6749 §6). Satisfies RFC 9700 §2.2.2 for public clients on default configuration.

- **Token-family revocation.** Every refresh token carries a `grant_id` claim (`JwtClaimTypes.GrantId`), minted by a dedicated `IGrantIdGenerator` sized by its own `OidcOptions.GrantIdLength`, that identifies the authorization grant the token belongs to and binds all tokens of that grant into a lineage: the first-issued token starts a family, each rotation carries the id forward. Rotation marks the previous token *superseded* (`Used`), not *killed* (`Revoked`). A replay of a superseded token is the breach signal that `TokenStatusValidatorDecorator` escalates into a whole-family revocation, after which every token of the lineage — active one included — is rejected on next use. Implements the §4.14.2 requirement to revoke the active token on reuse detection.

## Behavior notes

- The rotation status write runs only after the expiry check, so a refused renewal (expired token) never consumes the presented token.
- Confidential clients that set `AllowReuse = true` keep multi-use behavior.
- The grant lookup adds one registry read on the refresh path only; non-refresh tokens carry no `grant_id` and are unaffected.

## Standards

- RFC 9700 (OAuth 2.0 Security BCP) §2.2.2, §4.14.2
- RFC 6749 §6, §10.4
- RFC 7519 §4.3 (`grant_id` is a private claim; no IANA-registered claim captures per-grant refresh-token lineage)
