### PR TITLE
Reject a non-opening pairwise subject cleanly instead of faulting (#260)

### DIFF
--- a/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Endpoints.UserInfo;
 using Abblix.Oidc.Server.Endpoints.UserInfo.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
@@ -34,6 +35,7 @@ using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Abblix.Utils;
 using Moq;
 using Xunit;
 
@@ -146,7 +148,7 @@ public class UserInfoRequestValidatorTests
 
         _accessTokenService
             .Setup(s => s.AuthenticateByAccessTokenAsync(accessToken, It.IsAny<ClientInfo>()))
-            .ReturnsAsync((authSession, authContext));
+            .ReturnsAsync((Result<AuthorizedGrant, OidcError>)new AuthorizedGrant(authSession, authContext));
 
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(TestConstants.DefaultClientId))
@@ -187,7 +189,7 @@ public class UserInfoRequestValidatorTests
 
         _accessTokenService
             .Setup(s => s.AuthenticateByAccessTokenAsync(accessToken, It.IsAny<ClientInfo>()))
-            .ReturnsAsync((authSession, authContext));
+            .ReturnsAsync((Result<AuthorizedGrant, OidcError>)new AuthorizedGrant(authSession, authContext));
 
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(TestConstants.DefaultClientId))
@@ -368,7 +370,7 @@ public class UserInfoRequestValidatorTests
 
         _accessTokenService
             .Setup(s => s.AuthenticateByAccessTokenAsync(accessToken, It.IsAny<ClientInfo>()))
-            .ReturnsAsync((authSession, authContext));
+            .ReturnsAsync((Result<AuthorizedGrant, OidcError>)new AuthorizedGrant(authSession, authContext));
 
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync("unknown_client"))
@@ -407,7 +409,7 @@ public class UserInfoRequestValidatorTests
 
         _accessTokenService
             .Setup(s => s.AuthenticateByAccessTokenAsync(accessToken, It.IsAny<ClientInfo>()))
-            .ReturnsAsync((authSession, authContext));
+            .ReturnsAsync((Result<AuthorizedGrant, OidcError>)new AuthorizedGrant(authSession, authContext));
 
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(TestConstants.DefaultClientId))

--- a/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
@@ -177,10 +177,11 @@ public class SubjectTypeConverterTests
 
     /// <summary>
     /// A pairwise identifier sealed for one sector cannot be opened under another: the sector is bound as associated
-    /// data, so Recover under the wrong client's sector fails loudly instead of returning a wrong or forged subject.
+    /// data, so Recover under the wrong client's sector returns null instead of a wrong or forged subject, letting
+    /// the caller reject the token.
     /// </summary>
     [Fact]
-    public void Recover_UnderDifferentSector_Throws()
+    public void Recover_UnderDifferentSector_ReturnsNull()
     {
         var converter = CreateConverter();
         var sealingClient = CreatePairwiseClient("client-a", sectorIdentifier: "one.example.com");
@@ -188,7 +189,7 @@ public class SubjectTypeConverterTests
 
         var pairwise = converter.Convert(Subject, sealingClient);
 
-        Assert.Throws<InvalidOperationException>(() => converter.Recover(pairwise, otherSectorClient));
+        Assert.Null(converter.Recover(pairwise, otherSectorClient));
     }
 
     /// <summary>
@@ -277,16 +278,16 @@ public class SubjectTypeConverterTests
     }
 
     /// <summary>
-    /// A syntactically invalid pseudonym (not even valid base64url) is rejected loudly rather than mis-parsed into a
-    /// bogus subject.
+    /// A syntactically invalid pseudonym (not even valid base64url) returns null rather than being mis-parsed into a
+    /// bogus subject, letting the caller reject the token.
     /// </summary>
     [Fact]
-    public void Recover_MalformedPseudonym_Throws()
+    public void Recover_MalformedPseudonym_ReturnsNull()
     {
         var converter = CreateConverter();
         var client = CreatePairwiseClient("client-a", sectorIdentifier: "sector.example.com");
 
-        Assert.Throws<InvalidOperationException>(() => converter.Recover("not valid base64url!!", client));
+        Assert.Null(converter.Recover("not valid base64url!!", client));
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
@@ -339,7 +339,7 @@ public class AccessTokenServiceTests
         };
 
         // Act
-        var (authSession, _) = await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo());
+        var (authSession, _) = (await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo())).GetSuccess();
 
         // Assert
         Assert.Equal(UserId, authSession.Subject);
@@ -374,7 +374,7 @@ public class AccessTokenServiceTests
         };
 
         // Act
-        var (_, authContext) = await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo());
+        var (_, authContext) = (await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo())).GetSuccess();
 
         // Assert
         Assert.Equal(ClientId, authContext.ClientId);
@@ -407,7 +407,7 @@ public class AccessTokenServiceTests
         };
 
         // Act
-        var (_, authContext) = await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo());
+        var (_, authContext) = (await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo())).GetSuccess();
 
         // Assert
         Assert.Null(authContext.Resources);
@@ -437,7 +437,7 @@ public class AccessTokenServiceTests
         };
 
         // Act
-        var (authSession, _) = await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo());
+        var (authSession, _) = (await _service.AuthenticateByAccessTokenAsync(jwt, CreateClientInfo())).GetSuccess();
 
         // Assert
         Assert.NotNull(authSession.AdditionalClaims);
@@ -470,6 +470,56 @@ public class AccessTokenServiceTests
         // Assert
         Assert.NotNull(capturedToken);
         Assert.Equal(_currentTime + customExpiration, capturedToken!.Payload.ExpiresAt);
+    }
+
+    /// <summary>
+    /// A pairwise access token whose 'sub' does not open for the presenting client (a foreign-sector or pre-change
+    /// token) is rejected as invalid_token rather than faulting: recovery returns a failure result, not an exception.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateByAccessToken_PairwiseSubjectDoesNotOpen_ReturnsInvalidToken()
+    {
+        // Arrange: a service with real pairwise settings, and a 'sub' that is a valid pseudonym for a DIFFERENT
+        // sector, so it cannot open for the presenting client's sector.
+        var converter = new SubjectTypeConverter(
+            new PairwiseSubjectSettings { Salt = Convert.ToBase64String(new byte[32]) });
+        var service = new AccessTokenService(
+            Mock.Of<IIssuerProvider>(),
+            new FakeTimeProvider(_currentTime),
+            Mock.Of<ITokenIdGenerator>(),
+            Mock.Of<IAuthServiceJwtFormatter>(),
+            converter,
+            Options.Create(new OidcOptions()));
+
+        var presentingClient = new ClientInfo(ClientId)
+        {
+            SubjectType = SubjectTypes.Pairwise,
+            SectorIdentifier = "sector.example.com",
+        };
+        var foreignSectorSub = converter.Convert("real-user", new ClientInfo("other")
+        {
+            SubjectType = SubjectTypes.Pairwise,
+            SectorIdentifier = "other.example.com",
+        });
+        var jwt = new JsonWebToken
+        {
+            Payload =
+            {
+                Subject = foreignSectorSub,
+                SessionId = SessionId,
+                AuthenticationTime = _currentTime,
+                IdentityProvider = "local",
+                ClientId = ClientId,
+                Scope = [Scopes.OpenId],
+            },
+        };
+
+        // Act
+        var result = await service.AuthenticateByAccessTokenAsync(jwt, presentingClient);
+
+        // Assert
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
+++ b/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
@@ -109,9 +109,10 @@ public class UserInfoRequestValidator(
 		// Resolve the client before authenticating the token: a pairwise access token's 'sub' is opened back to
 		// the real subject with the client's sector, so AuthenticateByAccessTokenAsync needs the ClientInfo.
 		var clientId = token.Payload.ClientId;
-		var clientInfo = clientId is null
-			? null
-			: await clientInfoProvider.TryFindClientAsync(clientId).WithLicenseCheck();
+		var clientInfo = clientId is not null
+			? await clientInfoProvider.TryFindClientAsync(clientId).WithLicenseCheck()
+			: null;
+
 		if (clientInfo == null)
 		{
 			return new OidcError(
@@ -119,9 +120,10 @@ public class UserInfoRequestValidator(
 				$"The client '{clientId}' is not found");
 		}
 
-		var (authSession, authContext) = await accessTokenService.AuthenticateByAccessTokenAsync(token, clientInfo);
-
-		return new ValidUserInfoRequest(userInfoRequest, authSession, authContext, clientInfo);
+		// A pairwise subject that does not open for this client (a foreign-sector or pre-change token) comes back as
+		// an error rather than faulting, so it surfaces as a normal invalid_token rejection.
+		return (await accessTokenService.AuthenticateByAccessTokenAsync(token, clientInfo))
+			.MapSuccess(grant => new ValidUserInfoRequest(userInfoRequest, grant.AuthSession, grant.Context, clientInfo));
 	}
 
 	/// <summary>
@@ -131,7 +133,8 @@ public class UserInfoRequestValidator(
 	/// attributes.
 	/// </summary>
 	private static Result<string, OidcError> ExtractAccessToken(
-		UserInfoRequest userInfoRequest, ClientRequest clientRequest)
+		UserInfoRequest userInfoRequest,
+		ClientRequest clientRequest)
 	{
 		var authorizationHeader = clientRequest.AuthorizationHeader;
 		if (authorizationHeader == null)

--- a/Abblix.Oidc.Server/Features/PairwiseIdentifiers/ISubjectTypeConverter.cs
+++ b/Abblix.Oidc.Server/Features/PairwiseIdentifiers/ISubjectTypeConverter.cs
@@ -59,8 +59,10 @@ public interface ISubjectTypeConverter
     /// </summary>
     /// <param name="subject">The client-facing subject identifier (pairwise pseudonym or real subject).</param>
     /// <param name="clientInfo">The client the subject was issued for.</param>
-    /// <returns>The real subject identifier.</returns>
-    /// <exception cref="System.InvalidOperationException">Thrown when a pairwise pseudonym cannot be opened:
-    /// malformed, sealed for a different sector, or produced under a different pairwise salt.</exception>
-    string Recover(string subject, ClientInfo clientInfo);
+    /// <returns>The real subject identifier, or <c>null</c> when a pairwise pseudonym cannot be opened (malformed,
+    /// sealed for a different sector, or produced under a different pairwise salt) so the caller can reject the
+    /// token at the protocol level.</returns>
+    /// <exception cref="System.InvalidOperationException">Thrown only when pairwise identifiers are not configured
+    /// but a pairwise client is asked to recover, which is a server misconfiguration rather than a bad token.</exception>
+    string? Recover(string subject, ClientInfo clientInfo);
 }

--- a/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
+++ b/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
@@ -84,16 +84,22 @@ public class SubjectTypeConverter : ISubjectTypeConverter
 
     /// <summary>
     /// Recovers the real subject from the client-facing subject: for a pairwise client, opens the per-sector
-    /// pseudonym; for a public client, returns the subject unchanged.
+    /// pseudonym; for a public client, returns the subject unchanged. Returns <c>null</c> when a pairwise pseudonym
+    /// cannot be opened, so the caller can surface a protocol-level rejection instead of faulting.
     /// </summary>
-    public string Recover(string subject, ClientInfo clientInfo) => clientInfo.SubjectType switch
+    public string? Recover(string subject, ClientInfo clientInfo) => clientInfo.SubjectType switch
     {
         SubjectTypes.Pairwise => RecoverPairwise(subject, clientInfo),
         _ => subject,
     };
 
-    private string RecoverPairwise(string pseudonym, ClientInfo clientInfo)
+    private string? RecoverPairwise(string pseudonym, ClientInfo clientInfo)
     {
+        // The pseudonym is client-supplied (it rides in the token's 'sub'), so a value that is not valid base64url or
+        // does not open is a rejected input, not a server fault: return null and let the caller surface the protocol
+        // error. A missing pairwise configuration is a server misconfiguration and still throws (via Encryptor).
+        var encryptor = Encryptor(clientInfo);
+
         byte[] sealedData;
         try
         {
@@ -101,17 +107,11 @@ public class SubjectTypeConverter : ISubjectTypeConverter
         }
         catch (FormatException)
         {
-            throw new InvalidOperationException(
-                $"The pairwise subject for client '{clientInfo.ClientId}' is not a valid pseudonym.");
+            return null;
         }
 
-        var subject = Encryptor(clientInfo).Open(sealedData, Sector(clientInfo));
-        if (subject is null)
-            throw new InvalidOperationException(
-                $"The pairwise subject for client '{clientInfo.ClientId}' could not be recovered: it is malformed, " +
-                "sealed for a different sector, or was produced under a different pairwise salt.");
-
-        return Encoding.UTF8.GetString(subject);
+        var subject = encryptor.Open(sealedData, Sector(clientInfo));
+        return subject is not null ? Encoding.UTF8.GetString(subject) : null;
     }
 
     private DeterministicAeadEncryptor Encryptor(ClientInfo clientInfo)

--- a/Abblix.Oidc.Server/Features/TokenExchange/JwtSubjectTokenResolver.cs
+++ b/Abblix.Oidc.Server/Features/TokenExchange/JwtSubjectTokenResolver.cs
@@ -94,7 +94,16 @@ public sealed class JwtSubjectTokenResolver(
             : null;
 
         if (originalClient is not null)
-            subject = subjectTypeConverter.Recover(subject, originalClient);
+        {
+            // A pairwise 'sub' that does not open for its client (a foreign-sector or pre-change token) is rejected
+            // rather than faulting the exchange.
+            var recovered = subjectTypeConverter.Recover(subject, originalClient);
+            if (recovered is null)
+                return new OidcError(
+                    ErrorCodes.InvalidRequest, "The subject_token's subject could not be resolved.");
+
+            subject = recovered;
+        }
 
         // Direct raw access to authorization_details preserves byte-exact payload; DeepClone
         // detaches it from the subject_token's payload before it flows into a fresh

--- a/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
@@ -24,6 +24,7 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.Licensing;
@@ -31,6 +32,7 @@ using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.Tokens;
@@ -126,22 +128,29 @@ internal class AccessTokenService(
 	/// <param name="accessToken">The access token to be authenticated and analyzed.</param>
 	/// <param name="clientInfo">The client the token was issued for; its sector opens a pairwise subject back to
 	/// the real subject.</param>
-	/// <returns>A task that returns the <see cref="AuthSession"/> and <see cref="AuthorizationContext"/>
-	/// derived from the token.</returns>
+	/// <returns>A task with the <see cref="AuthorizedGrant"/> (session and authorization context) on success, or an
+	/// <see cref="OidcError"/> when a pairwise subject cannot be opened for this client so the caller rejects the
+	/// token.</returns>
 	/// <remarks>
 	/// This method facilitates the secure validation of access tokens, ensuring that only tokens issued by the trusted
 	/// authority and not tampered with are accepted. It decodes embedded claims to reconstruct the original
 	/// authorization and authentication details, supporting secure and informed access control decisions.
 	/// </remarks>
-	public Task<(AuthSession, AuthorizationContext)> AuthenticateByAccessTokenAsync(
-		JsonWebToken accessToken, ClientInfo clientInfo)
+	public Task<Result<AuthorizedGrant, OidcError>> AuthenticateByAccessTokenAsync(
+		JsonWebToken accessToken,
+		ClientInfo clientInfo)
 	{
 		var authSession = accessToken.Payload.ToAuthSession();
 		var authorizationContext = accessToken.Payload.ToAuthorizationContext();
 
 		// Recover the real subject: for a pairwise token 'sub' is the per-sector pseudonym the server opens back to
 		// the real subject (its sector comes from clientInfo). A public client's 'sub' is already the real subject.
-		var subject = subjectTypeConverter.Recover(authSession.Subject, clientInfo);
-		return Task.FromResult((authSession with { Subject = subject }, authorizationContext));
+		// A pairwise 'sub' that does not open (a foreign-sector or pre-change token) yields null, so reject the token
+		// at the protocol level instead of faulting.
+		var result = subjectTypeConverter.Recover(authSession.Subject, clientInfo)
+			.FailIfNull(new OidcError(ErrorCodes.InvalidToken, "The access token subject could not be resolved for this client"))
+			.MapSuccess(recovered => new AuthorizedGrant(authSession with { Subject = recovered }, authorizationContext));
+
+		return Task.FromResult(result);
 	}
 }

--- a/Abblix.Oidc.Server/Features/Tokens/IAccessTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/IAccessTokenService.cs
@@ -22,8 +22,10 @@
 
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Utils;
 
 namespace Abblix.Oidc.Server.Features.Tokens;
 
@@ -43,7 +45,8 @@ public interface IAccessTokenService
 	/// <param name="clientInfo">Information about the client for whom the token is being created.</param>
 	/// <returns>A task that represents the asynchronous create operation.
 	/// The task result contains the newly created <see cref="JsonWebToken"/>.</returns>
-	Task<EncodedJsonWebToken> CreateAccessTokenAsync(AuthSession authSession,
+	Task<EncodedJsonWebToken> CreateAccessTokenAsync(
+		AuthSession authSession,
 		AuthorizationContext authContext,
 		ClientInfo clientInfo);
 
@@ -53,7 +56,11 @@ public interface IAccessTokenService
 	/// <param name="accessToken">The access token to authenticate.</param>
 	/// <param name="clientInfo">The client the token was issued for; its sector opens a pairwise subject back to
 	/// the real subject.</param>
-	/// <returns>A task that represents the asynchronous authentication operation. The task result contains
-	/// the <see cref="AuthSession"/> and <see cref="AuthorizationContext"/> associated with the authenticated user.</returns>
-	Task<(AuthSession, AuthorizationContext)> AuthenticateByAccessTokenAsync(JsonWebToken accessToken, ClientInfo clientInfo);
+	/// <returns>A task that represents the asynchronous authentication operation. On success the result carries the
+	/// <see cref="AuthorizedGrant"/> (the authenticated user's session and authorization context); it carries an
+	/// <see cref="OidcError"/> when a pairwise subject cannot be opened for this client, so the caller rejects the
+	/// token at the protocol level. This mirrors the result shape of the refresh and token-exchange recovery paths.</returns>
+	Task<Result<AuthorizedGrant, OidcError>> AuthenticateByAccessTokenAsync(
+		JsonWebToken accessToken,
+		ClientInfo clientInfo);
 }

--- a/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -183,6 +183,14 @@ public class RefreshTokenService(
 		// the grant, so the grant carries the real subject the server refreshes and exchanges against - the
 		// refresh-token token-exchange resolver reads it from here. A public client's 'sub' is already real.
 		var subject = subjectTypeConverter.Recover(authSession.Subject, clientInfo);
+		if (subject is null)
+		{
+			// The pairwise 'sub' did not open for this client (a foreign-sector or pre-change token): reject the
+			// grant rather than faulting the refresh.
+			return Task.FromResult<Result<AuthorizedGrant, OidcError>>(
+				new OidcError(ErrorCodes.InvalidGrant, "The refresh token subject could not be resolved"));
+		}
+
 		return Task.FromResult<Result<AuthorizedGrant, OidcError>>(
 			new RefreshTokenAuthorizedGrant(authSession with { Subject = subject }, authContext, refreshToken));
 	}


### PR DESCRIPTION
Fixes #260.

A pairwise `sub` that cannot be opened for its client (a foreign-sector token, or a pairwise token issued before #256 that still carried the real subject) now surfaces as a normal token rejection rather than an unhandled exception that would otherwise fault the request.

`SubjectTypeConverter.Recover` returns null for a value that does not open (a client-supplied, thus expected, condition), while a missing pairwise configuration stays a fail-loud server error. The three recovery sites map the null to their protocol error:
- `invalid_token` at UserInfo,
- `invalid_grant` on refresh,
- `invalid_request` in token exchange.

`AuthenticateByAccessTokenAsync` now returns `Result<AuthorizedGrant, OidcError>`, mirroring the refresh and token-exchange recovery paths that already carry a protocol-error channel.

Note: this is a robustness fix, not a security fix. The access token is a signed JWS validated before recovery runs, so a tampered `sub` is already rejected at signature validation; the non-opening cases are operational (version skew, or a client reconfigured from public to pairwise with earlier tokens still in flight).
