### PR TITLE
Enforce strict request-object processing for FAPI 2.0 clients (RFC 9101 §6.3)

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -45,6 +45,7 @@ public class SecurityProfileTests
         Assert.False(requirements.RequirePushedAuthorizationRequests);
         Assert.False(requirements.RequireSenderConstrainedTokens);
         Assert.False(requirements.RequireCodeResponseTypeOnly);
+        Assert.False(requirements.RequireStrictRequestObjectProcessing);
     }
 
     [Fact]
@@ -57,6 +58,7 @@ public class SecurityProfileTests
         Assert.True(requirements.RequirePushedAuthorizationRequests);
         Assert.True(requirements.RequireSenderConstrainedTokens);
         Assert.True(requirements.RequireCodeResponseTypeOnly);
+        Assert.True(requirements.RequireStrictRequestObjectProcessing);
     }
 
     [Theory]

--- a/Abblix.Oidc.Server.UnitTests/Features/RequestObject/RequestObjectFetcherTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/RequestObject/RequestObjectFetcherTests.cs
@@ -22,8 +22,10 @@
 
 using System;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Abblix.Jwt;
+using Abblix.Oidc.Server;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Interfaces;
@@ -96,6 +98,62 @@ public class RequestObjectFetcherTests
     }
 
     private record TestRequest(string ClientId, string RedirectUri, string? State);
+
+    // A request type with wire-named JSON keys, mirroring how real request models bind, so strict
+    // RFC 9101 §6.3 processing can be exercised where parameter names line up with the object's claims.
+    private record JarTestRequest
+    {
+        [JsonPropertyName("client_id")] public string? ClientId { get; init; }
+        [JsonPropertyName("state")] public string? State { get; init; }
+        [JsonPropertyName("request")] public string? Request { get; init; }
+    }
+
+    /// <summary>
+    /// A client held to the FAPI 2.0 security profile is processed under the strict RFC 9101 §6.3 rule even
+    /// when the global default stays merge: a parameter passed outside the request object that the object does
+    /// not carry is dropped, and the drop is reported as a warning.
+    /// </summary>
+    [Fact]
+    public async Task FetchAsync_FapiProfileClient_ProcessesStrictlyAndWarnsOnOutsideParameter()
+    {
+        // Arrange — the global default stays merge; the FAPI profile is what forces strict for this client.
+        Assert.False(_oidcOptions.IgnoreParametersOutsideRequestObject);
+        _logger.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+        var fetcher = CreateFetcher();
+
+        const string jwt = "eyJhbGciOiJSUzI1NiJ9.eyJjbGllbnRfaWQiOiJjMSJ9.signature";
+        var request = new JarTestRequest { ClientId = "c1", State = "outside-only", Request = jwt };
+        var payload = new JsonObject { ["client_id"] = "c1" };
+        var token = new JsonWebToken
+        {
+            Header = new JsonWebTokenHeader(new JsonObject()),
+            Payload = new JsonWebTokenPayload(payload),
+        };
+        var fapiClient = new ClientInfo("c1") { SecurityProfile = ClientSecurityProfile.Fapi2 };
+
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(jwt, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, fapiClient));
+        _jsonObjectBinder
+            .Setup(b => b.BindModelAsync(payload, It.IsAny<JarTestRequest>()))
+            .ReturnsAsync((JsonObject _, JarTestRequest bound) => bound);
+
+        // Act
+        var result = await fetcher.FetchAsync(request, jwt);
+
+        // Assert — the payload bound onto a fresh model (the outside-only state is gone) and the drop was logged.
+        Assert.True(result.TryGetSuccess(out var value));
+        Assert.NotSame(request, value);
+        Assert.Null(value!.State);
+        _logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.Is<EventId>(e => e.Id == LogEvents.Misc.RequestObjectFetcher.ParametersOutsideRequestObjectIgnored),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
 
     /// <summary>
     /// Verifies that null requestObject returns original request unchanged.

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -256,11 +256,19 @@ public record OidcOptions
 	public bool RequireSignedRequestObject { get; set; } = false;
 
 	/// <summary>
-	/// Switches request-object processing to the strict RFC 9101 §5 semantics: when a request
-	/// object is used, the authorization request is exactly the content of the object and any
-	/// parameter passed outside it is ignored instead of merged. The default (off) keeps the
-	/// OpenID Connect Core §6.1 merge semantics, where parameters outside the object complement
-	/// the ones inside. FAPI-style OAuth-only deployments enable this switch.
+	/// Governs how a request object resolves a parameter that appears both inside the object and in the
+	/// OAuth query syntax — a choice between two specifications. When <c>false</c> (the default), request-object
+	/// processing follows the OpenID Connect Core §6.1 merge semantics: the object's values supersede those
+	/// passed outside it, but a parameter passed only outside the object is still used. Set to <c>true</c> for
+	/// the strict RFC 9101 §6.3 rule, where the authorization request is exactly the content of the object and
+	/// any parameter passed outside it is ignored ("the authorization server MUST only use the parameters in
+	/// the Request Object"). The strict rule suits FAPI-style OAuth deployments; as an OpenID Provider the
+	/// server defaults to the merge behaviour, since strict processing would drop parameters that existing
+	/// OpenID Connect clients commonly pass outside the object. A client held to the FAPI 2.0 security profile
+	/// is processed strictly regardless of this global default.
+	/// This switch affects only parameter exclusivity; the other RFC 9101 §6.3 requirement — that a
+	/// <c>client_id</c> or <c>response_type</c> present both inside and outside the object be identical — is
+	/// enforced in both modes and cannot be turned off.
 	/// </summary>
 	public bool IgnoreParametersOutsideRequestObject { get; set; } = false;
 

--- a/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
@@ -82,6 +82,14 @@ public sealed record SecurityProfileRequirements
     /// </summary>
     public bool RequireCodeResponseTypeOnly { get; init; }
 
+    /// <summary>
+    /// The profile requires strict RFC 9101 §6.3 request-object processing: only the parameters inside the
+    /// request object are used and any parameter passed outside it is ignored, instead of the OpenID Connect
+    /// Core §6.1 merge behaviour. FAPI 2.0 mandates JWT-Secured Authorization Requests with this exclusivity.
+    /// Enforced by <c>Features.RequestObject.RequestObjectFetcher</c>.
+    /// </summary>
+    public bool RequireStrictRequestObjectProcessing { get; init; }
+
     private static readonly SecurityProfileRequirements NoneRequirements = new();
 
     private static readonly SecurityProfileRequirements Fapi2Requirements = new()
@@ -91,6 +99,7 @@ public sealed record SecurityProfileRequirements
         RequirePushedAuthorizationRequests = true,
         RequireSenderConstrainedTokens = true,
         RequireCodeResponseTypeOnly = true,
+        RequireStrictRequestObjectProcessing = true,
     };
 
     /// <summary>

--- a/Abblix.Oidc.Server/Features/RequestObject/RequestObjectFetcher.Logging.cs
+++ b/Abblix.Oidc.Server/Features/RequestObject/RequestObjectFetcher.Logging.cs
@@ -38,4 +38,10 @@ partial class RequestObjectFetcher
         Level = LogLevel.Warning,
         Message = "The request object for {ClientId} is signed with {Algorithm}, but the client registered {RequiredAlgorithm}")]
     private partial void LogSigningAlgorithmMismatch(string ClientId, string? Algorithm, string RequiredAlgorithm);
+
+    [LoggerMessage(
+        EventId = LogEvents.Misc.RequestObjectFetcher.ParametersOutsideRequestObjectIgnored,
+        Level = LogLevel.Warning,
+        Message = "Strict request-object processing (RFC 9101) ignored these parameters passed outside the request object: {Parameters}")]
+    private partial void LogParametersOutsideRequestObjectIgnored(string Parameters);
 }

--- a/Abblix.Oidc.Server/Features/RequestObject/RequestObjectFetcher.cs
+++ b/Abblix.Oidc.Server/Features/RequestObject/RequestObjectFetcher.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
@@ -77,25 +78,67 @@ public partial class RequestObjectFetcher(
 
         var validationResult = await ValidateAsync(requestObject, requiredSigningAlgorithm);
         return await validationResult.BindAsync<T>(
-            async payload =>
+            async validated =>
             {
-                // RFC 9101 §5 strict mode: the authorization request is exactly the request object,
-                // so the payload binds onto a fresh model and parameters passed outside the object
-                // are ignored (the OAuth-syntax client_id/response_type duplicates are still
-                // cross-checked against the result by the authorization-endpoint adapter). The
-                // default keeps the OIDC Core §6.1 merge semantics, binding the payload over the
-                // outer request.
-                var target = options.Value.IgnoreParametersOutsideRequestObject
-                    ? Activator.CreateInstance<T>()
-                    : request;
+                var (payload, client) = validated;
+
+                // Strict RFC 9101 §6.3 processing — only the request object's parameters are used and anything
+                // passed outside it is ignored — applies when the host turns it on globally or the client's
+                // security profile (FAPI 2.0) mandates it. Otherwise the OpenID Connect Core §6.1 merge
+                // semantics bind the payload over the outer request. The OAuth-syntax client_id/response_type
+                // duplicates are cross-checked against the result by the authorization-endpoint adapter in both.
+                var strict = options.Value.IgnoreParametersOutsideRequestObject
+                    || SecurityProfileRequirements.For(client, options.Value.DefaultSecurityProfile)
+                        .RequireStrictRequestObjectProcessing;
+                var target = strict ? Activator.CreateInstance<T>() : request;
 
                 var updatedRequest = await jsonObjectBinder.BindModelAsync(payload, target);
                 if (updatedRequest == null)
                     return InvalidRequestObject("Unable to bind request object");
 
+                if (strict)
+                    WarnAboutIgnoredOutsideParameters(request, requestObject, payload);
+
                 return updatedRequest;
             }
         );
+    }
+
+    /// <summary>
+    /// In strict mode (RFC 9101 §6.3) parameters passed outside the request object are silently dropped.
+    /// This surfaces them as a warning so an operator can see a client sending parameters that never take
+    /// effect. A parameter is reported only when it is absent from the object, is not the parameter that
+    /// carries the object itself, and differs from the request model's default (so it was actually supplied).
+    /// </summary>
+    private void WarnAboutIgnoredOutsideParameters<T>(T request, string? requestObject, JsonObject payload)
+        where T : class
+    {
+        var outer = JsonSerializer.SerializeToNode(request)?.AsObject();
+        if (outer is null)
+            return;
+
+        var defaults = JsonSerializer.SerializeToNode(Activator.CreateInstance<T>())?.AsObject();
+
+        var ignored = new List<string>();
+        foreach (var (name, value) in outer)
+        {
+            // Carried by the object as well — used, not dropped.
+            if (payload.ContainsKey(name))
+                continue;
+
+            // The parameter that carries the request object itself is expected to be outside it.
+            if (value?.GetValueKind() == JsonValueKind.String && value.GetValue<string>() == requestObject)
+                continue;
+
+            // Left at its type default — the client did not actually supply it.
+            if (JsonNode.DeepEquals(value, defaults?[name]))
+                continue;
+
+            ignored.Add(name);
+        }
+
+        if (ignored.Count > 0)
+            LogParametersOutsideRequestObjectIgnored(string.Join(", ", ignored));
     }
 
     /// <summary>
@@ -113,7 +156,7 @@ public partial class RequestObjectFetcher(
     /// This method uses the configured OIDC options to determine whether the JWT must be signed and validates
     /// it accordingly. It retrieves a validator service from the DI container to perform the validation.
     /// </remarks>
-    private async Task<Result<JsonObject, OidcError>> ValidateAsync(
+    private async Task<Result<(JsonObject Payload, ClientInfo Client), OidcError>> ValidateAsync(
         string requestObject,
         Func<ClientInfo, string?>? requiredSigningAlgorithm)
     {
@@ -136,7 +179,7 @@ public partial class RequestObjectFetcher(
         var tokenValidator = scope.ServiceProvider.GetRequiredService<IClientJwtValidator>();
         var result = await tokenValidator.ValidateAsync(requestObject, validationOptions);
 
-        return result.Match<Result<JsonObject, OidcError>>(
+        return result.Match<Result<(JsonObject Payload, ClientInfo Client), OidcError>>(
             validJwt =>
             {
                 // RFC 9101 §10.5: a client registered with require_signed_request_object committed
@@ -164,7 +207,7 @@ public partial class RequestObjectFetcher(
                         "The request object signing algorithm does not match the client's registered algorithm");
                 }
 
-                return validJwt.Token.Payload.Json;
+                return (validJwt.Token.Payload.Json, validJwt.Client);
             },
             error => InvalidRequestObject(error));
     }

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -607,6 +607,7 @@ internal static class LogEvents
 
             public const int InvalidToken = Base + 1;
             public const int SigningAlgorithmMismatch = Base + 2;
+            public const int ParametersOutsideRequestObjectIgnored = Base + 3;
         }
 
         /// <summary>


### PR DESCRIPTION
## What

FAPI 2.0 mandates JWT-Secured Authorization Requests processed strictly (RFC 9101 §6.3): the authorization request is exactly the request object, and any parameter passed outside it is ignored. This wires that rule into the per-client FAPI 2.0 security profile.

- A client held to the FAPI 2.0 profile is processed strictly.
- Regular OpenID Connect clients keep the OpenID Connect Core §6.1 merge semantics (the object's values supersede, but a parameter passed only outside it is still used) — the default. Flipping this globally would deviate from OIDC Core §6.1 for every OIDC client that splits parameters across the object and the query, which RFC 9101's own Security Considerations warns "will break most existing deployments … especially with OpenID Connect".

## How

- `SecurityProfileRequirements` gains a `RequireStrictRequestObjectProcessing` flag, set for FAPI 2.0 — the single place the profile-to-controls mapping lives.
- `RequestObjectFetcher` resolves the effective decision as the global `OidcOptions.IgnoreParametersOutsideRequestObject` (default `false` = merge) **OR** the client's profile requirement, mirroring how `PushedRequestFetcher` composes the global PAR flag with the profile. The global option stays as a server-wide "strict for all clients" knob for pure OAuth 2.0 JAR deployments; the profile scopes strict per client.
- The `client_id`/`response_type` cross-check between the object and the query is unchanged and runs in both modes.

## Observability

When strict processing drops parameters a client passed outside the object, a warning names them, so an operator can spot a client sending parameters that never take effect.

## Standards

- RFC 9101 (JAR) §6.3
- OpenID Connect Core 1.0 §6.1
- FAPI 2.0 Security Profile
