### PR TITLE
Per-client response mode allow-list (#241) and JWT tampering hardening tests

### DIFF
--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -1404,4 +1404,173 @@ public class JsonWebTokenValidationTests
 
         Assert.True(result.TryGetSuccess(out _));
     }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Hardening coverage — token-shape confusion (segment count) and alg-stripping /
+    // payload tampering. RFC 7515 §7.1 fixes JWS compact serialization at exactly three
+    // dot-separated parts and RFC 7516 §9 fixes JWE at five; any other count must be
+    // rejected as malformed, never mis-routed into a validation path (the JWS-as-JWE
+    // type-confusion class). RFC 8725 §2.1/§3.1 warn that an attacker will strip 'alg'
+    // to none or rewrite the payload of a captured token — the validator must reject both.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// RFC 7515 §7.1 / RFC 7516 §9: a compact token has exactly 3 (JWS) or 5 (JWE) parts. A 4-,
+    /// 6-, or 7-segment string matches neither shape, so the part-count dispatch must fail it as
+    /// <see cref="JwtError.MalformedToken"/> rather than fall through to any validation path.
+    /// </summary>
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    [InlineData(7)]
+    public async Task MalformedJwt_WithUnsupportedSegmentCount_FailsAsMalformed(int segments)
+    {
+        var jwt = string.Join('.', Enumerable.Repeat("AAAA", segments));
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.MalformedToken, error.Error);
+    }
+
+    /// <summary>
+    /// The real-token variant of the segment-count guard: a genuine, correctly-signed JWS with one
+    /// extra segment appended (<c>header.payload.signature.injected</c>) is a 4-part string. The
+    /// validator must reject it as <see cref="JwtError.MalformedToken"/> on the part-count dispatch,
+    /// never strip the trailing junk and trust the valid three-part prefix.
+    /// </summary>
+    [Fact]
+    public async Task SignedJws_WithAppendedSegment_RejectedAsMalformed()
+    {
+        var signedJwt = await IssueToken(CreateValidToken(), SigningKey);
+        var tampered = signedJwt + ".injected";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(tampered, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.MalformedToken, error.Error);
+    }
+
+    /// <summary>
+    /// The 5-segment type-confusion variant: a genuine 3-part JWS padded with two extra segments
+    /// becomes a 5-part string, which the part-count dispatch routes to the JWE decryption path. The
+    /// signed JWS content must NOT be trusted — the JWE decrypt fails (a JWS 'alg' is not a JWE
+    /// key-management alg and no matching key exists), so the token is rejected rather than accepted
+    /// as its inner JWS.
+    /// </summary>
+    [Fact]
+    public async Task SignedJws_PaddedToFiveSegments_RoutedToJweAndRejected()
+    {
+        var signedJwt = await IssueToken(CreateValidToken(), SigningKey);
+        var tampered = signedJwt + ".injected.tag";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey, encryptionKey);
+
+        var result = await validator.ValidateAsync(tampered, parameters);
+
+        Assert.True(result.TryGetFailure(out _),
+            "A signed JWS padded to 5 segments must be rejected on the JWE path, not accepted as its inner JWS.");
+    }
+
+    /// <summary>
+    /// RFC 8725 §3.1 (alg-stripping): a header carrying no 'alg' at all must be rejected as
+    /// <see cref="JwtError.InvalidAlgorithm"/>, never treated as an implicit unsigned token. RFC 7515
+    /// §4.1.1 makes 'alg' REQUIRED.
+    /// </summary>
+    [Fact]
+    public async Task Jws_WithMissingAlgHeader_RejectedAsInvalidAlgorithm()
+    {
+        var header = EncodeBase64Url("""{"typ":"JWT"}""");
+        var payload = EncodeBase64Url($$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","sub":"test-user"}""");
+        var jwt = $"{header}.{payload}.";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidAlgorithm, error.Error);
+    }
+
+    /// <summary>
+    /// An empty JOSE header object <c>{}</c> likewise declares no 'alg' and must be rejected as
+    /// <see cref="JwtError.InvalidAlgorithm"/>. Guards the degenerate alg-stripping case where an
+    /// attacker blanks the entire header.
+    /// </summary>
+    [Fact]
+    public async Task Jws_WithEmptyHeaderObject_RejectedAsInvalidAlgorithm()
+    {
+        var header = EncodeBase64Url("{}");
+        var payload = EncodeBase64Url($$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","sub":"test-user"}""");
+        var jwt = $"{header}.{payload}.";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidAlgorithm, error.Error);
+    }
+
+    /// <summary>
+    /// RFC 8725 §3.1 (alg-stripping on a captured token): take a genuinely RS256-signed token, rewrite
+    /// its header 'alg' to 'none' and drop the signature. Under the default options (RequireSignedTokens)
+    /// the downgraded token must be rejected as <see cref="JwtError.InvalidAlgorithm"/> — the captured
+    /// payload is not trusted just because the attacker relabelled it unsigned.
+    /// </summary>
+    [Fact]
+    public async Task SignedJws_AlgStrippedToNone_RejectedWhenSigningRequired()
+    {
+        var signedJwt = await IssueToken(CreateValidToken(), SigningKey);
+        var parts = signedJwt.Split('.');
+
+        // Rewrite the header to alg=none, keep the original (signed) payload, drop the signature.
+        var strippedHeader = EncodeBase64Url("""{"alg":"none","typ":"JWT"}""");
+        var downgraded = $"{strippedHeader}.{parts[1]}.";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(downgraded, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidAlgorithm, error.Error);
+    }
+
+    /// <summary>
+    /// RFC 8725 §2.1 (payload tampering): take a genuinely signed token, rewrite a payload claim (a
+    /// privilege-escalation attempt on 'sub'), re-encode the payload but keep the ORIGINAL signature.
+    /// The signature no longer covers the mutated payload, so validation must fail as
+    /// <see cref="JwtError.InvalidSignature"/>. Header and 'alg' are untouched, isolating the payload
+    /// integrity check — and the rewrite is done at the JSON level so the payload stays parseable and
+    /// the token reaches the signature stage rather than short-circuiting as malformed.
+    /// </summary>
+    [Fact]
+    public async Task SignedJws_WithTamperedPayload_RejectedAsInvalidSignature()
+    {
+        var signedJwt = await IssueToken(CreateValidToken(), SigningKey);
+        var parts = signedJwt.Split('.');
+
+        var originalPayload = Encoding.UTF8.GetString(Base64Url.DecodeFromChars(parts[1]));
+        var tamperedPayload = originalPayload.Replace("test-user", "attacker");
+        Assert.NotEqual(originalPayload, tamperedPayload); // guard: the claim we rewrite is actually present
+        var tampered = $"{parts[0]}.{EncodeBase64Url(tamperedPayload)}.{parts[2]}";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey);
+
+        var result = await validator.ValidateAsync(tampered, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidSignature, error.Error);
+    }
 }

--- a/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -40,6 +40,9 @@ public class JsonWebTokenValidationTests
     private const string IssuerUri = "https://issuer.example.com";
     private const string TestAudience = "test-audience";
 
+    // alg=none JOSE header, shared by the unsigned-token and alg-stripping tests.
+    private const string NoneAlgHeaderJson = """{"alg":"none","typ":"JWT"}""";
+
     private static readonly JsonWebKey SigningKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
     private static readonly JsonWebKey encryptionKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Encryption);
     private static readonly JsonWebKey WrongSigningKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
@@ -744,7 +747,7 @@ public class JsonWebTokenValidationTests
     {
         // Create a JWT manually with an invalid exp claim (negative value triggers ArgumentOutOfRangeException)
         // Negative Unix timestamps represent dates before 1970 which can exceed valid DateTimeOffset range
-        var header = EncodeBase64Url(@"{""alg"":""none"",""typ"":""JWT""}");
+        var header = EncodeBase64Url(NoneAlgHeaderJson);
         var payload = EncodeBase64Url(
             $$"""
             {
@@ -783,7 +786,7 @@ public class JsonWebTokenValidationTests
     [Fact]
     public async Task TokenWithOutOfRangeIssuedAt_FailsValidationGracefully()
     {
-        var header = EncodeBase64Url(@"{""alg"":""none"",""typ"":""JWT""}");
+        var header = EncodeBase64Url(NoneAlgHeaderJson);
         var payload = EncodeBase64Url(
             $$"""
             {
@@ -825,7 +828,7 @@ public class JsonWebTokenValidationTests
         // Unix timestamp for year 10,001 would exceed DateTimeOffset.MaxValue
         var farFutureTimestamp = 253402300800L; // Year 10,000
 
-        var header = EncodeBase64Url(@"{""alg"":""none"",""typ"":""JWT""}");
+        var header = EncodeBase64Url(NoneAlgHeaderJson);
         var payload = EncodeBase64Url(
             $$"""
             {
@@ -1480,35 +1483,17 @@ public class JsonWebTokenValidationTests
     }
 
     /// <summary>
-    /// RFC 8725 §3.1 (alg-stripping): a header carrying no 'alg' at all must be rejected as
+    /// RFC 8725 §3.1 (alg-stripping): a header that declares no 'alg' — whether it carries other
+    /// parameters (<c>{"typ":"JWT"}</c>) or is the empty object (<c>{}</c>) — must be rejected as
     /// <see cref="JwtError.InvalidAlgorithm"/>, never treated as an implicit unsigned token. RFC 7515
     /// §4.1.1 makes 'alg' REQUIRED.
     /// </summary>
-    [Fact]
-    public async Task Jws_WithMissingAlgHeader_RejectedAsInvalidAlgorithm()
+    [Theory]
+    [InlineData("""{"typ":"JWT"}""")]
+    [InlineData("{}")]
+    public async Task Jws_WithNoAlgInHeader_RejectedAsInvalidAlgorithm(string headerJson)
     {
-        var header = EncodeBase64Url("""{"typ":"JWT"}""");
-        var payload = EncodeBase64Url($$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","sub":"test-user"}""");
-        var jwt = $"{header}.{payload}.";
-
-        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
-        var parameters = CreateValidationParameters(SigningKey);
-
-        var result = await validator.ValidateAsync(jwt, parameters);
-
-        Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(JwtError.InvalidAlgorithm, error.Error);
-    }
-
-    /// <summary>
-    /// An empty JOSE header object <c>{}</c> likewise declares no 'alg' and must be rejected as
-    /// <see cref="JwtError.InvalidAlgorithm"/>. Guards the degenerate alg-stripping case where an
-    /// attacker blanks the entire header.
-    /// </summary>
-    [Fact]
-    public async Task Jws_WithEmptyHeaderObject_RejectedAsInvalidAlgorithm()
-    {
-        var header = EncodeBase64Url("{}");
+        var header = EncodeBase64Url(headerJson);
         var payload = EncodeBase64Url($$"""{"iss":"{{IssuerUri}}","aud":"{{TestAudience}}","sub":"test-user"}""");
         var jwt = $"{header}.{payload}.";
 
@@ -1534,7 +1519,7 @@ public class JsonWebTokenValidationTests
         var parts = signedJwt.Split('.');
 
         // Rewrite the header to alg=none, keep the original (signed) payload, drop the signature.
-        var strippedHeader = EncodeBase64Url("""{"alg":"none","typ":"JWT"}""");
+        var strippedHeader = EncodeBase64Url(NoneAlgHeaderJson);
         var downgraded = $"{strippedHeader}.{parts[1]}.";
 
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();

--- a/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -84,6 +84,19 @@ builder.Services.AddOidcServices(options =>
             AllowedResponseTypes = [[ResponseTypes.None]],
             PkceRequired = false,
         },
+
+        // Client that opts in to the per-client response-mode allow-list, pinned to form_post, used to
+        // prove the response-mode downgrade backstop end to end: query/fragment (and an omitted
+        // response_mode that inherits the query default) are rejected, form_post is accepted.
+        new ClientInfo(TestConstants.ResponseModePinnedClientId)
+        {
+            ClientSecrets = [secret],
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+            RedirectUris = [redirect],
+            AllowedGrantTypes = [GrantTypes.AuthorizationCode],
+            PkceRequired = true,
+            AllowedResponseModes = [ResponseModes.FormPost],
+        },
     ];
 
     // A single registered RFC 8707 resource indicator. The AS only mints audience-restricted

--- a/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -63,6 +63,11 @@ public static class TestConstants
     /// returns no code or token — only state and iss.</summary>
     public const string NoneResponseTypeClientId = "e2e-none-response-type";
 
+    /// <summary>Client that opts in to the per-client <c>AllowedResponseModes</c> allow-list, pinned to
+    /// form_post: the response-mode downgrade backstop rejects a crafted request naming query or fragment
+    /// (and one that omits response_mode to inherit the query default). Drives the response-mode restriction E2E.</summary>
+    public const string ResponseModePinnedClientId = "e2e-response-mode-pinned";
+
     /// <summary>Shared secret across every pre-seeded client.</summary>
     public const string ConfidentialClientSecret = "e2e-secret";
 

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenFamilyRevocationTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenFamilyRevocationTests.cs
@@ -50,7 +50,7 @@ public class RefreshTokenFamilyRevocationTests(TestFactory factory) : TestBase(f
 
         // A legitimate auth-code flow with offline_access issues the first refresh token of a new family
         // (rt1). The test client does not set AllowReuse, so it rotates by default (the secure default).
-        var initial = await ObtainRefreshTokenAsync(client, discovery);
+        var initial = await ObtainConfidentialOfflineTokensAsync(client, discovery);
         var rt1 = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
 
         // A normal refresh rotates rt1 -> rt2: rt1 becomes superseded (marked Used) and rt2 is now the
@@ -77,7 +77,7 @@ public class RefreshTokenFamilyRevocationTests(TestFactory factory) : TestBase(f
 
         // Build a three-generation lineage rt1 -> rt2 -> rt3. Each rotation supersedes its predecessor and
         // carries the same grant_id forward, so rt1, rt2 and rt3 all belong to one family; rt3 is active.
-        var initial = await ObtainRefreshTokenAsync(client, discovery);
+        var initial = await ObtainConfidentialOfflineTokensAsync(client, discovery);
         var rt1 = initial[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
         var rt2 = await RotateAsync(client, discovery, rt1);
         var rt3 = await RotateAsync(client, discovery, rt2);
@@ -93,37 +93,6 @@ public class RefreshTokenFamilyRevocationTests(TestFactory factory) : TestBase(f
         // rt3 — the token an attacker who had rotated forward would be holding.
         await AssertInvalidGrantAsync(await RefreshAsync(client, discovery, rt2));
         await AssertInvalidGrantAsync(await RefreshAsync(client, discovery, rt3));
-    }
-
-    /// <summary>
-    /// Drives a plain (non-PAR) auth-code flow with <c>offline_access</c> for the confidential client and
-    /// returns the token response, whose <c>refresh_token</c> is the first member of a fresh family.
-    /// </summary>
-    private static async Task<JsonObject> ObtainRefreshTokenAsync(HttpClient client, DiscoveryDocument discovery)
-    {
-        var (verifier, challenge) = GeneratePkcePair();
-
-        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
-        {
-            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
-            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
-            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
-            [AuthorizationRequest.Parameters.Scope] = $"{Scopes.OpenId} {Scopes.OfflineAccess}",
-            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
-            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
-            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
-            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
-        });
-
-        return await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
-        {
-            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
-            [TokenRequest.Parameters.Code] = code,
-            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
-            [TokenRequest.Parameters.CodeVerifier] = verifier,
-            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
-            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-        });
     }
 
     private static async Task<HttpResponseMessage> RefreshAsync(

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenTamperingTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenTamperingTests.cs
@@ -112,37 +112,14 @@ public class RefreshTokenTamperingTests(TestFactory factory) : TestBase(factory)
     }
 
     /// <summary>
-    /// Drives a plain auth-code flow with <c>offline_access</c> for the confidential client and returns
-    /// the genuine refresh token together with the client and discovery document used to obtain it.
+    /// Obtains a genuine refresh token (confidential client, auth-code flow with <c>offline_access</c>)
+    /// via the shared helper, returning it together with the client and discovery document used to get it.
     /// </summary>
     private async Task<(HttpClient Client, DiscoveryDocument Discovery, string RefreshToken)> ObtainGenuineRefreshTokenAsync()
     {
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
-        var (verifier, challenge) = GeneratePkcePair();
-
-        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
-        {
-            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
-            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
-            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
-            [AuthorizationRequest.Parameters.Scope] = $"{Scopes.OpenId} {Scopes.OfflineAccess}",
-            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
-            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
-            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
-            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
-        });
-
-        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
-        {
-            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
-            [TokenRequest.Parameters.Code] = code,
-            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
-            [TokenRequest.Parameters.CodeVerifier] = verifier,
-            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
-            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
-        });
-
+        var tokens = await ObtainConfidentialOfflineTokensAsync(client, discovery);
         var refreshToken = tokens[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
         return (client, discovery, refreshToken);
     }

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenTamperingTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenTamperingTests.cs
@@ -1,0 +1,180 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end proof that the refresh_token grant runs every presented token through the real JWT
+/// validation gate (<c>RefreshTokenGrantHandler</c> → <c>AuthServiceJwtValidator</c> → the real
+/// signer) before it ever touches the token store: a tampered refresh token is rejected with
+/// <c>invalid_grant</c> however it was mutated. Covers the RFC 8725 attack matrix on the refresh-token
+/// path — alg-stripping (§3.1), payload tampering (§2.1), signature corruption, and segment-count
+/// confusion (RFC 7515 §7.1) — which the handler's unit tests cannot exercise because they mock the
+/// validator. Each test obtains its own genuine refresh token and only ever submits a mutated copy, so
+/// the real token is never spent and no rotation/family state is disturbed.
+/// </summary>
+public class RefreshTokenTamperingTests(TestFactory factory) : TestBase(factory)
+{
+    /// <summary>
+    /// alg-stripping: rewrite the header 'alg' to 'none' and drop the signature. The auth-service
+    /// validator requires signed tokens (its default options), so the downgraded token is rejected
+    /// at the JWT gate and the grant fails with invalid_grant.
+    /// </summary>
+    [Fact]
+    public async Task AlgStrippedToNone_RefreshToken_IsRejected()
+    {
+        var (client, discovery, refreshToken) = await ObtainGenuineRefreshTokenAsync();
+
+        var parts = refreshToken.Split('.');
+        var header = JsonNode.Parse(Encoding.UTF8.GetString(Base64UrlDecode(parts[0])))!.AsObject();
+        header["alg"] = SigningAlgorithms.None;
+        header.Remove(JwtClaimTypes.KeyId);
+        var tampered = $"{Base64UrlEncode(header.ToJsonString())}.{parts[1]}.";
+
+        await AssertRefreshRejectedAsync(client, discovery, tampered);
+    }
+
+    /// <summary>
+    /// Payload tampering: rewrite the subject (a privilege-escalation attempt) but keep the original
+    /// signature. The signature no longer covers the mutated payload, so verification fails and the
+    /// grant is rejected with invalid_grant.
+    /// </summary>
+    [Fact]
+    public async Task TamperedPayload_RefreshToken_IsRejected()
+    {
+        var (client, discovery, refreshToken) = await ObtainGenuineRefreshTokenAsync();
+
+        var parts = refreshToken.Split('.');
+        var payload = JsonNode.Parse(Encoding.UTF8.GetString(Base64UrlDecode(parts[1])))!.AsObject();
+        payload[IanaClaimTypes.Sub] = "attacker";
+        var tampered = $"{parts[0]}.{Base64UrlEncode(payload.ToJsonString())}.{parts[2]}";
+
+        await AssertRefreshRejectedAsync(client, discovery, tampered);
+    }
+
+    /// <summary>
+    /// Segment-count confusion: append a fourth segment to the genuine three-part JWS. The validator
+    /// rejects the 4-part string as malformed rather than stripping the junk and trusting the prefix.
+    /// </summary>
+    [Fact]
+    public async Task AppendedSegment_RefreshToken_IsRejected()
+    {
+        var (client, discovery, refreshToken) = await ObtainGenuineRefreshTokenAsync();
+
+        await AssertRefreshRejectedAsync(client, discovery, refreshToken + ".injected");
+    }
+
+    /// <summary>
+    /// Signature corruption: flip the final signature character so it no longer verifies. The grant is
+    /// rejected with invalid_grant, proving the signature is actually checked on the refresh path.
+    /// </summary>
+    [Fact]
+    public async Task CorruptedSignature_RefreshToken_IsRejected()
+    {
+        var (client, discovery, refreshToken) = await ObtainGenuineRefreshTokenAsync();
+
+        var parts = refreshToken.Split('.');
+        var signature = parts[2];
+        var flipped = signature[^1] == 'A' ? 'B' : 'A';
+        var tampered = $"{parts[0]}.{parts[1]}.{signature[..^1]}{flipped}";
+
+        await AssertRefreshRejectedAsync(client, discovery, tampered);
+    }
+
+    /// <summary>
+    /// Drives a plain auth-code flow with <c>offline_access</c> for the confidential client and returns
+    /// the genuine refresh token together with the client and discovery document used to obtain it.
+    /// </summary>
+    private async Task<(HttpClient Client, DiscoveryDocument Discovery, string RefreshToken)> ObtainGenuineRefreshTokenAsync()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var (verifier, challenge) = GeneratePkcePair();
+
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = $"{Scopes.OpenId} {Scopes.OfflineAccess}",
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+
+        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+        var refreshToken = tokens[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+        return (client, discovery, refreshToken);
+    }
+
+    private static async Task AssertRefreshRejectedAsync(
+        HttpClient client, DiscoveryDocument discovery, string refreshToken)
+    {
+        var response = await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
+            [TokenRequest.Parameters.RefreshToken] = refreshToken,
+            [ClientRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = JsonNode.Parse(raw)!.AsObject();
+        Assert.Equal(ErrorCodes.InvalidGrant, body["error"]!.GetValue<string>());
+    }
+
+    private static string Base64UrlEncode(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var padded = input.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResponseModeRestrictionTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResponseModeRestrictionTests.cs
@@ -1,0 +1,102 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using System.Net;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Response-mode downgrade backstop (RFC 9700) end-to-end. A client that opts in to the per-client
+/// <c>AllowedResponseModes</c> allow-list, pinned to form_post, exchanges the code from its backend and
+/// never needs it in the browser. A crafted authorization request that names an exposing delivery mode
+/// (query or fragment), or omits <c>response_mode</c> to inherit the query default, is rejected with
+/// <c>invalid_request</c>; form_post is accepted and the code is delivered by an auto-submitting POST.
+/// </summary>
+public class ResponseModeRestrictionTests(TestFactory factory) : TestBase(factory)
+{
+    /// <summary>
+    /// Verifies that the pinned client is rejected when the request names query or fragment, or omits
+    /// response_mode (inheriting the query default). Each rejection is delivered on the requested or
+    /// effective channel, so the test reads the error from whichever of query/fragment carries it.
+    /// </summary>
+    [Theory]
+    [InlineData(ResponseModes.Query)]
+    [InlineData(ResponseModes.Fragment)]
+    [InlineData(null)]
+    public async Task PinnedClient_ExposingOrOmittedMode_IsRejected(string? responseMode)
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var (_, challenge) = GeneratePkcePair();
+
+        var queryParams = new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ResponseModePinnedClientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        };
+        if (responseMode is not null)
+            queryParams[AuthorizationRequest.Parameters.ResponseMode] = responseMode;
+
+        var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, queryParams);
+        var response = await client.GetAsync(uri, TestContext.Current.CancellationToken);
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+            $"/authorize returned {(int)response.StatusCode}, expected an error redirect. Body: " +
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        var location = response.Headers.Location
+            ?? throw new InvalidOperationException("/authorize did not set Location header");
+
+        // query and the omitted default deliver the error in the query string; fragment delivers it in
+        // the fragment. Read whichever part carries the parameters.
+        var carrier = location.Query.Length > 0 ? location.Query : location.Fragment;
+        var callback = System.Web.HttpUtility.ParseQueryString(carrier.TrimStart('?', '#'));
+
+        Assert.Equal(ErrorCodes.InvalidRequest, callback["error"]);
+        Assert.Null(callback["code"]);
+    }
+
+    /// <summary>
+    /// Verifies that the pinned client is accepted when it requests form_post: the AS renders a 200
+    /// auto-submitting HTML form that POSTs the code to the redirect_uri, rather than an error redirect.
+    /// </summary>
+    [Fact]
+    public async Task PinnedClient_FormPost_IsAccepted()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var (_, challenge) = GeneratePkcePair();
+
+        var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ResponseModePinnedClientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.ResponseMode] = ResponseModes.FormPost,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = Scopes.OpenId,
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+        var response = await client.GetAsync(uri, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        // The auto-submitting form POSTs the authorization response back to the registered redirect_uri.
+        Assert.Contains(TestConstants.RedirectUri, body);
+        Assert.Contains(TokenRequest.Parameters.Code, body);
+    }
+}

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -139,6 +139,39 @@ public abstract class TestBase(TestFactory factory)
         return parsed;
     }
 
+    /// <summary>
+    /// Drives a plain auth-code flow with <c>offline_access</c> for the confidential test client and
+    /// returns the parsed token response — its <c>refresh_token</c> is the first member of a fresh
+    /// family. Shared by the refresh-token rotation and tampering scenarios so the flow lives in one place.
+    /// </summary>
+    protected static async Task<JsonObject> ObtainConfidentialOfflineTokensAsync(
+        HttpClient client, DiscoveryDocument discovery)
+    {
+        var (verifier, challenge) = GeneratePkcePair();
+
+        var code = await AuthorizeAndExtractCodeAsync(client, discovery, new Dictionary<string, string>
+        {
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [AuthorizationRequest.Parameters.ResponseType] = ResponseTypes.Code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [AuthorizationRequest.Parameters.Scope] = $"{Scopes.OpenId} {Scopes.OfflineAccess}",
+            [AuthorizationRequest.Parameters.State] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.Nonce] = Guid.NewGuid().ToString("N"),
+            [AuthorizationRequest.Parameters.CodeChallenge] = challenge,
+            [AuthorizationRequest.Parameters.CodeChallengeMethod] = CodeChallengeMethods.S256,
+        });
+
+        return await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.AuthorizationCode,
+            [TokenRequest.Parameters.Code] = code,
+            [AuthorizationRequest.Parameters.RedirectUri] = TestConstants.RedirectUri,
+            [TokenRequest.Parameters.CodeVerifier] = verifier,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+    }
+
     protected static JsonObject DecodeJwtPayload(string jwt)
     {
         var parts = jwt.Split('.');

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/ResponseModeValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/ResponseModeValidatorTests.cs
@@ -58,7 +58,9 @@ public class ResponseModeValidatorTests
     /// </summary>
     private static AuthorizationValidationContext CreateContext(
         FlowTypes flowType,
-        string? responseMode = null)
+        string? responseMode = null,
+        string[]? allowedResponseModes = null,
+        string defaultResponseMode = ResponseModes.Query)
     {
         var request = new AuthorizationRequest
         {
@@ -69,13 +71,19 @@ public class ResponseModeValidatorTests
             ResponseMode = responseMode,
         };
 
-        var clientInfo = new ClientInfo(ClientId);
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            AllowedResponseModes = allowedResponseModes,
+        };
 
         var context = new AuthorizationValidationContext(request)
         {
             ClientInfo = clientInfo,
             FlowType = flowType,
-            ResponseMode = ResponseModes.Query, // Default
+            // In the real pipeline FlowTypeValidator sets this to the flow default before
+            // ResponseModeValidator runs; the tests reproduce that so the effective-mode check
+            // (which reads context.ResponseMode when response_mode is omitted) sees the same value.
+            ResponseMode = defaultResponseMode,
         };
 
         return context;
@@ -562,5 +570,164 @@ public class ResponseModeValidatorTests
         // No trimming, so "query " != "query"
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+    }
+
+    /// <summary>
+    /// Verifies that an explicitly requested mode within the client's AllowedResponseModes list succeeds.
+    /// The per-client allow-list permits exactly the pinned mode and nothing else.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ClientAllowsMode_RequestUsesIt_ShouldSucceed()
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: ResponseModes.FormPost,
+            allowedResponseModes: [ResponseModes.FormPost]);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal(ResponseModes.FormPost, context.ResponseMode);
+    }
+
+    /// <summary>
+    /// Verifies that an explicitly requested mode outside the client's AllowedResponseModes list is rejected,
+    /// even though it is compatible with the flow. This is the response-mode downgrade backstop: a client
+    /// pinned to form_post cannot be driven with fragment on a crafted authorization request.
+    /// </summary>
+    [Theory]
+    [InlineData(ResponseModes.Fragment)]
+    [InlineData(ResponseModes.Query)]
+    public async Task ValidateAsync_ClientPinnedToFormPost_RequestsAnotherMode_ShouldReturnError(string requested)
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: requested,
+            allowedResponseModes: [ResponseModes.FormPost]);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+    }
+
+    /// <summary>
+    /// Verifies that omitting response_mode does not bypass the per-client restriction. A client pinned to
+    /// form_post that receives a request with no response_mode would otherwise inherit the flow default (query);
+    /// the effective-mode check rejects it, closing the omission variant of the downgrade.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ClientPinnedToFormPost_RequestOmitsResponseMode_ShouldReturnError()
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: null,
+            allowedResponseModes: [ResponseModes.FormPost],
+            defaultResponseMode: ResponseModes.Query);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+    }
+
+    /// <summary>
+    /// Verifies that omitting response_mode succeeds when the flow default is itself in the client's list.
+    /// The effective-mode check permits the inherited default when the host allows it.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ClientAllowsDefault_RequestOmitsResponseMode_ShouldSucceed()
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: null,
+            allowedResponseModes: [ResponseModes.Query, ResponseModes.FormPost],
+            defaultResponseMode: ResponseModes.Query);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal(ResponseModes.Query, context.ResponseMode);
+    }
+
+    /// <summary>
+    /// Verifies that a null AllowedResponseModes imposes no restriction (backward-compatible default).
+    /// Flow-only validation applies, so query remains valid for the code flow.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ClientAllowedModesNull_ShouldImposeNoRestriction()
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: ResponseModes.Query,
+            allowedResponseModes: null);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal(ResponseModes.Query, context.ResponseMode);
+    }
+
+    /// <summary>
+    /// Verifies that an empty AllowedResponseModes list is treated as unset (no restriction), so it never
+    /// bricks a client by permitting nothing.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ClientAllowedModesEmpty_ShouldImposeNoRestriction()
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: ResponseModes.Query,
+            allowedResponseModes: []);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal(ResponseModes.Query, context.ResponseMode);
+    }
+
+    /// <summary>
+    /// Verifies that a mode rejected by the per-client allow-list is logged as a warning, mirroring the
+    /// existing flow-incompatibility logging for security monitoring.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_ModeRejectedByClientList_ShouldLogWarning()
+    {
+        // Arrange
+        var context = CreateContext(
+            FlowTypes.AuthorizationCode,
+            responseMode: ResponseModes.Fragment,
+            allowedResponseModes: [ResponseModes.FormPost]);
+
+        // Act
+        await _validator.ValidateAsync(context);
+
+        // Assert
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("not allowed for the client")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ResponseModeValidator.Logging.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ResponseModeValidator.Logging.cs
@@ -31,4 +31,10 @@ partial class ResponseModeValidator
         Level = LogLevel.Warning,
         Message = "The response mode {ResponseMode} is not compatible with response type {ResponseType}")]
     private partial void LogIncompatibleResponseMode(string ResponseMode, string[]? ResponseType);
+
+    [LoggerMessage(
+        EventId = LogEvents.Endpoints.ResponseModeValidator.ResponseModeNotAllowedForClient,
+        Level = LogLevel.Warning,
+        Message = "The response mode {ResponseMode} is not allowed for the client {ClientId}")]
+    private partial void LogResponseModeNotAllowedForClient(string ResponseMode, string ClientId);
 }

--- a/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ResponseModeValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/Authorization/Validation/ResponseModeValidator.cs
@@ -38,6 +38,10 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 /// <c>fragment</c>, <c>form_post</c> is allowed; flows that issue tokens at the
 /// authorization endpoint (implicit, hybrid) refuse <c>query</c> because credentials
 /// must not appear in the URL query string.
+/// After that flow-compatibility check, when the client configures an explicit
+/// <see cref="Features.ClientInformation.ClientInfo.AllowedResponseModes"/> allow-list the effective response
+/// mode must be a member of it, letting a host pin the delivery channel and close a response-mode downgrade
+/// (RFC 9700).
 /// </summary>
 public partial class ResponseModeValidator(ILogger<ResponseModeValidator> logger) : SyncAuthorizationContextValidatorBase
 {
@@ -55,6 +59,17 @@ public partial class ResponseModeValidator(ILogger<ResponseModeValidator> logger
 			}
 
 			context.ResponseMode = responseMode;
+		}
+
+		// Optional per-client allow-list. The effective mode is context.ResponseMode: the explicit
+		// response_mode set just above, or the flow default FlowTypeValidator placed there when the
+		// parameter was omitted — so omitting response_mode cannot slip past a configured restriction.
+		var allowedModes = context.ClientInfo.AllowedResponseModes;
+		if (allowedModes is { Length: > 0 } && Array.IndexOf(allowedModes, context.ResponseMode) < 0)
+		{
+			LogResponseModeNotAllowedForClient(context.ResponseMode, context.ClientInfo.ClientId);
+
+			return context.InvalidRequest("The response mode is not allowed for the client");
 		}
 
 		return null;

--- a/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -131,6 +131,20 @@ public record ClientInfo(string ClientId)
     public string[] AllowedGrantTypes { get; set; } = [GrantTypes.AuthorizationCode];
 
     /// <summary>
+    /// Optionally restricts the <c>response_mode</c> values this client may use, pinning the channel through
+    /// which the authorization response is delivered. When set to a non-empty list, a request is rejected unless
+    /// its effective response mode (the explicit <c>response_mode</c>, or the flow default when the parameter is
+    /// omitted) is a member of the list, compared by exact, case-sensitive string match. This lets a host close a
+    /// response-mode downgrade: a client the host intends to run with
+    /// <see cref="Common.Constants.ResponseModes.FormPost"/> cannot be driven with <c>fragment</c> or
+    /// <c>query</c> on a crafted request, nor by omitting the parameter to inherit the flow default. The
+    /// restriction is applied on top of, and after, the flow-compatibility check. When <c>null</c> or empty (the
+    /// default) it imposes no per-client restriction. There is no registered DCR metadata parameter for it, so
+    /// the list is host-side configuration only.
+    /// </summary>
+    public string[]? AllowedResponseModes { get; set; }
+
+    /// <summary>
     /// Allows the client to request tokens that enable access to the user's resources while they’re offline.
     /// </summary>
     public bool? OfflineAccessAllowed { get; set; } = false;

--- a/Abblix.Oidc.Server/LogEvents.cs
+++ b/Abblix.Oidc.Server/LogEvents.cs
@@ -122,6 +122,7 @@ internal static class LogEvents
             private const int Base = 2065;
 
             public const int IncompatibleResponseMode = Base + 1;
+            public const int ResponseModeNotAllowedForClient = Base + 2;
         }
 
         /// <summary>


### PR DESCRIPTION
## Opt-in per-client response mode allow-list (#241)

Adds `ClientInfo.AllowedResponseModes`. When set to a non-empty list, an authorization request is rejected unless its effective response mode (the explicit `response_mode`, or the flow default when the parameter is omitted) is a member, applied after the existing flow-compatibility check. This lets a host pin the delivery channel and close a response-mode downgrade (RFC 9700). Null or empty imposes no restriction; it is host-side configuration only, with no Dynamic Client Registration metadata parameter.

The confidential-client `form_post` default explored during design was deliberately not shipped; the rationale is recorded on #241.

## JWT validation hardening coverage

Adds coverage for three attack classes against token validation:

- Segment-count confusion: 4/6/7-part inputs, and a genuine signed JWS padded to 4 or 5 segments, are rejected as malformed or on the JWE path, rather than mis-routed or trusted by a valid prefix (RFC 7515 section 7.1 / RFC 7516 section 9).
- alg-stripping and payload tampering: a missing or empty `alg` header, a signed token downgraded to `none`, and a signed token with a rewritten payload (RFC 8725 sections 2.1 and 3.1).
- The same tampering matrix end to end through the `refresh_token` grant, exercised through the real validation gate rather than a mocked validator.

Target branch: `develop`.
