### PR TITLE
feat: make PBES2 opt-in and bound its work factor to ecosystem consensus

### DIFF
--- a/Abblix.Jwt.UnitTests/Pbes2KeyEncryptionTests.cs
+++ b/Abblix.Jwt.UnitTests/Pbes2KeyEncryptionTests.cs
@@ -45,6 +45,8 @@ public class Pbes2KeyEncryptionTests
 		var services = new ServiceCollection();
 		services.AddSingleton(TimeProvider.System);
 		services.AddLogging();
+		// PBES2 is deliberately not part of the AddJsonWebTokens defaults — a host opts in explicitly
+		services.AddPbes2KeyManagement();
 		services.AddJsonWebTokens();
 		return services.BuildServiceProvider();
 	}
@@ -133,11 +135,12 @@ public class Pbes2KeyEncryptionTests
 	/// <summary>
 	/// The 'p2c' iteration count is attacker-controlled on inbound tokens. Values above the hard
 	/// cap must be rejected before any PBKDF2 work — otherwise a single crafted token demands an
-	/// arbitrary amount of computation (denial of service by iteration count). Values below the
+	/// arbitrary amount of computation (the CVE-2022-36083 class of denial of service; the cap of
+	/// 10,000 is the remediation consensus across JOSE implementations). Values below the
 	/// RFC 7518 §4.8.1.2 recommended minimum signal a downgrade and are rejected as well.
 	/// </summary>
 	[Theory]
-	[InlineData(1_000_001)]     // above the DoS cap
+	[InlineData(10_001)]        // above the DoS cap
 	[InlineData(int.MaxValue)]  // pathological
 	[InlineData(999)]           // below the spec minimum
 	[InlineData(0)]
@@ -204,7 +207,11 @@ public class Pbes2KeyEncryptionTests
 
 		Assert.NotNull(header.Pbes2SaltInput);
 		Assert.True(Base64Url.DecodeFromChars(header.Pbes2SaltInput).Length >= 8);
-		Assert.True(header.Pbes2IterationCount >= 1000);
+
+		// The outbound default must pass this library's own inbound bounds — and stay under the
+		// post-advisory inbound caps of the wider JOSE ecosystem, so produced tokens decrypt anywhere.
+		Assert.NotNull(header.Pbes2IterationCount);
+		Assert.InRange(header.Pbes2IterationCount.Value, 1000, 10_000);
 
 		Assert.True(encryptor.TryDecryptKey(header, passwordKey, encryptedKey, out var recoveredCek));
 		Assert.Equal(cek, recoveredCek);

--- a/Abblix.Jwt/Encryption/Pbes2KeyEncryptor.cs
+++ b/Abblix.Jwt/Encryption/Pbes2KeyEncryptor.cs
@@ -49,16 +49,13 @@ internal sealed class Pbes2KeyEncryptor(string algorithm) : IKeyEncryptor<OctetJ
 	public string Algorithm => algorithm;
 
 	/// <summary>
-	/// The PBKDF2 pseudorandom function, the derived KEK size and the default outbound iteration
-	/// count for this algorithm. The defaults follow the OWASP Password Storage recommendations
-	/// for PBKDF2 (600k for HMAC-SHA-256, 210k for the SHA-2 512-block-size family), well under
-	/// the inbound cap.
+	/// The PBKDF2 pseudorandom function and the derived KEK size for this algorithm.
 	/// </summary>
-	private readonly (HashAlgorithmName Prf, int KekSize, int DefaultIterationCount) _parameters = algorithm switch
+	private readonly (HashAlgorithmName Prf, int KekSize) _parameters = algorithm switch
 	{
-		EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW => (HashAlgorithmName.SHA256, 16, 600_000),
-		EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW => (HashAlgorithmName.SHA384, 24, 210_000),
-		EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW => (HashAlgorithmName.SHA512, 32, 210_000),
+		EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW => (HashAlgorithmName.SHA256, 16),
+		EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW => (HashAlgorithmName.SHA384, 24),
+		EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW => (HashAlgorithmName.SHA512, 32),
 		_ => throw new ArgumentException($"Unsupported PBES2 algorithm: {algorithm}", nameof(algorithm))
 	};
 
@@ -71,9 +68,16 @@ internal sealed class Pbes2KeyEncryptor(string algorithm) : IKeyEncryptor<OctetJ
 	// RFC 7518 §4.8.1.2: "A minimum iteration count of 1000 is RECOMMENDED" — enforced on inbound tokens.
 	private const int MinIterationCount = 1000;
 
-	// Hard upper bound on the inbound iteration count: 'p2c' is attacker-controlled, and without a cap
-	// a single crafted token could demand an arbitrary amount of PBKDF2 work before any authentication.
-	private const int MaxIterationCount = 1_000_000;
+	// Hard upper bound on the inbound iteration count: 'p2c' is attacker-controlled, and without a cap a
+	// single crafted token demands an arbitrary amount of PBKDF2 work before any authentication of the
+	// token (the CVE-2022-36083 class of denial of service). 10,000 is the remediation consensus across
+	// JOSE implementations; a legitimate producer has no reason to exceed it, because for PBES2 in JOSE
+	// the primary security control is the entropy of the password, not the iteration count.
+	private const int MaxIterationCount = 10_000;
+
+	// The outbound iteration count: the largest common power of two under the post-advisory inbound caps
+	// of the JOSE ecosystem (10,000 here and elsewhere), so tokens this library produces decrypt anywhere.
+	private const int DefaultIterationCount = 8192;
 
 	/// <inheritdoc />
 	/// <remarks>
@@ -86,12 +90,11 @@ internal sealed class Pbes2KeyEncryptor(string algorithm) : IKeyEncryptor<OctetJ
 			throw new InvalidOperationException("PBES2 requires an OctetJsonWebKey with a non-empty password value");
 
 		var saltInput = CryptoRandom.GetRandomBytes(SaltInputSize);
-		var iterationCount = _parameters.DefaultIterationCount;
 
 		header.Pbes2SaltInput = Base64Url.EncodeToString(saltInput);
-		header.Pbes2IterationCount = iterationCount;
+		header.Pbes2IterationCount = DefaultIterationCount;
 
-		var kek = DeriveKek(password, saltInput, iterationCount);
+		var kek = DeriveKek(password, saltInput, DefaultIterationCount);
 		return AesKeyWrap.Wrap(kek, keyToEncrypt);
 	}
 

--- a/Abblix.Jwt/EncryptionAlgorithms.cs
+++ b/Abblix.Jwt/EncryptionAlgorithms.cs
@@ -133,6 +133,8 @@ public static class EncryptionAlgorithms
 		/// from a password with PBKDF2 (native <c>Rfc2898DeriveBytes.Pbkdf2</c>) using the
 		/// 'p2s'/'p2c' header parameters, then wraps the CEK per RFC 3394. Inbound iteration counts
 		/// are bounded to keep an attacker-supplied token from demanding arbitrary PBKDF2 work.
+		/// Opt-in: the PBES2 family is enabled by <c>AddPbes2KeyManagement</c>, not by default —
+		/// accepting password-based key management from token producers is an explicit hosting decision.
 		/// </summary>
 		public const string Pbes2HmacSha256Aes128KW = "PBES2-HS256+A128KW";
 

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -100,12 +100,6 @@ public static class ServiceCollectionExtensions
             .AddKeyEncryptor<EllipticCurveJsonWebKey, EcdhEsKeyEncryptor>(EncryptionAlgorithms.KeyManagement.EcdhEsAes192KW)
             .AddKeyEncryptor<EllipticCurveJsonWebKey, EcdhEsKeyEncryptor>(EncryptionAlgorithms.KeyManagement.EcdhEsAes256KW);
 
-        // PBES2 password-based key encryption (PBKDF2 + RFC 3394 key wrapping)
-        services
-            .AddKeyEncryptor<OctetJsonWebKey, Pbes2KeyEncryptor>(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW)
-            .AddKeyEncryptor<OctetJsonWebKey, Pbes2KeyEncryptor>(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW)
-            .AddKeyEncryptor<OctetJsonWebKey, Pbes2KeyEncryptor>(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW);
-
         // Register content encryptors by algorithm
         services
             .AddContentEncryptor<AesCbcHmacEncryptor>(EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256)
@@ -139,6 +133,26 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Enables the PBES2 password-based key management algorithms (PBES2-HS256+A128KW,
+    /// PBES2-HS384+A192KW, PBES2-HS512+A256KW; RFC 7518 Section 4.8) for both producing and
+    /// consuming JWE tokens. They are deliberately not part of <see cref="AddJsonWebTokens"/>:
+    /// the 'p2c' header of an inbound token dictates PBKDF2 work performed before any
+    /// authentication of the token (the CVE-2022-36083 class of denial of service), and because
+    /// JWE decryption keys are matched by key identifier, an octet key configured for another
+    /// key-management algorithm could otherwise be driven into the PBKDF2 path by an
+    /// attacker-chosen 'alg' header. Accepting password-based key management is therefore an
+    /// explicit hosting decision. The iteration count of an inbound token is bounded to
+    /// [1000, 10,000] even when enabled.
+    /// </summary>
+    /// <param name="services">The service collection to register the PBES2 encryptors in.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddPbes2KeyManagement(this IServiceCollection services)
+        => services
+            .AddKeyEncryptor<OctetJsonWebKey, Pbes2KeyEncryptor>(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW)
+            .AddKeyEncryptor<OctetJsonWebKey, Pbes2KeyEncryptor>(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW)
+            .AddKeyEncryptor<OctetJsonWebKey, Pbes2KeyEncryptor>(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW);
 
     /// <summary>
     /// Registers an <see cref="ICriticalHeaderHandler"/> for a single JOSE header extension

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
@@ -358,6 +358,30 @@ public class ServiceCollectionOverrideTests
             provider.GetRequiredService<IJsonWebTokenValidator>().EncryptionAlgorithmsSupported);
     }
 
+    /// <summary>
+    /// PBES2 is deliberately absent from the <c>AddJsonWebTokens</c> defaults (the 'p2c' header of an
+    /// inbound token dictates pre-authentication PBKDF2 work — the CVE-2022-36083 class of denial of
+    /// service), and a host that opts in via <c>AddPbes2KeyManagement</c> gets the family registered
+    /// and advertised.
+    /// </summary>
+    [Fact]
+    public void AddPbes2KeyManagement_OptsInPbes2Algorithms()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+
+        services.AddPbes2KeyManagement();
+        services.AddJsonWebTokens();
+
+        using var provider = services.BuildServiceProvider();
+        var advertised = provider.GetRequiredService<IJsonWebTokenValidator>().EncryptionAlgorithmsSupported.ToList();
+
+        Assert.Contains(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW, advertised);
+        Assert.Contains(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW, advertised);
+        Assert.Contains(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW, advertised);
+    }
+
     [Fact]
     public void AddJsonWebTokens_DefaultAlgorithms_AdvertisedInRegistrationOrder()
     {
@@ -399,9 +423,6 @@ public class ServiceCollectionOverrideTests
                 EncryptionAlgorithms.KeyManagement.Aes192KW,
                 EncryptionAlgorithms.KeyManagement.Aes256KW,
                 EncryptionAlgorithms.KeyManagement.Dir,
-                EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW,
-                EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW,
-                EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW,
             ],
             validator.EncryptionAlgorithmsSupported);
         Assert.Equal(


### PR DESCRIPTION
Hardens the PBES2 family added in #230 (unreleased) against the CVE-2022-36083 class of denial of service and aligns it with post-advisory ecosystem practice:

- **Opt-in**: PBES2 is no longer registered by `AddJsonWebTokens`; a host enables it explicitly with `AddPbes2KeyManagement()`. The `p2c` header of an inbound token dictates PBKDF2 work performed before any authentication of the token, and since JWE decryption keys are matched by `kid`, an octet key configured for another algorithm could be driven into the PBKDF2 path by an attacker-chosen `alg` header. Discovery advertises PBES2 only for hosts that opted in.
- **Inbound `p2c` cap**: 1,000,000 → 10,000, the remediation consensus across JOSE implementations.
- **Outbound default `p2c`**: 8192 — the largest common power of two under the ecosystem's inbound caps, so produced tokens decrypt anywhere; the primary security control for PBES2 in JOSE is password entropy.

No compatibility impact: the PBES2 family has not shipped in any release.

Ref #233
