### PR TITLE
RFC 8725 (JWT BCP) audit remediation

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,7 +15,8 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 6 minutes: the suite grew past the 5-minute wall on slow runners as more E2E tests landed.
+    timeout-minutes: 6
     steps:
       # harden-runner in audit mode: this workflow restores/builds/tests
       # untrusted fork-PR code, so capture baseline egress for later review.

--- a/Abblix.Jwt.UnitTests/JsonWebTokenClaimsTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenClaimsTests.cs
@@ -790,6 +790,10 @@ public class JsonWebTokenClaimsTests
             Payload =
             {
                 JwtId = Guid.NewGuid().ToString("N"),
+                // A signed token is always signature-verified now (RFC 8725 §3.1/§3.3), and the
+                // issuer-resolved-keys branch needs an 'iss' to select keys; the resolver returns
+                // the signing key regardless of value, so any issuer lets verification proceed.
+                Issuer = "https://issuer.example.com",
                 IssuedAt = issuedAt,
                 NotBefore = issuedAt,
                 ExpiresAt = issuedAt + TimeSpan.FromHours(1),

--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -504,6 +504,36 @@ public class JsonWebTokenValidationTests
     }
 
     /// <summary>
+    /// RFC 8725 §3.1/§3.3: a signed token (alg != none) must ALWAYS have its signature verified,
+    /// even when the caller requests neither <see cref="ValidationOptions.RequireSignedTokens"/> nor
+    /// <see cref="ValidationOptions.ValidateIssuerSigningKey"/>. A token signed with one key must not
+    /// be accepted when only a different key resolves — otherwise a signed-but-unverified token is
+    /// silently trusted.
+    /// </summary>
+    [Fact]
+    public async Task SignedToken_WithoutSignatureFlags_StillVerifiesSignature()
+    {
+        var token = CreateValidToken();
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+
+        // Clear BOTH signature flags; keep issuer/audience/lifetime so signature is the only gate left.
+        var parameters = new ValidationParameters
+        {
+            Options = ValidationOptions.Default & ~ValidationOptions.RequireValidSignedTokens,
+            ValidateIssuer = _ => Task.FromResult(true),
+            ValidateAudience = _ => Task.FromResult(true),
+            ResolveIssuerSigningKeys = _ => WrongSigningKey.ToAsync(),
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out _),
+            "A signed token verified against the wrong key must be rejected, not silently accepted.");
+    }
+
+    /// <summary>
     /// Verifies that unsigned JWTs validate when ValidationOptions.RequireSignedTokens is disabled.
     /// Tests acceptance of unsecured JWTs (algorithm: none) per RFC 7515 Section 8.
     /// Warning: Accepting unsigned tokens in production is a severe security risk.

--- a/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -229,31 +229,26 @@ internal class JsonWebTokenValidator(
 
         // 'alg' is byte-exact per RFC 7515 §5.3 / §10.13: switching on the const string ensures
         // case-variants like "None"/"NONE" never match the unsecured-JWS branch.
-        switch (algorithm)
+        return algorithm switch
         {
-            case SigningAlgorithms.None when parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens):
-                return new JwtValidationError(
-                    JwtError.InvalidAlgorithm, "Unsigned tokens are not allowed");
+            SigningAlgorithms.None when parameters.Options.HasFlag(ValidationOptions.RequireSignedTokens) =>
+                new JwtValidationError(JwtError.InvalidAlgorithm, "Unsigned tokens are not allowed"),
+            
+            SigningAlgorithms.None when jwtParts[2].HasValue()
+                => new JwtValidationError(JwtError.MalformedToken, "Unsigned token must have empty signature"),
 
-            case SigningAlgorithms.None when jwtParts[2].HasValue():
-                return new JwtValidationError(
-                    JwtError.MalformedToken, "Unsigned token must have empty signature");
+            // Reached only by alg "none" when signatures are not required — accept the unsigned token.
+            SigningAlgorithms.None => token,
 
-            case not SigningAlgorithms.None when parameters.Options.HasAnyFlag(
-                    ValidationOptions.RequireSignedTokens | ValidationOptions.ValidateIssuerSigningKey):
-                break;
+            // Two trust-model branches selected by the caller via UseEmbeddedVerificationKey:
+            // either the JOSE header's 'jwk' is the signing key (DPoP-style proofs), or the
+            // payload's 'iss' selects keys via the resolver delegate (id_token-style flows).
+            // The selection is binary; mixing leads to attacker-controlled trust escalation.
+            _ when parameters.Options.HasFlag(ValidationOptions.UseEmbeddedVerificationKey)
+                => await ValidateEmbeddedKeyAsync(token, jwtParts),
 
-            default:
-                return token;
-        }
-
-        // Two trust-model branches selected by the caller via UseEmbeddedVerificationKey:
-        // either the JOSE header's 'jwk' is the signing key (DPoP-style proofs), or the
-        // payload's 'iss' selects keys via the resolver delegate (id_token-style flows).
-        // The selection is binary; mixing leads to attacker-controlled trust escalation.
-        return parameters.Options.HasFlag(ValidationOptions.UseEmbeddedVerificationKey)
-            ? await ValidateEmbeddedKeyAsync(token, jwtParts)
-            : await ValidateIssuerSignatureAsync(token, jwtParts, parameters);
+            _ => await ValidateIssuerSignatureAsync(token, jwtParts, parameters)
+        };
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Common/Configuration/SecretLengthOptionsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/Configuration/SecretLengthOptionsValidatorTests.cs
@@ -1,0 +1,88 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Verifies that <see cref="SecretLengthOptionsValidator"/> rejects a configuration whose
+/// secret-bearing lengths fall below the security floor for their kind, while the shipped defaults
+/// pass unchanged.
+/// </summary>
+public class SecretLengthOptionsValidatorTests
+{
+    private readonly SecretLengthOptionsValidator _validator = new();
+
+    /// <summary>
+    /// The shipped defaults are all at or above the floors, so a stock configuration validates.
+    /// </summary>
+    [Fact]
+    public void Validate_DefaultOptions_Succeeds()
+    {
+        var result = _validator.Validate(null, new OidcOptions());
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// A client secret below the HS256 HMAC-key floor (RFC 7518 §3.2) must be rejected at startup.
+    /// </summary>
+    [Fact]
+    public void Validate_ClientSecretBelowFloor_Fails()
+    {
+        var options = new OidcOptions
+        {
+            NewClientOptions = new NewClientOptions
+            {
+                ClientSecret = new ClientSecretOptions
+                {
+                    Length = SecretLengthOptionsValidator.MinimumClientSecretLength - 1,
+                },
+            },
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("ClientSecret"));
+    }
+
+    /// <summary>
+    /// An opaque random secret (here the authorization code) below the guess-resistance floor must
+    /// be rejected at startup.
+    /// </summary>
+    [Fact]
+    public void Validate_AuthorizationCodeBelowFloor_Fails()
+    {
+        var options = new OidcOptions
+        {
+            AuthorizationCodeLength = SecretLengthOptionsValidator.MinimumRandomSecretLength - 1,
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(OidcOptions.AuthorizationCodeLength)));
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidatorTests.cs
@@ -247,7 +247,11 @@ public class UserIdentityValidatorTests
     public async Task ValidateAsync_WithValidIdTokenHint_ShouldReturnNull()
     {
         // Arrange
-        var token = new JsonWebToken { Payload = { Audiences = ["test-client"] } };
+        var token = new JsonWebToken
+        {
+            Header = { Type = JwtTypes.IdToken },
+            Payload = { Audiences = ["test-client"] },
+        };
 
         _idTokenValidator
             .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationOptions>()))
@@ -264,6 +268,35 @@ public class UserIdentityValidatorTests
     }
 
     /// <summary>
+    /// RFC 8725 §3.12: the id_token_hint must be an ID Token, not another own-issued class.
+    /// A token whose 'typ' is not <c>id_token+jwt</c> (e.g. a stolen access token replayed as a
+    /// hint) must be rejected even when its audience matches the requesting client.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_IdTokenHintWrongType_ShouldReturnInvalidRequest()
+    {
+        // Arrange
+        var token = new JsonWebToken
+        {
+            Header = { Type = JwtTypes.AccessToken },
+            Payload = { Audiences = ["test-client"] },
+        };
+
+        _idTokenValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(token);
+
+        var context = CreateContext(idTokenHint: "access-token-as-hint");
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+    }
+
+    /// <summary>
     /// Verifies error when id_token_hint has wrong audience.
     /// ID token must be issued for the requesting client.
     /// </summary>
@@ -271,7 +304,11 @@ public class UserIdentityValidatorTests
     public async Task ValidateAsync_IdTokenHintWrongAudience_ShouldReturnInvalidRequest()
     {
         // Arrange
-        var token = new JsonWebToken { Payload = { Audiences = ["different-client"] } };
+        var token = new JsonWebToken
+        {
+            Header = { Type = JwtTypes.IdToken },
+            Payload = { Audiences = ["different-client"] },
+        };
 
         _idTokenValidator
             .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationOptions>()))

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -52,7 +52,9 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.DynamicClientManagement;
 /// </summary>
 public class RegisterClientHandlerIntegrationTests
 {
-    private static IServiceProvider BuildProvider(Action<IServiceCollection>? configure = null)
+    private static IServiceProvider BuildProvider(
+        Action<IServiceCollection>? configure = null,
+        Action<OidcOptions>? configureOptions = null)
     {
         var services = new ServiceCollection();
 
@@ -93,6 +95,8 @@ public class RegisterClientHandlerIntegrationTests
             // sees the request — masking the very behaviour we want to verify.
             opts.RequireInitialAccessToken = false;
 
+            // A test that exercises the initial access token gate re-enables it here.
+            configureOptions?.Invoke(opts);
         });
 
         return services.BuildServiceProvider();
@@ -339,6 +343,37 @@ public class RegisterClientHandlerIntegrationTests
         Assert.True(stored.RequirePushedAuthorizationRequests);
         Assert.True(stored.RequireSignedRequestObject);
         Assert.True(stored.TlsClientCertificateBoundAccessTokens);
+    }
+
+    /// <summary>
+    /// RFC 7591 §3: with the initial access token gate enabled, a client presenting a token minted
+    /// by this server's own <see cref="IInitialAccessTokenService"/> must be allowed to register.
+    /// The minted token carries no <c>aud</c> (registration authorizes at the issuer itself), so this
+    /// exercises the mint-side and validate-side option sets composing end to end: the validator must
+    /// not require an audience the mint deliberately omits.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WithMintedInitialAccessToken_Succeeds()
+    {
+        var provider = BuildProvider(configureOptions: opts => opts.RequireInitialAccessToken = true);
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+        var initialAccessTokenService = provider.GetRequiredService<IInitialAccessTokenService>();
+        var timeProvider = provider.GetRequiredService<TimeProvider>();
+
+        var token = await initialAccessTokenService.IssueTokenAsync(
+            subject: "registration-portal",
+            issuedAt: timeProvider.GetUtcNow(),
+            expiresIn: TimeSpan.FromHours(1));
+
+        var request = CreateRequest() with
+        {
+            AuthorizationHeader = new System.Net.Http.Headers.AuthenticationHeaderValue(TokenTypes.Bearer, token),
+        };
+
+        var result = await handler.HandleAsync(request);
+
+        Assert.True(result.TryGetSuccess(out _),
+            $"Expected success but got error: {(result.TryGetFailure(out var err) ? err.ErrorDescription : "<unknown>")}");
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/InitialAccessTokenValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/InitialAccessTokenValidatorTests.cs
@@ -240,6 +240,10 @@ public class InitialAccessTokenValidatorTests
         await _validator.ValidateAsync(context);
 
         Assert.NotNull(capturedOptions);
-        Assert.Equal(ValidationOptions.Default & ~ValidationOptions.ValidateAudience, capturedOptions);
+
+        // The whole RequireValidAudience pair (RequireAudience | ValidateAudience) must be cleared:
+        // an initial access token carries no 'aud', so leaving RequireAudience set would reject it.
+        Assert.Equal(ValidationOptions.Default & ~ValidationOptions.RequireValidAudience, capturedOptions);
+        Assert.False(capturedOptions.Value.HasFlag(ValidationOptions.RequireAudience));
     }
 }

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/Validation/IdTokenHintValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/Validation/IdTokenHintValidatorTests.cs
@@ -62,6 +62,7 @@ public class IdTokenHintValidatorTests
     private static JsonWebToken CreateValidIdToken(params string[] audiences)
     {
         var token = new JsonWebToken();
+        token.Header.Type = JwtTypes.IdToken;
         token.Payload.Audiences = audiences;
         return token;
     }
@@ -167,6 +168,33 @@ public class IdTokenHintValidatorTests
         Assert.NotNull(error);
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
         Assert.Contains("missing", error.ErrorDescription);
+    }
+
+    /// <summary>
+    /// RFC 8725 §3.12: the id_token_hint must be an ID Token, not another own-issued class.
+    /// A token whose 'typ' is not <c>id_token+jwt</c> (e.g. a stolen access token replayed as a
+    /// hint) must be rejected even when its audience matches the requesting client.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_WithNonIdTokenType_ShouldReturnError()
+    {
+        // Arrange
+        var context = CreateContext("access_token_as_hint");
+        var accessToken = CreateValidIdToken(TestConstants.DefaultClientId);
+        accessToken.Header.Type = JwtTypes.AccessToken;
+
+        _jwtValidator
+            .Setup(v => v.ValidateAsync(
+                "access_token_as_hint",
+                It.Is<ValidationOptions>(o => (o & ValidationOptions.ValidateLifetime) == 0)))
+            .ReturnsAsync(accessToken);
+
+        // Act
+        var error = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretHmacKeyLengthTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretHmacKeyLengthTests.cs
@@ -1,0 +1,114 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.RandomGenerators;
+using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
+
+/// <summary>
+/// A client authenticating with <c>client_secret_jwt</c> (OpenID Connect Core §9) signs its
+/// assertion with the client secret as the HMAC key. Per RFC 7518 §3.2 an HS256 key must be at
+/// least 32 bytes, and the JWT layer enforces that floor. This locks the default DCR-issued secret
+/// length to a value whose UTF-8 encoding is usable as an HS256 key, so a client that received a
+/// default secret can actually authenticate with it — the mismatch that the mocked
+/// <c>ClientSecretJwtAuthenticator</c> unit tests could not surface.
+/// </summary>
+public class ClientSecretHmacKeyLengthTests
+{
+    private static readonly IServiceProvider Jwt = BuildJwtServices();
+
+    private static IServiceProvider BuildJwtServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// The default client secret, encoded to UTF-8 as an HMAC key, must satisfy the RFC 7518 §3.2
+    /// HS256 floor (32 bytes). A shorter default (as before, 16 characters) leaves every
+    /// default-secret client unable to use HS256 client_secret_jwt at all.
+    /// </summary>
+    [Fact]
+    public void DefaultSecret_UsableAsHs256Key()
+    {
+        var secret = new ClientSecretGenerator().GenerateClientSecret(new ClientSecretOptions().Length);
+        Assert.True(
+            Encoding.UTF8.GetBytes(secret).Length >= 32,
+            $"Default client secret is {Encoding.UTF8.GetBytes(secret).Length} bytes, below the 32-byte HS256 key floor.");
+    }
+
+    /// <summary>
+    /// End to end through the real JWT stack: a client_secret_jwt assertion signed with a
+    /// default-length secret as its HS256 key must both sign and verify. With a below-floor secret
+    /// the signer rejects the key, so a default-secret client cannot produce a usable assertion.
+    /// </summary>
+    [Fact]
+    public async Task DefaultSecret_SignsAndVerifiesHs256Assertion()
+    {
+        var secret = new ClientSecretGenerator().GenerateClientSecret(new ClientSecretOptions().Length);
+        var key = new OctetJsonWebKey
+        {
+            Algorithm = SigningAlgorithms.HS256,
+            KeyValue = Encoding.UTF8.GetBytes(secret),
+        };
+
+        var issuedAt = TimeProvider.System.GetUtcNow();
+        var assertion = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithms.HS256 },
+            Payload =
+            {
+                JwtId = System.Guid.NewGuid().ToString("N"),
+                Issuer = "client-a",
+                Subject = "client-a",
+                Audiences = ["https://auth.example.com/token"],
+                IssuedAt = issuedAt,
+                NotBefore = issuedAt,
+                ExpiresAt = issuedAt + System.TimeSpan.FromMinutes(5),
+            },
+        };
+
+        var creator = Jwt.GetRequiredService<IJsonWebTokenCreator>();
+        var jws = await creator.IssueAsync(assertion, key);
+
+        var validator = Jwt.GetRequiredService<IJsonWebTokenValidator>();
+        var result = await validator.ValidateAsync(jws, new ValidationParameters
+        {
+            Options = ValidationOptions.RequireValidSignedTokens,
+            ResolveIssuerSigningKeys = _ => ((JsonWebKey)key).ToAsync(),
+        });
+
+        Assert.True(result.TryGetSuccess(out _),
+            result.TryGetFailure(out var error) ? error.ErrorDescription : "Validation failed");
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/ClientSecretOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ClientSecretOptions.cs
@@ -28,10 +28,13 @@ namespace Abblix.Oidc.Server.Common.Configuration;
 public record ClientSecretOptions
 {
     /// <summary>
-    /// The length of the generated client secret.
-    /// Specifies the number of characters in the secret. Default value is 16.
+    /// The length of the generated client secret, in characters.
+    /// The default is 32: a client authenticating with <c>client_secret_jwt</c> (OpenID Connect
+    /// Core §9) uses the secret's UTF-8 bytes as the HMAC key, and RFC 7518 §3.2 requires an HS256
+    /// key of at least 32 bytes. A host whose clients sign with HS384 or HS512 should raise this to
+    /// 48 or 64 respectively so the derived key meets that algorithm's floor.
     /// </summary>
-    public int Length { get; init; } = 16;
+    public int Length { get; init; } = 32;
 
     /// <summary>
     /// The expiration duration for the client secret.

--- a/Abblix.Oidc.Server/Common/Configuration/SecretLengthOptionsValidator.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/SecretLengthOptionsValidator.cs
@@ -1,0 +1,83 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Fails loudly at startup when a configured secret-bearing length is below the security floor for
+/// its kind, instead of silently generating a guessable client secret, authorization code or
+/// identifier at runtime. Every shipped default is already at or above these floors, so a valid
+/// configuration is unaffected; the validator only rejects a deliberately shortened value.
+/// </summary>
+public class SecretLengthOptionsValidator : IValidateOptions<OidcOptions>
+{
+    /// <summary>
+    /// Minimum length, in characters, of a generated client secret. A client authenticating with
+    /// <c>client_secret_jwt</c> (OpenID Connect Core §9) uses the secret's UTF-8 bytes as the HMAC
+    /// key, and RFC 7518 §3.2 requires an HS256 key of at least 32 bytes; a shorter secret cannot
+    /// serve that method at all.
+    /// </summary>
+    public const int MinimumClientSecretLength = 32;
+
+    /// <summary>
+    /// Minimum length, in characters, of an opaque random secret the server issues as a bearer value
+    /// (authorization code, PAR request URI, session/token/grant identifier). Below this a random
+    /// token becomes guessable; the value is a hard safety floor, well under every shipped default.
+    /// </summary>
+    public const int MinimumRandomSecretLength = 16;
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OidcOptions options)
+    {
+        var failures = new List<string>();
+
+        Check(failures, "NewClientOptions.ClientSecret.Length",
+            options.NewClientOptions.ClientSecret.Length, MinimumClientSecretLength);
+
+        Check(failures, nameof(options.AuthorizationCodeLength),
+            options.AuthorizationCodeLength, MinimumRandomSecretLength);
+        Check(failures, nameof(options.RequestUriLength),
+            options.RequestUriLength, MinimumRandomSecretLength);
+        Check(failures, nameof(options.SessionIdLength),
+            options.SessionIdLength, MinimumRandomSecretLength);
+        Check(failures, nameof(options.TokenIdLength),
+            options.TokenIdLength, MinimumRandomSecretLength);
+        Check(failures, nameof(options.GrantIdLength),
+            options.GrantIdLength, MinimumRandomSecretLength);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void Check(List<string> failures, string optionName, int configuredLength, int minimumLength)
+    {
+        if (configuredLength < minimumLength)
+        {
+            failures.Add(
+                $"{optionName} is {configuredLength}, below the minimum of {minimumLength} characters " +
+                $"required for a secret of this kind.");
+        }
+    }
+}

--- a/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidator.cs
@@ -149,6 +149,15 @@ public class UserIdentityValidator(
 
         var token = result.GetSuccess();
 
+        // RFC 8725 §3.12: pin the token class. The id_token_hint MUST be an ID Token; without this
+        // check another own-issued token whose audience matches (an access or refresh token) would
+        // be accepted here, since the audience/signature checks alone do not distinguish the class.
+        if (token.Header.Type != JwtTypes.IdToken)
+        {
+            return new OidcError(
+                ErrorCodes.InvalidRequest, "The id token hint is not an ID Token");
+        }
+
         var audiences = token.Payload.Audiences;
         if (!audiences.Contains(context.ClientInfo.ClientId, StringComparer.Ordinal))
         {

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/InitialAccessTokenValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/InitialAccessTokenValidator.cs
@@ -65,10 +65,12 @@ public class InitialAccessTokenValidator(
         }
 
         // Skip audience validation: initial access tokens authorize registration at the issuer itself,
-        // so no audience claim is set or expected.
+        // so no audience claim is set or expected. Clearing RequireValidAudience drops BOTH the
+        // presence requirement and the value check; clearing only ValidateAudience would leave
+        // RequireAudience set, and an initial access token carries no 'aud', so it would be rejected.
         var result = await jwtValidator.ValidateAsync(
             header.Parameter,
-            ValidationOptions.Default & ~ValidationOptions.ValidateAudience);
+            ValidationOptions.Default & ~ValidationOptions.RequireValidAudience);
 
         if (result.TryGetFailure(out var error))
             return new OidcError(ErrorCodes.InvalidToken, error.ErrorDescription);

--- a/Abblix.Oidc.Server/Endpoints/EndSession/Validation/IdTokenHintValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/EndSession/Validation/IdTokenHintValidator.cs
@@ -53,6 +53,13 @@ public class IdTokenHintValidator(IAuthServiceJwtValidator jwtValidator) : IEndS
 
             var idToken = result.GetSuccess();
 
+            // RFC 8725 §3.12: pin the token class. The id_token_hint MUST be an ID Token; without this
+            // check another own-issued token whose audience matches (an access or refresh token) would
+            // be accepted here, since the audience/signature checks alone do not distinguish the class.
+            if (idToken.Header.Type != JwtTypes.IdToken)
+                return new OidcError(
+                    ErrorCodes.InvalidRequest, "The id token hint is not an ID Token");
+
             var audiences = idToken.Payload.Audiences;
             if (!request.ClientId.HasValue())
             {

--- a/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
+++ b/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
@@ -56,6 +56,14 @@ public class ResponseJwtBuilder(
 
         var now = timeProvider.GetUtcNow();
 
+        // No 'typ' header is set on purpose. The JARM specification defines none for the authorization
+        // response, and RFC 7519 Section 5.1 makes 'typ' OPTIONAL. The explicit-typing benefit of
+        // RFC 8725 Section 3.11 comes from a DISTINCT media type that disambiguates one token class from
+        // another (as RFC 9101 Section 10.8 registers 'oauth-authz-req+jwt' for request objects); a
+        // generic 'JWT' distinguishes nothing. And there is no confusion vector to close here: the
+        // response is consumed by the client, never re-validated by this server against other token
+        // classes, unlike the id_token_hint path where token-type pinning matters. Do not add a generic
+        // 'typ' back without a registered JARM media type and a concrete threat it addresses.
         var token = new JsonWebToken
         {
             Header = { Algorithm = clientInfo.AuthorizationSignedResponseAlgorithm },

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -134,6 +134,11 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, OidcOptionsSecurityProfileValidator>());
 
+        // Fail loud at startup when a configured secret-bearing length is below the security floor
+        // for its kind, instead of generating a guessable secret or an unusable HMAC key at runtime.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, SecretLengthOptionsValidator>());
+
         // Fail loud at startup when EnabledEndpoints advertises an opt-in endpoint whose feature services were
         // never registered by the matching AddX() call, instead of 500-ing on every request to it.
         services.TryAddEnumerable(


### PR DESCRIPTION
Remediation from an audit of the token layer against RFC 8725 (JSON Web Token Best Current Practices). Each change is behavior-scoped and independently committed.

**Initial access token audience.** An initial access token is minted with no `aud` (registration authorizes at the issuer itself), but the validator cleared only the audience-value check while leaving the audience-presence requirement set, so every such token was rejected with "Missing audience". A host that requires an initial access token could not register any client. The validator now drops the whole audience requirement, matching the mint side.

**id_token_hint token-type pinning (§3.12).** The end-session and CIBA `id_token_hint` validators accepted any own-issued JWT whose audience matched the client. They now require `typ=id_token+jwt`, so a token of another class is no longer taken as an ID Token. Issued ID Tokens carry that type, so legitimate hints are unaffected.

**Always verify a present signature (§3.1/§3.3).** A signed JWT (`alg` other than `none`) is now signature-verified regardless of the `RequireSignedTokens`/`ValidateIssuerSigningKey` options. Those options govern the unsigned-token policy only; they no longer gate verification of a signature that is present.

**Secret minimum lengths (§3.5).** The default client secret length is raised to 32 so its UTF-8 bytes meet the HS256 key floor (RFC 7518 §3.2) that a `client_secret_jwt` assertion needs. A startup options validator fails loudly when any secret-bearing length (client secret, authorization code, request URI, session/token/grant identifier) is configured below the security floor for its kind.

**JARM typ decision.** Documented, in code, why the JARM authorization response deliberately carries no explicit `typ`: the JARM spec defines none, RFC 7519 §5.1 makes it optional, and a generic `JWT` would not deliver the distinct-typing benefit of §3.11 for a response the server never re-validates.
