### PR TITLE
Apply TryAdd semantics to JWT crypto registrations and advertise host-registered algorithms

### DIFF
--- a/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
+++ b/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
@@ -294,6 +294,8 @@ public class JwtEncryptionTests
     {
         public int LastCekLength { get; private set; } = -1;
 
+        public string Algorithm => EncryptionAlgorithms.ContentEncryption.Aes256Gcm;
+
         public int KeySizeInBytes { get; } = keySizeInBytes;
 
         public EncryptedData Encrypt(byte[] cek, byte[] plaintext, byte[] additionalAuthenticatedData)

--- a/Abblix.Jwt/Encryption/AesCbcHmacEncryptor.cs
+++ b/Abblix.Jwt/Encryption/AesCbcHmacEncryptor.cs
@@ -41,6 +41,9 @@ internal sealed class AesCbcHmacEncryptor(string algorithm) : IDataEncryptor
 	private readonly int _keySize = GetKeySize(algorithm);
 
 	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
+	/// <inheritdoc />
 	public int KeySizeInBytes => _keySize * 2;
 
 	/// <inheritdoc />

--- a/Abblix.Jwt/Encryption/AesGcmEncryptor.cs
+++ b/Abblix.Jwt/Encryption/AesGcmEncryptor.cs
@@ -41,6 +41,9 @@ internal sealed class AesGcmEncryptor(string algorithm) : IDataEncryptor
 	private readonly int _keySize = GetKeySize(algorithm);
 
 	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
+	/// <inheritdoc />
 	public int KeySizeInBytes => _keySize;
 
 	/// <inheritdoc />

--- a/Abblix.Jwt/Encryption/AesGcmKeyWrapEncryptor.cs
+++ b/Abblix.Jwt/Encryption/AesGcmKeyWrapEncryptor.cs
@@ -43,6 +43,9 @@ namespace Abblix.Jwt.Encryption;
 /// </remarks>
 internal sealed class AesGcmKeyWrapEncryptor(string algorithm) : IKeyEncryptor<OctetJsonWebKey>
 {
+	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
 	private readonly int _keySize = algorithm switch
 	{
 		// A128GCMKW uses 128-bit (16-byte) AES key

--- a/Abblix.Jwt/Encryption/DirectKeyAgreement.cs
+++ b/Abblix.Jwt/Encryption/DirectKeyAgreement.cs
@@ -53,6 +53,10 @@ internal sealed class DirectKeyAgreement : IKeyEncryptor<OctetJsonWebKey>
 				nameof(algorithm));
 		}
 	}
+
+	/// <inheritdoc />
+	public string Algorithm => EncryptionAlgorithms.KeyManagement.Dir;
+
 	/// <inheritdoc />
 	/// <remarks>
 	/// For direct key agreement, the symmetric key IS the Content Encryption Key.

--- a/Abblix.Jwt/Encryption/IDataEncryptor.cs
+++ b/Abblix.Jwt/Encryption/IDataEncryptor.cs
@@ -31,6 +31,14 @@ namespace Abblix.Jwt.Encryption;
 internal interface IDataEncryptor
 {
 	/// <summary>
+	/// The JWE content-encryption algorithm identifier this encryptor implements (e.g. "A256GCM").
+	/// Must equal the DI key the encryptor is registered under: discovery enumerates the keyed
+	/// registrations and projects this value into the <c>*_encryption_enc_values_supported</c> lists,
+	/// so a mismatch would advertise an algorithm name the dispatch cannot resolve.
+	/// </summary>
+	string Algorithm { get; }
+
+	/// <summary>
 	/// Gets the required Content Encryption Key (CEK) size in bytes for this algorithm.
 	/// </summary>
 	int KeySizeInBytes { get; }

--- a/Abblix.Jwt/Encryption/IKeyEncryptor.cs
+++ b/Abblix.Jwt/Encryption/IKeyEncryptor.cs
@@ -41,6 +41,14 @@ public interface IKeyEncryptor<in TJsonWebKey>
 	where TJsonWebKey: JsonWebKey
 {
 	/// <summary>
+	/// The JWE key-management algorithm identifier this encryptor implements (e.g. "RSA-OAEP-256").
+	/// Must equal the DI key the encryptor is registered under: discovery enumerates the keyed
+	/// registrations and projects this value into the <c>*_encryption_alg_values_supported</c> lists,
+	/// so a mismatch would advertise an algorithm name the dispatch cannot resolve.
+	/// </summary>
+	string Algorithm { get; }
+
+	/// <summary>
 	/// Encrypts a Content Encryption Key (CEK) using the configured key management algorithm.
 	/// Used when creating JWE tokens to protect the CEK with the recipient's public key.
 	/// </summary>

--- a/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -42,6 +42,9 @@ namespace Abblix.Jwt.Encryption;
 /// </remarks>
 internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, string algorithm) : IKeyEncryptor<RsaJsonWebKey>
 {
+	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
 	private readonly RSAEncryptionPadding _padding = algorithm switch
 	{
 		// - Section 4.3: RSA-OAEP uses RSAES-OAEP with default parameters (SHA-1)

--- a/Abblix.Jwt/EncryptionAlgorithmsProvider.cs
+++ b/Abblix.Jwt/EncryptionAlgorithmsProvider.cs
@@ -32,14 +32,13 @@ internal sealed class EncryptionAlgorithmsProvider(IServiceProvider serviceProvi
     /// <summary>
     /// Gets the supported JWE content-encryption algorithms (the <c>enc</c> values, e.g. "A256GCM").
     /// </summary>
-    public IEnumerable<string> ContentEncryptionAlgorithms =>
-        serviceProvider
+    public IEnumerable<string> ContentEncryptionAlgorithms
+        => serviceProvider
             .GetKeyedServices<IDataEncryptor>(KeyedService.AnyKey)
             .Select(encryptor => encryptor.Algorithm)
             .Distinct();
 
-    private IEnumerable<string> KeyManagementAlgorithmsFor<TJsonWebKey>()
-        where TJsonWebKey : JsonWebKey
+    private IEnumerable<string> KeyManagementAlgorithmsFor<TJsonWebKey>() where TJsonWebKey : JsonWebKey
         => serviceProvider
             .GetKeyedServices<IKeyEncryptor<TJsonWebKey>>(KeyedService.AnyKey)
             .Select(encryptor => encryptor.Algorithm);

--- a/Abblix.Jwt/EncryptionAlgorithmsProvider.cs
+++ b/Abblix.Jwt/EncryptionAlgorithmsProvider.cs
@@ -1,39 +1,46 @@
+using Abblix.Jwt.Encryption;
+
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Abblix.Jwt;
 
 /// <summary>
 /// Provides access to the collections of JWE algorithms supported by the JWT infrastructure.
-/// Tracks key-management and content-encryption algorithms as the corresponding encryptors are
-/// registered in the dependency injection container.
+/// Projects both sets — key-management algorithms (the JWE <c>alg</c>, e.g. "RSA-OAEP-256") and
+/// content-encryption algorithms (the JWE <c>enc</c>, e.g. "A256GCM") — from the live keyed
+/// <see cref="IKeyEncryptor{TJsonWebKey}"/> and <see cref="IDataEncryptor"/> registrations, so
+/// discovery always reflects exactly the encryptors the host currently has registered — including
+/// algorithms the host added or replaced — with no registration-time bookkeeping to keep in sync.
 /// </summary>
 /// <remarks>
-/// The provider maintains two lists — key-management algorithms (the JWE <c>alg</c>, e.g.
-/// "RSA-OAEP-256") and content-encryption algorithms (the JWE <c>enc</c>, e.g. "A256GCM") — populated
-/// during service registration via <see cref="AddKeyManagement"/> and <see cref="AddContentEncryption"/>,
-/// and exposed via <see cref="KeyManagementAlgorithms"/> and <see cref="ContentEncryptionAlgorithms"/>
-/// for discovery.
+/// The enumerated key types mirror the dispatch switch in <see cref="JsonWebTokenEncryptor"/>: an
+/// encryptor registered for any other <see cref="JsonWebKey"/> subtype is unreachable at run time,
+/// so it is deliberately not advertised. The enumeration order (RSA, EC, octet) preserves the order
+/// the built-in algorithms have always appeared in published discovery documents.
 /// </remarks>
-internal class EncryptionAlgorithmsProvider
+internal sealed class EncryptionAlgorithmsProvider(IServiceProvider serviceProvider)
 {
-    private readonly List<string> _keyManagementAlgorithms = [];
-    private readonly List<string> _contentEncryptionAlgorithms = [];
-
     /// <summary>
     /// Gets the supported JWE key-management algorithms (the <c>alg</c> values, e.g. "RSA-OAEP-256").
     /// </summary>
-    public IEnumerable<string> KeyManagementAlgorithms => _keyManagementAlgorithms;
+    public IEnumerable<string> KeyManagementAlgorithms =>
+        KeyManagementAlgorithmsFor<RsaJsonWebKey>()
+            .Concat(KeyManagementAlgorithmsFor<EllipticCurveJsonWebKey>())
+            .Concat(KeyManagementAlgorithmsFor<OctetJsonWebKey>())
+            .Distinct();
 
     /// <summary>
     /// Gets the supported JWE content-encryption algorithms (the <c>enc</c> values, e.g. "A256GCM").
     /// </summary>
-    public IEnumerable<string> ContentEncryptionAlgorithms => _contentEncryptionAlgorithms;
+    public IEnumerable<string> ContentEncryptionAlgorithms =>
+        serviceProvider
+            .GetKeyedServices<IDataEncryptor>(KeyedService.AnyKey)
+            .Select(encryptor => encryptor.Algorithm)
+            .Distinct();
 
-    /// <summary>
-    /// Adds a key-management algorithm to the collection of supported algorithms.
-    /// </summary>
-    public void AddKeyManagement(string algorithm) => _keyManagementAlgorithms.Add(algorithm);
-
-    /// <summary>
-    /// Adds a content-encryption algorithm to the collection of supported algorithms.
-    /// </summary>
-    public void AddContentEncryption(string algorithm) => _contentEncryptionAlgorithms.Add(algorithm);
+    private IEnumerable<string> KeyManagementAlgorithmsFor<TJsonWebKey>()
+        where TJsonWebKey : JsonWebKey
+        => serviceProvider
+            .GetKeyedServices<IKeyEncryptor<TJsonWebKey>>(KeyedService.AnyKey)
+            .Select(encryptor => encryptor.Algorithm);
 }

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -54,14 +54,16 @@ public static class ServiceCollectionExtensions
     /// <returns>The configured <see cref="IServiceCollection"/>, enabling further chaining of service registrations.</returns>
     public static IServiceCollection AddJsonWebTokens(this IServiceCollection services)
     {
-        services
-            .AddSingleton<IJsonWebTokenCreator, JsonWebTokenCreator>()
-            .AddSingleton<IJsonWebTokenValidator, JsonWebTokenValidator>()
-            .AddSingleton<IJsonWebTokenEncryptor, JsonWebTokenEncryptor>()
-            .AddSingleton<IJsonWebTokenSigner, JsonWebTokenSigner>();
+        services.TryAddSingleton<IJsonWebTokenCreator, JsonWebTokenCreator>();
+        services.TryAddSingleton<IJsonWebTokenValidator, JsonWebTokenValidator>();
+        services.TryAddSingleton<IJsonWebTokenEncryptor, JsonWebTokenEncryptor>();
+        services.TryAddSingleton<IJsonWebTokenSigner, JsonWebTokenSigner>();
 
-        // Tracks the registered JWE algorithms for discovery (request_object_encryption_*_values_supported).
-        var encryptionAlgorithmsProvider = new EncryptionAlgorithmsProvider();
+        // Discovery providers project the advertised algorithm sets from the live keyed
+        // registrations, so an algorithm the host registers under its own 'alg'/'enc' key is
+        // advertised automatically (signing_alg / encryption_alg / encryption_enc values).
+        services.TryAddSingleton<SigningAlgorithmsProvider>();
+        services.TryAddSingleton<EncryptionAlgorithmsProvider>();
 
         // Register key encryptors by algorithm.
         // RSA-OAEP and RSA-OAEP-256 are the recommended algorithms. RSA1_5 (RSAES-PKCS1-v1_5) is
@@ -71,53 +73,50 @@ public static class ServiceCollectionExtensions
         // that fails to decrypt is replaced with a random CEK and the AEAD step still runs, so a
         // decryption failure is processed identically regardless of padding validity.
         services
-            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep, encryptionAlgorithmsProvider)
-            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep256, encryptionAlgorithmsProvider)
-            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.Rsa1_5, encryptionAlgorithmsProvider);
+            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep)
+            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep256)
+            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.Rsa1_5);
 
         // AES-GCM Key Wrap (symmetric key encryption with GCM)
         services
-            .AddKeyEncryptor<OctetJsonWebKey, AesGcmKeyWrapEncryptor>(EncryptionAlgorithms.KeyManagement.Aes128Gcmkw, encryptionAlgorithmsProvider)
-            .AddKeyEncryptor<OctetJsonWebKey, AesGcmKeyWrapEncryptor>(EncryptionAlgorithms.KeyManagement.Aes192Gcmkw, encryptionAlgorithmsProvider)
-            .AddKeyEncryptor<OctetJsonWebKey, AesGcmKeyWrapEncryptor>(EncryptionAlgorithms.KeyManagement.Aes256Gcmkw, encryptionAlgorithmsProvider);
+            .AddKeyEncryptor<OctetJsonWebKey, AesGcmKeyWrapEncryptor>(EncryptionAlgorithms.KeyManagement.Aes128Gcmkw)
+            .AddKeyEncryptor<OctetJsonWebKey, AesGcmKeyWrapEncryptor>(EncryptionAlgorithms.KeyManagement.Aes192Gcmkw)
+            .AddKeyEncryptor<OctetJsonWebKey, AesGcmKeyWrapEncryptor>(EncryptionAlgorithms.KeyManagement.Aes256Gcmkw);
 
         // Direct Key Agreement (no key encryption)
         services
-            .AddKeyEncryptor<OctetJsonWebKey, DirectKeyAgreement>(EncryptionAlgorithms.KeyManagement.Dir, encryptionAlgorithmsProvider);
+            .AddKeyEncryptor<OctetJsonWebKey, DirectKeyAgreement>(EncryptionAlgorithms.KeyManagement.Dir);
 
         // Register content encryptors by algorithm
         services
-            .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256, encryptionAlgorithmsProvider)
-            .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes192CbcHmacSha384, encryptionAlgorithmsProvider)
-            .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512, encryptionAlgorithmsProvider)
-            .AddContentEncryptor<AesGcmEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes128Gcm, encryptionAlgorithmsProvider)
-            .AddContentEncryptor<AesGcmEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes192Gcm, encryptionAlgorithmsProvider)
-            .AddContentEncryptor<AesGcmEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes256Gcm, encryptionAlgorithmsProvider);
+            .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256)
+            .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes192CbcHmacSha384)
+            .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512)
+            .AddContentEncryptor<AesGcmEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes128Gcm)
+            .AddContentEncryptor<AesGcmEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes192Gcm)
+            .AddContentEncryptor<AesGcmEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes256Gcm);
 
-        services.AddSingleton(encryptionAlgorithmsProvider);
-
-        // Register signers by algorithm
-        var signingAlgorithmsProvider = new SigningAlgorithmsProvider();
+        // Register signers by algorithm.
+        // NoneSigner is registered directly: it is the only signer whose constructor takes no
+        // algorithm parameter, so the AddDataSigner factory (which passes the algorithm as
+        // a constructor override) cannot instantiate it.
+        services.TryAddKeyedSingleton<IDataSigner<JsonWebKey>, NoneSigner>(SigningAlgorithms.None);
 
         services
-            .AddDataSigner<JsonWebKey, NoneSigner>(SigningAlgorithms.None, signingAlgorithmsProvider)
+            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.RS256)
+            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.RS384)
+            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.RS512)
+            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.PS256)
+            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.PS384)
+            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.PS512)
 
-            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.RS256, signingAlgorithmsProvider)
-            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.RS384, signingAlgorithmsProvider)
-            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.RS512, signingAlgorithmsProvider)
-            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.PS256, signingAlgorithmsProvider)
-            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.PS384, signingAlgorithmsProvider)
-            .AddDataSigner<RsaJsonWebKey, RsaSigner>(SigningAlgorithms.PS512, signingAlgorithmsProvider)
+            .AddDataSigner<EllipticCurveJsonWebKey, EcdsaSigner>(SigningAlgorithms.ES256)
+            .AddDataSigner<EllipticCurveJsonWebKey, EcdsaSigner>(SigningAlgorithms.ES384)
+            .AddDataSigner<EllipticCurveJsonWebKey, EcdsaSigner>(SigningAlgorithms.ES512)
 
-            .AddDataSigner<EllipticCurveJsonWebKey, EcdsaSigner>(SigningAlgorithms.ES256, signingAlgorithmsProvider)
-            .AddDataSigner<EllipticCurveJsonWebKey, EcdsaSigner>(SigningAlgorithms.ES384, signingAlgorithmsProvider)
-            .AddDataSigner<EllipticCurveJsonWebKey, EcdsaSigner>(SigningAlgorithms.ES512, signingAlgorithmsProvider)
-
-            .AddDataSigner<OctetJsonWebKey, HmacSigner>(SigningAlgorithms.HS256, signingAlgorithmsProvider)
-            .AddDataSigner<OctetJsonWebKey, HmacSigner>(SigningAlgorithms.HS384, signingAlgorithmsProvider)
-            .AddDataSigner<OctetJsonWebKey, HmacSigner>(SigningAlgorithms.HS512, signingAlgorithmsProvider)
-
-            .AddSingleton(signingAlgorithmsProvider);
+            .AddDataSigner<OctetJsonWebKey, HmacSigner>(SigningAlgorithms.HS256)
+            .AddDataSigner<OctetJsonWebKey, HmacSigner>(SigningAlgorithms.HS384)
+            .AddDataSigner<OctetJsonWebKey, HmacSigner>(SigningAlgorithms.HS512);
 
         return services;
     }
@@ -159,24 +158,23 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TEncryptor">The IKeyEncryptor implementation for encrypting/decrypting Content Encryption Keys.</typeparam>
     /// <param name="services">The service collection to register the encryptor in.</param>
     /// <param name="algorithm">The JWE key management algorithm identifier (e.g., "RSA-OAEP-256", "A256GCMKW", "dir").</param>
-    /// <param name="encryptionAlgorithmsProvider">Accumulates the registered algorithm for discovery advertisement.</param>
     /// <returns>The service collection for method chaining.</returns>
     /// <remarks>
     /// Registers the encryptor as a keyed singleton service, retrievable by algorithm name.
     /// The algorithm parameter is passed to the encryptor constructor via dependency injection override.
+    /// TryAdd dedups by (service, key) first-wins, so a host pre-registration for the algorithm wins
+    /// over the built-in default.
     /// </remarks>
     private static IServiceCollection AddKeyEncryptor<TKey, TEncryptor>(
         this IServiceCollection services,
-        string algorithm,
-        EncryptionAlgorithmsProvider encryptionAlgorithmsProvider)
+        string algorithm)
         where TKey : JsonWebKey
         where TEncryptor : IKeyEncryptor<TKey>
     {
-        encryptionAlgorithmsProvider.AddKeyManagement(algorithm);
-
-        return services.AddKeyedSingleton<IKeyEncryptor<TKey>>(
+        services.TryAddKeyedSingleton<IKeyEncryptor<TKey>>(
             algorithm,
             (sp, _) => sp.CreateService<TEncryptor>(Dependency.Override(algorithm)));
+        return services;
     }
 
     /// <summary>
@@ -186,24 +184,23 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TEncryptor">The IDataEncryptor implementation for encrypting/decrypting JWE content.</typeparam>
     /// <param name="services">The service collection to register the encryptor in.</param>
     /// <param name="algorithm">The JWE content encryption algorithm identifier (e.g., "A256GCM", "A128CBC-HS256").</param>
-    /// <param name="encryptionAlgorithmsProvider">Accumulates the registered algorithm for discovery advertisement.</param>
     /// <returns>The service collection for method chaining.</returns>
     /// <remarks>
     /// Registers the encryptor as a keyed singleton service, retrievable by algorithm name.
     /// The algorithm parameter is passed to the encryptor constructor via dependency injection override.
     /// Content encryption is performed after the Content Encryption Key (CEK) is encrypted/wrapped by the key encryptor.
+    /// TryAdd dedups by (service, key) first-wins, so a host pre-registration for the algorithm wins
+    /// over the built-in default.
     /// </remarks>
     private static IServiceCollection AddContentEncryptor<TEncryptor>(
         this IServiceCollection services,
-        string algorithm,
-        EncryptionAlgorithmsProvider encryptionAlgorithmsProvider)
+        string algorithm)
         where TEncryptor : IDataEncryptor
     {
-        encryptionAlgorithmsProvider.AddContentEncryption(algorithm);
-
-        return services.AddKeyedSingleton<IDataEncryptor>(
+        services.TryAddKeyedSingleton<IDataEncryptor>(
             algorithm,
             (sp, _) => sp.CreateService<TEncryptor>(Dependency.Override(algorithm)));
+        return services;
     }
 
     /// <summary>
@@ -214,24 +211,22 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TSigner">The IDataSigner implementation for creating/verifying digital signatures.</typeparam>
     /// <param name="services">The service collection to register the signer in.</param>
     /// <param name="algorithm">The JWS signing algorithm identifier (e.g., "RS256", "ES384", "HS512").</param>
-    /// <param name="signingAlgorithmsProvider">The provider that tracks all registered signing algorithms for discovery.</param>
     /// <returns>The service collection for method chaining.</returns>
     /// <remarks>
     /// Registers the signer as a keyed singleton service, retrievable by algorithm name.
     /// The algorithm parameter is passed to the signer constructor via dependency injection override.
-    /// Additionally registers the algorithm in the provider for algorithm discovery by consumers.
+    /// TryAdd dedups by (service, key) first-wins, so a host pre-registration for the algorithm wins
+    /// over the built-in default.
     /// </remarks>
     private static IServiceCollection AddDataSigner<TKey, TSigner>(
         this IServiceCollection services,
-        string algorithm,
-        SigningAlgorithmsProvider signingAlgorithmsProvider)
+        string algorithm)
         where TKey: JsonWebKey
         where TSigner: IDataSigner<TKey>
     {
-        signingAlgorithmsProvider.Add(algorithm);
-
-        return services.AddKeyedSingleton<IDataSigner<TKey>>(
+        services.TryAddKeyedSingleton<IDataSigner<TKey>>(
             algorithm,
             (sp, _) => sp.CreateService<TSigner>(Dependency.Override(algorithm)));
+        return services;
     }
 }

--- a/Abblix.Jwt/Signing/EcdsaSigner.cs
+++ b/Abblix.Jwt/Signing/EcdsaSigner.cs
@@ -37,6 +37,9 @@ internal sealed class EcdsaSigner(string algorithm) : IDataSigner<EllipticCurveJ
 	private readonly (HashAlgorithmName hashAlgorithm, int signatureLength) _parameters = GetAlgorithmParameters(algorithm);
 
 	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
+	/// <inheritdoc />
 	public byte[] Sign(EllipticCurveJsonWebKey ecKey, byte[] data)
 	{
 		var signature = new byte[_parameters.signatureLength];

--- a/Abblix.Jwt/Signing/HmacSigner.cs
+++ b/Abblix.Jwt/Signing/HmacSigner.cs
@@ -40,6 +40,9 @@ namespace Abblix.Jwt.Signing;
 internal sealed class HmacSigner(string algorithm) : IDataSigner<OctetJsonWebKey>
 {
 	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
+	/// <inheritdoc />
 	public byte[] Sign(OctetJsonWebKey octetKey, byte[] data)
 	{
 		var keyValue = octetKey.KeyValue;

--- a/Abblix.Jwt/Signing/IDataSigner.cs
+++ b/Abblix.Jwt/Signing/IDataSigner.cs
@@ -28,6 +28,14 @@ namespace Abblix.Jwt.Signing;
 public interface IDataSigner<in TJsonWebKey> where TJsonWebKey : JsonWebKey
 {
 	/// <summary>
+	/// The JWS signing algorithm identifier this signer implements (e.g. "RS256", "ES384").
+	/// Must equal the DI key the signer is registered under: discovery enumerates the keyed
+	/// registrations and projects this value into the <c>*_signing_alg_values_supported</c> lists,
+	/// so a mismatch would advertise an algorithm name the dispatch cannot resolve.
+	/// </summary>
+	string Algorithm { get; }
+
+	/// <summary>
 	/// Signs the provided data using the configured algorithm and specified key.
 	/// </summary>
 	/// <param name="key">The key to use for signing.</param>

--- a/Abblix.Jwt/Signing/NoneSigner.cs
+++ b/Abblix.Jwt/Signing/NoneSigner.cs
@@ -33,6 +33,9 @@ namespace Abblix.Jwt.Signing;
 internal sealed class NoneSigner : IDataSigner<JsonWebKey>
 {
 	/// <inheritdoc />
+	public string Algorithm => SigningAlgorithms.None;
+
+	/// <inheritdoc />
 	public byte[] Sign(JsonWebKey key, byte[] data) => [];
 
 	/// <inheritdoc />

--- a/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/Abblix.Jwt/Signing/RsaSigner.cs
@@ -35,6 +35,9 @@ internal sealed class RsaSigner(string algorithm) : IDataSigner<RsaJsonWebKey>
 	private readonly (HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) _parameters = GetAlgorithmParameters(algorithm);
 
 	/// <inheritdoc />
+	public string Algorithm => algorithm;
+
+	/// <inheritdoc />
 	public byte[] Sign(RsaJsonWebKey rsaKey, byte[] data)
 	{
 		using var rsa = rsaKey.ToRsa();

--- a/Abblix.Jwt/SigningAlgorithmsProvider.cs
+++ b/Abblix.Jwt/SigningAlgorithmsProvider.cs
@@ -29,8 +29,7 @@ internal sealed class SigningAlgorithmsProvider(IServiceProvider serviceProvider
             .Concat(AlgorithmsFor<OctetJsonWebKey>())
             .Distinct();
 
-    private IEnumerable<string> AlgorithmsFor<TJsonWebKey>()
-        where TJsonWebKey : JsonWebKey
+    private IEnumerable<string> AlgorithmsFor<TJsonWebKey>() where TJsonWebKey : JsonWebKey
         => serviceProvider
             .GetKeyedServices<IDataSigner<TJsonWebKey>>(KeyedService.AnyKey)
             .Select(signer => signer.Algorithm);

--- a/Abblix.Jwt/SigningAlgorithmsProvider.cs
+++ b/Abblix.Jwt/SigningAlgorithmsProvider.cs
@@ -1,28 +1,37 @@
+using Abblix.Jwt.Signing;
+
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Abblix.Jwt;
 
 /// <summary>
 /// Provides access to the collection of signing algorithms supported by the JWT infrastructure.
-/// Tracks signing algorithms as IDataSigner services are registered in the dependency injection container.
+/// Projects the set from the live keyed <see cref="IDataSigner{TJsonWebKey}"/> registrations, so
+/// discovery always reflects exactly the signers the host currently has registered — including
+/// algorithms the host added or replaced — with no registration-time bookkeeping to keep in sync.
 /// </summary>
 /// <remarks>
-/// This provider maintains a list of algorithm identifiers (e.g., "RS256", "ES256", "HS256")
-/// that are added during service registration. The list is populated by calling <see cref="Add"/>
-/// for each registered signing algorithm and is exposed via <see cref="Algorithms"/> for discovery.
+/// The enumerated key types mirror the dispatch switch in <see cref="JsonWebTokenSigner"/>: a signer
+/// registered for any other <see cref="JsonWebKey"/> subtype is unreachable at run time, so it is
+/// deliberately not advertised. The enumeration order (none, RSA, EC, octet) preserves the order the
+/// built-in algorithms have always appeared in published discovery documents.
 /// </remarks>
-internal class SigningAlgorithmsProvider
+internal sealed class SigningAlgorithmsProvider(IServiceProvider serviceProvider)
 {
-    private readonly List<string> _algorithms = [];
-
     /// <summary>
     /// Gets the collection of signing algorithms supported for JWT creation and validation.
-    /// Returns algorithm identifiers as they were registered (e.g., "RS256", "ES384", "HS512").
+    /// Returns algorithm identifiers self-declared by the registered signers (e.g. "RS256", "ES384").
     /// </summary>
-    public IEnumerable<string> Algorithms => _algorithms;
+    public IEnumerable<string> Algorithms =>
+        AlgorithmsFor<JsonWebKey>()
+            .Concat(AlgorithmsFor<RsaJsonWebKey>())
+            .Concat(AlgorithmsFor<EllipticCurveJsonWebKey>())
+            .Concat(AlgorithmsFor<OctetJsonWebKey>())
+            .Distinct();
 
-    /// <summary>
-    /// Adds a signing algorithm to the collection of supported algorithms.
-    /// Called during service registration for each IDataSigner being registered.
-    /// </summary>
-    /// <param name="algorithm">The algorithm identifier (e.g., "RS256", "ES256", "HS256").</param>
-    public void Add(string algorithm) => _algorithms.Add(algorithm);
+    private IEnumerable<string> AlgorithmsFor<TJsonWebKey>()
+        where TJsonWebKey : JsonWebKey
+        => serviceProvider
+            .GetKeyedServices<IDataSigner<TJsonWebKey>>(KeyedService.AnyKey)
+            .Select(signer => signer.Algorithm);
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
@@ -21,8 +21,13 @@
 // info@abblix.com
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+
+using Abblix.Jwt;
+using Abblix.Jwt.Encryption;
+using Abblix.Jwt.Signing;
 
 using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common.Interfaces;
@@ -199,5 +204,185 @@ public class ServiceCollectionOverrideTests
 
         using var provider = services.BuildServiceProvider(
             new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+    }
+
+    // A signing algorithm the library does not ship (secp256k1); models a host bringing its own signer.
+    private const string HostSigningAlgorithm = "ES256K";
+
+    // A key-management algorithm the library does not ship (ECDH-ES); models a host bringing its own encryptor.
+    private const string HostKeyManagementAlgorithm = "ECDH-ES";
+
+    [Fact]
+    public void AddJsonWebTokens_HostPreregisteredKeyedSigner_Wins()
+    {
+        // Issue #224: a host pre-registers an alternative signer (e.g. HSM-backed) under a built-in
+        // algorithm key. The library registration must not shadow it.
+        var services = new ServiceCollection();
+        var stub = new HostRsaSigner();
+        services.AddKeyedSingleton<IDataSigner<RsaJsonWebKey>>(SigningAlgorithms.RS256, stub);
+
+        services.AddJsonWebTokens();
+
+        var descriptor = Assert.Single(
+            services,
+            d => d.ServiceType == typeof(IDataSigner<RsaJsonWebKey>) &&
+                 Equals(d.ServiceKey, SigningAlgorithms.RS256));
+        Assert.Same(stub, descriptor.KeyedImplementationInstance);
+    }
+
+    [Fact]
+    public void AddJsonWebTokens_HostPreregisteredCreator_Wins()
+    {
+        var services = new ServiceCollection();
+        var stub = new Mock<IJsonWebTokenCreator>().Object;
+        services.AddSingleton(stub);
+
+        services.AddJsonWebTokens();
+
+        var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IJsonWebTokenCreator));
+        Assert.Same(stub, descriptor.ImplementationInstance);
+    }
+
+    [Fact]
+    public void AddJsonWebTokens_InvokedTwice_DefaultsRegisteredOnce()
+    {
+        var services = new ServiceCollection();
+
+        services.AddJsonWebTokens();
+        services.AddJsonWebTokens();
+
+        Assert.Single(services, d => d.ServiceType == typeof(IJsonWebTokenCreator));
+        Assert.Single(services, d => d.ServiceType == typeof(IJsonWebTokenValidator));
+        Assert.Single(
+            services,
+            d => d.ServiceType == typeof(IDataSigner<RsaJsonWebKey>) &&
+                 Equals(d.ServiceKey, SigningAlgorithms.RS256));
+        Assert.Single(
+            services,
+            d => d.ServiceType == typeof(IKeyEncryptor<RsaJsonWebKey>) &&
+                 Equals(d.ServiceKey, EncryptionAlgorithms.KeyManagement.RsaOaep256));
+    }
+
+    [Fact]
+    public void AddJsonWebTokens_HostRegisteredSigningAlgorithm_IsAdvertised()
+    {
+        // Issue #224: an algorithm the host registers under its own 'alg' key participates in signing,
+        // so discovery must advertise it in the *_signing_alg_values_supported lists.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+        services.AddKeyedSingleton<IDataSigner<EllipticCurveJsonWebKey>>(
+            HostSigningAlgorithm, new HostEllipticCurveSigner());
+
+        services.AddJsonWebTokens();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Contains(
+            HostSigningAlgorithm,
+            provider.GetRequiredService<IJsonWebTokenCreator>().SignedResponseAlgorithmsSupported);
+        Assert.Contains(
+            HostSigningAlgorithm,
+            provider.GetRequiredService<IJsonWebTokenValidator>().SigningAlgorithmsSupported);
+    }
+
+    [Fact]
+    public void AddJsonWebTokens_HostRegisteredKeyManagementAlgorithm_IsAdvertised()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+        services.AddKeyedSingleton<IKeyEncryptor<EllipticCurveJsonWebKey>>(
+            HostKeyManagementAlgorithm, new HostEllipticCurveKeyEncryptor());
+
+        services.AddJsonWebTokens();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Contains(
+            HostKeyManagementAlgorithm,
+            provider.GetRequiredService<IJsonWebTokenValidator>().EncryptionAlgorithmsSupported);
+    }
+
+    [Fact]
+    public void AddJsonWebTokens_DefaultAlgorithms_AdvertisedInRegistrationOrder()
+    {
+        // Parity guard for the discovery lists: the advertised defaults keep the exact content and
+        // order the accumulate-at-registration providers produced, so published discovery documents
+        // do not churn.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+
+        services.AddJsonWebTokens();
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Equal(
+            [
+                SigningAlgorithms.None,
+                SigningAlgorithms.RS256, SigningAlgorithms.RS384, SigningAlgorithms.RS512,
+                SigningAlgorithms.PS256, SigningAlgorithms.PS384, SigningAlgorithms.PS512,
+                SigningAlgorithms.ES256, SigningAlgorithms.ES384, SigningAlgorithms.ES512,
+                SigningAlgorithms.HS256, SigningAlgorithms.HS384, SigningAlgorithms.HS512,
+            ],
+            provider.GetRequiredService<IJsonWebTokenCreator>().SignedResponseAlgorithmsSupported);
+
+        var validator = provider.GetRequiredService<IJsonWebTokenValidator>();
+        Assert.Equal(
+            [
+                EncryptionAlgorithms.KeyManagement.RsaOaep,
+                EncryptionAlgorithms.KeyManagement.RsaOaep256,
+                EncryptionAlgorithms.KeyManagement.Rsa1_5,
+                EncryptionAlgorithms.KeyManagement.Aes128Gcmkw,
+                EncryptionAlgorithms.KeyManagement.Aes192Gcmkw,
+                EncryptionAlgorithms.KeyManagement.Aes256Gcmkw,
+                EncryptionAlgorithms.KeyManagement.Dir,
+            ],
+            validator.EncryptionAlgorithmsSupported);
+        Assert.Equal(
+            [
+                EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256,
+                EncryptionAlgorithms.ContentEncryption.Aes192CbcHmacSha384,
+                EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512,
+                EncryptionAlgorithms.ContentEncryption.Aes128Gcm,
+                EncryptionAlgorithms.ContentEncryption.Aes192Gcm,
+                EncryptionAlgorithms.ContentEncryption.Aes256Gcm,
+            ],
+            validator.EncryptionMethodsSupported);
+    }
+
+    private sealed class HostRsaSigner : IDataSigner<RsaJsonWebKey>
+    {
+        public string Algorithm => SigningAlgorithms.RS256;
+
+        public byte[] Sign(RsaJsonWebKey key, byte[] data) => [];
+
+        public bool Verify(RsaJsonWebKey key, byte[] data, byte[] signature) => false;
+    }
+
+    private sealed class HostEllipticCurveSigner : IDataSigner<EllipticCurveJsonWebKey>
+    {
+        public string Algorithm => HostSigningAlgorithm;
+
+        public byte[] Sign(EllipticCurveJsonWebKey key, byte[] data) => [];
+
+        public bool Verify(EllipticCurveJsonWebKey key, byte[] data, byte[] signature) => false;
+    }
+
+    private sealed class HostEllipticCurveKeyEncryptor : IKeyEncryptor<EllipticCurveJsonWebKey>
+    {
+        public string Algorithm => HostKeyManagementAlgorithm;
+
+        public byte[] EncryptKey(JsonWebTokenHeader header, EllipticCurveJsonWebKey encryptionKey, byte[] keyToEncrypt)
+            => [];
+
+        public bool TryDecryptKey(
+            JsonWebTokenHeader header,
+            EllipticCurveJsonWebKey decryptingKey,
+            byte[] encryptedKey,
+            [NotNullWhen(true)] out byte[]? decryptedKey)
+        {
+            decryptedKey = null;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Ref #224.

Two related gaps in `Abblix.Jwt/ServiceCollectionExtensions.cs`, closed together:

**Registration semantics now follow the library-wide convention.** The singular JOSE services (`IJsonWebTokenCreator`, `IJsonWebTokenValidator`, signer/encryptor front services) register via `TryAddSingleton`, and the keyed crypto registrations (`IDataSigner<TKey>`, `IKeyEncryptor<TKey>`, `IDataEncryptor`) via `TryAddKeyedSingleton` — first-wins by (service, key), so a host that pre-registers an alternative implementation (e.g. an HSM-backed RS256 signer) before `AddOidcCore` keeps it.

**Host-registered algorithms are advertised.** `SigningAlgorithmsProvider` / `EncryptionAlgorithmsProvider` no longer accumulate names at registration time; they project the advertised sets from the live keyed registrations (`GetKeyedServices(KeyedService.AnyKey)`), mirroring the pattern shipped for RAR detail validators (`AuthorizationDetailsMetadataProvider`). Each signer/encryptor self-declares its algorithm through a new `Algorithm` member on `IDataSigner<TKey>`, `IKeyEncryptor<TKey>`, and the internal `IDataEncryptor`. The enumerated key types mirror the dispatch switches, and the default lists keep their exact content and order (guarded by a parity test), so published discovery documents do not churn.

Enumerating the keyed registrations surfaced a latent factory bug: `AddDataSigner` passes the algorithm as a constructor override, and `NoneSigner` — the only signer with a parameterless constructor — could not be instantiated by it. Its factory had simply never executed before. `NoneSigner` is now registered directly.

New seams covered in `ServiceCollectionOverrideTests` (red-first): host pre-registered keyed signer wins, host pre-registered creator wins, double invocation registers defaults once, host-registered signing and key-management algorithms appear in the advertised lists, plus the default-order parity guard.

Note: the `Algorithm` member on the public `IDataSigner<TKey>` / `IKeyEncryptor<TKey>` is a compile-time break for host implementations of those interfaces; the extension-point map in Docs deliberately did not document this seam until this change (follow-up: add the "add or replace an algorithm" row, Abblix/Docs#17).
