### PR TITLE
Rename the none-response-type feature namespace to NoneResponse

### DIFF
--- a/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -12,7 +12,7 @@ using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Consents;
 using Abblix.Oidc.Server.Features.Licensing;
-using Abblix.Oidc.Server.Features.NoneResponseType;
+using Abblix.Oidc.Server.Features.NoneResponse;
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Features.UserInfo;

--- a/Abblix.Oidc.Server/Features/NoneResponse/NoneResponseBuilder.cs
+++ b/Abblix.Oidc.Server/Features/NoneResponse/NoneResponseBuilder.cs
@@ -24,7 +24,7 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 
-namespace Abblix.Oidc.Server.Features.NoneResponseType;
+namespace Abblix.Oidc.Server.Features.NoneResponse;
 
 /// <summary>
 /// Builds the <c>none</c> response-type component of an authorization endpoint success response

--- a/Abblix.Oidc.Server/Features/NoneResponse/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/NoneResponse/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@
 using Abblix.Oidc.Server.Endpoints;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Abblix.Oidc.Server.Features.NoneResponseType;
+namespace Abblix.Oidc.Server.Features.NoneResponse;
 
 /// <summary>
 /// DI extensions that opt the host into the OAuth 2.0 <c>none</c> response type.


### PR DESCRIPTION
Renames the `Features/NoneResponseType` namespace and folder to `Features/NoneResponse`, shortening the containing namespace of the none-response-type support added in #211.

- The `EnableNoneResponseType()` opt-in keeps its name and public shape; only the namespace changes.
- Completes an in-progress rename that had removed the old `using` from the test host without adding the new one (build was red); the correct `using` is now in place.
- Behaviour unchanged; the feature is new in this cycle, so no host has migrated to the old namespace yet.
