### PR TITLE
fix: honor host pre-registrations on alias-registered seams

### DIFF
--- a/Abblix.DependencyInjection.UnitTests/AddKeyedAliasTests.cs
+++ b/Abblix.DependencyInjection.UnitTests/AddKeyedAliasTests.cs
@@ -111,6 +111,85 @@ public class AddKeyedAliasTests
 	}
 
 	/// <summary>
+	/// Verifies that TryAddKeyedAlias honors a pre-existing registration of the alias
+	/// service type under the same key: the earlier registration wins and the alias is skipped.
+	/// </summary>
+	[Fact]
+	public void TryAddKeyedAlias_WhenAliasKeyAlreadyRegistered_PreregistrationWins()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		const string key = "test-key";
+		var preregistered = new ServiceA();
+
+		services.AddKeyedSingleton<IPrimaryService>(key, preregistered);
+		services.AddKeyedSingleton<ServiceA>(key);
+
+		// Act
+		services.TryAddKeyedAlias<IPrimaryService, ServiceA>(key, key);
+
+		// Assert - the pre-registration stays the only (IPrimaryService, key) descriptor
+		Assert.Single(services, d => d.ServiceType == typeof(IPrimaryService) && Equals(d.ServiceKey, key));
+
+		var serviceProvider = services.BuildServiceProvider();
+		Assert.Same(preregistered, serviceProvider.GetRequiredKeyedService<IPrimaryService>(key));
+	}
+
+	/// <summary>
+	/// Verifies that with no prior registration TryAddKeyedAlias behaves exactly like
+	/// AddKeyedAlias: the alias resolves to the same instance as the source registration.
+	/// </summary>
+	[Fact]
+	public void TryAddKeyedAlias_WhenAbsent_RegistersAlias()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		const string key = "test-key";
+
+		services.AddKeyedSingleton<ServiceA>(key);
+
+		// Act
+		services.TryAddKeyedAlias<IPrimaryService, ServiceA>(key, key);
+
+		var serviceProvider = services.BuildServiceProvider();
+
+		// Assert
+		Assert.Same(
+			serviceProvider.GetRequiredKeyedService<ServiceA>(key),
+			serviceProvider.GetRequiredKeyedService<IPrimaryService>(key));
+	}
+
+	/// <summary>
+	/// Verifies that TryAddKeyedAlias deduplicates on the (service type, key) pair, not the
+	/// service type alone: an alias under a different key is still added.
+	/// </summary>
+	[Fact]
+	public void TryAddKeyedAlias_DifferentKey_StillAdds()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		const string key1 = "key1";
+		const string key2 = "key2";
+
+		services.AddKeyedSingleton<ServiceA>(key1);
+		services.AddKeyedSingleton<ServiceA>(key2);
+		services.TryAddKeyedAlias<IPrimaryService, ServiceA>(key1, key1);
+
+		// Act
+		services.TryAddKeyedAlias<IPrimaryService, ServiceA>(key2, key2);
+
+		var serviceProvider = services.BuildServiceProvider();
+
+		// Assert - both keys resolve, each through its own source
+		Assert.Same(
+			serviceProvider.GetRequiredKeyedService<ServiceA>(key1),
+			serviceProvider.GetRequiredKeyedService<IPrimaryService>(key1));
+		Assert.Same(
+			serviceProvider.GetRequiredKeyedService<ServiceA>(key2),
+			serviceProvider.GetRequiredKeyedService<IPrimaryService>(key2));
+	}
+
+	/// <summary>
 	/// Verifies that AddKeyedAlias preserves the lifetime of the original registration.
 	/// </summary>
 	[Theory]

--- a/Abblix.DependencyInjection.UnitTests/AddKeyedAliasTests.cs
+++ b/Abblix.DependencyInjection.UnitTests/AddKeyedAliasTests.cs
@@ -33,6 +33,8 @@ namespace Abblix.DependencyInjection.UnitTests;
 /// </summary>
 public class AddKeyedAliasTests
 {
+	private const string TestKey = "test-key";
+
 	/// <summary>
 	/// Verifies that resolving keyed aliases from different interfaces returns the same instance.
 	/// </summary>
@@ -41,7 +43,7 @@ public class AddKeyedAliasTests
 	{
 		// Arrange
 		var services = new ServiceCollection();
-		const string key = "test-key";
+		const string key = TestKey;
 
 		services.AddKeyedSingleton<ServiceA>(key);
 		services.AddKeyedAlias<IPrimaryService, ServiceA>(key, key);
@@ -119,7 +121,7 @@ public class AddKeyedAliasTests
 	{
 		// Arrange
 		var services = new ServiceCollection();
-		const string key = "test-key";
+		const string key = TestKey;
 		var preregistered = new ServiceA();
 
 		services.AddKeyedSingleton<IPrimaryService>(key, preregistered);
@@ -144,7 +146,7 @@ public class AddKeyedAliasTests
 	{
 		// Arrange
 		var services = new ServiceCollection();
-		const string key = "test-key";
+		const string key = TestKey;
 
 		services.AddKeyedSingleton<ServiceA>(key);
 
@@ -200,7 +202,7 @@ public class AddKeyedAliasTests
 	{
 		// Arrange
 		var services = new ServiceCollection();
-		const string key = "test-key";
+		const string key = TestKey;
 
 		switch (lifetime)
 		{

--- a/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
@@ -69,6 +69,32 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Adds <typeparamref name="TService"/> as a SHARED-instance alias for the existing
+    /// <typeparamref name="TImplementation"/> registration — unless <typeparamref name="TService"/>
+    /// is already registered. Sister of <see cref="AddAlias{TService,TImplementation}"/> with
+    /// <c>TryAdd</c> semantics on the alias service type: a host pre-registration of the aliased
+    /// contract wins, which keeps the library-wide "host pre-registration wins" convention on
+    /// singular seams whose library default is routed through an alias. Use plain
+    /// <see cref="AddAlias{TService,TImplementation}"/> only where the alias must be added
+    /// unconditionally (e.g. composition machinery that appends to an enumerable set).
+    /// </summary>
+    /// <typeparam name="TService">The service type to register the alias under.</typeparam>
+    /// <typeparam name="TImplementation">The implementation type already registered as a
+    /// concrete (or as another service) in the service collection.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no registration is found for <typeparamref name="TImplementation"/>.
+    /// </exception>
+    public static IServiceCollection TryAddAlias<TService, TImplementation>(this IServiceCollection services)
+        where TImplementation : class, TService
+        where TService : class
+    {
+        services.TryAdd(services.BuildAliasDescriptor<TService, TImplementation>());
+        return services;
+    }
+
+    /// <summary>
     /// Adds <typeparamref name="TService"/> to an enumerable strategy set as a SHARED-instance
     /// alias for the existing <typeparamref name="TImplementation"/> registration. Sister of
     /// <see cref="AddAlias{TService,TImplementation}"/>: same semantic of «route this service

--- a/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
@@ -278,6 +278,53 @@ public static class ServiceCollectionExtensions
         where TService : class
         where TSource : class
     {
+        services.Add(services.BuildKeyedAliasDescriptor<TService, TSource>(serviceKey, sourceKey));
+        return services;
+    }
+
+    /// <summary>
+    /// Creates a keyed alias registration for <typeparamref name="TService"/> under
+    /// <paramref name="serviceKey"/> — unless that (service type, key) pair is already
+    /// registered. Sister of <see cref="AddKeyedAlias{TService,TSource}"/> with <c>TryAdd</c>
+    /// semantics on the alias identity: a pre-existing registration under the same key wins,
+    /// mirroring <see cref="TryAddAlias{TService,TImplementation}"/> for keyed seams and
+    /// keeping the library-wide "host pre-registration wins" convention.
+    /// </summary>
+    /// <typeparam name="TService">The service type for the alias registration.</typeparam>
+    /// <typeparam name="TSource">The source service type that is already registered.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <param name="serviceKey">The service key to associate with the alias.</param>
+    /// <param name="sourceKey">The service key of the source registration. Use null for non-keyed source.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no registration is found for <typeparamref name="TSource"/> with the specified <paramref name="sourceKey"/>.
+    /// </exception>
+    public static IServiceCollection TryAddKeyedAlias<TService, TSource>(
+        this IServiceCollection services,
+        object? serviceKey,
+        object? sourceKey = null)
+        where TService : class
+        where TSource : class
+    {
+        services.TryAdd(services.BuildKeyedAliasDescriptor<TService, TSource>(serviceKey, sourceKey));
+        return services;
+    }
+
+    /// <summary>
+    /// Builds the keyed alias <see cref="ServiceDescriptor"/> shared by
+    /// <see cref="AddKeyedAlias{TService,TSource}"/> and
+    /// <see cref="TryAddKeyedAlias{TService,TSource}"/>: locates the most recent
+    /// registration of <typeparamref name="TSource"/> under <paramref name="sourceKey"/>
+    /// and clones it with <typeparamref name="TService"/> and <paramref name="serviceKey"/>
+    /// as the new service identity.
+    /// </summary>
+    private static ServiceDescriptor BuildKeyedAliasDescriptor<TService, TSource>(
+        this IServiceCollection services,
+        object? serviceKey,
+        object? sourceKey)
+        where TService : class
+        where TSource : class
+    {
         // Find the most recent keyed registration of TSource
         var source = services.LastOrDefault(s =>
             (s.ServiceType == typeof(TSource) || s.ImplementationType == typeof(TSource)) &&
@@ -287,9 +334,7 @@ public static class ServiceCollectionExtensions
                 $"Register it first before creating an alias.");
 
         // Clone the descriptor with TService as the new ServiceType and serviceKey
-        services.Add(source.CloneKeyed(typeof(TService), serviceKey));
-
-        return services;
+        return source.CloneKeyed(typeof(TService), serviceKey);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
@@ -31,8 +31,11 @@ using Abblix.Jwt.Signing;
 
 using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints;
+using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
+using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.DPoP;
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
@@ -129,6 +132,59 @@ public class ServiceCollectionOverrideTests
         services.AddDPoP();
 
         Assert.Single(services, d => d.ServiceType == typeof(IProofValidator));
+    }
+
+    [Fact]
+    public void AddClientInformation_HostPreregisteredClientInfoProvider_Wins()
+    {
+        // Issue #226: the alias registrations must honor a host pre-registration the same
+        // way TryAdd* seams do — "store clients in your own database" is the flagship case.
+        var services = new ServiceCollection();
+        var stub = new Mock<IClientInfoProvider>().Object;
+        services.AddSingleton<IClientInfoProvider>(stub);
+
+        services.AddClientInformation();
+
+        var descriptors = services
+            .Where(d => d.ServiceType == typeof(IClientInfoProvider))
+            .ToList();
+
+        Assert.Single(descriptors);
+        Assert.Same(stub, descriptors[0].ImplementationInstance);
+    }
+
+    [Fact]
+    public void AddClientInformation_HostPreregisteredClientInfoManager_Wins()
+    {
+        var services = new ServiceCollection();
+        var stub = new Mock<IClientInfoManager>().Object;
+        services.AddSingleton<IClientInfoManager>(stub);
+
+        services.AddClientInformation();
+
+        var descriptors = services
+            .Where(d => d.ServiceType == typeof(IClientInfoManager))
+            .ToList();
+
+        Assert.Single(descriptors);
+        Assert.Same(stub, descriptors[0].ImplementationInstance);
+    }
+
+    [Fact]
+    public void AddAuthorizationEndpoint_HostPreregisteredAuthorizationHandler_Wins()
+    {
+        var services = new ServiceCollection();
+        var stub = new Mock<IAuthorizationHandler>().Object;
+        services.AddSingleton<IAuthorizationHandler>(stub);
+
+        services.AddAuthorizationEndpoint();
+
+        var descriptors = services
+            .Where(d => d.ServiceType == typeof(IAuthorizationHandler))
+            .ToList();
+
+        Assert.Single(descriptors);
+        Assert.Same(stub, descriptors[0].ImplementationInstance);
     }
 
     [Fact]

--- a/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -143,7 +143,8 @@ public static class ServiceCollectionExtensions
         // IAuthorizationResponseBuilder now contributes its own grant types directly to the
         // IGrantTypeInformer set, so the IGrantTypeInformer chain stays Singleton-friendly
         // (every contributor is Singleton — no captive-dep risk for Singleton consumers).
-        return services.AddAlias<IAuthorizationHandler, AuthorizationHandler>();
+        // TryAddAlias keeps the host-first contract on this seam (issue #226).
+        return services.TryAddAlias<IAuthorizationHandler, AuthorizationHandler>();
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -139,9 +139,11 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, EnabledEndpointsRegistrationValidator>());
 
+        // TryAddAlias: a host that pre-registers its own client store must win over the
+        // OidcOptions-backed default (issue #226) — same host-first contract as TryAdd* seams.
         return services
-            .AddAlias<IClientInfoProvider, ClientInfoStorage>()
-            .AddAlias<IClientInfoManager, ClientInfoStorage>();
+            .TryAddAlias<IClientInfoProvider, ClientInfoStorage>()
+            .TryAddAlias<IClientInfoManager, ClientInfoStorage>();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #226.

`AddAlias` appends unconditionally, so the library's aliases for `IClientInfoProvider`, `IClientInfoManager`, and `IAuthorizationHandler` silently overrode a host's earlier registration on singular resolve — breaking the library-wide "host pre-registration wins" convention for exactly the documented scenario (a host-supplied client store).

- New `TryAddAlias` in Abblix.DependencyInjection: skips the alias when the service type is already registered; XML doc records when plain `AddAlias` remains correct (composition machinery appending to enumerable sets).
- The three host-facing call sites switch to it, with WHY comments.
- Red-first regression cases in `ServiceCollectionOverrideTests` for all three contracts (fail on the previous commit, pass now).