### PR TITLE
Detect reuse of a constant PKCE code_challenge or nonce (RFC 9700 §2.1.1)

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -47,6 +47,7 @@ using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
+using Abblix.Oidc.Server.Features.ReusePrevention;
 using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization;
@@ -94,7 +95,7 @@ public class AuthorizationRequestProcessorTests
             _consentsProvider.Object,
             _timeProvider,
             [
-                new AuthorizationCodeBuilder(_authorizationCodeService.Object),
+                new AuthorizationCodeBuilder(_authorizationCodeService.Object, Mock.Of<IAuthorizationValueReuseDetector>()),
                 new TokenResponseBuilder(_accessTokenService.Object),
                 new IdTokenResponseBuilder(_identityTokenService.Object),
             ],

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/NonceValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/NonceValidatorTests.cs
@@ -27,6 +27,8 @@ using Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Abblix.Oidc.Server.Features.ReusePrevention;
+using Moq;
 using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization.Validation;
@@ -45,7 +47,7 @@ public class NonceValidatorTests
 
     public NonceValidatorTests()
     {
-        _validator = new NonceValidator();
+        _validator = new NonceValidator(Mock.Of<IAuthorizationValueReuseDetector>());
     }
 
     /// <summary>
@@ -89,6 +91,29 @@ public class NonceValidatorTests
 
         // Assert
         Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that a nonce the client already used for a previously issued authorization code is rejected
+    /// when reuse detection is enabled — a nonce must be transaction-specific (RFC 9700 Section 2.1.1). The
+    /// code response type keeps the nonce optional, so the rejection comes from reuse, not a missing nonce.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithReusedNonce_ShouldFail()
+    {
+        // Arrange
+        var reuseDetector = new Mock<IAuthorizationValueReuseDetector>();
+        reuseDetector
+            .Setup(d => d.IsReusedAsync(ClientId, It.IsAny<string>(), ValidNonce))
+            .ReturnsAsync(true);
+        var validator = new NonceValidator(reuseDetector.Object);
+        var context = CreateContext([ResponseTypes.Code], nonce: ValidNonce);
+
+        // Act
+        var result = await validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/PkceValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/PkceValidatorTests.cs
@@ -29,6 +29,8 @@ using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Microsoft.Extensions.Options;
+using Abblix.Oidc.Server.Features.ReusePrevention;
+using Moq;
 using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization.Validation;
@@ -52,8 +54,36 @@ public class PkceValidatorTests
     }
 
     private static PkceValidator CreateValidator(
-        ClientSecurityProfile defaultSecurityProfile = ClientSecurityProfile.None)
-        => new(Options.Create(new OidcOptions { DefaultSecurityProfile = defaultSecurityProfile }));
+        ClientSecurityProfile defaultSecurityProfile = ClientSecurityProfile.None,
+        IAuthorizationValueReuseDetector? reuseDetector = null)
+        => new(
+            Options.Create(new OidcOptions { DefaultSecurityProfile = defaultSecurityProfile }),
+            reuseDetector ?? Mock.Of<IAuthorizationValueReuseDetector>());
+
+    /// <summary>
+    /// Verifies that a code_challenge the client already used for a previously issued authorization code is
+    /// rejected when reuse detection is enabled — a code_challenge must be transaction-specific (RFC 9700
+    /// Section 2.1.1). A structurally valid S256 challenge would otherwise pass.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithReusedCodeChallenge_ShouldFail()
+    {
+        // Arrange
+        var reuseDetector = new Mock<IAuthorizationValueReuseDetector>();
+        reuseDetector
+            .Setup(d => d.IsReusedAsync(ClientId, It.IsAny<string>(), CodeChallengeS256))
+            .ReturnsAsync(true);
+        var validator = CreateValidator(reuseDetector: reuseDetector.Object);
+        var context = CreateContext(
+            codeChallenge: CodeChallengeS256,
+            codeChallengeMethod: CodeChallengeMethods.S256);
+
+        // Act
+        var result = await validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+    }
 
     /// <summary>
     /// Creates an AuthorizationValidationContext for testing.

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/UpdateClientRequestProcessorTests.cs
@@ -49,7 +49,7 @@ public class UpdateClientRequestProcessorTests
         var clientInfoManager = new Mock<IClientInfoManager>(MockBehavior.Strict);
         clientInfoManager
             .Setup(m => m.UpdateClientAsync(It.IsAny<ClientInfo>()))
-            .Callback<ClientInfo>(onSave)
+            .Callback(onSave)
             .Returns(Task.CompletedTask);
 
         var tokenService = new Mock<IRegistrationAccessTokenService>(MockBehavior.Loose);

--- a/Abblix.Oidc.Server.UnitTests/Features/ReusePrevention/AuthorizationValueReuseDetectorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ReusePrevention/AuthorizationValueReuseDetectorTests.cs
@@ -1,0 +1,103 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.ReusePrevention;
+using Abblix.Oidc.Server.Features.Storages;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.ReusePrevention;
+
+/// <summary>
+/// Unit tests for <see cref="AuthorizationValueReuseDetector"/> covering the RFC 9700 Section 2.1.1
+/// constant-value detection: a value recorded once is reported as reused, distinct values/kinds/clients stay
+/// independent, and the whole mechanism is inert unless the detection interval is configured.
+/// </summary>
+public class AuthorizationValueReuseDetectorTests
+{
+    private const string CodeChallenge = "code_challenge";
+    private const string Nonce = "nonce";
+
+    private static AuthorizationValueReuseDetector CreateDetector(TimeSpan? interval)
+        => new(
+            new InMemoryEntityStorage(),
+            new EntityStorageKeyFactory(),
+            Options.Create(new OidcOptions { PkceAndNonceReuseDetectionInterval = interval }));
+
+    [Fact]
+    public async Task Enabled_RecordThenCheck_ReportsReused()
+    {
+        var detector = CreateDetector(TimeSpan.FromMinutes(5));
+
+        // A value not yet recorded is fresh; after recording, the same value is flagged as reused.
+        Assert.False(await detector.IsReusedAsync("c1", CodeChallenge, "value-1"));
+        await detector.RecordAsync("c1", CodeChallenge, "value-1");
+        Assert.True(await detector.IsReusedAsync("c1", CodeChallenge, "value-1"));
+
+        // A different value, a different kind, and a different client are all independent.
+        Assert.False(await detector.IsReusedAsync("c1", CodeChallenge, "value-2"));
+        Assert.False(await detector.IsReusedAsync("c1", Nonce, "value-1"));
+        Assert.False(await detector.IsReusedAsync("c2", CodeChallenge, "value-1"));
+    }
+
+    [Fact]
+    public async Task Disabled_IsInert()
+    {
+        var detector = CreateDetector(interval: null);
+
+        await detector.RecordAsync("c1", CodeChallenge, "value-1");
+
+        // Nothing is recorded and nothing is flagged while detection is off.
+        Assert.False(await detector.IsReusedAsync("c1", CodeChallenge, "value-1"));
+    }
+
+    private sealed class InMemoryEntityStorage : IEntityStorage
+    {
+        private readonly Dictionary<string, object?> _store = new();
+
+        public Task SetAsync<T>(string key, T value, StorageOptions options, CancellationToken? token = null)
+        {
+            _store[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<T?> GetAsync<T>(string key, bool removeOnRetrieval, CancellationToken? token = null)
+        {
+            var found = _store.TryGetValue(key, out var value);
+            if (found && removeOnRetrieval)
+                _store.Remove(key);
+
+            return Task.FromResult(found ? (T?)value : default);
+        }
+
+        public Task RemoveAsync(string key, CancellationToken? token = null)
+        {
+            _store.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -316,4 +316,17 @@ public record OidcOptions
 	/// individual metadata flags, so existing deployments are unaffected.
 	/// </summary>
 	public ClientSecurityProfile DefaultSecurityProfile { get; set; } = ClientSecurityProfile.None;
+
+	/// <summary>
+	/// Enables detection of a client reusing a constant PKCE <c>code_challenge</c> or OpenID Connect
+	/// <c>nonce</c> across authorization requests, which defeats the transaction-binding those values provide
+	/// (RFC 9700 Section 2.1.1 encourages the authorization server to make a reasonable effort to detect and
+	/// prevent it). When set, the server records each value at the moment it issues an authorization code and
+	/// rejects a later authorization request from the same client that repeats a value within this interval.
+	/// Recording at code issuance — not on every authorization request — means re-processing one request
+	/// across a login or consent redirect is not flagged. Left <c>null</c> (the default) the check is off:
+	/// a conforming client generates a fresh value per request and is never affected, but a client that
+	/// incorrectly reuses a value across separate authorizations would then be rejected, so it is opt-in.
+	/// </summary>
+	public TimeSpan? PkceAndNonceReuseDetectionInterval { get; set; }
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationCodeBuilder.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationCodeBuilder.cs
@@ -23,7 +23,9 @@
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+using Abblix.Oidc.Server.Features.ReusePrevention;
 using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.Model;
 
 namespace Abblix.Oidc.Server.Endpoints.Authorization;
 
@@ -36,7 +38,9 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization;
 /// <c>authorization_code</c> in <see cref="GrantTypesSupported"/> so the discovery
 /// endpoint and registration-time gates aggregate it transparently.
 /// </summary>
-public class AuthorizationCodeBuilder(IAuthorizationCodeService authorizationCodeService)
+public class AuthorizationCodeBuilder(
+    IAuthorizationCodeService authorizationCodeService,
+    IAuthorizationValueReuseDetector reuseDetector)
     : IAuthorizationResponseBuilder
 {
     /// <inheritdoc />
@@ -57,5 +61,14 @@ public class AuthorizationCodeBuilder(IAuthorizationCodeService authorizationCod
         result.Code = await authorizationCodeService.GenerateAuthorizationCodeAsync(
             authorizedGrant,
             request.ClientInfo.AuthorizationCodeExpiresIn);
+
+        // Record this transaction's replay-protection values so a later reuse of a constant code_challenge
+        // or nonce by the same client is detected (RFC 9700 §2.1.1). Doing it here — once per issued code —
+        // means the same request re-processed across a login or consent redirect is not flagged.
+        var context = authorizedGrant.Context;
+        if (context.CodeChallenge is { } codeChallenge)
+            await reuseDetector.RecordAsync(context.ClientId, AuthorizationRequest.Parameters.CodeChallenge, codeChallenge);
+        if (context.Nonce is { } nonce)
+            await reuseDetector.RecordAsync(context.ClientId, AuthorizationRequest.Parameters.Nonce, nonce);
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/NonceValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/NonceValidator.cs
@@ -22,6 +22,7 @@
 
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
+using Abblix.Oidc.Server.Features.ReusePrevention;
 using Abblix.Utils;
 using static Abblix.Oidc.Server.Model.AuthorizationRequest;
 
@@ -34,7 +35,7 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 /// synchronous validation.
 /// Refer to RFC 6749 and OpenID Connect Core 1.0 for more details on authorization request parameters.
 /// </summary>
-public class NonceValidator : SyncAuthorizationContextValidatorBase
+public class NonceValidator(IAuthorizationValueReuseDetector reuseDetector) : IAuthorizationContextValidator
 {
     /// <summary>
     /// Validates the nonce in the authorization request as per OpenID Connect Core 1.0 specifications.
@@ -46,7 +47,7 @@ public class NonceValidator : SyncAuthorizationContextValidatorBase
     /// when the response type includes an ID token, as by OpenID Connect Core 1.0;
     /// otherwise, null indicating successful validation.
     /// </returns>
-    protected override AuthorizationRequestValidationError? Validate(AuthorizationValidationContext context)
+    public async Task<AuthorizationRequestValidationError?> ValidateAsync(AuthorizationValidationContext context)
     {
         var request = context.Request;
         var responseType = request.ResponseType.NotNull(nameof(request.ResponseType));
@@ -65,6 +66,14 @@ public class NonceValidator : SyncAuthorizationContextValidatorBase
         {
             return context.InvalidRequest(
                 $"Nonce is required for the requested {Parameters.ResponseType}, as specified in OpenID Connect Core 1.0.");
+        }
+
+        // A nonce must be transaction-specific (RFC 9700 §2.1.1). When reuse detection is on, reject a
+        // value this client already used for a previously issued authorization code.
+        if (request.Nonce is { } nonce && !string.IsNullOrEmpty(nonce) &&
+            await reuseDetector.IsReusedAsync(context.ClientInfo.ClientId, Parameters.Nonce, nonce))
+        {
+            return context.InvalidRequest("The nonce must be unique per authorization request");
         }
 
         return null;

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/PkceValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/PkceValidator.cs
@@ -25,8 +25,10 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.ReusePrevention;
 using Abblix.Utils;
 using Microsoft.Extensions.Options;
+using static Abblix.Oidc.Server.Model.AuthorizationRequest;
 
 
 namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
@@ -39,7 +41,11 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 /// </summary>
 /// <param name="options">Provides the server-wide default security profile a client inherits when it
 /// states none, which tightens PKCE enforcement (mandatory PKCE, S256-only) under a profile.</param>
-public class PkceValidator(IOptions<OidcOptions> options) : SyncAuthorizationContextValidatorBase
+/// <param name="reuseDetector">Detects a client repeating a code_challenge across authorization requests
+/// when reuse detection is enabled (RFC 9700 Section 2.1.1).</param>
+public class PkceValidator(
+	IOptions<OidcOptions> options,
+	IAuthorizationValueReuseDetector reuseDetector) : IAuthorizationContextValidator
 {
 	/// <summary>
 	/// Validates the PKCE-related parameters in the authorization request against the client's
@@ -51,11 +57,11 @@ public class PkceValidator(IOptions<OidcOptions> options) : SyncAuthorizationCon
 	/// An AuthorizationRequestValidationError if the validation fails due to non-compliance with PKCE requirements,
 	/// or null if the request is valid. Refer to Section 4.3 of RFC 7636 for more details.
 	/// </returns>
-	protected override AuthorizationRequestValidationError? Validate(AuthorizationValidationContext context)
+	public async Task<AuthorizationRequestValidationError?> ValidateAsync(AuthorizationValidationContext context)
 	{
 		var profile = SecurityProfileRequirements.For(context.ClientInfo, options.Value.DefaultSecurityProfile);
 
-		if (context.Request.CodeChallenge.HasValue())
+		if (context.Request.CodeChallenge is { } codeChallenge && codeChallenge.HasValue())
 		{
 			// Under a profile that pins the method (FAPI 2.0 names S256), anything other than S256 is
 			// rejected — including plain and the non-standard S512 — before the per-client plain check,
@@ -72,6 +78,13 @@ public class PkceValidator(IOptions<OidcOptions> options) : SyncAuthorizationCon
 			    !context.ClientInfo.PlainPkceAllowed)
 			{
 				return context.InvalidRequest("The client is not allowed PKCE plain method");
+			}
+
+			// A code_challenge must be transaction-specific (RFC 9700 §2.1.1). When reuse detection is on,
+			// reject a value this client already used for a previously issued authorization code.
+			if (await reuseDetector.IsReusedAsync(context.ClientInfo.ClientId, Parameters.CodeChallenge, codeChallenge))
+			{
+				return context.InvalidRequest("The PKCE code_challenge must be unique per authorization request");
 			}
 		}
 		else if ((profile.RequirePkce || (context.ClientInfo.PkceRequired ?? true)) &&

--- a/Abblix.Oidc.Server/Features/ReusePrevention/AuthorizationValueReuseDetector.cs
+++ b/Abblix.Oidc.Server/Features/ReusePrevention/AuthorizationValueReuseDetector.cs
@@ -1,0 +1,72 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.Storages;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Features.ReusePrevention;
+
+/// <summary>
+/// Default <see cref="IAuthorizationValueReuseDetector"/> implementation backed by <see cref="IEntityStorage"/>.
+/// It records a SHA-256 hash of each value under a per-client, per-kind key with a time-to-live equal to the
+/// configured detection window, so a raw code_challenge or nonce never lands in the cache and entries expire
+/// on their own.
+/// </summary>
+public class AuthorizationValueReuseDetector(
+    IEntityStorage storage,
+    IEntityStorageKeyFactory keyFactory,
+    IOptions<OidcOptions> options) : IAuthorizationValueReuseDetector
+{
+    private const string Marker = "used";
+
+    /// <inheritdoc />
+    public async Task<bool> IsReusedAsync(string clientId, string valueKind, string value)
+    {
+        if (options.Value.PkceAndNonceReuseDetectionInterval is null)
+            return false;
+
+        var seen = await storage.GetAsync<string>(KeyOf(clientId, valueKind, value), removeOnRetrieval: false);
+        return seen is not null;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(string clientId, string valueKind, string value)
+    {
+        if (options.Value.PkceAndNonceReuseDetectionInterval is not { } interval)
+            return;
+
+        await storage.SetAsync(
+            KeyOf(clientId, valueKind, value),
+            Marker,
+            new StorageOptions { AbsoluteExpirationRelativeToNow = interval });
+    }
+
+    private string KeyOf(string clientId, string valueKind, string value)
+    {
+        var hash = Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+        return keyFactory.AuthorizationValueReuseKey(clientId, valueKind, hash);
+    }
+}

--- a/Abblix.Oidc.Server/Features/ReusePrevention/IAuthorizationValueReuseDetector.cs
+++ b/Abblix.Oidc.Server/Features/ReusePrevention/IAuthorizationValueReuseDetector.cs
@@ -1,0 +1,53 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.ReusePrevention;
+
+/// <summary>
+/// Detects reuse of an authorization request's transaction-binding values — the PKCE
+/// <c>code_challenge</c> (RFC 7636) and the OpenID Connect <c>nonce</c>. Both must be
+/// transaction-specific; a client that keeps sending a constant value defeats the protection they provide.
+/// RFC 9700 (OAuth 2.0 Security BCP) Section 2.1.1 encourages the authorization server to make a
+/// reasonable effort to detect and prevent this. Detection is off unless
+/// <see cref="Common.Configuration.OidcOptions.PkceAndNonceReuseDetectionInterval"/> is set.
+/// </summary>
+public interface IAuthorizationValueReuseDetector
+{
+    /// <summary>
+    /// Reports whether a value of the given kind has already been recorded for this client within the
+    /// detection window — that is, whether the client is repeating a value that must be unique per request.
+    /// </summary>
+    /// <param name="clientId">The client presenting the value.</param>
+    /// <param name="valueKind">A discriminator for the value's role (for example the parameter name), so
+    /// a <c>code_challenge</c> and a <c>nonce</c> that happen to coincide are tracked separately.</param>
+    /// <param name="value">The raw value; only a hash of it is ever stored.</param>
+    /// <returns><c>true</c> when the value was seen before within the window; otherwise <c>false</c>.
+    /// Always <c>false</c> when detection is disabled.</returns>
+    Task<bool> IsReusedAsync(string clientId, string valueKind, string value);
+
+    /// <summary>
+    /// Records a value as used by this client so a later reuse within the detection window is caught.
+    /// A no-op when detection is disabled. Called once per issued authorization code, not on every
+    /// authorization request, so re-processing one request across a login or consent redirect is not flagged.
+    /// </summary>
+    Task RecordAsync(string clientId, string valueKind, string value);
+}

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ using Abblix.Oidc.Server.Features.Consents;
 using Abblix.Oidc.Server.Features.DeviceAuthorization;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 using Abblix.Oidc.Server.Features.DPoP;
+using Abblix.Oidc.Server.Features.ReusePrevention;
 using Abblix.Oidc.Server.Features.Hashing;
 using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.ResponseObject;
@@ -435,6 +436,7 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddSingleton<IEntityStorageKeyFactory, EntityStorageKeyFactory>();
         services.TryAddSingleton<IAuthorizationCodeService, AuthorizationCodeService>();
+        services.TryAddSingleton<IAuthorizationValueReuseDetector, AuthorizationValueReuseDetector>();
         services.TryAddSingleton<IAuthorizationRequestStorage, AuthorizationRequestStorage>();
         return services;
     }

--- a/Abblix.Oidc.Server/Features/Storages/EntityStorageKeyFactory.cs
+++ b/Abblix.Oidc.Server/Features/Storages/EntityStorageKeyFactory.cs
@@ -99,4 +99,8 @@ public class EntityStorageKeyFactory : IEntityStorageKeyFactory
     /// <returns>A formatted storage key for the client's current registration-access-token jti.</returns>
     public string RegistrationAccessTokenKey(string clientId)
         => $"Abblix.Oidc.Server:RegistrationAccessToken:{clientId}";
+
+    /// <inheritdoc />
+    public string AuthorizationValueReuseKey(string clientId, string valueKind, string valueHash)
+        => $"Abblix.Oidc.Server:{clientId}:Reuse:{valueKind}:{valueHash}";
 }

--- a/Abblix.Oidc.Server/Features/Storages/IEntityStorageKeyFactory.cs
+++ b/Abblix.Oidc.Server/Features/Storages/IEntityStorageKeyFactory.cs
@@ -90,4 +90,14 @@ public interface IEntityStorageKeyFactory
     /// <param name="clientId">The identifier of the registered client.</param>
     /// <returns>A formatted storage key for the client's current registration-access-token jti.</returns>
     string RegistrationAccessTokenKey(string clientId);
+
+    /// <summary>
+    /// Generates a storage key for reuse detection of an authorization request value (a PKCE
+    /// <c>code_challenge</c> or an OpenID Connect <c>nonce</c>), scoped to a client and the value's kind.
+    /// </summary>
+    /// <param name="clientId">The client the value belongs to.</param>
+    /// <param name="valueKind">A discriminator for the value's role, so distinct kinds never collide.</param>
+    /// <param name="valueHash">A hash of the value; the raw value is never part of the key.</param>
+    /// <returns>A formatted storage key for the recorded value.</returns>
+    string AuthorizationValueReuseKey(string clientId, string valueKind, string valueHash);
 }


### PR DESCRIPTION
## What

RFC 9700 (OAuth 2.0 Security BCP) §2.1.1 requires the PKCE `code_challenge` and the OpenID Connect `nonce` to be transaction-specific, and encourages the authorization server to make a reasonable effort to detect and prevent a client using a constant value. This adds that detection.

- A client that repeats a `code_challenge` or `nonce` it already used for a previously issued authorization code is rejected on its next authorization request.
- Opt-in via `OidcOptions.PkceAndNonceReuseDetectionInterval`. Left `null` (the default) the whole mechanism is inert — a conforming client generates a fresh value per request and is never affected, but a client that incorrectly reuses a value across separate authorizations would be rejected, so it stays opt-in.

## How

- A dedicated `IAuthorizationValueReuseDetector` records each value — SHA-256 hashed, under a per-client key from `IEntityStorageKeyFactory`, over `IEntityStorage` with a TTL equal to the configured window (structured exactly like `TokenRegistry`, but a distinct concern so a distinct interface).
- Recording happens once per issued authorization code (`AuthorizationCodeBuilder`), not on every authorization request, so re-processing one request across a login or consent redirect is not flagged as reuse.
- The check lives in the existing `PkceValidator` (code_challenge) and `NonceValidator` (nonce); both were made async to consult the detector.

## Standards

- RFC 9700 §2.1.1
- RFC 7636 (PKCE), OpenID Connect Core 1.0 (nonce)
