### PR TITLE
feat: make RSA1_5 JWE key management opt-in

### DIFF
--- a/Abblix.Jwt.UnitTests/InteropTests.cs
+++ b/Abblix.Jwt.UnitTests/InteropTests.cs
@@ -68,6 +68,9 @@ public class InteropTests
 		var services = new ServiceCollection();
 		services.AddSingleton(TimeProvider.System);
 		services.AddLogging();
+		// RSA1_5 is deliberately not part of the AddJsonWebTokens defaults — the legacy-interop
+		// theories below opt in explicitly
+		services.AddRsaPkcs1KeyManagement();
 		services.AddJsonWebTokens();
 		return services.BuildServiceProvider();
 	}

--- a/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
+++ b/Abblix.Jwt.UnitTests/JwtEncryptionTests.cs
@@ -51,6 +51,9 @@ public class JwtEncryptionTests
         var services = new ServiceCollection();
         services.AddSingleton(TimeProvider.System);
         services.AddLogging();
+        // RSA1_5 is deliberately not part of the AddJsonWebTokens defaults — the legacy-interop
+        // round-trip and Bleichenbacher-mitigation tests below opt in explicitly
+        services.AddRsaPkcs1KeyManagement();
         services.AddJsonWebTokens();
         return services.BuildServiceProvider();
     }
@@ -146,9 +149,10 @@ public class JwtEncryptionTests
     }
 
     /// <summary>
-    /// Verifies RSA1_5 (RSAES-PKCS1-v1_5) round-trips: it is kept for backward compatibility, and a
-    /// JWE encrypted with it decrypts correctly. The Bleichenbacher oracle that PKCS1-v1.5 would
-    /// otherwise expose is closed by the RFC 7516 §11.5 random-CEK mitigation (see
+    /// Verifies RSA1_5 (RSAES-PKCS1-v1_5) round-trips once a host opts in via
+    /// <c>AddRsaPkcs1KeyManagement</c> (this class's service provider does): a JWE encrypted with it
+    /// decrypts correctly and the algorithm is advertised. The Bleichenbacher oracle that PKCS1-v1.5
+    /// would otherwise expose is closed by the RFC 7516 §11.5 random-CEK mitigation (see
     /// <see cref="TamperedEncryptedKey_IsRejected_Uniformly"/>).
     /// </summary>
     [Fact]

--- a/Abblix.Jwt/EncryptionAlgorithms.cs
+++ b/Abblix.Jwt/EncryptionAlgorithms.cs
@@ -40,7 +40,9 @@ public static class EncryptionAlgorithms
 		/// RSAES-PKCS1-v1_5 key encryption (RFC 7518 Section 4.2). Backed by .NET <c>RSA</c>
 		/// with <c>RSAEncryptionPadding.Pkcs1</c>.
 		/// Kept for interoperability with legacy peers; OAEP variants should be preferred
-		/// because PKCS#1 v1.5 padding is vulnerable to chosen-ciphertext attacks (Bleichenbacher).
+		/// because PKCS#1 v1.5 padding is vulnerable to chosen-ciphertext attacks (Bleichenbacher)
+		/// and NIST SP 800-131A Rev. 2 disallows it for key transport.
+		/// Opt-in: enabled by <c>AddRsaPkcs1KeyManagement</c>, not by default.
 		/// </summary>
 		public const string Rsa1_5 = "RSA1_5";
 

--- a/Abblix.Jwt/ServiceCollectionExtensions.cs
+++ b/Abblix.Jwt/ServiceCollectionExtensions.cs
@@ -66,16 +66,11 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<EncryptionAlgorithmsProvider>();
 
         // Register key encryptors by algorithm.
-        // RSA-OAEP and RSA-OAEP-256 are the recommended algorithms. RSA1_5 (RSAES-PKCS1-v1_5) is
-        // kept for backward compatibility despite RFC 8725 §3.2's advice to prefer RSAES-OAEP: its
-        // padding would otherwise make the decryption endpoint a Bleichenbacher oracle. That oracle
-        // is closed in JsonWebTokenEncryptor.DecryptAsync by the RFC 7516 §11.5 mitigation — a CEK
-        // that fails to decrypt is replaced with a random CEK and the AEAD step still runs, so a
-        // decryption failure is processed identically regardless of padding validity.
+        // RSA-OAEP and RSA-OAEP-256 are the recommended algorithms; RSA1_5 is opt-in via
+        // AddRsaPkcs1KeyManagement (NIST SP 800-131A Rev. 2 disallows PKCS#1 v1.5 key transport).
         services
             .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep)
-            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep256)
-            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.Rsa1_5);
+            .AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.RsaOaep256);
 
         // AES-GCM Key Wrap (symmetric key encryption with GCM)
         services
@@ -133,6 +128,22 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Enables the RSA1_5 (RSAES-PKCS1-v1_5) key management algorithm (RFC 7518 Section 4.2) for
+    /// both producing and consuming JWE tokens. It is deliberately not part of
+    /// <see cref="AddJsonWebTokens"/>: NIST SP 800-131A Rev. 2 disallows RSA key transport with
+    /// PKCS#1 v1.5 padding after 2023, and RFC 8725 §3.2 prescribes preferring RSAES-OAEP —
+    /// interoperating with a legacy peer that still requires it is an explicit hosting decision.
+    /// The padding's Bleichenbacher decryption oracle stays closed for opted-in hosts by the
+    /// RFC 7516 §11.5 mitigation in <see cref="JsonWebTokenEncryptor"/>: a CEK that fails to
+    /// decrypt is replaced with a random CEK and the AEAD step still runs, so a decryption
+    /// failure is processed identically regardless of padding validity.
+    /// </summary>
+    /// <param name="services">The service collection to register the encryptor in.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddRsaPkcs1KeyManagement(this IServiceCollection services)
+        => services.AddKeyEncryptor<RsaJsonWebKey, RsaKeyEncryptor>(EncryptionAlgorithms.KeyManagement.Rsa1_5);
 
     /// <summary>
     /// Enables the PBES2 password-based key management algorithms (PBES2-HS256+A128KW,

--- a/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
@@ -382,6 +382,28 @@ public class ServiceCollectionOverrideTests
         Assert.Contains(EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW, advertised);
     }
 
+    /// <summary>
+    /// RSA1_5 is deliberately absent from the <c>AddJsonWebTokens</c> defaults (NIST SP 800-131A Rev. 2
+    /// disallows PKCS#1 v1.5 key transport), and a host interoperating with a legacy peer opts in via
+    /// <c>AddRsaPkcs1KeyManagement</c>.
+    /// </summary>
+    [Fact]
+    public void AddRsaPkcs1KeyManagement_OptsInRsa1_5()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+
+        services.AddRsaPkcs1KeyManagement();
+        services.AddJsonWebTokens();
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Contains(
+            EncryptionAlgorithms.KeyManagement.Rsa1_5,
+            provider.GetRequiredService<IJsonWebTokenValidator>().EncryptionAlgorithmsSupported);
+    }
+
     [Fact]
     public void AddJsonWebTokens_DefaultAlgorithms_AdvertisedInRegistrationOrder()
     {
@@ -411,7 +433,6 @@ public class ServiceCollectionOverrideTests
             [
                 EncryptionAlgorithms.KeyManagement.RsaOaep,
                 EncryptionAlgorithms.KeyManagement.RsaOaep256,
-                EncryptionAlgorithms.KeyManagement.Rsa1_5,
                 EncryptionAlgorithms.KeyManagement.EcdhEs,
                 EncryptionAlgorithms.KeyManagement.EcdhEsAes128KW,
                 EncryptionAlgorithms.KeyManagement.EcdhEsAes192KW,


### PR DESCRIPTION
Makes RSA1_5 (RSAES-PKCS1-v1_5) key management opt-in:

- **Rationale**: NIST SP 800-131A Rev. 2 disallows RSA key transport with PKCS#1 v1.5 padding after December 31, 2023 — a formal prohibition in FIPS contexts, not a recommendation — and RFC 8725 §3.2 prescribes preferring RSAES-OAEP. Interoperating with a legacy peer that still requires the algorithm becomes an explicit hosting decision.
- **Change**: `AddJsonWebTokens` no longer registers RSA1_5; a host enables it with `AddRsaPkcs1KeyManagement()`. Without the opt-in, an inbound `alg: RSA1_5` resolves no key encryptor and is rejected through the standard random-CEK path, discovery does not advertise the algorithm, and registration requests asking for it are rejected by the existing supported-algorithms validation.
- The RFC 7516 §11.5 random-CEK mitigation keeps the Bleichenbacher decryption oracle closed for hosts that opt in (covered by the existing tamper-uniformity and wrong-length-CEK tests, which now run against an opted-in service provider).

**Breaking**: hosts whose clients registered RSA1_5 encryption (supported since 2.3) must call the opt-in method after upgrading. Recorded in the 2.4 breaking-changes notes.

Ref #235
