### PR TITLE
ci: scope PR-test permissions at job level

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -20,6 +20,8 @@ jobs:
     # 5 minutes per shard: the slowest shard runs ~3m14s, so this keeps ample headroom while
     # catching a runaway sooner than the previous single-job wall did.
     timeout-minutes: 5
+    permissions:
+      contents: read
     strategy:
       # Report every shard's result; do not cancel siblings when one fails.
       fail-fast: false
@@ -103,6 +105,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # The gate only inspects shard results; it never touches the repo or the GITHUB_TOKEN.
+    permissions: {}
     steps:
       - name: Fail if any shard failed
         if: needs.test-shard.result != 'success'


### PR DESCRIPTION
## Why

SonarCloud's `githubactions:S8264` (MAJOR / VULNERABILITY) flagged the workflow-level `permissions: contents: read` in `pr-tests.yml` because both jobs inherit it implicitly rather than declaring their own. It dropped the Security Rating on New Code to C and turned the "SonarCloud Code Analysis" quality gate red. The other three workflows already declare per-job permissions, so only this file tripped the rule.

The finding is not a regression from a recent change: S8264 was newly activated in Sonar's default profile, and the first analysis after activation flagged the pre-existing lines (Sonar backdates a new rule's issue to the blame date of the line).

## Change

- `test-shard`: declare `permissions: contents: read` — the only scope its `actions/checkout` needs.
- `test` (aggregate gate): declare `permissions: {}` — it only reads shard results, never touches the repo or the token.
- Workflow-root `contents: read` stays as the safe default for any future job.

Mirrors the per-job least-privilege pattern already used in `codeql.yml`, `enhanced-release.yml`, and `publish-dev-builds.yml`.

Checked: Permissions (per-job least privilege, root read retained), Pinning (all `uses:` SHA-pinned, unchanged), Timeouts (every job/step bounded, unchanged), Concurrency (PR-only, cancel-in-progress: true, unchanged). N/A: Inputs/Secrets/Provenance (no step or secret changes). actionlint + lint-no-inline-secrets clean; shellcheck on PATH.