### PR TITLE
feat: per-type signing and encryption for service-issued JWTs (#245)

### DIFF
--- a/Abblix.Jwt/IJsonWebTokenCreator.cs
+++ b/Abblix.Jwt/IJsonWebTokenCreator.cs
@@ -33,6 +33,13 @@ public interface IJsonWebTokenCreator
 	IEnumerable<string> SignedResponseAlgorithmsSupported { get; }
 
 	/// <summary>
+	/// Lists the JWE key-management algorithms (the <c>alg</c> values, e.g. "RSA-OAEP-256") supported for
+	/// encrypting a JWT on creation. The symmetric counterpart of <see cref="SignedResponseAlgorithmsSupported"/>,
+	/// projected from the registered encryptors.
+	/// </summary>
+	IEnumerable<string> EncryptedResponseAlgorithmsSupported { get; }
+
+	/// <summary>
 	/// Issues a new JWT based on the specified JsonWebToken object, signing key, and optional encrypting key.
 	/// </summary>
 	/// <param name="token">The JsonWebToken object containing the payload of the JWT.</param>

--- a/Abblix.Jwt/JsonWebTokenCreator.cs
+++ b/Abblix.Jwt/JsonWebTokenCreator.cs
@@ -33,16 +33,24 @@ namespace Abblix.Jwt;
 /// <param name="signer">The JWT signer for creating signatures.</param>
 /// <param name="encryptor">The JWT encryptor for creating encrypted tokens.</param>
 /// <param name="signingAlgorithmsProvider">The provider for supported signing algorithms.</param>
+/// <param name="encryptionAlgorithmsProvider">The provider for supported JWE key-management algorithms.</param>
 internal sealed class JsonWebTokenCreator(
     IJsonWebTokenSigner signer,
     IJsonWebTokenEncryptor encryptor,
-    SigningAlgorithmsProvider signingAlgorithmsProvider) : IJsonWebTokenCreator
+    SigningAlgorithmsProvider signingAlgorithmsProvider,
+    EncryptionAlgorithmsProvider encryptionAlgorithmsProvider) : IJsonWebTokenCreator
 {
     /// <summary>
     /// Gets the collection of signing algorithms supported for JWT creation.
     /// Dynamically determined from registered signers in the dependency injection container.
     /// </summary>
     public IEnumerable<string> SignedResponseAlgorithmsSupported => signingAlgorithmsProvider.Algorithms;
+
+    /// <summary>
+    /// Gets the collection of JWE key-management algorithms supported for encrypting a JWT on creation.
+    /// Dynamically determined from the registered encryptors in the dependency injection container.
+    /// </summary>
+    public IEnumerable<string> EncryptedResponseAlgorithmsSupported => encryptionAlgorithmsProvider.KeyManagementAlgorithms;
 
     /// <summary>
     /// Asynchronously issues a JWT based on the specified JsonWebToken, signing key, and optional encryption key.

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/ServiceTokenEncryptionTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/ServiceTokenEncryptionTests.cs
@@ -1,0 +1,127 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end proof that service-token encryption is an explicit per-type opt-in, not an implicit global
+/// trigger. Configuring <see cref="OidcOptions.EncryptionKeys"/> — as a host would for an inbound need such as
+/// decrypting client-sent request objects — no longer encrypts the outbound access token: it stays a signed
+/// JWS that external resource servers can read. Encryption is turned on per token type by its
+/// <see cref="ServiceTokenOptions.Encryption"/> block, and the two types are controlled independently. These
+/// settings are enabled on an isolated host so the shared default suite is untouched.
+/// </summary>
+public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory)
+{
+    /// <summary>
+    /// The plan's security regression: with an encryption key configured but no <c>AccessToken.Encryption</c>
+    /// block, the access token issued through the real flow is a signed JWS (three segments), not a JWE
+    /// (five). Under the previous implicit rule any configured encryption key encrypted it, breaking external
+    /// resource servers that hold only the signing public key.
+    /// </summary>
+    [Fact]
+    public async Task EncryptionKeysConfigured_WithoutAccessTokenEncryptionBlock_AccessTokenIsSignedJws()
+    {
+        using var host = CreateHost(_ => { });
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ObtainConfidentialOfflineTokensAsync(client, discovery);
+        var accessToken = tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
+
+        Assert.Equal(3, SegmentCount(accessToken));
+    }
+
+    /// <summary>
+    /// Per-type independence: turning on the refresh token's <c>Encryption</c> block encrypts the refresh
+    /// token (a five-segment JWE) while the access token stays a signed JWS. The encrypted refresh token then
+    /// round-trips: the server decrypts and validates its own JWE on the refresh grant, issuing a new access
+    /// token.
+    /// </summary>
+    [Fact]
+    public async Task RefreshTokenEncryptionBlock_EncryptsRefreshTokenButLeavesAccessTokenSigned()
+    {
+        using var host = CreateHost(options =>
+            options.ServiceTokens.RefreshToken.Encryption = new JwtEncryptionSettings());
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ObtainConfidentialOfflineTokensAsync(client, discovery);
+        var accessToken = tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
+        var refreshToken = tokens[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        Assert.Equal(3, SegmentCount(accessToken));
+        Assert.Equal(5, SegmentCount(refreshToken));
+
+        var refreshed = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
+            [TokenRequest.Parameters.RefreshToken] = refreshToken,
+            [ClientRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+        Assert.NotNull(refreshed[UserInfoRequest.Parameters.AccessToken]);
+    }
+
+    /// <summary>
+    /// Builds an isolated host with a service encryption key configured, plus any per-test option tweak, so the
+    /// shared default host (and the rest of the suite) stays on the signed-only defaults. The key is generated
+    /// once and captured, so the same key pair encrypts and later decrypts within the host.
+    /// </summary>
+    private WebApplicationFactory<Program> CreateHost(Action<OidcOptions> configure)
+    {
+        var encryptionKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Encryption);
+        return Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
+                    new PostConfigureOptions<OidcOptions>(
+                        Options.DefaultName,
+                        options =>
+                        {
+                            options.EncryptionKeys = [encryptionKey];
+                            configure(options);
+                        }))));
+    }
+
+    private static HttpClient CreateClientFor(WebApplicationFactory<Program> host)
+        => host.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = TestServerAddress.BaseAddress,
+        });
+
+    private static int SegmentCount(string jwt) => jwt.Split('.').Length;
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/ServiceTokenEncryptionTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/ServiceTokenEncryptionTests.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Net.Http.Headers;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
@@ -36,23 +37,22 @@ using Xunit;
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 
 /// <summary>
-/// End-to-end proof that service-token encryption is an explicit per-type opt-in, not an implicit global
-/// trigger. Configuring <see cref="OidcOptions.EncryptionKeys"/> — as a host would for an inbound need such as
-/// decrypting client-sent request objects — no longer encrypts the outbound access token: it stays a signed
-/// JWS that external resource servers can read. Encryption is turned on per token type by its
-/// <see cref="ServiceTokenOptions.Encryption"/> block, and the two types are controlled independently. These
-/// settings are enabled on an isolated host so the shared default suite is untouched.
+/// End-to-end proof of the service-token encryption model: when a server encryption key is configured, the
+/// tokens the server issues for itself are encrypted to it by default (as in prior versions), and encryption
+/// can be turned off per token type. The default is opaque-first — an encrypted access token is consumed by
+/// the server's own UserInfo endpoint — and a host keeps the access token readable by external resource
+/// servers by disabling its encryption. These settings are enabled on an isolated host so the shared default
+/// suite is untouched.
 /// </summary>
 public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory)
 {
     /// <summary>
-    /// The plan's security regression: with an encryption key configured but no <c>AccessToken.Encryption</c>
-    /// block, the access token issued through the real flow is a signed JWS (three segments), not a JWE
-    /// (five). Under the previous implicit rule any configured encryption key encrypted it, breaking external
-    /// resource servers that hold only the signing public key.
+    /// With an encryption key configured and default settings, the access token issued through the real flow
+    /// is an encrypted JWE (five segments), reproducing the prior-version behavior, and the server's own
+    /// UserInfo endpoint reads it back — the access token is opaque to third parties but consumed first-party.
     /// </summary>
     [Fact]
-    public async Task EncryptionKeysConfigured_WithoutAccessTokenEncryptionBlock_AccessTokenIsSignedJws()
+    public async Task EncryptionKeyConfigured_AccessTokenEncryptedByDefault_AndConsumedByOwnUserInfo()
     {
         using var host = CreateHost(_ => { });
         var client = CreateClientFor(host);
@@ -61,20 +61,28 @@ public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory
         var tokens = await ObtainConfidentialOfflineTokensAsync(client, discovery);
         var accessToken = tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
 
-        Assert.Equal(3, SegmentCount(accessToken));
+        Assert.Equal(5, SegmentCount(accessToken));
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, discovery.UserInfoEndpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue(TokenTypes.Bearer, accessToken);
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.True(
+            response.IsSuccessStatusCode,
+            $"/userinfo rejected the encrypted access token: {(int)response.StatusCode} " +
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
     /// <summary>
-    /// Per-type independence: turning on the refresh token's <c>Encryption</c> block encrypts the refresh
-    /// token (a five-segment JWE) while the access token stays a signed JWS. The encrypted refresh token then
-    /// round-trips: the server decrypts and validates its own JWE on the refresh grant, issuing a new access
-    /// token.
+    /// Encryption is turned off per token type: disabling the access token's encryption leaves it a signed JWS
+    /// (three segments) even though a key is configured, while the refresh token stays encrypted (five
+    /// segments). The encrypted refresh token still round-trips — the server decrypts and validates its own
+    /// JWE on the refresh grant.
     /// </summary>
     [Fact]
-    public async Task RefreshTokenEncryptionBlock_EncryptsRefreshTokenButLeavesAccessTokenSigned()
+    public async Task AccessTokenEncryptionDisabled_AccessTokenSignedOnly_RefreshStillEncrypted()
     {
-        using var host = CreateHost(options =>
-            options.ServiceTokens.RefreshToken.Encryption = new JwtEncryptionSettings());
+        using var host = CreateHost(options => options.ServiceTokens.AccessToken.Encrypt = false);
         var client = CreateClientFor(host);
         var discovery = await FetchDiscoveryAsync(client);
 
@@ -98,8 +106,8 @@ public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory
 
     /// <summary>
     /// Builds an isolated host with a service encryption key configured, plus any per-test option tweak, so the
-    /// shared default host (and the rest of the suite) stays on the signed-only defaults. The key is generated
-    /// once and captured, so the same key pair encrypts and later decrypts within the host.
+    /// shared default host (and the rest of the suite) stays untouched. The key is generated once and captured,
+    /// so the same key pair encrypts and later decrypts within the host.
     /// </summary>
     private WebApplicationFactory<Program> CreateHost(Action<OidcOptions> configure)
     {

--- a/Abblix.Oidc.Server.UnitTests/Common/Configuration/ServiceTokensAlgorithmsValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Common/Configuration/ServiceTokensAlgorithmsValidatorTests.cs
@@ -1,0 +1,116 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Verifies that <see cref="ServiceTokensAlgorithmsValidator"/> accepts a configuration whose service-token
+/// signing and encryption algorithms are among the registered ones, and rejects one that names an algorithm
+/// no registered signer or encryptor can produce.
+/// </summary>
+public class ServiceTokensAlgorithmsValidatorTests
+{
+    private static readonly string[] RegisteredSigningAlgorithms =
+        [SigningAlgorithms.RS256, SigningAlgorithms.RS384, SigningAlgorithms.ES256];
+
+    private static readonly string[] RegisteredKeyManagementAlgorithms =
+        [EncryptionAlgorithms.KeyManagement.RsaOaep256, EncryptionAlgorithms.KeyManagement.RsaOaep];
+
+    private readonly ServiceTokensAlgorithmsValidator _validator;
+
+    public ServiceTokensAlgorithmsValidatorTests()
+    {
+        var jwtCreator = new Mock<IJsonWebTokenCreator>(MockBehavior.Strict);
+        jwtCreator.SetupGet(c => c.SignedResponseAlgorithmsSupported).Returns(RegisteredSigningAlgorithms);
+        jwtCreator.SetupGet(c => c.EncryptedResponseAlgorithmsSupported).Returns(RegisteredKeyManagementAlgorithms);
+
+        _validator = new ServiceTokensAlgorithmsValidator(jwtCreator.Object);
+    }
+
+    /// <summary>
+    /// The shipped defaults sign every service token with RS256 (a registered algorithm) and encrypt none,
+    /// so a stock configuration validates.
+    /// </summary>
+    [Fact]
+    public void Validate_DefaultOptions_Succeeds()
+    {
+        var result = _validator.Validate(null, new OidcOptions());
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// A signing algorithm no registered signer can produce must be rejected at startup rather than failing
+    /// per-request at issuance.
+    /// </summary>
+    [Fact]
+    public void Validate_UnknownSigningAlgorithm_Fails()
+    {
+        var options = new OidcOptions();
+        options.ServiceTokens.AccessToken.Signing.Algorithm = "made-up-alg";
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("AccessToken.Signing.Algorithm"));
+    }
+
+    /// <summary>
+    /// A key-management algorithm no registered encryptor can produce must be rejected at startup.
+    /// </summary>
+    [Fact]
+    public void Validate_UnknownEncryptionAlgorithm_Fails()
+    {
+        var options = new OidcOptions();
+        options.ServiceTokens.RefreshToken.Encryption = new JwtEncryptionSettings { Algorithm = "made-up-alg" };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("RefreshToken.Encryption.Algorithm"));
+    }
+
+    /// <summary>
+    /// A configuration whose signing and encryption algorithms are both registered validates, including a
+    /// derive-from-key encryption block that leaves the algorithm unset.
+    /// </summary>
+    [Fact]
+    public void Validate_RegisteredExplicitAlgorithms_Succeeds()
+    {
+        var options = new OidcOptions();
+        options.ServiceTokens.AccessToken.Signing.Algorithm = SigningAlgorithms.ES256;
+        options.ServiceTokens.AccessToken.Encryption = new JwtEncryptionSettings
+        {
+            Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256,
+        };
+        options.ServiceTokens.RefreshToken.Encryption = new JwtEncryptionSettings(); // derive-from-key, Algorithm null
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+}

--- a/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/InitialAccessTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/InitialAccessTokenServiceTests.cs
@@ -23,11 +23,13 @@
 using System;
 using System.Threading.Tasks;
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -57,7 +59,8 @@ public class InitialAccessTokenServiceTests
 
         _service = new InitialAccessTokenService(
             _jwtFormatter.Object,
-            _issuerProvider.Object);
+            _issuerProvider.Object,
+            Options.Create(new OidcOptions()));
     }
 
     [Fact]
@@ -65,8 +68,8 @@ public class InitialAccessTokenServiceTests
     {
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(t => capturedToken = t)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((t, _) => capturedToken = t)
             .ReturnsAsync("formatted-jwt");
 
         await _service.IssueTokenAsync("admin-portal", FixedIssuedAt, TimeSpan.FromHours(1));
@@ -81,8 +84,8 @@ public class InitialAccessTokenServiceTests
     {
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(t => capturedToken = t)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((t, _) => capturedToken = t)
             .ReturnsAsync("formatted-jwt");
 
         await _service.IssueTokenAsync("admin-portal", FixedIssuedAt, TimeSpan.FromHours(1));
@@ -96,8 +99,8 @@ public class InitialAccessTokenServiceTests
     {
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(t => capturedToken = t)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((t, _) => capturedToken = t)
             .ReturnsAsync("formatted-jwt");
 
         var expiresIn = TimeSpan.FromDays(30);
@@ -115,8 +118,8 @@ public class InitialAccessTokenServiceTests
     {
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(t => capturedToken = t)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((t, _) => capturedToken = t)
             .ReturnsAsync("formatted-jwt");
 
         await _service.IssueTokenAsync("admin-portal", FixedIssuedAt, expiresIn: null);
@@ -129,7 +132,7 @@ public class InitialAccessTokenServiceTests
     public async Task IssueTokenAsync_ShouldReturnFormattedJwt()
     {
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
             .ReturnsAsync("eyJhbGciOiJSUzI1NiJ9.test.signature");
 
         var result = await _service.IssueTokenAsync("admin-portal", FixedIssuedAt, TimeSpan.FromHours(1));

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
@@ -25,6 +25,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
@@ -32,6 +33,7 @@ using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -73,7 +75,8 @@ public class AccessTokenServiceTests
             issuerProvider.Object,
             timeProvider,
             tokenIdGenerator.Object,
-            _jwtFormatter.Object);
+            _jwtFormatter.Object,
+            Options.Create(new OidcOptions()));
     }
 
     /// <summary>
@@ -91,8 +94,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -122,8 +125,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -161,8 +164,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -197,8 +200,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -225,8 +228,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -264,8 +267,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -295,7 +298,7 @@ public class AccessTokenServiceTests
         var clientInfo = CreateClientInfo();
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -453,8 +456,8 @@ public class AccessTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -478,14 +481,14 @@ public class AccessTokenServiceTests
         var clientInfo = CreateClientInfo();
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
         await _service.CreateAccessTokenAsync(authSession, authContext, clientInfo);
 
         // Assert
-        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>()), Times.Once);
+        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()), Times.Once);
     }
 
     // Helper methods to create test objects

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
@@ -161,6 +161,35 @@ public class AuthServiceJwtFormatterTests
         _keysProvider.Verify(p => p.GetEncryptionKeys(It.IsAny<bool>()), Times.Never);
     }
 
+    /// <summary>
+    /// Verifies that turning encryption off (<c>Encrypt = false</c>) while the encryption algorithm and key id
+    /// remain configured still yields a signed-only JWS and does not resolve the encryption keys: the flag alone
+    /// disables encryption, so a host can flip it back on later without re-entering the settings.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_EncryptDisabledWithSettingsRetained_SignsOnly()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+
+        var disabledButConfigured = new ServiceJwtEncryption(
+            Encrypt: false,
+            EncryptionAlgorithms.KeyManagement.RsaOaep256,
+            KeyId: "enc-key",
+            ContentEnc);
+
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
+
+        await _formatter.FormatAsync(token, disabledButConfigured);
+
+        Assert.Null(capturedEncryptionKey);
+        _keysProvider.Verify(p => p.GetEncryptionKeys(It.IsAny<bool>()), Times.Never);
+    }
+
     // Encryption
 
     /// <summary>
@@ -289,22 +318,32 @@ public class AuthServiceJwtFormatterTests
     }
 
     /// <summary>
-    /// Verifies that a policy asking for encryption while no encryption key is configured fails loudly at
-    /// issuance rather than silently downgrading to a signed-only token.
+    /// Verifies that a policy asking for encryption while no encryption key is configured falls back to a
+    /// signed-only JWS rather than failing, matching the behavior of prior versions a host keeps by leaving
+    /// encryption on without configuring a key.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_Encrypt_WithNoEncryptionKey_Throws()
+    public async Task FormatAsync_Encrypt_WithNoEncryptionKey_SignsOnly()
     {
         var token = TokenWith();
         SetupSigningKeys(_signingKeyRS256);
         SetupEncryptionKeys();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await _formatter.FormatAsync(token, Encrypt()));
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
+
+        var result = await _formatter.FormatAsync(token, Encrypt());
+
+        Assert.Equal(EncodedJwt, result);
+        Assert.Null(capturedEncryptionKey);
     }
 
     /// <summary>
-    /// Verifies that a pinned encryption <c>kid</c> that matches no configured key fails loudly.
+    /// Verifies that a pinned encryption <c>kid</c> that matches no configured key fails loudly rather than
+    /// silently downgrading: pinning a key is an explicit intent, so a missing pinned key is a misconfiguration.
     /// </summary>
     [Fact]
     public async Task FormatAsync_Encrypt_WithUnknownPinnedEncryptionKeyId_Throws()

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
@@ -31,24 +31,27 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using JsonWebKey = Abblix.Jwt.JsonWebKey;
-using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Formatters;
 
 /// <summary>
-/// Unit tests for <see cref="AuthServiceJwtFormatter"/> verifying JWT formatting, signing, and encryption
-/// for tokens issued by the authentication service per RFC 7519 (JWT), RFC 7515 (JWS), and RFC 7516 (JWE).
-/// Tests cover signing key selection, optional encryption, and error handling.
+/// Unit tests for <see cref="AuthServiceJwtFormatter"/> verifying JWT formatting, signing and encryption
+/// for tokens the authorization server issues for itself, per RFC 7519 (JWT), RFC 7515 (JWS) and RFC 7516
+/// (JWE). The tests exercise the explicit <see cref="ServiceJwtEncryption"/> policy overload — signed only,
+/// encrypt with a key-derived or explicit key-management algorithm, signing- and encryption-key pinning by
+/// <c>kid</c>, and the missing-key error — plus the retained implicit legacy path.
 /// </summary>
 public class AuthServiceJwtFormatterTests
 {
     private const string EncodedJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature";
+    private const string ContentEnc = EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512;
 
     private readonly Mock<IJsonWebTokenCreator> _jwtCreator;
     private readonly Mock<IAuthServiceKeysProvider> _keysProvider;
     private readonly AuthServiceJwtFormatter _formatter;
 
     private readonly JsonWebKey _signingKeyRS256;
+    private readonly JsonWebKey _signingKeyRS256Alt;
     private readonly JsonWebKey _signingKeyRS384;
     private readonly JsonWebKey _encryptionKey;
 
@@ -61,552 +64,306 @@ public class AuthServiceJwtFormatterTests
         _formatter = new AuthServiceJwtFormatter(_jwtCreator.Object, _keysProvider.Object, options);
 
         _signingKeyRS256 = new RsaJsonWebKey { KeyId = "sig-rs256", Algorithm = SigningAlgorithms.RS256 };
+        _signingKeyRS256Alt = new RsaJsonWebKey { KeyId = "sig-rs256-alt", Algorithm = SigningAlgorithms.RS256 };
         _signingKeyRS384 = new RsaJsonWebKey { KeyId = "sig-rs384", Algorithm = SigningAlgorithms.RS384 };
-        _encryptionKey = new RsaJsonWebKey { KeyId = "enc-key", Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep };
+        _encryptionKey = new RsaJsonWebKey
+        {
+            KeyId = "enc-key",
+            Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep,
+        };
     }
 
-    #region Signing Key Selection Tests
+    private static ServiceJwtEncryption SignedOnly => new(
+        Encrypt: false, KeyManagementAlgorithm: null, KeyId: null, ContentEnc);
+
+    private static ServiceJwtEncryption Encrypt(string? keyManagementAlgorithm = null, string? keyId = null) => new(
+        Encrypt: true, keyManagementAlgorithm, keyId, ContentEnc);
+
+    private void SetupSigningKeys(params JsonWebKey[] keys) =>
+        _keysProvider.Setup(p => p.GetSigningKeys(true)).Returns(keys.ToAsyncEnumerable());
+
+    private void SetupEncryptionKeys(params JsonWebKey[] keys) =>
+        _keysProvider.Setup(p => p.GetEncryptionKeys(false)).Returns(keys.ToAsyncEnumerable());
+
+    private static JsonWebToken TokenWith(string algorithm = SigningAlgorithms.RS256, string? keyId = null) => new()
+    {
+        Header = { Algorithm = algorithm, KeyId = keyId },
+        Payload = { Subject = "user123" },
+    };
+
+    // Signing key selection
 
     /// <summary>
-    /// Verifies that FormatAsync selects signing key matching JWT header algorithm.
-    /// Per RFC 7515 Section 4.1.1, alg header parameter identifies signing algorithm.
-    /// Critical for security - ensures correct key is used for token signatures.
+    /// Verifies that the signing key is chosen by the token header algorithm (RFC 7515 Section 4.1.1), so
+    /// each service-token type is signed with the algorithm its issuing service placed in the header.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_WithRS256Algorithm_ShouldSelectMatchingSigningKey()
+    public async Task FormatAsync_SelectsSigningKeyByHeaderAlgorithm()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
+        var token = TokenWith(SigningAlgorithms.RS384);
+        SetupSigningKeys(_signingKeyRS256, _signingKeyRS384);
 
         JsonWebKey? capturedSigningKey = null;
-        JsonWebKey? capturedEncryptionKey = null;
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256, _signingKeyRS384 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
         _jwtCreator
-            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, sig, enc, _, _) =>
-            {
-                capturedSigningKey = sig;
-                capturedEncryptionKey = enc;
-            })
-            .ReturnsAsync(EncodedJwt);
-
-        // Act
-        await _formatter.FormatAsync(token);
-
-        // Assert
-        Assert.Same(_signingKeyRS256, capturedSigningKey);
-    }
-
-    /// <summary>
-    /// Verifies that FormatAsync selects RS384 signing key when specified in JWT header.
-    /// Ensures formatter correctly handles multiple available signing algorithms.
-    /// </summary>
-    [Fact]
-    public async Task FormatAsync_WithRS384Algorithm_ShouldSelectMatchingSigningKey()
-    {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS384 },
-            Payload = { Subject = "user123" }
-        };
-
-        JsonWebKey? capturedSigningKey = null;
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256, _signingKeyRS384 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), null, It.IsAny<string>(), It.IsAny<string>()))
             .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, sig, _, _, _) => capturedSigningKey = sig)
             .ReturnsAsync(EncodedJwt);
 
-        // Act
-        await _formatter.FormatAsync(token);
+        await _formatter.FormatAsync(token, SignedOnly);
 
-        // Assert
         Assert.Same(_signingKeyRS384, capturedSigningKey);
     }
 
     /// <summary>
-    /// Verifies that FormatAsync throws when no signing key matches JWT algorithm.
-    /// Critical security requirement - prevents token issuance with unsupported/misconfigured algorithms.
-    /// FirstByAlgorithmAsync returns null when no match found, causing IssueAsync to fail.
+    /// Verifies that a pinned signing <c>kid</c> selects that exact key among several sharing the algorithm,
+    /// letting a host rotate or pin the signing key deterministically (RFC 7517 Section 4.4, RFC 7515 Section 4.1.4).
     /// </summary>
     [Fact]
-    public async Task FormatAsync_WithNoMatchingSigningKey_ShouldThrow()
+    public async Task FormatAsync_WithPinnedSigningKeyId_SelectsThatKey()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS512 },
-            Payload = { Subject = "user123" }
-        };
+        var token = TokenWith(SigningAlgorithms.RS256, keyId: "sig-rs256-alt");
+        SetupSigningKeys(_signingKeyRS256, _signingKeyRS256Alt);
 
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256, _signingKeyRS384 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        // IssueAsync will be called with null signing key, which should fail
+        JsonWebKey? capturedSigningKey = null;
         _jwtCreator
-            .Setup(c => c.IssueAsync(token, null!, null, It.IsAny<string>(), It.IsAny<string>()))
-            .ThrowsAsync(new InvalidOperationException("Signing key is required"));
-
-        // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await _formatter.FormatAsync(token));
-    }
-
-    /// <summary>
-    /// Verifies that FormatAsync requests only public signing keys (activeOnly=true).
-    /// Ensures only currently active signing keys are used for token generation.
-    /// </summary>
-    [Fact]
-    public async Task FormatAsync_ShouldRequestActiveSigningKeys()
-    {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), null, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, sig, _, _, _) => capturedSigningKey = sig)
             .ReturnsAsync(EncodedJwt);
 
-        // Act
-        await _formatter.FormatAsync(token);
+        await _formatter.FormatAsync(token, SignedOnly);
 
-        // Assert
-        _keysProvider.Verify(p => p.GetSigningKeys(true), Times.Once);
+        Assert.Same(_signingKeyRS256Alt, capturedSigningKey);
     }
 
-    #endregion
-
-    #region Encryption Tests
+    // Signed only
 
     /// <summary>
-    /// Verifies that FormatAsync uses encryption key when available.
-    /// Per RFC 7516, JWE provides confidentiality protection for JWTs.
-    /// Important for sensitive tokens (refresh tokens, private claims).
+    /// Verifies that a signed-only policy issues a JWS with no encryption key, and — mirroring the client
+    /// formatter's JARM signed-only branch — does not even resolve the server's encryption keys. The strict
+    /// mock has no <c>GetEncryptionKeys</c> setup, so any attempt to resolve them would fail the test.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_WithEncryptionKeyAvailable_ShouldUseEncryption()
+    public async Task FormatAsync_SignedOnly_IssuesJwsWithoutResolvingEncryptionKeys()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
 
         JsonWebKey? capturedEncryptionKey = null;
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(new[] { _encryptionKey }.ToAsyncEnumerable());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
-            .ReturnsAsync(EncodedJwt);
-
-        // Act
-        await _formatter.FormatAsync(token);
-
-        // Assert
-        Assert.Same(_encryptionKey, capturedEncryptionKey);
-    }
-
-    /// <summary>
-    /// Verifies that FormatAsync creates token without encryption when no encryption keys available.
-    /// Ensures formatter degrades gracefully when encryption is not configured.
-    /// Tokens remain signed but unencrypted (JWS without JWE).
-    /// </summary>
-    [Fact]
-    public async Task FormatAsync_WithNoEncryptionKeys_ShouldCreateUnencryptedToken()
-    {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
-
-        JsonWebKey? capturedEncryptionKey = null;
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
-            .ReturnsAsync(EncodedJwt);
-
-        // Act
-        await _formatter.FormatAsync(token);
-
-        // Assert
-        Assert.Null(capturedEncryptionKey);
-    }
-
-    /// <summary>
-    /// Verifies that FormatAsync uses only the first available encryption key.
-    /// Per implementation, encryption is optional and uses first key if available.
-    /// Ensures consistent encryption key selection behavior.
-    /// </summary>
-    [Fact]
-    public async Task FormatAsync_WithMultipleEncryptionKeys_ShouldUseFirstKey()
-    {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
-
-        var secondEncryptionKey = new RsaJsonWebKey { KeyId = "enc-key-2", Algorithm = "RSA-OAEP" };
-        JsonWebKey? capturedEncryptionKey = null;
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(new[] { _encryptionKey, secondEncryptionKey }.ToAsyncEnumerable());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
-            .ReturnsAsync(EncodedJwt);
-
-        // Act
-        await _formatter.FormatAsync(token);
-
-        // Assert
-        Assert.Same(_encryptionKey, capturedEncryptionKey);
-    }
-
-    #endregion
-
-    #region JWT Creation Tests
-
-    /// <summary>
-    /// Verifies that FormatAsync returns JWT string from IJsonWebTokenCreator.
-    /// Ensures complete JWT creation flow produces expected encoded token.
-    /// </summary>
-    [Fact]
-    public async Task FormatAsync_ShouldReturnEncodedJwtFromCreator()
-    {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
         _jwtCreator
             .Setup(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
             .ReturnsAsync(EncodedJwt);
 
-        // Act
-        var result = await _formatter.FormatAsync(token);
+        var result = await _formatter.FormatAsync(token, SignedOnly);
 
-        // Assert
         Assert.Equal(EncodedJwt, result);
+        Assert.Null(capturedEncryptionKey);
+        _keysProvider.Verify(p => p.GetEncryptionKeys(It.IsAny<bool>()), Times.Never);
     }
 
+    // Encryption
+
     /// <summary>
-    /// Verifies that FormatAsync passes correct token to IJsonWebTokenCreator.
-    /// Ensures token integrity throughout formatting process.
+    /// Verifies that when the policy leaves the key-management algorithm unset, it is derived from the
+    /// selected encryption key's declared <c>alg</c> (RFC 7517 Section 4.4).
     /// </summary>
     [Fact]
-    public async Task FormatAsync_ShouldPassTokenToCreator()
+    public async Task FormatAsync_Encrypt_DerivesKeyManagementAlgorithmFromKey()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = "at+jwt" },
-            Payload =
-            {
-                Subject = "user123",
-                Issuer = "https://auth.example.com",
-                Audiences = ["api"]
-            }
-        };
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey); // declares RSA-OAEP
 
-        JsonWebToken? capturedToken = null;
-
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
+        string? capturedAlg = null;
+        JsonWebKey? capturedEncryptionKey = null;
         _jwtCreator
-            .Setup(c => c.IssueAsync(It.IsAny<JsonWebToken>(), It.IsAny<JsonWebKey>(), It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((t, _, _, _, _) => capturedToken = t)
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, It.IsAny<JsonWebKey?>(), It.IsAny<string>(), ContentEnc))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, alg, _) =>
+            {
+                capturedEncryptionKey = enc;
+                capturedAlg = alg;
+            })
             .ReturnsAsync(EncodedJwt);
 
-        // Act
-        await _formatter.FormatAsync(token);
+        await _formatter.FormatAsync(token, Encrypt());
 
-        // Assert
-        Assert.Same(token, capturedToken);
+        Assert.Same(_encryptionKey, capturedEncryptionKey);
+        Assert.Equal(EncryptionAlgorithms.KeyManagement.RsaOaep, capturedAlg);
     }
 
     /// <summary>
-    /// Verifies that FormatAsync invokes IJsonWebTokenCreator exactly once.
-    /// Ensures no duplicate token creation or unnecessary operations.
+    /// Verifies that when neither the policy nor the key declares a key-management algorithm, it falls back
+    /// to RSA-OAEP-256, the library's default JWE <c>alg</c>.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_ShouldInvokeCreatorOnce()
+    public async Task FormatAsync_Encrypt_FallsBackToRsaOaep256_WhenKeyDeclaresNoAlgorithm()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
+        var token = TokenWith();
+        var agnosticKey = new RsaJsonWebKey { KeyId = "enc-agnostic", Algorithm = null };
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(agnosticKey);
 
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
+        string? capturedAlg = null;
         _jwtCreator
-            .Setup(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, agnosticKey, It.IsAny<string>(), ContentEnc))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, _, alg, _) => capturedAlg = alg)
             .ReturnsAsync(EncodedJwt);
 
-        // Act
-        await _formatter.FormatAsync(token);
+        await _formatter.FormatAsync(token, Encrypt());
 
-        // Assert
-        _jwtCreator.Verify(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        Assert.Equal(EncryptionAlgorithms.KeyManagement.RsaOaep256, capturedAlg);
     }
 
-    #endregion
-
-    #region Integration Tests
-
     /// <summary>
-    /// Verifies complete JWT formatting flow with signing and encryption.
-    /// Tests end-to-end token creation with both cryptographic operations.
-    /// Represents typical production scenario for refresh tokens.
+    /// Verifies that an explicit policy key-management algorithm overrides the key's declared <c>alg</c>.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_WithSigningAndEncryption_ShouldProduceCompleteJwt()
+    public async Task FormatAsync_Encrypt_ExplicitPolicyAlgorithmOverridesKeyDeclaredAlgorithm()
     {
-        // Arrange
-        var token = new JsonWebToken
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey); // declares RSA-OAEP
+
+        string? capturedAlg = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, _encryptionKey, It.IsAny<string>(), ContentEnc))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, _, alg, _) => capturedAlg = alg)
+            .ReturnsAsync(EncodedJwt);
+
+        await _formatter.FormatAsync(token, Encrypt(EncryptionAlgorithms.KeyManagement.RsaOaep256));
+
+        Assert.Equal(EncryptionAlgorithms.KeyManagement.RsaOaep256, capturedAlg);
+    }
+
+    /// <summary>
+    /// Verifies that a pinned encryption <c>kid</c> selects that exact encryption key among several.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_Encrypt_WithPinnedEncryptionKeyId_SelectsThatKey()
+    {
+        var token = TokenWith();
+        var otherEncryptionKey = new RsaJsonWebKey
         {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = "JWT" },
-            Payload =
-            {
-                JwtId = Guid.NewGuid().ToString("N"),
-                Subject = "user123",
-                Issuer = "https://auth.example.com",
-                Audiences = ["https://api.example.com"],
-                IssuedAt = DateTimeOffset.UtcNow,
-                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
-            }
+            KeyId = "enc-key-2",
+            Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256,
         };
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey, otherEncryptionKey);
 
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256, _signingKeyRS384 }.ToAsyncEnumerable());
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, It.IsAny<JsonWebKey?>(), It.IsAny<string>(), ContentEnc))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
 
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(new[] { _encryptionKey }.ToAsyncEnumerable());
+        await _formatter.FormatAsync(token, Encrypt(keyId: "enc-key-2"));
 
+        Assert.Same(otherEncryptionKey, capturedEncryptionKey);
+    }
+
+    /// <summary>
+    /// Verifies that the policy's content-encryption algorithm flows through to the JWE <c>enc</c>.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_Encrypt_PassesPolicyContentEncryptionAlgorithm()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey);
+
+        var policy = new ServiceJwtEncryption(
+            Encrypt: true,
+            KeyManagementAlgorithm: null,
+            KeyId: null,
+            EncryptionAlgorithms.ContentEncryption.Aes128Gcm);
+
+        string? capturedEnc = null;
         _jwtCreator
             .Setup(c => c.IssueAsync(token, _signingKeyRS256, _encryptionKey, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, _, _, enc) => capturedEnc = enc)
             .ReturnsAsync(EncodedJwt);
 
-        // Act
-        var result = await _formatter.FormatAsync(token);
+        await _formatter.FormatAsync(token, policy);
 
-        // Assert
-        Assert.Equal(EncodedJwt, result);
-        _keysProvider.Verify(p => p.GetSigningKeys(true), Times.Once);
-        _keysProvider.Verify(p => p.GetEncryptionKeys(false), Times.Once);
-        _jwtCreator.Verify(c => c.IssueAsync(token, _signingKeyRS256, _encryptionKey, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        Assert.Equal(EncryptionAlgorithms.ContentEncryption.Aes128Gcm, capturedEnc);
     }
 
     /// <summary>
-    /// Verifies JWT formatting flow for access token without encryption.
-    /// Tests typical access token scenario (signed but not encrypted for performance).
-    /// Per OAuth 2.0 best practices, access tokens often unencrypted for efficiency.
+    /// Verifies that a policy asking for encryption while no encryption key is configured fails loudly at
+    /// issuance rather than silently downgrading to a signed-only token.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_ForAccessToken_ShouldProduceSignedJwt()
+    public async Task FormatAsync_Encrypt_WithNoEncryptionKey_Throws()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = "at+jwt" },
-            Payload =
-            {
-                JwtId = Guid.NewGuid().ToString("N"),
-                Subject = "user123",
-                Issuer = "https://auth.example.com",
-                Audiences = ["https://api.example.com"],
-                Scope = [TestConstants.DefaultScope, "profile", "email"],
-                IssuedAt = DateTimeOffset.UtcNow,
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(15),
-            }
-        };
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys();
 
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(EncodedJwt);
-
-        // Act
-        var result = await _formatter.FormatAsync(token);
-
-        // Assert
-        Assert.Equal(EncodedJwt, result);
-        _jwtCreator.Verify(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _formatter.FormatAsync(token, Encrypt()));
     }
 
     /// <summary>
-    /// Verifies JWT formatting for Registration Access Token.
-    /// Per RFC 7592 Section 3, Registration Access Tokens authenticate client configuration requests.
-    /// Ensures formatter correctly handles all auth service token types.
+    /// Verifies that a pinned encryption <c>kid</c> that matches no configured key fails loudly.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_ForRegistrationAccessToken_ShouldProduceJwt()
+    public async Task FormatAsync_Encrypt_WithUnknownPinnedEncryptionKeyId_Throws()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = "JWT" },
-            Payload =
-            {
-                JwtId = Guid.NewGuid().ToString("N"),
-                Subject = "client_abc123",
-                Issuer = "https://auth.example.com",
-                Audiences = ["https://auth.example.com/register"],
-                IssuedAt = DateTimeOffset.UtcNow,
-                ExpiresAt = DateTimeOffset.UtcNow.AddDays(1),
-            }
-        };
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey);
 
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(new[] { _signingKeyRS256 }.ToAsyncEnumerable());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        _jwtCreator
-            .Setup(c => c.IssueAsync(token, _signingKeyRS256, null, It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(EncodedJwt);
-
-        // Act
-        var result = await _formatter.FormatAsync(token);
-
-        // Assert
-        Assert.Equal(EncodedJwt, result);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _formatter.FormatAsync(token, Encrypt(keyId: "missing-kid")));
     }
 
-    #endregion
-
-    #region Error Handling Tests
+    // Retained implicit legacy path
 
     /// <summary>
-    /// Verifies that FormatAsync throws when GetSigningKeys returns empty sequence.
-    /// Critical security check - prevents token issuance when no signing keys configured.
+    /// Verifies that the retained, obsolete parameterless overload still encrypts implicitly whenever any
+    /// service encryption key exists, preserving backward compatibility for callers not yet migrated.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_WithNoSigningKeys_ShouldThrowInvalidOperationException()
+    public async Task Legacy_FormatAsync_WithEncryptionKey_EncryptsImplicitly()
     {
-        // Arrange
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = SigningAlgorithms.RS256 },
-            Payload = { Subject = "user123" }
-        };
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey);
 
-        _keysProvider
-            .Setup(p => p.GetSigningKeys(true))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
-        _keysProvider
-            .Setup(p => p.GetEncryptionKeys(false))
-            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
-
+        JsonWebKey? capturedEncryptionKey = null;
         _jwtCreator
-            .Setup(c => c.IssueAsync(token, null!, null, It.IsAny<string>(), It.IsAny<string>()))
-            .ThrowsAsync(new InvalidOperationException("Signing key is required"));
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
 
-        // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await _formatter.FormatAsync(token));
+#pragma warning disable CS0618 // exercising the retained obsolete overload on purpose
+        await _formatter.FormatAsync(token);
+#pragma warning restore CS0618
+
+        Assert.Same(_encryptionKey, capturedEncryptionKey);
     }
 
-    #endregion
+    /// <summary>
+    /// Verifies that the obsolete parameterless overload produces a signed-only token when no service
+    /// encryption key is configured.
+    /// </summary>
+    [Fact]
+    public async Task Legacy_FormatAsync_WithNoEncryptionKey_SignsOnly()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys();
+
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, It.IsAny<JsonWebKey?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
+
+#pragma warning disable CS0618 // exercising the retained obsolete overload on purpose
+        await _formatter.FormatAsync(token);
+#pragma warning restore CS0618
+
+        Assert.Null(capturedEncryptionKey);
+    }
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -35,6 +35,7 @@ using Abblix.Oidc.Server.Features.Tokens;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.Tokens.Revocation;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -86,7 +87,8 @@ public class RefreshTokenServiceTests
             tokenIdGenerator.Object,
             grantIdGenerator.Object,
             _jwtFormatter.Object,
-            _tokenRegistry.Object);
+            _tokenRegistry.Object,
+            Options.Create(new OidcOptions()));
     }
 
     /// <summary>
@@ -105,8 +107,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -142,8 +144,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -173,8 +175,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -208,8 +210,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -239,8 +241,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -287,7 +289,7 @@ public class RefreshTokenServiceTests
             .Returns(Task.CompletedTask);
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -315,8 +317,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -358,8 +360,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -398,7 +400,7 @@ public class RefreshTokenServiceTests
         };
 
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -442,8 +444,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -476,8 +478,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -523,8 +525,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -575,8 +577,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act
@@ -626,7 +628,7 @@ public class RefreshTokenServiceTests
 
         // Assert
         Assert.Null(result);
-        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>()), Times.Never);
+        _jwtFormatter.Verify(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()), Times.Never);
     }
 
     /// <summary>
@@ -644,8 +646,8 @@ public class RefreshTokenServiceTests
 
         JsonWebToken? capturedToken = null;
         _jwtFormatter
-            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>()))
-            .Callback<JsonWebToken>(jwt => capturedToken = jwt)
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((jwt, _) => capturedToken = jwt)
             .ReturnsAsync(EncodedToken);
 
         // Act

--- a/Abblix.Oidc.Server/Common/Configuration/JwtEncryptionSettings.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/JwtEncryptionSettings.cs
@@ -23,9 +23,9 @@
 namespace Abblix.Oidc.Server.Common.Configuration;
 
 /// <summary>
-/// The encryption settings for a JWT the authorization server issues for itself. Reused, one instance per
-/// service token type. The mere presence of this block on a token type is the opt-in to encrypt that type:
-/// without it the token is signed only.
+/// How a JWT the authorization server issues for itself is encrypted. Reused, one instance per service token
+/// type. Whether the token is encrypted at all is governed by <see cref="ServiceTokenOptions.Encrypt"/>; this
+/// block only selects the key-management algorithm and key used when it is.
 /// </summary>
 /// <remarks>
 /// The content-encryption algorithm (the JWE <c>enc</c>) is not per-key, so it is not carried here; it stays

--- a/Abblix.Oidc.Server/Common/Configuration/JwtEncryptionSettings.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/JwtEncryptionSettings.cs
@@ -1,0 +1,48 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// The encryption settings for a JWT the authorization server issues for itself. Reused, one instance per
+/// service token type. The mere presence of this block on a token type is the opt-in to encrypt that type:
+/// without it the token is signed only.
+/// </summary>
+/// <remarks>
+/// The content-encryption algorithm (the JWE <c>enc</c>) is not per-key, so it is not carried here; it stays
+/// on the root <see cref="OidcOptions.DefaultContentEncryptionAlgorithm"/>.
+/// </remarks>
+public record JwtEncryptionSettings
+{
+    /// <summary>
+    /// The JWE key-management algorithm (the <c>alg</c> header value, e.g. <c>RSA-OAEP-256</c>). When
+    /// <c>null</c> it is derived from the selected encryption key's declared <c>alg</c> (RFC 7517
+    /// Section 4.4), falling back to <c>RSA-OAEP-256</c> when the key declares none.
+    /// </summary>
+    public string? Algorithm { get; set; }
+
+    /// <summary>
+    /// The <c>kid</c> of the encryption key to use. When <c>null</c> the first configured encryption key is
+    /// chosen; when set, the key with this identifier is pinned.
+    /// </summary>
+    public string? KeyId { get; set; }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/JwtSigningSettings.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/JwtSigningSettings.cs
@@ -1,0 +1,47 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// The signing settings for a JWT the authorization server issues for itself. Reused, one instance per
+/// service token type, so each type carries its own explicit JWS <c>alg</c> and signing-key selection
+/// instead of the previously hardcoded RS256.
+/// </summary>
+public record JwtSigningSettings
+{
+    /// <summary>
+    /// The JWS signing algorithm (the <c>alg</c> header value, e.g. <c>RS256</c>, <c>ES256</c>).
+    /// Defaults to <see cref="SigningAlgorithms.RS256"/> so that, left unset, the token is byte-identical
+    /// to what the server issued before this setting existed.
+    /// </summary>
+    public string Algorithm { get; set; } = SigningAlgorithms.RS256;
+
+    /// <summary>
+    /// The <c>kid</c> of the signing key to use. When <c>null</c> the first key matching
+    /// <see cref="Algorithm"/> is chosen (RFC 7517 Section 4.4); when set, the key with this identifier is
+    /// pinned and its <c>kid</c> is emitted in the JWS header.
+    /// </summary>
+    public string? KeyId { get; set; }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -165,11 +165,12 @@ public record OidcOptions
 
 	/// <summary>
 	/// Per-type signing and encryption settings for the JWTs the server issues for itself (access, refresh,
-	/// registration access and initial access tokens). Each type signs with RS256 and is signed only by
-	/// default; a host encrypts a specific type by setting that type's
-	/// <see cref="ServiceTokenOptions.Encryption"/> block. This makes outbound service-token encryption an
-	/// explicit per-type choice: populating <see cref="EncryptionKeys"/> for an inbound need (such as
-	/// decrypting client-sent encrypted request objects) no longer encrypts any outbound service token.
+	/// registration access and initial access tokens). Each type signs with RS256 and, when a server
+	/// <see cref="EncryptionKeys"/> entry is configured, is encrypted to it by default, as in prior versions.
+	/// A host controls each type independently: it can pin the signing algorithm or key, choose the
+	/// key-management algorithm or encryption key, or disable encryption for a specific type by setting that
+	/// type's <see cref="ServiceTokenOptions.Encrypt"/> to <c>false</c> (for example to keep the access token
+	/// readable by external resource servers).
 	/// </summary>
 	public ServiceTokensOptions ServiceTokens { get; set; } = new();
 

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -164,6 +164,16 @@ public record OidcOptions
 	public string DefaultContentEncryptionAlgorithm { get; set; } = EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512;
 
 	/// <summary>
+	/// Per-type signing and encryption settings for the JWTs the server issues for itself (access, refresh,
+	/// registration access and initial access tokens). Each type signs with RS256 and is signed only by
+	/// default; a host encrypts a specific type by setting that type's
+	/// <see cref="ServiceTokenOptions.Encryption"/> block. This makes outbound service-token encryption an
+	/// explicit per-type choice: populating <see cref="EncryptionKeys"/> for an inbound need (such as
+	/// decrypting client-sent encrypted request objects) no longer encrypts any outbound service token.
+	/// </summary>
+	public ServiceTokensOptions ServiceTokens { get; set; } = new();
+
+	/// <summary>
 	/// The duration for which a Pushed Authorization Request (PAR) is valid. PAR is a security enhancement that allows
 	/// clients to pre-register authorization requests directly with the authorization server. This duration specifies
 	/// the maximum time a pre-registered request is considered valid, balancing the need for security with usability

--- a/Abblix.Oidc.Server/Common/Configuration/ServiceTokenOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ServiceTokenOptions.cs
@@ -1,0 +1,43 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// The signing and encryption settings for one type of JWT the authorization server issues for itself
+/// (access, refresh, registration access or initial access token). The same shape is reused for every type
+/// via <see cref="ServiceTokensOptions"/>.
+/// </summary>
+public record ServiceTokenOptions
+{
+    /// <summary>
+    /// The signing settings, always present. Left at its defaults it signs with RS256 and lets the server
+    /// choose the first matching key, reproducing the output the server produced before this option existed.
+    /// </summary>
+    public JwtSigningSettings Signing { get; set; } = new();
+
+    /// <summary>
+    /// The encryption settings. <c>null</c> (the default) means the token is signed only; setting this block
+    /// opts the token type in to being encrypted as a JWE to the server's own encryption key.
+    /// </summary>
+    public JwtEncryptionSettings? Encryption { get; set; }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/ServiceTokenOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ServiceTokenOptions.cs
@@ -36,8 +36,18 @@ public record ServiceTokenOptions
     public JwtSigningSettings Signing { get; set; } = new();
 
     /// <summary>
-    /// The encryption settings. <c>null</c> (the default) means the token is signed only; setting this block
-    /// opts the token type in to being encrypted as a JWE to the server's own encryption key.
+    /// Whether to encrypt this token type to the server's own encryption key. <c>true</c> (the default)
+    /// encrypts it whenever a server encryption key is configured and otherwise signs it only, matching the
+    /// behavior of prior versions. Set to <c>false</c> to keep the token signed only even when an encryption
+    /// key exists — for example to keep the access token readable by external resource servers that validate
+    /// it against the published key set.
     /// </summary>
-    public JwtEncryptionSettings? Encryption { get; set; }
+    public bool Encrypt { get; set; } = true;
+
+    /// <summary>
+    /// How this token type is encrypted when <see cref="Encrypt"/> is on and a server encryption key is
+    /// available: the JWE key-management algorithm and the key to use. Left at its defaults it derives the
+    /// algorithm from the selected key and takes the first configured encryption key.
+    /// </summary>
+    public JwtEncryptionSettings Encryption { get; set; } = new();
 }

--- a/Abblix.Oidc.Server/Common/Configuration/ServiceTokensAlgorithmsValidator.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ServiceTokensAlgorithmsValidator.cs
@@ -66,8 +66,8 @@ public sealed class ServiceTokensAlgorithmsValidator(
                     $"registered signing algorithms ({string.Join(", ", signingAlgorithms)}).");
             }
 
-            var encryptionAlgorithm = token.Encryption?.Algorithm;
-            if (encryptionAlgorithm is not null && !keyManagementAlgorithms.Contains(encryptionAlgorithm))
+            var encryptionAlgorithm = token.Encryption.Algorithm;
+            if (token.Encrypt && encryptionAlgorithm is not null && !keyManagementAlgorithms.Contains(encryptionAlgorithm))
             {
                 results.Add(
                     $"ServiceTokens.{tokenType}.Encryption.Algorithm '{encryptionAlgorithm}' is not among the " +

--- a/Abblix.Oidc.Server/Common/Configuration/ServiceTokensAlgorithmsValidator.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ServiceTokensAlgorithmsValidator.cs
@@ -1,0 +1,78 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Fails loudly at startup when a configured <see cref="ServiceTokensOptions"/> names a signing or
+/// key-management algorithm that no registered signer or encryptor can produce, instead of letting the
+/// contradiction surface at token-issuance time as a per-request failure. The accepted sets are read from
+/// the live JWT registrations, the same union OpenID Connect discovery advertises, so a host that adds or
+/// replaces an algorithm is validated against exactly what it registered — no static allow-list to keep in sync.
+/// </summary>
+/// <param name="jwtCreator">Source of the registered signing and JWE key-management algorithms. The creator is
+/// deliberately the only dependency: it is lightweight, so validating options does not drag the runtime token
+/// pipeline (and its storage) into startup.</param>
+public sealed class ServiceTokensAlgorithmsValidator(
+    IJsonWebTokenCreator jwtCreator) : IValidateOptions<OidcOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OidcOptions options)
+    {
+        var signingAlgorithms = jwtCreator.SignedResponseAlgorithmsSupported.ToHashSet(StringComparer.Ordinal);
+        var keyManagementAlgorithms = jwtCreator.EncryptedResponseAlgorithmsSupported.ToHashSet(StringComparer.Ordinal);
+
+        var failures = new List<string>();
+        var serviceTokens = options.ServiceTokens;
+
+        Check(failures, nameof(serviceTokens.AccessToken), serviceTokens.AccessToken);
+        Check(failures, nameof(serviceTokens.RefreshToken), serviceTokens.RefreshToken);
+        Check(failures, nameof(serviceTokens.RegistrationAccessToken), serviceTokens.RegistrationAccessToken);
+        Check(failures, nameof(serviceTokens.InitialAccessToken), serviceTokens.InitialAccessToken);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+
+        void Check(List<string> results, string tokenType, ServiceTokenOptions token)
+        {
+            var signingAlgorithm = token.Signing.Algorithm;
+            if (!signingAlgorithms.Contains(signingAlgorithm))
+            {
+                results.Add(
+                    $"ServiceTokens.{tokenType}.Signing.Algorithm '{signingAlgorithm}' is not among the " +
+                    $"registered signing algorithms ({string.Join(", ", signingAlgorithms)}).");
+            }
+
+            var encryptionAlgorithm = token.Encryption?.Algorithm;
+            if (encryptionAlgorithm is not null && !keyManagementAlgorithms.Contains(encryptionAlgorithm))
+            {
+                results.Add(
+                    $"ServiceTokens.{tokenType}.Encryption.Algorithm '{encryptionAlgorithm}' is not among the " +
+                    $"registered JWE key-management algorithms ({string.Join(", ", keyManagementAlgorithms)}).");
+            }
+        }
+    }
+}

--- a/Abblix.Oidc.Server/Common/Configuration/ServiceTokensOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ServiceTokensOptions.cs
@@ -26,35 +26,36 @@ namespace Abblix.Oidc.Server.Common.Configuration;
 /// The per-type signing and encryption settings for the four JWTs the authorization server issues for itself.
 /// Grouping the four here keeps them together and avoids a name clash with the per-client
 /// <see cref="Features.ClientInformation.ClientInfo.RefreshToken"/> (which governs lifetime and reuse, a
-/// different concern). Each token type defaults to signed-only RS256; a host encrypts a specific type by
-/// setting that type's <see cref="ServiceTokenOptions.Encryption"/> block.
+/// different concern). Each token type signs with RS256 and, when a server encryption key is configured, is
+/// encrypted to it by default, as in prior versions; a host disables encryption for a specific type by
+/// setting that type's <see cref="ServiceTokenOptions.Encrypt"/> to <c>false</c>.
 /// </summary>
 public record ServiceTokensOptions
 {
     /// <summary>
-    /// Settings for the access token. Because the access token is forwarded to external resource servers,
-    /// which hold only the signing public key, leaving <see cref="ServiceTokenOptions.Encryption"/> unset
-    /// (signed only) is the safe default; encrypting it to the server's own key would make those servers
-    /// unable to read it.
+    /// Settings for the access token. Like the other service tokens it is encrypted to the server's own key
+    /// when one is configured. A host whose access token is validated by external resource servers against
+    /// the published key set (which hold only the signing public key) sets
+    /// <see cref="ServiceTokenOptions.Encrypt"/> to <c>false</c> so the token stays a readable signed JWS.
     /// </summary>
     public ServiceTokenOptions AccessToken { get; set; } = new();
 
     /// <summary>
-    /// Settings for the refresh token. The refresh token is a server round-trip value (issued, stored
-    /// opaquely by the holder, presented back and validated by the server), so encrypting it to the
-    /// server's own key is safe and can protect its contents at rest when the encryption block is set.
+    /// Settings for the refresh token. A server round-trip value (issued, stored opaquely by the holder,
+    /// presented back and validated by the server), so encrypting it to the server's own key both protects
+    /// its contents at rest and is read back by the server itself.
     /// </summary>
     public ServiceTokenOptions RefreshToken { get; set; } = new();
 
     /// <summary>
-    /// Settings for the registration access token (RFC 7592). A server round-trip value, so encrypting it
-    /// to the server's own key is safe when the encryption block is set.
+    /// Settings for the registration access token (RFC 7592). A server round-trip value, read back only by
+    /// the server, so encrypting it to the server's own key is safe.
     /// </summary>
     public ServiceTokenOptions RegistrationAccessToken { get; set; } = new();
 
     /// <summary>
-    /// Settings for the initial access token (RFC 7591 Section 3). A server round-trip value, so encrypting
-    /// it to the server's own key is safe when the encryption block is set.
+    /// Settings for the initial access token (RFC 7591 Section 3). A server round-trip value, read back only
+    /// by the server, so encrypting it to the server's own key is safe.
     /// </summary>
     public ServiceTokenOptions InitialAccessToken { get; set; } = new();
 }

--- a/Abblix.Oidc.Server/Common/Configuration/ServiceTokensOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/ServiceTokensOptions.cs
@@ -1,0 +1,60 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// The per-type signing and encryption settings for the four JWTs the authorization server issues for itself.
+/// Grouping the four here keeps them together and avoids a name clash with the per-client
+/// <see cref="Features.ClientInformation.ClientInfo.RefreshToken"/> (which governs lifetime and reuse, a
+/// different concern). Each token type defaults to signed-only RS256; a host encrypts a specific type by
+/// setting that type's <see cref="ServiceTokenOptions.Encryption"/> block.
+/// </summary>
+public record ServiceTokensOptions
+{
+    /// <summary>
+    /// Settings for the access token. Because the access token is forwarded to external resource servers,
+    /// which hold only the signing public key, leaving <see cref="ServiceTokenOptions.Encryption"/> unset
+    /// (signed only) is the safe default; encrypting it to the server's own key would make those servers
+    /// unable to read it.
+    /// </summary>
+    public ServiceTokenOptions AccessToken { get; set; } = new();
+
+    /// <summary>
+    /// Settings for the refresh token. The refresh token is a server round-trip value (issued, stored
+    /// opaquely by the holder, presented back and validated by the server), so encrypting it to the
+    /// server's own key is safe and can protect its contents at rest when the encryption block is set.
+    /// </summary>
+    public ServiceTokenOptions RefreshToken { get; set; } = new();
+
+    /// <summary>
+    /// Settings for the registration access token (RFC 7592). A server round-trip value, so encrypting it
+    /// to the server's own key is safe when the encryption block is set.
+    /// </summary>
+    public ServiceTokenOptions RegistrationAccessToken { get; set; } = new();
+
+    /// <summary>
+    /// Settings for the initial access token (RFC 7591 Section 3). A server round-trip value, so encrypting
+    /// it to the server's own key is safe when the encryption block is set.
+    /// </summary>
+    public ServiceTokenOptions InitialAccessToken { get; set; } = new();
+}

--- a/Abblix.Oidc.Server/Common/JsonWebKeyExtensions.cs
+++ b/Abblix.Oidc.Server/Common/JsonWebKeyExtensions.cs
@@ -63,4 +63,47 @@ public static class JsonWebKeyExtensions
         }
         return key;
     }
+
+    /// <summary>
+    /// Asynchronously retrieves the first <see cref="JsonWebKey"/> matching an optional algorithm and an
+    /// optional key id. This is the key-id-aware sibling of <see cref="FirstByAlgorithmAsync(IAsyncEnumerable{JsonWebKey}, string?)"/>:
+    /// signing passes the token's <c>alg</c> and pinned <c>kid</c>; encryption passes a <c>null</c> algorithm
+    /// (the key-management <c>alg</c> is derived from the chosen key afterwards) and only the pinned <c>kid</c>.
+    /// </summary>
+    /// <param name="credentials">The asynchronous sequence of <see cref="JsonWebKey"/> objects.</param>
+    /// <param name="algorithm">The algorithm to match, or <c>null</c> to not filter by algorithm. Prioritizes
+    /// keys declaring an exact match, then algorithm-agnostic keys (Algorithm == null) per RFC 7517
+    /// Section 4.4. Returns <c>null</c> for <see cref="SigningAlgorithms.None"/>.</param>
+    /// <param name="keyId">The <c>kid</c> to match, or <c>null</c> to not filter by key id.</param>
+    /// <returns>The first matching key, or <c>null</c> when the sequence yields none and neither filter was
+    /// applied. Throws when a filter was applied but nothing matched, so a pinned key id or a required
+    /// algorithm that resolves to no key fails loudly rather than silently downgrading.</returns>
+    public static async Task<JsonWebKey?> FirstByAlgorithmAsync(
+        this IAsyncEnumerable<JsonWebKey> credentials,
+        string? algorithm,
+        string? keyId)
+    {
+        if (algorithm is SigningAlgorithms.None)
+            return null;
+
+        if (keyId.HasValue())
+            credentials = credentials.Where(key => key.KeyId == keyId);
+
+        if (algorithm.HasValue())
+        {
+            // Prioritize exact algorithm match, then fall back to algorithm-agnostic keys (Algorithm == null)
+            credentials = credentials
+                .Where(key => key.Algorithm == algorithm || key.Algorithm == null)
+                .OrderBy(key => key.Algorithm == algorithm ? 0 : 1); // Exact match first (0), then null (1)
+        }
+
+        var key = await credentials.FirstOrDefaultAsync();
+        if (key is null && (algorithm.HasValue() || keyId.HasValue()))
+        {
+            throw new InvalidOperationException(
+                $"No key found for algorithm '{algorithm}' and key id '{keyId}'. " +
+                $"Ensure the corresponding keys are properly configured and loaded.");
+        }
+        return key;
+    }
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/InitialAccessTokenService.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/InitialAccessTokenService.cs
@@ -21,11 +21,13 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 
@@ -34,17 +36,21 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 /// </summary>
 public class InitialAccessTokenService(
     IAuthServiceJwtFormatter serviceJwtFormatter,
-    IIssuerProvider issuerProvider) : IInitialAccessTokenService
+    IIssuerProvider issuerProvider,
+    IOptions<OidcOptions> options) : IInitialAccessTokenService
 {
     /// <inheritdoc />
     public Task<string> IssueTokenAsync(string subject, DateTimeOffset issuedAt, TimeSpan? expiresIn)
     {
+        var signing = options.Value.ServiceTokens.InitialAccessToken.Signing;
+
         var token = new JsonWebToken
         {
             Header =
             {
                 Type = JwtTypes.InitialAccessToken,
-                Algorithm = SigningAlgorithms.RS256,
+                Algorithm = signing.Algorithm,
+                KeyId = signing.KeyId,
             },
             Payload =
             {
@@ -57,6 +63,7 @@ public class InitialAccessTokenService(
             },
         };
 
-        return serviceJwtFormatter.FormatAsync(token);
+        return serviceJwtFormatter.FormatAsync(
+            token, ServiceJwtEncryption.ForInitialAccessToken(options.Value));
     }
 }

--- a/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenService.cs
+++ b/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegistrationAccessTokenService.cs
@@ -21,11 +21,13 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 
@@ -34,7 +36,8 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement;
 /// </summary>
 public class RegistrationAccessTokenService(
     IAuthServiceJwtFormatter serviceJwtFormatter,
-    IIssuerProvider issuerProvider) : IRegistrationAccessTokenService
+    IIssuerProvider issuerProvider,
+    IOptions<OidcOptions> options) : IRegistrationAccessTokenService
 {
     /// <summary>
     /// Issues a registration access token for a registered client.
@@ -46,12 +49,15 @@ public class RegistrationAccessTokenService(
     /// <returns>A task that results in the encoded registration access token.</returns>
     public Task<string> IssueTokenAsync(string clientId, DateTimeOffset issuedAt, TimeSpan? expiresIn, string tokenId)
     {
+        var signing = options.Value.ServiceTokens.RegistrationAccessToken.Signing;
+
         var token = new JsonWebToken
         {
             Header =
             {
                 Type = JwtTypes.RegistrationAccessToken,
-                Algorithm = SigningAlgorithms.RS256,
+                Algorithm = signing.Algorithm,
+                KeyId = signing.KeyId,
             },
             Payload =
             {
@@ -69,6 +75,7 @@ public class RegistrationAccessTokenService(
             },
         };
 
-        return serviceJwtFormatter.FormatAsync(token);
+        return serviceJwtFormatter.FormatAsync(
+            token, ServiceJwtEncryption.ForRegistrationAccessToken(options.Value));
     }
 }

--- a/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -144,6 +144,11 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, EnabledEndpointsRegistrationValidator>());
 
+        // Fail loud at startup when a ServiceTokens signing or encryption algorithm is not one the registered
+        // signers/encryptors can produce, instead of failing per-request at token issuance.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, ServiceTokensAlgorithmsValidator>());
+
         // TryAddAlias: a host that pre-registers its own client store must win over the
         // OidcOptions-backed default (issue #226) — same host-first contract as TryAdd* seams.
         return services

--- a/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
@@ -22,6 +22,7 @@
 
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
@@ -29,6 +30,7 @@ using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.Tokens;
 
@@ -45,11 +47,14 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// enhancing security by enabling token revocation and tracking capabilities.</param>
 /// <param name="serviceJwtFormatter">The formatter used for encoding the JSON Web Token (JWT), ensuring it meets
 /// the standards required for secure transmission and validation.</param>
+/// <param name="options">OIDC configuration options, source of the access token's signing and encryption settings.
+/// </param>
 internal class AccessTokenService(
 	IIssuerProvider issuerProvider,
 	TimeProvider clock,
 	ITokenIdGenerator tokenIdGenerator,
-	IAuthServiceJwtFormatter serviceJwtFormatter) : IAccessTokenService
+	IAuthServiceJwtFormatter serviceJwtFormatter,
+	IOptions<OidcOptions> options) : IAccessTokenService
 {
 	/// <summary>
 	/// Asynchronously generates a new access token incorporating the authentication session and authorization context
@@ -75,13 +80,15 @@ internal class AccessTokenService(
 		ClientInfo clientInfo)
 	{
 		var issuedAt = clock.GetUtcNow();
+		var signing = options.Value.ServiceTokens.AccessToken.Signing;
 
 		var accessToken = new JsonWebToken
 		{
 			Header =
 			{
 				Type = JwtTypes.AccessToken,
-				Algorithm = SigningAlgorithms.RS256,
+				Algorithm = signing.Algorithm,
+				KeyId = signing.KeyId,
 			},
 			Payload =
 			{
@@ -96,7 +103,9 @@ internal class AccessTokenService(
 		authSession.ApplyTo(accessToken.Payload);
 		authContext.ApplyTo(accessToken.Payload);
 
-		return new EncodedJsonWebToken(accessToken, await serviceJwtFormatter.FormatAsync(accessToken));
+		var encoded = await serviceJwtFormatter.FormatAsync(
+			accessToken, ServiceJwtEncryption.ForAccessToken(options.Value));
+		return new EncodedJsonWebToken(accessToken, encoded);
 	}
 
 	/// <summary>

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
@@ -57,6 +57,9 @@ public class AuthServiceJwtFormatter(
 	/// that is ready for use in authenticating and authorizing service operations, including access tokens,
 	/// refresh tokens and Registration Access Tokens.
 	/// </remarks>
+	[Obsolete("Use FormatAsync(JsonWebToken, ServiceJwtEncryption) with an explicit encryption policy. " +
+	          "This overload encrypts implicitly whenever any service encryption key exists and is kept for " +
+	          "backward compatibility.")]
 	public async Task<string> FormatAsync(JsonWebToken token)
 	{
 		// Select the appropriate signing key based on the JWT specified algorithm
@@ -79,5 +82,43 @@ public class AuthServiceJwtFormatter(
 			encryptingCredentials,
 			keyEncryptionAlgorithm,
 			contentEncryptionAlgorithm);
+	}
+
+	/// <inheritdoc />
+	public async Task<string> FormatAsync(JsonWebToken token, ServiceJwtEncryption encryption)
+	{
+		// The signing algorithm and any pinned signing-key id live in the token header, placed there by the
+		// issuing service from its ServiceTokens.<Type>.Signing settings. The signer restamps the header kid
+		// from the chosen key, so passing the header kid here only selects which signing key is used.
+		var signingCredentials = await serviceKeysProvider.GetSigningKeys(true)
+			.FirstByAlgorithmAsync(token.Header.Algorithm, token.Header.KeyId);
+
+		// Signed only: do not even resolve the server's encryption keys, mirroring the client formatter's
+		// JARM signed-only branch.
+		if (!encryption.Encrypt)
+			return await jwtCreator.IssueAsync(token, signingCredentials);
+
+		// Encryption is an explicit opt-in for this token type, so a missing key is a configuration error
+		// rather than a silent fall-through to a signed-only token.
+		var encryptingCredentials = await serviceKeysProvider.GetEncryptionKeys()
+			.FirstByAlgorithmAsync(algorithm: null, encryption.KeyId);
+
+		if (encryptingCredentials is null)
+			throw new InvalidOperationException(
+				"Service token encryption is configured but no encryption key was found. " +
+				"Ensure OidcOptions.EncryptionKeys contains a usable key" +
+				(encryption.KeyId is null ? "." : $" with kid '{encryption.KeyId}'."));
+
+		// Derive the key-management alg from the policy, else the key's declared alg (RFC 7517 §4.4), else the default.
+		var keyEncryptionAlgorithm = encryption.KeyManagementAlgorithm
+			?? encryptingCredentials.Algorithm
+			?? EncryptionAlgorithms.KeyManagement.RsaOaep256;
+
+		return await jwtCreator.IssueAsync(
+			token,
+			signingCredentials,
+			encryptingCredentials,
+			keyEncryptionAlgorithm,
+			encryption.ContentEncryptionAlgorithm);
 	}
 }

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
@@ -93,21 +93,19 @@ public class AuthServiceJwtFormatter(
 		var signingCredentials = await serviceKeysProvider.GetSigningKeys(true)
 			.FirstByAlgorithmAsync(token.Header.Algorithm, token.Header.KeyId);
 
-		// Signed only: do not even resolve the server's encryption keys, mirroring the client formatter's
-		// JARM signed-only branch.
+		// Opt-out: this token type is configured signed only, so the server's encryption keys are not even
+		// resolved, mirroring the client formatter's JARM signed-only branch.
 		if (!encryption.Encrypt)
 			return await jwtCreator.IssueAsync(token, signingCredentials);
 
-		// Encryption is an explicit opt-in for this token type, so a missing key is a configuration error
-		// rather than a silent fall-through to a signed-only token.
+		// Encrypt when a server encryption key is available, otherwise fall back to a signed-only JWS (the
+		// behavior of prior versions a host keeps by leaving Encrypt on). A pinned key id that matches no
+		// configured key still fails loudly inside the selector.
 		var encryptingCredentials = await serviceKeysProvider.GetEncryptionKeys()
 			.FirstByAlgorithmAsync(algorithm: null, encryption.KeyId);
 
 		if (encryptingCredentials is null)
-			throw new InvalidOperationException(
-				"Service token encryption is configured but no encryption key was found. " +
-				"Ensure OidcOptions.EncryptionKeys contains a usable key" +
-				(encryption.KeyId is null ? "." : $" with kid '{encryption.KeyId}'."));
+			return await jwtCreator.IssueAsync(token, signingCredentials);
 
 		// Derive the key-management alg from the policy, else the key's declared alg (RFC 7517 §4.4), else the default.
 		var keyEncryptionAlgorithm = encryption.KeyManagementAlgorithm

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/IAuthServiceJwtFormatter.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/IAuthServiceJwtFormatter.cs
@@ -25,10 +25,10 @@ using Abblix.Jwt;
 namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
 
 /// <summary>
-/// Serializes a <see cref="JsonWebToken"/> minted by the authorization server itself (access
-/// tokens, refresh tokens, Registration Access Tokens) into a compact JWS form (RFC 7515) using
-/// the server's signing keys, optionally wrapping the result in a JWE (RFC 7516) when an
-/// encryption key is available.
+/// Serializes a <see cref="JsonWebToken"/> minted by the authorization server itself (access tokens, refresh
+/// tokens, registration access tokens, initial access tokens) into a compact JWS form (RFC 7515) using the
+/// server's signing keys, and — per an explicit <see cref="ServiceJwtEncryption"/> policy — optionally wraps
+/// the result in a JWE (RFC 7516) encrypted to the server's own encryption key.
 /// </summary>
 public interface IAuthServiceJwtFormatter
 {
@@ -39,5 +39,20 @@ public interface IAuthServiceJwtFormatter
     /// <param name="token">The JSON Web Token (JWT) to be formatted and signed, potentially also encrypted.</param>
     /// <returns>A task representing the asynchronous operation, which results in the JWT formatted as a string.
     /// </returns>
+    [Obsolete("Use FormatAsync(JsonWebToken, ServiceJwtEncryption) with an explicit encryption policy. " +
+              "This overload encrypts implicitly whenever any service encryption key exists and is kept for " +
+              "backward compatibility.")]
     Task<string> FormatAsync(JsonWebToken token);
+
+    /// <summary>
+    /// Formats and signs a JWT for use within the authentication service, and — per the supplied
+    /// <paramref name="encryption"/> policy — optionally encrypts it as a JWE to the server's own encryption key.
+    /// The signing algorithm and pinned signing key id come from the token header, set by the issuing service.
+    /// </summary>
+    /// <param name="token">The JSON Web Token (JWT) to be formatted and signed, potentially also encrypted.</param>
+    /// <param name="encryption">The encryption policy: whether to encrypt, which key-management algorithm and
+    /// encryption key to use, and the content-encryption algorithm.</param>
+    /// <returns>A task representing the asynchronous operation, which results in the JWT formatted as a string.
+    /// </returns>
+    Task<string> FormatAsync(JsonWebToken token, ServiceJwtEncryption encryption);
 }

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
@@ -1,0 +1,80 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Configuration;
+
+namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
+
+/// <summary>
+/// The encryption policy a caller hands to <see cref="AuthServiceJwtFormatter"/> when formatting a JWT the
+/// server issues for itself. It is the service-side mirror of <see cref="ClientJwtEncryption"/>: it makes
+/// explicit whether the token is encrypted and, if so, to which of the server's own keys and with which
+/// algorithms, so the formatter no longer encrypts implicitly whenever any encryption key happens to exist.
+/// Each service-token type supplies its own policy via the static factories below, projected from
+/// <see cref="OidcOptions.ServiceTokens"/>.
+/// </summary>
+/// <param name="Encrypt">Whether to encrypt the token. <c>false</c> yields a signed-only JWS and the
+/// server's encryption keys are not even resolved.</param>
+/// <param name="KeyManagementAlgorithm">The JWE key-management <c>alg</c>, or <c>null</c> to derive it from
+/// the selected encryption key's declared <c>alg</c> (RFC 7517 Section 4.4), falling back to
+/// <c>RSA-OAEP-256</c>.</param>
+/// <param name="KeyId">The <c>kid</c> of the encryption key to select, or <c>null</c> to take the first
+/// configured encryption key.</param>
+/// <param name="ContentEncryptionAlgorithm">The JWE content-encryption <c>enc</c>, taken from
+/// <see cref="OidcOptions.DefaultContentEncryptionAlgorithm"/>.</param>
+public sealed record ServiceJwtEncryption(
+    bool Encrypt,
+    string? KeyManagementAlgorithm,
+    string? KeyId,
+    string ContentEncryptionAlgorithm)
+{
+    /// <summary>Policy for the access token, projected from <c>ServiceTokens.AccessToken</c>.</summary>
+    public static ServiceJwtEncryption ForAccessToken(OidcOptions options)
+        => FromSettings(options.ServiceTokens.AccessToken, options);
+
+    /// <summary>Policy for the refresh token, projected from <c>ServiceTokens.RefreshToken</c>.</summary>
+    public static ServiceJwtEncryption ForRefreshToken(OidcOptions options)
+        => FromSettings(options.ServiceTokens.RefreshToken, options);
+
+    /// <summary>
+    /// Policy for the registration access token, projected from <c>ServiceTokens.RegistrationAccessToken</c>.
+    /// </summary>
+    public static ServiceJwtEncryption ForRegistrationAccessToken(OidcOptions options)
+        => FromSettings(options.ServiceTokens.RegistrationAccessToken, options);
+
+    /// <summary>
+    /// Policy for the initial access token, projected from <c>ServiceTokens.InitialAccessToken</c>.
+    /// </summary>
+    public static ServiceJwtEncryption ForInitialAccessToken(OidcOptions options)
+        => FromSettings(options.ServiceTokens.InitialAccessToken, options);
+
+    private static ServiceJwtEncryption FromSettings(ServiceTokenOptions token, OidcOptions options)
+    {
+        var encryption = token.Encryption;
+
+        return new ServiceJwtEncryption(
+            encryption != null,
+            encryption?.Algorithm,
+            encryption?.KeyId,
+            options.DefaultContentEncryptionAlgorithm);
+    }
+}

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
@@ -33,7 +33,8 @@ namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
 /// <see cref="OidcOptions.ServiceTokens"/>.
 /// </summary>
 /// <param name="Encrypt">Whether to encrypt the token. <c>false</c> yields a signed-only JWS and the
-/// server's encryption keys are not even resolved.</param>
+/// server's encryption keys are not even resolved. <c>true</c> encrypts when a server encryption key is
+/// available and otherwise falls back to a signed-only JWS (the behavior of prior versions).</param>
 /// <param name="KeyManagementAlgorithm">The JWE key-management <c>alg</c>, or <c>null</c> to derive it from
 /// the selected encryption key's declared <c>alg</c> (RFC 7517 Section 4.4), falling back to
 /// <c>RSA-OAEP-256</c>.</param>
@@ -68,13 +69,9 @@ public sealed record ServiceJwtEncryption(
         => FromSettings(options.ServiceTokens.InitialAccessToken, options);
 
     private static ServiceJwtEncryption FromSettings(ServiceTokenOptions token, OidcOptions options)
-    {
-        var encryption = token.Encryption;
-
-        return new ServiceJwtEncryption(
-            encryption != null,
-            encryption?.Algorithm,
-            encryption?.KeyId,
+        => new(
+            token.Encrypt,
+            token.Encryption.Algorithm,
+            token.Encryption.KeyId,
             options.DefaultContentEncryptionAlgorithm);
-    }
 }

--- a/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -34,6 +34,7 @@ using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.Tokens.Revocation;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.Tokens;
 
@@ -48,13 +49,16 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// <param name="grantIdGenerator">Generator for unique refresh-token grant identifiers.</param>
 /// <param name="jwtFormatter">Formatter for encoding JWTs.</param>
 /// <param name="tokenRegistry">Registry for tracking token status.</param>
+/// <param name="options">OIDC configuration options, source of the refresh token's signing and encryption settings.
+/// </param>
 public class RefreshTokenService(
 	IIssuerProvider issuerProvider,
 	TimeProvider clock,
 	ITokenIdGenerator tokenIdGenerator,
 	IGrantIdGenerator grantIdGenerator,
 	IAuthServiceJwtFormatter jwtFormatter,
-	ITokenRegistry tokenRegistry) : IRefreshTokenService
+	ITokenRegistry tokenRegistry,
+	IOptions<OidcOptions> options) : IRefreshTokenService
 {
 	/// <summary>
 	/// Generates a new refresh token based on the user's current authentication session and authorization context,
@@ -98,12 +102,15 @@ public class RefreshTokenService(
 		// grant id ties every refresh token of one authorization grant into a family a detected replay revokes whole.
 		var grantId = refreshToken?.Payload.GrantId ?? grantIdGenerator.GenerateGrantId();
 
+		var signing = options.Value.ServiceTokens.RefreshToken.Signing;
+
 		var newToken = new JsonWebToken
 		{
 			Header =
 			{
 				Type = JwtTypes.RefreshToken,
-				Algorithm = SigningAlgorithms.RS256,
+				Algorithm = signing.Algorithm,
+				KeyId = signing.KeyId,
 			},
 			Payload =
 			{
@@ -119,7 +126,9 @@ public class RefreshTokenService(
 		authSession.ApplyTo(newToken.Payload);
 		authContext.ApplyTo(newToken.Payload);
 
-		return new EncodedJsonWebToken(newToken, await jwtFormatter.FormatAsync(newToken));
+		var encoded = await jwtFormatter.FormatAsync(
+			newToken, ServiceJwtEncryption.ForRefreshToken(options.Value));
+		return new EncodedJsonWebToken(newToken, encoded);
 	}
 
 	private static DateTimeOffset CalculateExpiresAt(


### PR DESCRIPTION
Closes #245.

Each token the authorization server issues for itself (access, refresh, registration access, initial access) gets its own signing and encryption settings through `OidcOptions.ServiceTokens`, the service-side mirror of `ClientJwtEncryption`.

**Backward-compatible.** The default is unchanged: each type is signed and, when a server encryption key is configured, encrypted to it, as in prior versions. Signing defaults to RS256, so default output is byte-identical.

**Adds** per-type independent control: signing algorithm and key, key-management algorithm and encryption key, and an `Encrypt` switch that turns encryption off per type while keeping its other settings (for example to keep the access token a readable signed JWS for external resource servers). Configured algorithms are validated at startup against the ones the server can produce.

The access token stays opaque to third parties but first-party consumable: the E2E suite shows the server's own UserInfo endpoint reading an encrypted-by-default access token, and the per-type opt-out producing a signed JWS while the refresh token stays encrypted and round-trips.
