### PR TITLE
fix: gate discovery and JWKS on HTTPS in both adapters (#228)

### DIFF
--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/TransportSecurityTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/TransportSecurityTests.cs
@@ -1,0 +1,39 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end guard that the MVC adapter gates its public metadata endpoints on HTTPS. DiscoveryController
+/// (serving discovery and JWKS) carries <c>[RequireHttps]</c> like the credential-bearing controllers, so a
+/// cleartext GET is redirected to the https URL rather than served: over plain HTTP a man-in-the-middle could
+/// rewrite the advertised endpoints or signing keys and steer clients onto attacker infrastructure. This pins the
+/// MVC adapter to the same all-endpoints transport policy as the Minimal API adapter.
+/// </summary>
+public class TransportSecurityTests(TestFactory factory) : TestBase(factory)
+{
+    [Theory]
+    [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    [InlineData("/.well-known/jwks")]
+    [SuppressMessage("Minor Code Smell", "S1075", Justification = "In-memory TestServer http base address; not a deployment URL.")]
+    public async Task Non_https_metadata_get_is_redirected_to_https(string path)
+    {
+        var httpClient = Factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("http://localhost"),
+        });
+
+        // TestServer honours the request scheme, so Request.IsHttps is false here and [RequireHttps] redirects.
+        var response = await httpClient.GetAsync(path, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal(Uri.UriSchemeHttps, response.Headers.Location!.Scheme);
+    }
+}

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
@@ -307,6 +307,28 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
+    [Theory]
+    [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    [InlineData("/.well-known/jwks")]
+    [SuppressMessage("Minor Code Smell", "S1075", Justification = "In-memory TestServer http base address; not a deployment URL.")]
+    public async Task Non_https_metadata_get_is_redirected_to_https(string path)
+    {
+        var httpClient = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("http://localhost"),
+        });
+
+        // Discovery and JWKS are gated on HTTPS like every other endpoint: over cleartext a man-in-the-middle could
+        // rewrite the advertised endpoints or signing keys, so the group's HTTPS filter redirects the GET to the https
+        // URL rather than serving metadata in the clear. TestServer honours the request scheme, so IsHttps is false.
+        var response = await httpClient.GetAsync(path, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal(Uri.UriSchemeHttps, response.Headers.Location!.Scheme);
+    }
+
     [Fact]
     public async Task Oauth_authorization_server_suffix_serves_the_same_metadata_as_openid_configuration()
     {

--- a/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -75,8 +75,14 @@ public static class EndpointRouteBuilderExtensions
         var routes = endpoints.ServiceProvider.GetRequiredService<IOptions<OidcRouteOptions>>().Value;
         var oidcGroup = endpoints.MapGroup(prefix);
 
-        // Mirror the MVC controllers' [RequireHttps]: on a host that also binds HTTP, never serve client credentials
-        // or tokens in cleartext (RFC 6749 §3.2/§10.1). See RequireHttpsAsync for the redirect/refuse behaviour.
+        // Gate every OIDC endpoint on HTTPS, the public discovery and JWKS metadata included. This mirrors the
+        // [RequireHttps] carried by every MVC controller (DiscoveryController included): the credential- and
+        // token-bearing endpoints must never serve secrets in cleartext (RFC 6749 §3.2/§10.1), and the metadata must
+        // not be readable over plain HTTP either — a man-in-the-middle could rewrite the advertised endpoints or
+        // jwks_uri and steer clients onto attacker infrastructure (the reason OpenIddict enforces transport security
+        // on all endpoints by default). A host that genuinely needs an ungated route — a liveness/health probe — maps
+        // it outside MapOidcEndpoints; the library gates all of its own endpoints without exception. See
+        // RequireHttpsAsync for the redirect/refuse behaviour.
         oidcGroup.AddEndpointFilter(RequireHttpsAsync);
 
         // RFC 6749 §5.1 no-store, applied group-wide so every OIDC response (token, PAR, CIBA, device, userinfo,

--- a/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
@@ -51,6 +51,10 @@ namespace Abblix.Oidc.Server.Mvc.Controllers;
 /// <see href="https://openid.net/specs/openid-connect-discovery-1_0.html"/>.
 /// </remarks>
 [ApiController]
+// Discovery and JWKS are public, unauthenticated metadata, but they are still gated on HTTPS like the credential-
+// bearing controllers: over cleartext a man-in-the-middle could rewrite the advertised endpoints or jwks_uri and
+// steer clients onto attacker infrastructure. A host needing an ungated route (a health probe) adds its own.
+[RequireHttps]
 [ReturnsOidcInvalidRequest]
 [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [SkipStatusCodePages]


### PR DESCRIPTION
The two adapters treated the public discovery and JWKS metadata inconsistently: the Minimal API adapter gated the whole endpoint group on HTTPS, while the MVC `DiscoveryController` (serving discovery + JWKS) carried no `[RequireHttps]`. This resolves the inconsistency by gating **every** endpoint on HTTPS in **both** adapters — metadata included.

**Why gate the public metadata too.** Discovery and JWKS carry no secrets, but over cleartext a man-in-the-middle can rewrite the advertised endpoints or `jwks_uri`, or substitute the signing keys a client then trusts, and steer clients onto attacker infrastructure. Serving the provider configuration only over TLS closes that at the library level.

**Changes**
- MVC: add `[RequireHttps]` to `DiscoveryController` (the credential-bearing controllers already carry it). The Minimal API group HTTPS filter already covered every endpoint.
- E2E in both adapters: a cleartext GET to discovery / `oauth-authorization-server` / JWKS is redirected to the https URL.
- A host that needs an ungated route (a liveness/health probe) maps its own outside the OIDC endpoints; the library gates all of its own without exception.

Supersedes the earlier direction on this branch (exempting the metadata to match MVC); the decision instead aligns MVC up to the same stricter policy as the Minimal API adapter.

#228
