### PR TITLE
Version-aware external key rotation and symmetric key selection

### DIFF
--- a/Abblix.Jwt.UnitTests/ExternalKeyDecryptorTests.cs
+++ b/Abblix.Jwt.UnitTests/ExternalKeyDecryptorTests.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text.Json.Nodes;
 using Abblix.Jwt.Encryption;
@@ -217,10 +218,10 @@ public class ExternalKeyDecryptorTests
         public int AgreeCalls { get; private set; }
 
         // This custodian holds only encryption keys, so the library never routes a signing operation here.
-        public ValueTask<byte[]> SignAsync(string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
+        public Task<byte[]> SignAsync(string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
             => throw new NotSupportedException("This decryption custodian holds no signing keys.");
 
-        public ValueTask<byte[]?> UnwrapKeyAsync(
+        public Task<byte[]?> UnwrapKeyAsync(
             string keyId,
             string algorithm,
             JsonWebTokenHeader header,
@@ -237,10 +238,10 @@ public class ExternalKeyDecryptorTests
 
                 _ => null,
             };
-            return new ValueTask<byte[]?>(cek);
+            return Task.FromResult(cek);
         }
 
-        public ValueTask<byte[]> AgreeKeyAsync(
+        public Task<byte[]> AgreeKeyAsync(
             string keyId,
             string algorithm,
             JsonWebKey ephemeralPublicKey,
@@ -249,11 +250,15 @@ public class ExternalKeyDecryptorTests
             AgreeCalls++;
             using var recipient = ((EllipticCurveJsonWebKey)fullKey).ToEcdh();
             using var ephemeral = ((EllipticCurveJsonWebKey)ephemeralPublicKey).ToEcdh();
-            return new ValueTask<byte[]>(recipient.DeriveRawSecretAgreement(ephemeral.PublicKey));
+            return Task.FromResult(recipient.DeriveRawSecretAgreement(ephemeral.PublicKey));
         }
 
-        public ValueTask<JsonWebKey> GetPublicKeyAsync(string keyId, CancellationToken cancellationToken)
-            => new(fullKey.Sanitize(includePrivateKeys: false));
+        public async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+            string keyName, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield return new KeyVersion(fullKey.Sanitize(includePrivateKeys: false), DateTimeOffset.MinValue);
+        }
 
         private static byte[]? RsaDecrypt(RsaJsonWebKey key, string algorithm, byte[] encryptedKey)
         {

--- a/Abblix.Jwt.UnitTests/ExternalSignerTests.cs
+++ b/Abblix.Jwt.UnitTests/ExternalSignerTests.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using Abblix.Jwt.Signing;
 using Microsoft.Extensions.DependencyInjection;
@@ -130,7 +131,7 @@ public class ExternalSignerTests
         public string? LastKid { get; private set; }
         public string? LastAlgorithm { get; private set; }
 
-        public ValueTask<byte[]> SignAsync(string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
+        public Task<byte[]> SignAsync(string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             CallCount++;
@@ -139,18 +140,22 @@ public class ExternalSignerTests
 
             // RS256 is RSASSA-PKCS1-v1_5 over SHA-256; the library verifies this against the public key.
             using var rsa = privateKey.ToRsa();
-            return new ValueTask<byte[]>(rsa.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+            return Task.FromResult(rsa.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
         }
 
-        public ValueTask<byte[]?> UnwrapKeyAsync(
+        public Task<byte[]?> UnwrapKeyAsync(
             string keyId, string algorithm, JsonWebTokenHeader header, byte[] encryptedKey, CancellationToken cancellationToken)
             => throw new NotSupportedException("This signing custodian holds no decryption keys.");
 
-        public ValueTask<byte[]> AgreeKeyAsync(
+        public Task<byte[]> AgreeKeyAsync(
             string keyId, string algorithm, JsonWebKey ephemeralPublicKey, CancellationToken cancellationToken)
             => throw new NotSupportedException("This signing custodian holds no decryption keys.");
 
-        public ValueTask<JsonWebKey> GetPublicKeyAsync(string keyId, CancellationToken cancellationToken)
-            => new(privateKey.Sanitize(includePrivateKeys: false));
+        public async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+            string keyName, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield return new KeyVersion(privateKey.Sanitize(includePrivateKeys: false), DateTimeOffset.MinValue);
+        }
     }
 }

--- a/Abblix.Jwt/Encryption/CompositeDecryptor.cs
+++ b/Abblix.Jwt/Encryption/CompositeDecryptor.cs
@@ -36,7 +36,7 @@ internal sealed class CompositeDecryptor(IEnumerable<IContentKeyDecryptor> backe
 {
     public bool CanDecrypt(JsonWebKey key) => backends.Any(backend => backend.CanDecrypt(key));
 
-    public ValueTask<byte[]?> DecryptKeyAsync(
+    public Task<byte[]?> DecryptKeyAsync(
         JsonWebTokenHeader header,
         JsonWebKey key,
         string algorithm,

--- a/Abblix.Jwt/Encryption/ExternalKeyDecryptor.cs
+++ b/Abblix.Jwt/Encryption/ExternalKeyDecryptor.cs
@@ -40,7 +40,7 @@ internal sealed class ExternalKeyDecryptor(IKeyCustodian custodian, IServiceProv
     /// <summary>Owns any public-only key: its private half lives with the custodian, not in process.</summary>
     public bool CanDecrypt(JsonWebKey key) => !key.HasPrivateKey;
 
-    public async ValueTask<byte[]?> DecryptKeyAsync(
+    public async Task<byte[]?> DecryptKeyAsync(
         JsonWebTokenHeader header,
         JsonWebKey key,
         string algorithm,
@@ -78,7 +78,7 @@ internal sealed class ExternalKeyDecryptor(IKeyCustodian custodian, IServiceProv
     /// raw shared secret Z; the Concat KDF and any AES key unwrap run locally. Mirrors the guards of the
     /// in-process EcdhEsKeyEncryptor.TryDecryptKey - only the agreement step is remote.
     /// </summary>
-    private async ValueTask<byte[]?> AgreeExternallyAsync(
+    private async Task<byte[]?> AgreeExternallyAsync(
         JsonWebTokenHeader header,
         EllipticCurveJsonWebKey recipientKey,
         string algorithm,

--- a/Abblix.Jwt/Encryption/IContentKeyDecryptor.cs
+++ b/Abblix.Jwt/Encryption/IContentKeyDecryptor.cs
@@ -58,7 +58,7 @@ public interface IContentKeyDecryptor
     /// <param name="encryptedKey">The wrapped or RSA-encrypted CEK from the JWE Encrypted Key.</param>
     /// <param name="cancellationToken">Cancels the operation, including a custodian round-trip.</param>
     /// <returns>The recovered CEK, or null on a decryption failure.</returns>
-    ValueTask<byte[]?> DecryptKeyAsync(
+    Task<byte[]?> DecryptKeyAsync(
         JsonWebTokenHeader header,
         JsonWebKey key,
         string algorithm,

--- a/Abblix.Jwt/Encryption/LocalKeyDecryptor.cs
+++ b/Abblix.Jwt/Encryption/LocalKeyDecryptor.cs
@@ -39,7 +39,7 @@ internal sealed class LocalKeyDecryptor(IServiceProvider serviceProvider) : ICon
     /// </summary>
     public bool CanDecrypt(JsonWebKey key) => key.HasPrivateKey;
 
-    public ValueTask<byte[]?> DecryptKeyAsync(
+    public Task<byte[]?> DecryptKeyAsync(
         JsonWebTokenHeader header,
         JsonWebKey key,
         string algorithm,
@@ -59,7 +59,7 @@ internal sealed class LocalKeyDecryptor(IServiceProvider serviceProvider) : ICon
                 "key custodian, but none is configured.");
 
         var contentEncryptionKey = DecryptLocally(key);
-        return new ValueTask<byte[]?>(contentEncryptionKey);
+        return Task.FromResult(contentEncryptionKey);
 
         byte[]? DecryptLocally(JsonWebKey localKey) => localKey switch
         {

--- a/Abblix.Jwt/IKeyCustodian.cs
+++ b/Abblix.Jwt/IKeyCustodian.cs
@@ -20,8 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System.Runtime.CompilerServices;
-
 namespace Abblix.Jwt;
 
 /// <summary>
@@ -33,12 +31,15 @@ namespace Abblix.Jwt;
 /// custodian. Wire it with <c>AddKeyCustodian</c>; a host with no external keys leaves it unregistered.
 /// </summary>
 /// <remarks>
-/// Every operation is addressed by <c>kid</c>, the custodian's handle for the key, identical to the published
-/// key's <c>kid</c> - there is no separate identifier and no mapping. The implementation never receives or
-/// returns private key material, and only needs to implement the operations its own keys require: a signing-only
-/// custodian leaves unwrap and agree unreachable, and a decryption-only custodian leaves sign unreachable.
-/// Direct encryption (<c>dir</c>) and password-based key management (PBES2) have no external form - the CEK is
-/// the secret itself, or is derived from it by a password KDF - so they are never routed here and fail closed.
+/// Every private operation is addressed by <c>kid</c>, the custodian's handle for that exact key version,
+/// identical to the published key's <c>kid</c> - there is no separate identifier and no mapping. The public
+/// halves the library publishes come from <see cref="GetKeyVersionsAsync"/>, which enumerates a named key's
+/// versions so a rotation can overlap. The implementation never receives or returns private key material, and
+/// only needs to implement the private operations its own keys require: a signing-only custodian leaves unwrap
+/// and agree unreachable, and a decryption-only custodian leaves sign unreachable. Direct encryption (<c>dir</c>)
+/// and password-based key management (PBES2) have no external form - the CEK is the secret itself, or is derived
+/// from it by a password KDF - so they are never routed here and fail closed. Every operation is a round-trip to
+/// the custodian, so the contract returns <see cref="Task{TResult}"/> throughout.
 /// </remarks>
 public interface IKeyCustodian
 {
@@ -46,12 +47,12 @@ public interface IKeyCustodian
     /// Signs <paramref name="data"/> with a signing key held by the custodian, returning the signature in the
     /// JWS wire format for <paramref name="algorithm"/>. Called for a signing key the library holds public-only.
     /// </summary>
-    /// <param name="keyId">The custodian's handle for the signing key.</param>
+    /// <param name="keyId">The custodian's handle for the signing key version.</param>
     /// <param name="algorithm">The JWS algorithm identifier (e.g. RS256, ES256) the signature must use.</param>
     /// <param name="data">The signing input bytes, BASE64URL(header) + '.' + BASE64URL(payload).</param>
     /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
     /// <returns>The raw signature bytes in JWS wire format for the algorithm.</returns>
-    ValueTask<byte[]> SignAsync(
+    Task<byte[]> SignAsync(
         string keyId,
         string algorithm,
         byte[] data,
@@ -61,7 +62,7 @@ public interface IKeyCustodian
     /// Recovers a Content Encryption Key: an RSA decryption (RSA-OAEP / RSA-OAEP-256 / RSA1_5) or a symmetric
     /// unwrap (AES-KW / AES-GCM-KW), selected by <paramref name="algorithm"/>.
     /// </summary>
-    /// <param name="keyId">The custodian's handle for the recipient key.</param>
+    /// <param name="keyId">The custodian's handle for the recipient key version.</param>
     /// <param name="algorithm">The JWE <c>alg</c> value identifying the key-management operation.</param>
     /// <param name="header">The JWE header; AES-GCM-KW reads its <c>iv</c> / <c>tag</c> parameters from it.</param>
     /// <param name="encryptedKey">The wrapped or RSA-encrypted CEK from the JWE Encrypted Key.</param>
@@ -69,7 +70,7 @@ public interface IKeyCustodian
     /// <returns>The recovered CEK, or null on any failure. Returning null rather than throwing keeps a
     /// decryption failure indistinguishable from a wrong key, which the RFC 7516 §11.5 mitigation upstream
     /// relies on to close the Bleichenbacher / padding-oracle side channel.</returns>
-    ValueTask<byte[]?> UnwrapKeyAsync(
+    Task<byte[]?> UnwrapKeyAsync(
         string keyId,
         string algorithm,
         JsonWebTokenHeader header,
@@ -81,44 +82,27 @@ public interface IKeyCustodian
     /// and the originator's ephemeral public key, returning the raw shared secret Z. The library runs the
     /// Concat KDF over Z and any AES key unwrap, so those steps never leave it.
     /// </summary>
-    /// <param name="keyId">The custodian's handle for the recipient key.</param>
+    /// <param name="keyId">The custodian's handle for the recipient key version.</param>
     /// <param name="algorithm">The JWE <c>alg</c> value (ECDH-ES or an ECDH-ES+A*KW variant).</param>
     /// <param name="ephemeralPublicKey">The originator's ephemeral public key from the <c>epk</c> header.</param>
     /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
     /// <returns>The raw ECDH shared secret Z (the agreement's field-sized X-coordinate).</returns>
-    ValueTask<byte[]> AgreeKeyAsync(
+    Task<byte[]> AgreeKeyAsync(
         string keyId,
         string algorithm,
         JsonWebKey ephemeralPublicKey,
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Fetches the public half of a key the custodian holds as a public-only <see cref="JsonWebKey"/> (RSA or EC,
-    /// per the key type), carrying only the key material. The caller stamps the <c>kid</c>, use and algorithm.
-    /// Called once per key at startup, so JWKS publishing and signature verification run locally against it and
-    /// never touch the custodian on the hot path.
-    /// </summary>
-    /// <param name="keyId">The custodian's handle for the key.</param>
-    /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
-    /// <returns>The public-only key material for the key.</returns>
-    ValueTask<JsonWebKey> GetPublicKeyAsync(string keyId, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Enumerates every current version of the key named <paramref name="keyName"/> as its public half, each
     /// carrying the version-specific <c>kid</c> that routes a private operation back to that exact version, plus
-    /// the custodian's creation time for that version. The default yields the single key returned by
-    /// <see cref="GetPublicKeyAsync"/> with an unset (<see cref="DateTimeOffset.MinValue"/>) creation time, so a
-    /// custodian that does not version its keys needs no change; a version-aware custodian (Vault Transit, Azure
-    /// Key Vault) overrides this to publish every version, which a rotation policy overlaps for zero-downtime
-    /// key rollover.
+    /// the custodian's creation time for that version. A custodian that does not version its keys yields a single
+    /// element; a version-aware custodian (Vault Transit, Azure Key Vault) yields every version, which a rotation
+    /// policy overlaps for zero-downtime key rollover. Called at publication time, so JWKS publishing and local
+    /// signature verification run against the returned public halves and never touch the custodian on the hot path.
     /// </summary>
     /// <param name="keyName">The custodian's name for the logical key whose versions to enumerate.</param>
     /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
     /// <returns>The key's versions, each a public-only <see cref="KeyVersion"/>.</returns>
-    async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
-        string keyName,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        yield return new KeyVersion(await GetPublicKeyAsync(keyName, cancellationToken), DateTimeOffset.MinValue);
-    }
+    IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(string keyName, CancellationToken cancellationToken);
 }

--- a/Abblix.Jwt/IKeyCustodian.cs
+++ b/Abblix.Jwt/IKeyCustodian.cs
@@ -20,6 +20,8 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Runtime.CompilerServices;
+
 namespace Abblix.Jwt;
 
 /// <summary>
@@ -100,4 +102,23 @@ public interface IKeyCustodian
     /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
     /// <returns>The public-only key material for the key.</returns>
     ValueTask<JsonWebKey> GetPublicKeyAsync(string keyId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Enumerates every current version of the key named <paramref name="keyName"/> as its public half, each
+    /// carrying the version-specific <c>kid</c> that routes a private operation back to that exact version, plus
+    /// the custodian's creation time for that version. The default yields the single key returned by
+    /// <see cref="GetPublicKeyAsync"/> with an unset (<see cref="DateTimeOffset.MinValue"/>) creation time, so a
+    /// custodian that does not version its keys needs no change; a version-aware custodian (Vault Transit, Azure
+    /// Key Vault) overrides this to publish every version, which a rotation policy overlaps for zero-downtime
+    /// key rollover.
+    /// </summary>
+    /// <param name="keyName">The custodian's name for the logical key whose versions to enumerate.</param>
+    /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
+    /// <returns>The key's versions, each a public-only <see cref="KeyVersion"/>.</returns>
+    async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+        string keyName,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return new KeyVersion(await GetPublicKeyAsync(keyName, cancellationToken), DateTimeOffset.MinValue);
+    }
 }

--- a/Abblix.Jwt/IKeyCustodian.cs
+++ b/Abblix.Jwt/IKeyCustodian.cs
@@ -104,5 +104,7 @@ public interface IKeyCustodian
     /// <param name="keyName">The custodian's name for the logical key whose versions to enumerate.</param>
     /// <param name="cancellationToken">Cancels the round-trip to the custodian.</param>
     /// <returns>The key's versions, each a public-only <see cref="KeyVersion"/>.</returns>
-    IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(string keyName, CancellationToken cancellationToken);
+    IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+        string keyName,
+        CancellationToken cancellationToken);
 }

--- a/Abblix.Jwt/KeyVersion.cs
+++ b/Abblix.Jwt/KeyVersion.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Jwt;
+
+/// <summary>
+/// One version of a custodian-held key: its public half and when the custodian created that version. The
+/// public key carries the version-specific <c>kid</c> that routes a private operation back to this exact
+/// version, so publishing a key's versions lets a client verify a signature made by any of them and lets the
+/// server unwrap a JWE encrypted to any of them. The creation time is what a rotation policy reads to hold a
+/// freshly minted version as announced-but-not-yet-signing until client JWKS caches catch up (the propagation
+/// window), and to keep a superseded version published until its tokens expire.
+/// </summary>
+/// <param name="PublicKey">The public-only key material for this version, with its version-specific <c>kid</c>.</param>
+/// <param name="CreatedAt">When the custodian created this version. A custodian that does not track a creation
+/// time reports <see cref="DateTimeOffset.MinValue"/>, which a rotation policy treats as "always past the
+/// propagation window", so a single non-rotating key is always eligible to sign.</param>
+public sealed record KeyVersion(JsonWebKey PublicKey, DateTimeOffset CreatedAt);

--- a/Abblix.Jwt/KeyVersion.cs
+++ b/Abblix.Jwt/KeyVersion.cs
@@ -34,4 +34,4 @@ namespace Abblix.Jwt;
 /// <param name="CreatedAt">When the custodian created this version. A custodian that does not track a creation
 /// time reports <see cref="DateTimeOffset.MinValue"/>, which a rotation policy treats as "always past the
 /// propagation window", so a single non-rotating key is always eligible to sign.</param>
-public sealed record KeyVersion(JsonWebKey PublicKey, DateTimeOffset CreatedAt);
+public readonly record struct KeyVersion(JsonWebKey PublicKey, DateTimeOffset CreatedAt);

--- a/Abblix.Jwt/Signing/CompositeSigner.cs
+++ b/Abblix.Jwt/Signing/CompositeSigner.cs
@@ -35,7 +35,7 @@ internal sealed class CompositeSigner(IEnumerable<IDataSigner> backends) : IData
 {
     public bool CanSign(JsonWebKey key) => backends.Any(backend => backend.CanSign(key));
 
-    public ValueTask<byte[]> SignAsync(
+    public Task<byte[]> SignAsync(
         JsonWebKey key,
         string algorithm,
         byte[] data,

--- a/Abblix.Jwt/Signing/ExternalKeySigner.cs
+++ b/Abblix.Jwt/Signing/ExternalKeySigner.cs
@@ -34,7 +34,7 @@ internal sealed class ExternalKeySigner(IKeyCustodian custodian) : IDataSigner
     /// </summary>
     public bool CanSign(JsonWebKey key) => !key.HasPrivateKey;
 
-    public ValueTask<byte[]> SignAsync(
+    public Task<byte[]> SignAsync(
         JsonWebKey key,
         string algorithm,
         byte[] data,

--- a/Abblix.Jwt/Signing/IDataSigner.cs
+++ b/Abblix.Jwt/Signing/IDataSigner.cs
@@ -51,7 +51,7 @@ public interface IDataSigner
     /// <param name="data">The signing input bytes, BASE64URL(header) + '.' + BASE64URL(payload).</param>
     /// <param name="cancellationToken">Cancels the signing operation, including a custodian round-trip.</param>
     /// <returns>The raw signature bytes in JWS wire format for the algorithm.</returns>
-    ValueTask<byte[]> SignAsync(
+    Task<byte[]> SignAsync(
         JsonWebKey key,
         string algorithm,
         byte[] data,

--- a/Abblix.Jwt/Signing/LocalKeySigner.cs
+++ b/Abblix.Jwt/Signing/LocalKeySigner.cs
@@ -38,7 +38,7 @@ internal sealed class LocalKeySigner(IServiceProvider serviceProvider) : IDataSi
     /// </summary>
     public bool CanSign(JsonWebKey key) => key.HasPrivateKey;
 
-    public ValueTask<byte[]> SignAsync(
+    public Task<byte[]> SignAsync(
         JsonWebKey key,
         string algorithm,
         byte[] data,
@@ -60,7 +60,7 @@ internal sealed class LocalKeySigner(IServiceProvider serviceProvider) : IDataSi
             _ => throw new InvalidOperationException($"No signer registered for key type: {key.GetType().Name}"),
         };
 
-        return new ValueTask<byte[]>(signature);
+        return Task.FromResult(signature);
     }
 
     private byte[] SignBy<TJsonWebKey>(TJsonWebKey jwk, string algorithm, byte[] data)

--- a/Abblix.Oidc.Server.AspNetCore/HttpResponseExtensions.cs
+++ b/Abblix.Oidc.Server.AspNetCore/HttpResponseExtensions.cs
@@ -66,4 +66,20 @@ public static class HttpResponseExtensions
         headers.CacheControl = PreventStorageInAnyCache;
         response.Headers.Pragma = CacheControlHeaderValue.NoCacheString;
     }
+
+    /// <summary>
+    /// Advertises a positive cache lifetime for a public, cacheable metadata response - the JWKS endpoint. Sets
+    /// <c>Cache-Control: public, max-age=&lt;maxAge&gt;</c> and clears any <c>Pragma</c> / <c>Expires</c> a
+    /// no-cache policy left behind, so the response carries a single, non-contradictory caching directive. Size
+    /// <paramref name="maxAge"/> to the key-rollover propagation window, so a client honouring the header always
+    /// holds a new signing key's public half before the server produces tokens with it.
+    /// </summary>
+    /// <param name="response">The HTTP response to modify.</param>
+    /// <param name="maxAge">How long a shared or private cache may reuse the response.</param>
+    public static void SetCacheableHeaders(this HttpResponse response, TimeSpan maxAge)
+    {
+        response.GetTypedHeaders().CacheControl = new () { Public = true, MaxAge = maxAge };
+        response.Headers.Pragma = default;
+        response.Headers.Expires = default;
+    }
 }

--- a/Abblix.Oidc.Server.Azure.UnitTests/AddAzureExternalKeysTests.cs
+++ b/Abblix.Oidc.Server.Azure.UnitTests/AddAzureExternalKeysTests.cs
@@ -45,6 +45,11 @@ public class AddAzureExternalKeysTests
             options.EncryptionKeyName = "oidc-enc";
         });
 
+        // The external-keys provider is an add-on to an OIDC server, which supplies the options and the clock via
+        // AddOidcServices. Mirror that minimally here so the provider resolves without the whole OIDC stack.
+        services.AddOptions();
+        services.AddSingleton(TimeProvider.System);
+
         Assert.Contains(services, d => d.ServiceType == typeof(IKeyCustodian));
 
         using var provider = services.BuildServiceProvider();

--- a/Abblix.Oidc.Server.Azure.UnitTests/AzureKeyVaultClientTests.cs
+++ b/Abblix.Oidc.Server.Azure.UnitTests/AzureKeyVaultClientTests.cs
@@ -41,15 +41,23 @@ public class AzureKeyVaultClientTests
     private static AzureKeyVaultClient ClientOver(StubHttpMessageHandler handler)
         => new(new AzureKeyVaultOptions { KeyVaultUri = VaultUri }, new StaticTokenCredential(), new HttpClient(handler));
 
+    private static async Task<JsonWebKey> FirstPublicKeyAsync(IAsyncEnumerable<KeyVersion> versions)
+    {
+        await using var enumerator = versions.GetAsyncEnumerator();
+        if (!await enumerator.MoveNextAsync())
+            throw new InvalidOperationException("The custodian returned no key versions.");
+        return enumerator.Current.PublicKey;
+    }
+
     [Fact]
-    public async Task GetPublicKeyAsync_ImportsAnRsaKeyThroughTheInjectedTransport()
+    public async Task GetKeyVersionsAsync_ImportsAnRsaKeyThroughTheInjectedTransport()
     {
         using var rsa = RSA.Create(2048);
         var expected = rsa.ExportParameters(false);
         var handler = new StubHttpMessageHandler(
             _ => StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyBundle(VaultUri, "oidc-sign", expected)));
 
-        var key = await ClientOver(handler).GetPublicKeyAsync("oidc-sign", TestContext.Current.CancellationToken);
+        var key = await FirstPublicKeyAsync(ClientOver(handler).GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken));
 
         var rsaKey = Assert.IsType<RsaJsonWebKey>(key);
         Assert.Equal(expected.Modulus, rsaKey.Modulus);
@@ -57,13 +65,13 @@ public class AzureKeyVaultClientTests
     }
 
     [Fact]
-    public async Task GetPublicKeyAsync_ImportsAnEcKeyThroughTheInjectedTransport()
+    public async Task GetKeyVersionsAsync_ImportsAnEcKeyThroughTheInjectedTransport()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var handler = new StubHttpMessageHandler(_ => StubHttpMessageHandler.Json(
             HttpStatusCode.OK, AzureResponses.EcKeyBundle(VaultUri, "oidc-sign", ecdsa.ExportParameters(false))));
 
-        var key = await ClientOver(handler).GetPublicKeyAsync("oidc-sign", TestContext.Current.CancellationToken);
+        var key = await FirstPublicKeyAsync(ClientOver(handler).GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken));
 
         var ecKey = Assert.IsType<EllipticCurveJsonWebKey>(key);
         Assert.Equal("P-256", ecKey.Curve);
@@ -102,7 +110,7 @@ public class AzureKeyVaultClientTests
         var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
 
         await Assert.ThrowsAsync<NotSupportedException>(() => ClientOver(handler)
-            .SignAsync("oidc-sign", "HS256", [1], TestContext.Current.CancellationToken).AsTask());
+            .SignAsync("oidc-sign", "HS256", [1], TestContext.Current.CancellationToken));
 
         Assert.Null(handler.LastRequest);
     }

--- a/Abblix.Oidc.Server.Azure.UnitTests/AzureKeyVaultClientTests.cs
+++ b/Abblix.Oidc.Server.Azure.UnitTests/AzureKeyVaultClientTests.cs
@@ -54,8 +54,10 @@ public class AzureKeyVaultClientTests
     {
         using var rsa = RSA.Create(2048);
         var expected = rsa.ExportParameters(false);
-        var handler = new StubHttpMessageHandler(
-            _ => StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyBundle(VaultUri, "oidc-sign", expected)));
+        var handler = new StubHttpMessageHandler(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/versions", StringComparison.Ordinal)
+                ? StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyVersionsList(VaultUri, "oidc-sign", ("v1", 1_700_000_000L)))
+                : StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyBundle(VaultUri, "oidc-sign", expected)));
 
         var key = await FirstPublicKeyAsync(ClientOver(handler).GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken));
 
@@ -68,14 +70,51 @@ public class AzureKeyVaultClientTests
     public async Task GetKeyVersionsAsync_ImportsAnEcKeyThroughTheInjectedTransport()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
-        var handler = new StubHttpMessageHandler(_ => StubHttpMessageHandler.Json(
-            HttpStatusCode.OK, AzureResponses.EcKeyBundle(VaultUri, "oidc-sign", ecdsa.ExportParameters(false))));
+        var handler = new StubHttpMessageHandler(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/versions", StringComparison.Ordinal)
+                ? StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyVersionsList(VaultUri, "oidc-sign", ("v1", 1_700_000_000L)))
+                : StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.EcKeyBundle(VaultUri, "oidc-sign", ecdsa.ExportParameters(false))));
 
         var key = await FirstPublicKeyAsync(ClientOver(handler).GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken));
 
         var ecKey = Assert.IsType<EllipticCurveJsonWebKey>(key);
         Assert.Equal("P-256", ecKey.Curve);
         Assert.False(ecKey.HasPrivateKey);
+    }
+
+    [Fact]
+    public async Task GetKeyVersionsAsync_PublishesEveryEnabledVersion_WithVersionedKidsAndCreationTimes()
+    {
+        using var rsa1 = RSA.Create(2048);
+        using var rsa2 = RSA.Create(2048);
+        var created1 = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000L);
+        var created2 = DateTimeOffset.FromUnixTimeSeconds(1_710_000_000L);
+
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith("/versions", StringComparison.Ordinal))
+                return StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyVersionsList(
+                    VaultUri, "oidc-sign", ("v1", created1.ToUnixTimeSeconds()), ("v2", created2.ToUnixTimeSeconds())));
+
+            // A per-version key fetch: the crypto material of the version the path names. The bundle's own kid is
+            // ignored - the client stamps the kid from the key name and version.
+            var parameters = path.EndsWith("/v1", StringComparison.Ordinal)
+                ? rsa1.ExportParameters(false)
+                : rsa2.ExportParameters(false);
+            return StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyBundle(VaultUri, "oidc-sign", parameters));
+        });
+
+        var versions = new List<KeyVersion>();
+        await foreach (var version in ClientOver(handler).GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken))
+            versions.Add(version);
+
+        Assert.Equal(2, versions.Count);
+        var first = versions.Single(version => version.PublicKey.KeyId == "oidc-sign/v1");
+        var second = versions.Single(version => version.PublicKey.KeyId == "oidc-sign/v2");
+        Assert.Equal(created1, first.CreatedAt);
+        Assert.Equal(created2, second.CreatedAt);
+        Assert.Equal(rsa1.ExportParameters(false).Modulus, Assert.IsType<RsaJsonWebKey>(first.PublicKey).Modulus);
     }
 
     [Fact]

--- a/Abblix.Oidc.Server.Azure.UnitTests/AzureKeyVaultTestDoubles.cs
+++ b/Abblix.Oidc.Server.Azure.UnitTests/AzureKeyVaultTestDoubles.cs
@@ -104,4 +104,17 @@ internal static class AzureResponses
     /// <summary>A sign or decrypt result, both shaped <c>{ kid, value }</c> with a base64url value.</summary>
     public static string CryptoResult(string vaultUri, string keyName, byte[] value)
         => JsonSerializer.Serialize(new { kid = $"{vaultUri}keys/{keyName}/v1", value = Base64Url(value) });
+
+    /// <summary>A "get key versions" page: each version's identifier, creation time (Unix seconds) and enabled
+    /// flag, the shape <c>KeyClient.GetPropertiesOfKeyVersions</c> pages over.</summary>
+    public static string KeyVersionsList(string vaultUri, string keyName, params (string Version, long CreatedUnix)[] versions)
+        => JsonSerializer.Serialize(new
+        {
+            value = versions.Select(version => new
+            {
+                kid = $"{vaultUri}keys/{keyName}/{version.Version}",
+                attributes = new { enabled = true, created = version.CreatedUnix },
+            }).ToArray(),
+            nextLink = (string?)null,
+        });
 }

--- a/Abblix.Oidc.Server.Azure/AzureKeyVaultClient.cs
+++ b/Abblix.Oidc.Server.Azure/AzureKeyVaultClient.cs
@@ -157,16 +157,27 @@ public sealed class AzureKeyVaultClient : IKeyCustodian
             "Azure Key Vault exposes no ECDH key-agreement primitive; ECDH-ES is not supported by this store.");
 
     /// <summary>
-    /// Enumerates the Key Vault key's versions as public-only JWKs (RSA or EC, per the key type). Called at
-    /// publication time, so JWKS publishing and signature verification run locally against the result and never
-    /// touch the vault on the hot path. This build publishes the latest version only; enumerating every version
-    /// for rotation overlap is a forthcoming step.
+    /// Enumerates every enabled version of the Key Vault key as a public-only JWK (RSA or EC, per the key type),
+    /// each carrying the version-specific <c>kid</c> (<c>&lt;name&gt;/&lt;version&gt;</c>) and the version's
+    /// creation time. Key Vault lists version metadata but not the public key, so each version's key is fetched.
+    /// Called at publication time, so JWKS publishing and signature verification run locally against the result
+    /// and never touch the vault on the hot path. The versioned <c>kid</c> is a Key Vault key identifier, which
+    /// the crypto client turns straight back into a versioned URI for sign/unwrap, so no separate handle mapping
+    /// is needed.
     /// </summary>
     public async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
         string keyName, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var key = await _keyClient.GetKeyAsync(keyName, cancellationToken: cancellationToken);
-        yield return new KeyVersion(ImportPublicKey(key.Value.Key), DateTimeOffset.MinValue);
+        await foreach (var properties in _keyClient.GetPropertiesOfKeyVersionsAsync(keyName, cancellationToken))
+        {
+            // A disabled version (rotated out, or not yet enabled) must not be published or produced with.
+            if (properties.Enabled != true)
+                continue;
+
+            var key = await _keyClient.GetKeyAsync(keyName, properties.Version, cancellationToken);
+            var publicKey = ImportPublicKey(key.Value.Key) with { KeyId = $"{keyName}/{properties.Version}" };
+            yield return new KeyVersion(publicKey, properties.CreatedOn ?? DateTimeOffset.MinValue);
+        }
     }
 
     // Imports a Key Vault public key into a public-only JWK of the matching type.

--- a/Abblix.Oidc.Server.Azure/AzureKeyVaultClient.cs
+++ b/Abblix.Oidc.Server.Azure/AzureKeyVaultClient.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Abblix.Jwt;
 using Azure;
 using Azure.Core;
@@ -95,7 +96,7 @@ public sealed class AzureKeyVaultClient : IKeyCustodian
     /// Signs the JWS signing input with a Key Vault key under the given JWS algorithm. Key Vault hashes the data
     /// and returns the raw signature already in JWS wire format (R||S for EC).
     /// </summary>
-    public async ValueTask<byte[]> SignAsync(string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
+    public async Task<byte[]> SignAsync(string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
     {
         var client = GetCryptographyClient(keyId);
         var result = await client.SignDataAsync(MapSignatureAlgorithm(algorithm), data, cancellationToken);
@@ -122,7 +123,7 @@ public sealed class AzureKeyVaultClient : IKeyCustodian
     /// key or tampered ciphertext is indistinguishable, which the seam's padding-oracle mitigation relies on. The
     /// JWE header is unused: an RSA unwrap needs only the ciphertext.
     /// </summary>
-    public async ValueTask<byte[]?> UnwrapKeyAsync(
+    public async Task<byte[]?> UnwrapKeyAsync(
         string keyId, string algorithm, JsonWebTokenHeader header, byte[] encryptedKey, CancellationToken cancellationToken)
     {
         var encryptionAlgorithm = MapEncryptionAlgorithm(algorithm);
@@ -150,21 +151,27 @@ public sealed class AzureKeyVaultClient : IKeyCustodian
     /// Derives the ECDH-ES shared secret. Azure Key Vault exposes no key-agreement primitive, so this store does
     /// not support ECDH-ES; a store built on AWS KMS (DeriveSharedSecret) or a PKCS#11 HSM (CKM_ECDH1_DERIVE) can.
     /// </summary>
-    public ValueTask<byte[]> AgreeKeyAsync(
+    public Task<byte[]> AgreeKeyAsync(
         string keyId, string algorithm, JsonWebKey ephemeralPublicKey, CancellationToken cancellationToken)
         => throw new NotSupportedException(
             "Azure Key Vault exposes no ECDH key-agreement primitive; ECDH-ES is not supported by this store.");
 
     /// <summary>
-    /// Fetches the public half of a Key Vault key as a public-only JWK (RSA or EC, per the key type). Called once
-    /// per key at startup, so JWKS publishing and signature verification run locally against it and never touch
-    /// the vault on the hot path.
+    /// Enumerates the Key Vault key's versions as public-only JWKs (RSA or EC, per the key type). Called at
+    /// publication time, so JWKS publishing and signature verification run locally against the result and never
+    /// touch the vault on the hot path. This build publishes the latest version only; enumerating every version
+    /// for rotation overlap is a forthcoming step.
     /// </summary>
-    public async ValueTask<JsonWebKey> GetPublicKeyAsync(string keyId, CancellationToken cancellationToken)
+    public async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+        string keyName, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var key = await _keyClient.GetKeyAsync(keyId, cancellationToken: cancellationToken);
-        var webKey = key.Value.Key;
+        var key = await _keyClient.GetKeyAsync(keyName, cancellationToken: cancellationToken);
+        yield return new KeyVersion(ImportPublicKey(key.Value.Key), DateTimeOffset.MinValue);
+    }
 
+    // Imports a Key Vault public key into a public-only JWK of the matching type.
+    private static JsonWebKey ImportPublicKey(KeyVault.JsonWebKey webKey)
+    {
         if (webKey.KeyType == KeyVault.KeyType.Ec || webKey.KeyType == KeyVault.KeyType.EcHsm)
         {
             using var ecdsa = webKey.ToECDsa();

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwksCacheTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwksCacheTests.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end guard that the MVC adapter advertises the JWKS endpoint as cacheable with a lifetime equal to the
+/// key-rollover propagation window (<c>OidcOptions.KeyRolloverPropagation</c>, one hour by default). A client
+/// honouring the header is then never staler than that window, which is what makes a signing-key rotation
+/// zero-downtime: the new key's public half is cached before the server starts producing tokens with it. This
+/// pins the deliberate exception to the discovery controller's otherwise no-store metadata policy.
+/// </summary>
+public class JwksCacheTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task Jwks_is_cacheable_for_the_rollover_propagation_window()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync("/.well-known/jwks", TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl!.Public);
+        Assert.Equal(TimeSpan.FromHours(1), cacheControl.MaxAge); // the default KeyRolloverPropagation window
+        Assert.False(cacheControl.NoStore);
+        Assert.False(cacheControl.NoCache);
+    }
+}

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/JwksCacheTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/JwksCacheTests.cs
@@ -1,0 +1,36 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Abblix.Oidc.Server.MinimalApi.E2E.Tests;
+
+/// <summary>
+/// End-to-end guard that the Minimal API adapter advertises the JWKS endpoint as cacheable with a lifetime equal
+/// to the key-rollover propagation window (<c>OidcOptions.KeyRolloverPropagation</c>, one hour by default),
+/// overriding the group-wide no-cache policy for this one endpoint. A client honouring the header is then never
+/// staler than that window, which makes a signing-key rotation zero-downtime.
+/// </summary>
+public sealed class JwksCacheTests(TestFactory factory) : IClassFixture<TestFactory>
+{
+    [Fact]
+    public async Task Jwks_is_cacheable_for_the_rollover_propagation_window()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = TestFactory.BaseAddress,
+        });
+
+        var response = await client.GetAsync("/.well-known/jwks", TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl!.Public);
+        Assert.Equal(TimeSpan.FromHours(1), cacheControl.MaxAge); // the default KeyRolloverPropagation window
+        Assert.False(cacheControl.NoStore);
+        Assert.False(cacheControl.NoCache);
+    }
+}

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
@@ -236,8 +236,8 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
     [Theory]
     [InlineData("/.well-known/openid-configuration")]
     [InlineData("/.well-known/oauth-authorization-server")]
-    [InlineData("/.well-known/jwks")]
-    public async Task Every_oidc_response_is_no_store_like_the_mvc_controllers(string path)
+    // /.well-known/jwks is the deliberate exception: it is public, cacheable metadata (see JwksCacheTests).
+    public async Task Discovery_responses_are_no_store_like_the_mvc_controllers(string path)
     {
         var client = ClientOf(factory);
         var response = await client.GetAsync(path, TestContext.Current.CancellationToken);

--- a/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -468,9 +468,17 @@ public static class EndpointRouteBuilderExtensions
     /// </summary>
     private static async Task<IResult> KeysAsync(
         IAuthServiceKeysProvider serviceKeysProvider,
+        IOptions<OidcOptions> options,
+        HttpResponse response,
         ILogger<IAuthServiceKeysProvider> logger)
     {
         var keys = await serviceKeysProvider.GetPublishedKeysAsync(logger);
+
+        // The JWKS is public, cacheable metadata: advertise a lifetime equal to the key-rollover propagation
+        // window, overriding the group-wide no-cache policy (SetCacheableHeaders clears the Pragma/Expires the
+        // no-cache filter set) for this one endpoint.
+        response.SetCacheableHeaders(options.Value.KeyRolloverPropagation);
+
         return Results.Json(new JsonWebKeySet(keys));
     }
 }

--- a/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
+++ b/Abblix.Oidc.Server.Mvc/Controllers/DiscoveryController.cs
@@ -22,6 +22,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
+using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Common.Interfaces;
@@ -32,6 +33,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using JsonWebKeySet = Abblix.Jwt.JsonWebKeySet;
 
 
@@ -57,7 +59,6 @@ namespace Abblix.Oidc.Server.Mvc.Controllers;
 // steer clients onto attacker infrastructure. A host needing an ungated route (a health probe) adds its own.
 [RequireHttps]
 [ReturnsOidcInvalidRequest]
-[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [SkipStatusCodePages]
 [EnableCors(OidcConstants.CorsPolicyName)]
 [SuppressMessage("SonarLint", "S6934:Route attributes should be specified on the controller", Justification = "All action methods have explicit route templates; class-level route is redundant")]
@@ -82,6 +83,7 @@ public sealed class DiscoveryController : ControllerBase
 	[Produces(MediaTypeNames.Application.Json)]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	[EnabledBy(OidcEndpoints.Configuration)]
+	[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 	public async Task<ActionResult<Abblix.Oidc.Server.Model.ConfigurationResponse>> ConfigurationAsync(
 		[FromServices] IConfigurationHandler handler,
 		[FromServices] IConfigurationResponseFormatter formatter)
@@ -96,6 +98,7 @@ public sealed class DiscoveryController : ControllerBase
 	/// Clients can use these keys to verify the authenticity of identity tokens and access tokens issued by the provider.
 	/// </summary>
 	/// <param name="serviceKeysProvider">Provider for retrieving the service's public key information.</param>
+	/// <param name="options">OIDC options; supplies the key-rollover propagation window used as the JWKS cache lifetime.</param>
 	/// <param name="logger">Logger used to warn if a key still carrying private material is stripped before publication.</param>
 	/// <returns>
 	/// A JSON Web Key Set (JWKS) response in the form of <see cref="JsonWebKeySet"/> if the Keys endpoint is enabled,
@@ -106,9 +109,15 @@ public sealed class DiscoveryController : ControllerBase
 	[EnabledBy(OidcEndpoints.Keys)]
 	public async Task<ActionResult<JsonWebKeySet>> KeysAsync(
 		[FromServices] IAuthServiceKeysProvider serviceKeysProvider,
+		[FromServices] IOptions<OidcOptions> options,
 		[FromServices] ILogger<IAuthServiceKeysProvider> logger)
 	{
 		var keys = await serviceKeysProvider.GetPublishedKeysAsync(logger);
+
+		// The JWKS is public, cacheable metadata: advertise a lifetime equal to the key-rollover propagation
+		// window (the deliberate exception to this controller's otherwise no-store metadata policy).
+		Response.SetCacheableHeaders(options.Value.KeyRolloverPropagation);
+
 		return new JsonWebKeySet(keys);
 	}
 }

--- a/Abblix.Oidc.Server.UnitTests/Features/ExternalKeys/ExternalKeysProviderTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/ExternalKeys/ExternalKeysProviderTests.cs
@@ -20,20 +20,26 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Features.ExternalKeys;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.ExternalKeys;
 
 /// <summary>
-/// Verifies that <see cref="ExternalKeysProvider"/> stamps the configured kid, use and algorithm onto the bare
-/// public key the custodian returns, keeping its runtime type (RSA or EC), and never publishes private material.
+/// Verifies that <see cref="ExternalKeysProvider"/> publishes every version of a custodian key public-only,
+/// stamps the configured use and algorithm while keeping each version's kid, and orders the set produce-first:
+/// the active version (newest past the server's key-rollover propagation window) leads, a freshly rotated version
+/// trails as announced-but-not-yet-signing, and a single non-rotating key is served as-is.
 /// </summary>
 public class ExternalKeysProviderTests
 {
@@ -41,8 +47,9 @@ public class ExternalKeysProviderTests
     public async Task GetSigningKeys_StampsConfiguredAlgorithm_OnAnRsaKey()
     {
         using var rsa = RSA.Create(2048);
-        var provider = ProviderPublishing(
-            "sign-key", new RsaJsonWebKey().Apply(rsa.ExportParameters(false)), SigningAlgorithms.PS256);
+        var custodian = CustodianWith("sign-key", BareVersion(new RsaJsonWebKey().Apply(rsa.ExportParameters(false))));
+        var provider = Provider(custodian, TimeProvider.System, TimeSpan.FromHours(1),
+            signingKeyName: "sign-key", signingAlgorithm: SigningAlgorithms.PS256);
 
         var key = await SingleAsync(provider.GetSigningKeys(), TestContext.Current.CancellationToken);
 
@@ -58,17 +65,18 @@ public class ExternalKeysProviderTests
     public async Task GetSigningKeys_StampsConfiguredAlgorithm_OnAnEcKey()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
-        var provider = ProviderPublishing(
-            "sign-key", new EllipticCurveJsonWebKey().Apply(ecdsa.ExportParameters(false)), SigningAlgorithms.ES256);
+        var custodian = CustodianWith(
+            "sign-key", BareVersion(new EllipticCurveJsonWebKey().Apply(ecdsa.ExportParameters(false))));
+        var provider = Provider(custodian, TimeProvider.System, TimeSpan.FromHours(1),
+            signingKeyName: "sign-key", signingAlgorithm: SigningAlgorithms.ES256);
 
         var key = await SingleAsync(provider.GetSigningKeys(), TestContext.Current.CancellationToken);
 
-        // The provider keeps the store's key type; an EC store key is published as an EC JWK.
+        // The provider keeps the custodian's key type; an EC key is published as an EC JWK.
         Assert.IsType<EllipticCurveJsonWebKey>(key);
         Assert.Equal("sign-key", key.KeyId);
         Assert.Equal(PublicKeyUsages.Signature, key.Usage);
         Assert.Equal(SigningAlgorithms.ES256, key.Algorithm);
-        Assert.True(key.HasPublicKey);
         Assert.False(key.HasPrivateKey);
     }
 
@@ -76,11 +84,9 @@ public class ExternalKeysProviderTests
     public async Task GetEncryptionKeys_StampsConfiguredAlgorithm()
     {
         using var rsa = RSA.Create(2048);
-        var store = new Mock<IKeyCustodian>();
-        store.Setup(s => s.GetPublicKeyAsync("enc-key", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RsaJsonWebKey().Apply(rsa.ExportParameters(false)));
-        var provider = new ExternalKeysProvider(store.Object, new TestKeyConfiguration(
-            "sign-key", SigningAlgorithms.RS256, "enc-key", EncryptionAlgorithms.KeyManagement.RsaOaep));
+        var custodian = CustodianWith("enc-key", BareVersion(new RsaJsonWebKey().Apply(rsa.ExportParameters(false))));
+        var provider = Provider(custodian, TimeProvider.System, TimeSpan.FromHours(1),
+            encryptionKeyName: "enc-key", encryptionAlgorithm: EncryptionAlgorithms.KeyManagement.RsaOaep);
 
         var key = await SingleAsync(provider.GetEncryptionKeys(), TestContext.Current.CancellationToken);
 
@@ -90,25 +96,113 @@ public class ExternalKeysProviderTests
         Assert.False(key.HasPrivateKey);
     }
 
-    private static ExternalKeysProvider ProviderPublishing(string signingKeyName, JsonWebKey publicKey, string signingAlgorithm)
+    [Fact]
+    public async Task GetSigningKeys_PublishesEveryVersion_KeepingEachVersionsKid()
     {
-        var store = new Mock<IKeyCustodian>();
-        store.Setup(s => s.GetPublicKeyAsync(signingKeyName, It.IsAny<CancellationToken>())).ReturnsAsync(publicKey);
-        return new ExternalKeysProvider(store.Object, new TestKeyConfiguration(
-            signingKeyName, signingAlgorithm, "enc-key", EncryptionAlgorithms.KeyManagement.RsaOaep256));
+        var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
+        var custodian = CustodianWith(
+            "sign-key",
+            VersionAt("v1", now - TimeSpan.FromDays(2)),
+            VersionAt("v2", now - TimeSpan.FromHours(1)));
+        var provider = Provider(custodian, TimeAt(now), TimeSpan.FromMinutes(30), signingKeyName: "sign-key");
+
+        var keys = await ToListAsync(provider.GetSigningKeys(), TestContext.Current.CancellationToken);
+
+        // Both versions are published, each carrying the custodian-assigned kid (not the configured key name).
+        Assert.Equal(new[] { "v1", "v2" }, keys.Select(k => k.KeyId).OrderBy(k => k));
+        Assert.All(keys, k => Assert.False(k.HasPrivateKey));
+    }
+
+    [Fact]
+    public async Task GetSigningKeys_ActiveIsNewestPastPropagation_FreshVersionTrailsAsPending()
+    {
+        var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
+        var propagation = TimeSpan.FromMinutes(30);
+
+        var old = VersionAt("v1", now - TimeSpan.FromDays(2));       // long past propagation
+        var active = VersionAt("v2", now - TimeSpan.FromHours(1));   // past propagation, newest such
+        var fresh = VersionAt("v3", now - TimeSpan.FromMinutes(5));  // within the 30-minute window, still pending
+
+        // Custodian enumeration order is irrelevant; the provider imposes the produce-first order.
+        var custodian = CustodianWith("sign-key", fresh, active, old);
+        var provider = Provider(custodian, TimeAt(now), propagation, signingKeyName: "sign-key");
+
+        var keys = await ToListAsync(provider.GetSigningKeys(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, keys.Count); // every version is published for verification and rotation overlap
+        Assert.Equal("v2", keys[0].KeyId); // the produce role signs with the newest version PAST propagation
+        Assert.Contains(keys, k => k.KeyId == "v3"); // the still-propagating version is announced, never leads
+    }
+
+    [Fact]
+    public async Task GetSigningKeys_AllVersionsWithinPropagation_NewestLeads_Bootstrap()
+    {
+        var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
+        var propagation = TimeSpan.FromHours(1);
+
+        var newer = VersionAt("v1", now - TimeSpan.FromMinutes(20));
+        var newest = VersionAt("v2", now - TimeSpan.FromMinutes(2));
+
+        // Both are still inside the window; with no version past propagation the newest overall must lead, so the
+        // very first rollover still has something to sign with. There is no older version a client could hold.
+        var custodian = CustodianWith("sign-key", newer, newest);
+        var provider = Provider(custodian, TimeAt(now), propagation, signingKeyName: "sign-key");
+
+        var keys = await ToListAsync(provider.GetSigningKeys(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, keys.Count);
+        Assert.Equal("v2", keys[0].KeyId);
+    }
+
+    private static ExternalKeysProvider Provider(
+        IKeyCustodian custodian,
+        TimeProvider timeProvider,
+        TimeSpan propagation,
+        string signingKeyName = "sign-key",
+        string signingAlgorithm = SigningAlgorithms.RS256,
+        string encryptionKeyName = "enc-key",
+        string encryptionAlgorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256)
+    {
+        var config = new TestKeyConfiguration(signingKeyName, signingAlgorithm, encryptionKeyName, encryptionAlgorithm);
+        var options = Options.Create(new OidcOptions { KeyRolloverPropagation = propagation });
+        return new ExternalKeysProvider(custodian, config, options, timeProvider);
+    }
+
+    private static IKeyCustodian CustodianWith(string keyName, params KeyVersion[] versions)
+    {
+        var custodian = new Mock<IKeyCustodian>();
+        custodian.Setup(c => c.GetKeyVersionsAsync(keyName, It.IsAny<CancellationToken>()))
+            .Returns(versions.ToAsyncEnumerable());
+        return custodian.Object;
+    }
+
+    // A version with an unset creation time and no kid, standing for a single non-rotating custodian key.
+    private static KeyVersion BareVersion(JsonWebKey publicKey) => new(publicKey, DateTimeOffset.MinValue);
+
+    // A version carrying the custodian-assigned kid and a creation time, for the produce-first ordering tests.
+    private static KeyVersion VersionAt(string kid, DateTimeOffset createdAt)
+    {
+        using var rsa = RSA.Create(2048);
+        var publicKey = new RsaJsonWebKey().Apply(rsa.ExportParameters(false)) with { KeyId = kid };
+        return new KeyVersion(publicKey, createdAt);
     }
 
     private static async Task<JsonWebKey> SingleAsync(IAsyncEnumerable<JsonWebKey> keys, CancellationToken ct)
-    {
-        JsonWebKey? single = null;
-        await foreach (var key in keys.WithCancellation(ct))
-        {
-            Assert.Null(single); // the provider publishes exactly one key per usage
-            single = key;
-        }
+        => Assert.Single(await ToListAsync(keys, ct));
 
-        Assert.NotNull(single);
-        return single;
+    private static async Task<List<JsonWebKey>> ToListAsync(IAsyncEnumerable<JsonWebKey> keys, CancellationToken ct)
+    {
+        var list = new List<JsonWebKey>();
+        await foreach (var key in keys.WithCancellation(ct))
+            list.Add(key);
+        return list;
+    }
+
+    private static TimeProvider TimeAt(DateTimeOffset now)
+    {
+        var timeProvider = new Mock<TimeProvider>();
+        timeProvider.Setup(t => t.GetUtcNow()).Returns(now);
+        return timeProvider.Object;
     }
 
     private sealed record TestKeyConfiguration(

--- a/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
+++ b/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
@@ -245,24 +245,83 @@ public class AuthServiceJwtFormatterTests
     }
 
     /// <summary>
-    /// Verifies that an explicit policy key-management algorithm overrides the key's declared <c>alg</c>.
+    /// Verifies that an explicit policy key-management algorithm selects an algorithm-agnostic encryption key
+    /// (no declared <c>alg</c>, which matches any algorithm per RFC 7517 Section 4.4) and is set as the JWE
+    /// <c>alg</c>. Under the symmetric selection model the policy algorithm drives key selection, so an agnostic
+    /// key is the one a policy algorithm binds to.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_Encrypt_ExplicitPolicyAlgorithmOverridesKeyDeclaredAlgorithm()
+    public async Task FormatAsync_Encrypt_ExplicitPolicyAlgorithmSelectsAgnosticKeyAndSetsHeaderAlgorithm()
     {
         var token = TokenWith();
+        var agnosticKey = new RsaJsonWebKey { KeyId = "enc-agnostic", Algorithm = null };
         SetupSigningKeys(_signingKeyRS256);
-        SetupEncryptionKeys(_encryptionKey); // declares RSA-OAEP
+        SetupEncryptionKeys(agnosticKey);
 
+        JsonWebKey? capturedEncryptionKey = null;
         string? capturedAlg = null;
         _jwtCreator
-            .Setup(c => c.IssueAsync(token, _signingKeyRS256, _encryptionKey, It.IsAny<string>(), ContentEnc))
-            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, _, alg, _) => capturedAlg = alg)
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, agnosticKey, It.IsAny<string>(), ContentEnc))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, alg, _) =>
+            {
+                capturedEncryptionKey = enc;
+                capturedAlg = alg;
+            })
             .ReturnsAsync(EncodedJwt);
 
         await _formatter.FormatAsync(token, Encrypt(EncryptionAlgorithms.KeyManagement.RsaOaep256));
 
+        Assert.Same(agnosticKey, capturedEncryptionKey);
         Assert.Equal(EncryptionAlgorithms.KeyManagement.RsaOaep256, capturedAlg);
+    }
+
+    /// <summary>
+    /// Verifies that a policy key-management algorithm matching no configured encryption key fails loudly
+    /// rather than silently downgrading to a different key or algorithm: a required algorithm is an explicit
+    /// intent, mirroring the pinned-key-id case and the signing side.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_Encrypt_WithUnmatchedPolicyAlgorithm_Throws()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey); // declares RSA-OAEP only
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _formatter.FormatAsync(token, Encrypt(EncryptionAlgorithms.KeyManagement.RsaOaep256)));
+    }
+
+    /// <summary>
+    /// Verifies the produce-side symmetry with signing: among several encryption keys declaring different
+    /// key-management algorithms, the policy's key-management algorithm SELECTS the matching key, not merely
+    /// the first one (RFC 7517 Section 4.4). Mirrors signing-key selection by the token 'alg'.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_Encrypt_SelectsEncryptionKeyByPolicyAlgorithm()
+    {
+        var token = TokenWith();
+        var rsaOaepKey = new RsaJsonWebKey
+        {
+            KeyId = "enc-oaep",
+            Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep,
+        };
+        var rsaOaep256Key = new RsaJsonWebKey
+        {
+            KeyId = "enc-oaep256",
+            Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256,
+        };
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(rsaOaepKey, rsaOaep256Key); // RSA-OAEP first, RSA-OAEP-256 second
+
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, It.IsAny<JsonWebKey?>(), It.IsAny<string>(), ContentEnc))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
+
+        await _formatter.FormatAsync(token, Encrypt(EncryptionAlgorithms.KeyManagement.RsaOaep256));
+
+        Assert.Same(rsaOaep256Key, capturedEncryptionKey);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.Vault.UnitTests/AddVaultExternalKeysTests.cs
+++ b/Abblix.Oidc.Server.Vault.UnitTests/AddVaultExternalKeysTests.cs
@@ -46,6 +46,11 @@ public class AddVaultExternalKeysTests
             options.SigningKeyName = "oidc-sign";
             options.EncryptionKeyName = "oidc-enc";
         });
+
+        // The external-keys provider is an add-on to an OIDC server, which supplies the options and the clock via
+        // AddOidcServices. Mirror that minimally here so the provider resolves without the whole OIDC stack.
+        services.AddOptions();
+        services.AddSingleton(TimeProvider.System);
         return services;
     }
 

--- a/Abblix.Oidc.Server.Vault.UnitTests/VaultTransitClientTests.cs
+++ b/Abblix.Oidc.Server.Vault.UnitTests/VaultTransitClientTests.cs
@@ -99,7 +99,7 @@ public sealed class VaultTransitClientTests : IDisposable
         var client = ClientOver(handler);
 
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => client.SignAsync("oidc-sign", "HS256", [1], TestContext.Current.CancellationToken).AsTask());
+            () => client.SignAsync("oidc-sign", "HS256", [1], TestContext.Current.CancellationToken));
 
         Assert.Null(handler.LastRequest);
     }
@@ -146,7 +146,7 @@ public sealed class VaultTransitClientTests : IDisposable
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.UnwrapKeyAsync(
             "oidc-enc", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
-            [1], TestContext.Current.CancellationToken).AsTask());
+            [1], TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -157,20 +157,20 @@ public sealed class VaultTransitClientTests : IDisposable
 
         await Assert.ThrowsAsync<NotSupportedException>(() => client.UnwrapKeyAsync(
             "oidc-enc", EncryptionAlgorithms.KeyManagement.Rsa1_5, new JsonWebTokenHeader(new JsonObject()),
-            [1], TestContext.Current.CancellationToken).AsTask());
+            [1], TestContext.Current.CancellationToken));
 
         Assert.Null(handler.LastRequest);
     }
 
     [Fact]
-    public async Task GetPublicKeyAsync_ImportsLatestVersion_OfAnRsaKey()
+    public async Task GetKeyVersionsAsync_ImportsLatestVersion_OfAnRsaKey()
     {
         using var rsa = RSA.Create(2048);
         var expected = rsa.ExportParameters(false);
         var handler = KeyResponse("rsa-2048", rsa.ExportSubjectPublicKeyInfoPem());
         var client = ClientOver(handler);
 
-        var key = await client.GetPublicKeyAsync("oidc-sign", TestContext.Current.CancellationToken);
+        var key = await FirstPublicKeyAsync(client.GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken));
 
         var rsaKey = Assert.IsType<RsaJsonWebKey>(key);
         Assert.Equal(expected.Modulus, rsaKey.Modulus);
@@ -178,13 +178,13 @@ public sealed class VaultTransitClientTests : IDisposable
     }
 
     [Fact]
-    public async Task GetPublicKeyAsync_ImportsLatestVersion_OfAnEcKey()
+    public async Task GetKeyVersionsAsync_ImportsLatestVersion_OfAnEcKey()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var handler = KeyResponse("ecdsa-p256", ecdsa.ExportSubjectPublicKeyInfoPem());
         var client = ClientOver(handler);
 
-        var key = await client.GetPublicKeyAsync("oidc-sign", TestContext.Current.CancellationToken);
+        var key = await FirstPublicKeyAsync(client.GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken));
 
         var ecKey = Assert.IsType<EllipticCurveJsonWebKey>(key);
         Assert.Equal("P-256", ecKey.Curve);
@@ -203,4 +203,12 @@ public sealed class VaultTransitClientTests : IDisposable
                     keys = new Dictionary<string, object> { ["1"] = new { public_key = publicKeyPem } },
                 },
             }));
+
+    private static async Task<JsonWebKey> FirstPublicKeyAsync(IAsyncEnumerable<KeyVersion> versions)
+    {
+        await using var enumerator = versions.GetAsyncEnumerator();
+        if (!await enumerator.MoveNextAsync())
+            throw new InvalidOperationException("The custodian returned no key versions.");
+        return enumerator.Current.PublicKey;
+    }
 }

--- a/Abblix.Oidc.Server.Vault.UnitTests/VaultTransitClientTests.cs
+++ b/Abblix.Oidc.Server.Vault.UnitTests/VaultTransitClientTests.cs
@@ -34,10 +34,25 @@ namespace Abblix.Oidc.Server.Vault.UnitTests;
 /// EC sign request shapes, the <c>vault:v&lt;n&gt;:</c> envelope framing, the 400-to-null decryption semantics,
 /// the algorithm gate, and the RSA / EC public-key import.
 /// </summary>
-public class VaultTransitClientTests
+public sealed class VaultTransitClientTests : IDisposable
 {
-    private static VaultTransitClient ClientOver(StubHttpMessageHandler handler)
-        => new(new HttpClient(handler) { BaseAddress = new Uri("https://vault.test/v1/transit/") });
+    // Each test builds a client over a stub transport. In production IHttpClientFactory owns the HttpClient and
+    // VaultTransitClient deliberately does not dispose it (a typed client never owns the factory's handler), so
+    // here the test owns that lifetime: track every created HttpClient and dispose them at test-class teardown.
+    private readonly List<HttpClient> _httpClients = [];
+
+    private VaultTransitClient ClientOver(StubHttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://vault.test/v1/transit/") };
+        _httpClients.Add(httpClient);
+        return new VaultTransitClient(httpClient);
+    }
+
+    public void Dispose()
+    {
+        foreach (var httpClient in _httpClients)
+            httpClient.Dispose();
+    }
 
     [Fact]
     public async Task SignAsync_Rs256_PostsPkcs1v15Sha256_AndStripsVersionPrefix()

--- a/Abblix.Oidc.Server.Vault.UnitTests/VaultTransitClientTests.cs
+++ b/Abblix.Oidc.Server.Vault.UnitTests/VaultTransitClientTests.cs
@@ -63,7 +63,7 @@ public sealed class VaultTransitClientTests : IDisposable
         var client = ClientOver(handler);
 
         var data = "\t\t"u8.ToArray();
-        var result = await client.SignAsync("oidc-sign", SigningAlgorithms.RS256, data, TestContext.Current.CancellationToken);
+        var result = await client.SignAsync("oidc-sign:2", SigningAlgorithms.RS256, data, TestContext.Current.CancellationToken);
 
         Assert.Equal(signature, result);
         using var body = JsonDocument.Parse(handler.LastRequestBody!);
@@ -72,6 +72,7 @@ public sealed class VaultTransitClientTests : IDisposable
         Assert.Equal("pkcs1v15", root.GetProperty("signature_algorithm").GetString());
         Assert.Equal("sha2-256", root.GetProperty("hash_algorithm").GetString());
         Assert.False(root.GetProperty("prehashed").GetBoolean());
+        Assert.Equal(2, root.GetProperty("key_version").GetInt32()); // the version the kid pins
     }
 
     [Fact]
@@ -82,13 +83,14 @@ public sealed class VaultTransitClientTests : IDisposable
             HttpStatusCode.OK, new { data = new { signature = $"vault:v1:{Convert.ToBase64String(signature)}" } }));
         var client = ClientOver(handler);
 
-        var result = await client.SignAsync("oidc-sign", SigningAlgorithms.ES256, [1], TestContext.Current.CancellationToken);
+        var result = await client.SignAsync("oidc-sign:4", SigningAlgorithms.ES256, [1], TestContext.Current.CancellationToken);
 
         Assert.Equal(signature, result);
         using var body = JsonDocument.Parse(handler.LastRequestBody!);
         var root = body.RootElement;
         Assert.Equal("jws", root.GetProperty("marshaling_algorithm").GetString());
         Assert.Equal("sha2-256", root.GetProperty("hash_algorithm").GetString());
+        Assert.Equal(4, root.GetProperty("key_version").GetInt32());
         Assert.False(root.TryGetProperty("signature_algorithm", out _)); // EC has no signature_algorithm
     }
 
@@ -99,7 +101,7 @@ public sealed class VaultTransitClientTests : IDisposable
         var client = ClientOver(handler);
 
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => client.SignAsync("oidc-sign", "HS256", [1], TestContext.Current.CancellationToken));
+            () => client.SignAsync("oidc-sign:1", "HS256", [1], TestContext.Current.CancellationToken));
 
         Assert.Null(handler.LastRequest);
     }
@@ -114,12 +116,12 @@ public sealed class VaultTransitClientTests : IDisposable
 
         var ciphertext = new byte[] { 5, 5 };
         var result = await client.UnwrapKeyAsync(
-            "oidc-enc", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
+            "oidc-enc:3", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
             ciphertext, TestContext.Current.CancellationToken);
 
         Assert.Equal(plaintext, result);
         using var body = JsonDocument.Parse(handler.LastRequestBody!);
-        Assert.Equal("vault:v1:" + Convert.ToBase64String(ciphertext),
+        Assert.Equal("vault:v3:" + Convert.ToBase64String(ciphertext), // the kid's version frames the ciphertext
             body.RootElement.GetProperty("ciphertext").GetString());
     }
 
@@ -131,7 +133,7 @@ public sealed class VaultTransitClientTests : IDisposable
         var client = ClientOver(handler);
 
         var result = await client.UnwrapKeyAsync(
-            "oidc-enc", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
+            "oidc-enc:1", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
             [1], TestContext.Current.CancellationToken);
 
         Assert.Null(result);
@@ -145,7 +147,7 @@ public sealed class VaultTransitClientTests : IDisposable
         var client = ClientOver(handler);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.UnwrapKeyAsync(
-            "oidc-enc", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
+            "oidc-enc:1", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
             [1], TestContext.Current.CancellationToken));
     }
 
@@ -156,7 +158,7 @@ public sealed class VaultTransitClientTests : IDisposable
         var client = ClientOver(handler);
 
         await Assert.ThrowsAsync<NotSupportedException>(() => client.UnwrapKeyAsync(
-            "oidc-enc", EncryptionAlgorithms.KeyManagement.Rsa1_5, new JsonWebTokenHeader(new JsonObject()),
+            "oidc-enc:1", EncryptionAlgorithms.KeyManagement.Rsa1_5, new JsonWebTokenHeader(new JsonObject()),
             [1], TestContext.Current.CancellationToken));
 
         Assert.Null(handler.LastRequest);
@@ -191,6 +193,53 @@ public sealed class VaultTransitClientTests : IDisposable
         Assert.False(ecKey.HasPrivateKey);
     }
 
+    [Fact]
+    public async Task GetKeyVersionsAsync_PublishesEveryVersion_WithVersionedKidsAndCreationTimes()
+    {
+        using var rsa1 = RSA.Create(2048);
+        using var rsa2 = RSA.Create(2048);
+        var handler = new StubHttpMessageHandler((_, _) => StubHttpMessageHandler.Json(
+            HttpStatusCode.OK,
+            new
+            {
+                data = new
+                {
+                    type = "rsa-2048",
+                    latest_version = 2,
+                    keys = new Dictionary<string, object>
+                    {
+                        ["1"] = new { public_key = rsa1.ExportSubjectPublicKeyInfoPem(), creation_time = "2026-01-01T00:00:00Z" },
+                        ["2"] = new { public_key = rsa2.ExportSubjectPublicKeyInfoPem(), creation_time = "2026-02-01T00:00:00Z" },
+                    },
+                },
+            }));
+        var client = ClientOver(handler);
+
+        var versions = new List<KeyVersion>();
+        await foreach (var version in client.GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken))
+            versions.Add(version);
+
+        Assert.Equal(2, versions.Count);
+        var first = versions.Single(version => version.PublicKey.KeyId == "oidc-sign:1");
+        var second = versions.Single(version => version.PublicKey.KeyId == "oidc-sign:2");
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), first.CreatedAt);
+        Assert.Equal(new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero), second.CreatedAt);
+        Assert.All(versions, version => Assert.IsType<RsaJsonWebKey>(version.PublicKey));
+    }
+
+    [Fact]
+    public async Task SignAsync_RejectsKeyIdWithoutVersion()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => StubHttpMessageHandler.Json(HttpStatusCode.OK, new { }));
+        var client = ClientOver(handler);
+
+        // A kid without the ":<version>" the enumeration stamps cannot address a Transit version, so it fails loud.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.SignAsync("oidc-sign", SigningAlgorithms.RS256, [1], TestContext.Current.CancellationToken));
+
+        Assert.Null(handler.LastRequest);
+    }
+
     private static StubHttpMessageHandler KeyResponse(string keyType, string publicKeyPem)
         => new((_, _) => StubHttpMessageHandler.Json(
             HttpStatusCode.OK,
@@ -200,7 +249,10 @@ public sealed class VaultTransitClientTests : IDisposable
                 {
                     type = keyType,
                     latest_version = 1,
-                    keys = new Dictionary<string, object> { ["1"] = new { public_key = publicKeyPem } },
+                    keys = new Dictionary<string, object>
+                    {
+                        ["1"] = new { public_key = publicKeyPem, creation_time = "2026-01-01T00:00:00Z" },
+                    },
                 },
             }));
 

--- a/Abblix.Oidc.Server.Vault/VaultTransitClient.cs
+++ b/Abblix.Oidc.Server.Vault/VaultTransitClient.cs
@@ -23,6 +23,7 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Abblix.Jwt;
@@ -43,7 +44,7 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
     /// R||S already, with no ASN.1 conversion. Transit hashes the input itself (<c>prehashed: false</c>). Returns
     /// the raw JWS signature bytes after stripping Transit's <c>vault:v&lt;n&gt;:</c> version prefix.
     /// </summary>
-    public async ValueTask<byte[]> SignAsync(
+    public async Task<byte[]> SignAsync(
         string keyId,
         string algorithm,
         byte[] data,
@@ -92,7 +93,7 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
     /// ciphertext is indistinguishable, which the seam's padding-oracle mitigation depends on; a 403/5xx (bad
     /// token, sealed Vault) still throws. The JWE header is unused: RSA-OAEP unwrap needs only the ciphertext.
     /// </summary>
-    public async ValueTask<byte[]?> UnwrapKeyAsync(
+    public async Task<byte[]?> UnwrapKeyAsync(
         string keyId,
         string algorithm,
         JsonWebTokenHeader header,
@@ -123,7 +124,7 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
     /// Derives the ECDH-ES shared secret. Vault Transit exposes no key-agreement primitive, so this store does not
     /// support ECDH-ES; a store built on AWS KMS (DeriveSharedSecret) or a PKCS#11 HSM (CKM_ECDH1_DERIVE) can.
     /// </summary>
-    public ValueTask<byte[]> AgreeKeyAsync(
+    public Task<byte[]> AgreeKeyAsync(
         string keyId, string algorithm, JsonWebKey ephemeralPublicKey, CancellationToken cancellationToken)
         => throw new NotSupportedException(
             "Vault Transit exposes no ECDH key-agreement primitive; ECDH-ES is not supported by this store.");
@@ -139,19 +140,28 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
     }
 
     /// <summary>
-    /// Fetches the public half of a Transit key as a public-only JWK (RSA or EC, per the Transit key type).
-    /// Transit returns it as a PEM (SubjectPublicKeyInfo). Called once per key at startup: the public key is a
-    /// durable artifact captured at generation, so JWKS publishing and signature verification run locally against
-    /// it and never touch this client on the hot path.
+    /// Enumerates the Transit key's versions as public-only JWKs (RSA or EC, per the Transit key type). Transit
+    /// returns each version's public half as a PEM (SubjectPublicKeyInfo). Called at publication time, so JWKS
+    /// publishing and signature verification run locally against the result and never touch this client on the
+    /// hot path. This build publishes the latest version only; enumerating every version for rotation overlap is
+    /// a forthcoming step.
     /// </summary>
-    public async ValueTask<JsonWebKey> GetPublicKeyAsync(string keyId, CancellationToken cancellationToken)
+    public async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+        string keyName,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        using var document = await SendAsync(HttpMethod.Get, $"keys/{keyId}", body: null, cancellationToken);
+        using var document = await SendAsync(HttpMethod.Get, $"keys/{keyName}", body: null, cancellationToken);
         var data = document.RootElement.GetProperty("data");
         var keyType = data.GetProperty("type").GetString()!;
         var latestVersion = data.GetProperty("latest_version").GetInt32().ToString(CultureInfo.InvariantCulture);
         var pem = data.GetProperty("keys").GetProperty(latestVersion).GetProperty("public_key").GetString()!;
 
+        yield return new KeyVersion(ImportPublicKey(keyType, pem), DateTimeOffset.MinValue);
+    }
+
+    // Imports a Transit public key PEM (SubjectPublicKeyInfo) into a public-only JWK of the matching type.
+    private static JsonWebKey ImportPublicKey(string keyType, string pem)
+    {
         if (keyType.StartsWith(KeyFamilyTypes.Ecdsa, StringComparison.Ordinal))
         {
             using var ecdsa = ECDsa.Create();

--- a/Abblix.Oidc.Server.Vault/VaultTransitClient.cs
+++ b/Abblix.Oidc.Server.Vault/VaultTransitClient.cs
@@ -50,9 +50,10 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
         byte[] data,
         CancellationToken cancellationToken)
     {
-        var request = BuildSignRequest(Convert.ToBase64String(data), algorithm);
+        var (name, version) = ParseKeyId(keyId);
+        var request = BuildSignRequest(Convert.ToBase64String(data), algorithm, version);
 
-        using var document = await SendAsync(HttpMethod.Post, $"sign/{keyId}", request, cancellationToken);
+        using var document = await SendAsync(HttpMethod.Post, $"sign/{name}", request, cancellationToken);
         var signature = document.RootElement.GetProperty("data").GetProperty("signature").GetString()!;
 
         // Transit returns "vault:v<version>:<base64(signature)>"; the wire signature is the last segment.
@@ -68,30 +69,34 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
     private const string Sha2With512 = "sha2-512";
     private const string JwsMarshaling = "jws";
 
-    // Maps a JWS algorithm to the Transit sign request; an unmapped algorithm is rejected.
-    private static object BuildSignRequest(string input, string algorithm) => algorithm switch
+    // Maps a JWS algorithm to the Transit sign request pinned to the given key version; an unmapped algorithm is
+    // rejected. key_version pins the exact version the kid names, so the produce role signs with the active
+    // version even when a newer version is already published but still propagating.
+    private static object BuildSignRequest(string input, string algorithm, int version) => algorithm switch
     {
-        SigningAlgorithms.RS256 => new { input, prehashed = false, hash_algorithm = Sha2With256, signature_algorithm = Pkcs1V15 },
-        SigningAlgorithms.RS384 => new { input, prehashed = false, hash_algorithm = Sha2With384, signature_algorithm = Pkcs1V15 },
-        SigningAlgorithms.RS512 => new { input, prehashed = false, hash_algorithm = Sha2With512, signature_algorithm = Pkcs1V15 },
+        SigningAlgorithms.RS256 => new { input, prehashed = false, hash_algorithm = Sha2With256, signature_algorithm = Pkcs1V15, key_version = version },
+        SigningAlgorithms.RS384 => new { input, prehashed = false, hash_algorithm = Sha2With384, signature_algorithm = Pkcs1V15, key_version = version },
+        SigningAlgorithms.RS512 => new { input, prehashed = false, hash_algorithm = Sha2With512, signature_algorithm = Pkcs1V15, key_version = version },
 
-        SigningAlgorithms.PS256 => new { input, prehashed = false, hash_algorithm = Sha2With256, signature_algorithm = Pss },
-        SigningAlgorithms.PS384 => new { input, prehashed = false, hash_algorithm = Sha2With384, signature_algorithm = Pss },
-        SigningAlgorithms.PS512 => new { input, prehashed = false, hash_algorithm = Sha2With512, signature_algorithm = Pss },
+        SigningAlgorithms.PS256 => new { input, prehashed = false, hash_algorithm = Sha2With256, signature_algorithm = Pss, key_version = version },
+        SigningAlgorithms.PS384 => new { input, prehashed = false, hash_algorithm = Sha2With384, signature_algorithm = Pss, key_version = version },
+        SigningAlgorithms.PS512 => new { input, prehashed = false, hash_algorithm = Sha2With512, signature_algorithm = Pss, key_version = version },
 
-        SigningAlgorithms.ES256 => new { input, prehashed = false, hash_algorithm = Sha2With256, marshaling_algorithm = JwsMarshaling },
-        SigningAlgorithms.ES384 => new { input, prehashed = false, hash_algorithm = Sha2With384, marshaling_algorithm = JwsMarshaling },
-        SigningAlgorithms.ES512 => new { input, prehashed = false, hash_algorithm = Sha2With512, marshaling_algorithm = JwsMarshaling },
+        SigningAlgorithms.ES256 => new { input, prehashed = false, hash_algorithm = Sha2With256, marshaling_algorithm = JwsMarshaling, key_version = version },
+        SigningAlgorithms.ES384 => new { input, prehashed = false, hash_algorithm = Sha2With384, marshaling_algorithm = JwsMarshaling, key_version = version },
+        SigningAlgorithms.ES512 => new { input, prehashed = false, hash_algorithm = Sha2With512, marshaling_algorithm = JwsMarshaling, key_version = version },
 
         _ => throw new NotSupportedException($"The Vault Transit store does not sign '{algorithm}'."),
     };
 
     /// <summary>
     /// Unwraps (decrypts) an RSA-OAEP-256 Content Encryption Key with a Transit RSA key (the only key-management
-    /// algorithm Transit's RSA decrypt provisions). A standard JWE ciphertext is addressed by framing it as
-    /// <c>vault:v1:&lt;base64&gt;</c>. Returns null on a decryption failure (HTTP 400) so a wrong key or tampered
-    /// ciphertext is indistinguishable, which the seam's padding-oracle mitigation depends on; a 403/5xx (bad
-    /// token, sealed Vault) still throws. The JWE header is unused: RSA-OAEP unwrap needs only the ciphertext.
+    /// algorithm Transit's RSA decrypt provisions). Transit reads the key version from the ciphertext framing, so
+    /// the standard JWE ciphertext is framed as <c>vault:v&lt;version&gt;:&lt;base64&gt;</c> with the version the
+    /// <c>kid</c> names, addressing the exact version that wrapped the CEK. Returns null on a decryption failure
+    /// (HTTP 400) so a wrong key or tampered ciphertext is indistinguishable, which the seam's padding-oracle
+    /// mitigation depends on; a 403/5xx (bad token, sealed Vault) still throws. The JWE header is unused: RSA-OAEP
+    /// unwrap needs only the ciphertext.
     /// </summary>
     public async Task<byte[]?> UnwrapKeyAsync(
         string keyId,
@@ -104,17 +109,16 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
             throw new NotSupportedException(
                 $"The Vault Transit store unwraps {EncryptionAlgorithms.KeyManagement.RsaOaep256} only; got '{algorithm}'.");
 
-        // A key that never rotates has only version v1. A rotating production custodian records which version
-        // wrapped each CEK and frames the prefix with that version instead of a constant.
-        var request = new { ciphertext = $"vault:v1:{Convert.ToBase64String(encryptedKey)}" };
+        var (name, version) = ParseKeyId(keyId);
+        var request = new { ciphertext = $"vault:v{version}:{Convert.ToBase64String(encryptedKey)}" };
 
-        var (status, document) = await TrySendAsync(HttpMethod.Post, $"decrypt/{keyId}", request, cancellationToken);
+        var (status, document) = await TrySendAsync(HttpMethod.Post, $"decrypt/{name}", request, cancellationToken);
         using (document)
         {
             if (status == HttpStatusCode.BadRequest)
                 return null;
 
-            EnsureSuccess(status, document, $"decrypt/{keyId}");
+            EnsureSuccess(status, document, $"decrypt/{name}");
             var plaintext = document!.RootElement.GetProperty("data").GetProperty("plaintext").GetString()!;
             return Convert.FromBase64String(plaintext);
         }
@@ -140,11 +144,11 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
     }
 
     /// <summary>
-    /// Enumerates the Transit key's versions as public-only JWKs (RSA or EC, per the Transit key type). Transit
-    /// returns each version's public half as a PEM (SubjectPublicKeyInfo). Called at publication time, so JWKS
-    /// publishing and signature verification run locally against the result and never touch this client on the
-    /// hot path. This build publishes the latest version only; enumerating every version for rotation overlap is
-    /// a forthcoming step.
+    /// Enumerates every version of the Transit key as a public-only JWK (RSA or EC, per the Transit key type),
+    /// each carrying the version-specific <c>kid</c> (<c>&lt;name&gt;:&lt;version&gt;</c>) and the version's
+    /// creation time. Transit returns each version's public half as a PEM (SubjectPublicKeyInfo). Called at
+    /// publication time, so JWKS publishing and signature verification run locally against the result and never
+    /// touch this client on the hot path.
     /// </summary>
     public async IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
         string keyName,
@@ -153,10 +157,32 @@ public sealed class VaultTransitClient(HttpClient httpClient) : IKeyCustodian
         using var document = await SendAsync(HttpMethod.Get, $"keys/{keyName}", body: null, cancellationToken);
         var data = document.RootElement.GetProperty("data");
         var keyType = data.GetProperty("type").GetString()!;
-        var latestVersion = data.GetProperty("latest_version").GetInt32().ToString(CultureInfo.InvariantCulture);
-        var pem = data.GetProperty("keys").GetProperty(latestVersion).GetProperty("public_key").GetString()!;
 
-        yield return new KeyVersion(ImportPublicKey(keyType, pem), DateTimeOffset.MinValue);
+        // Transit returns every version under "keys" as { "<version>": { public_key, creation_time } }. Publish
+        // them all so a rotation overlaps; the kid names the version so a later sign/unwrap addresses it exactly.
+        foreach (var version in data.GetProperty("keys").EnumerateObject())
+        {
+            var pem = version.Value.GetProperty("public_key").GetString()!;
+            var createdAt = DateTimeOffset.Parse(
+                version.Value.GetProperty("creation_time").GetString()!,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind);
+            var publicKey = ImportPublicKey(keyType, pem) with { KeyId = $"{keyName}:{version.Name}" };
+            yield return new KeyVersion(publicKey, createdAt);
+        }
+    }
+
+    // The published kid is "<transit key name>:<version>"; split it to address the Transit key and pin the
+    // version for a private operation. Transit key names contain no colon, so the last colon is the separator.
+    private static (string Name, int Version) ParseKeyId(string keyId)
+    {
+        var separator = keyId.LastIndexOf(':');
+        if (separator > 0 && int.TryParse(
+                keyId.AsSpan(separator + 1), NumberStyles.None, CultureInfo.InvariantCulture, out var version))
+            return (keyId[..separator], version);
+
+        throw new InvalidOperationException(
+            $"Malformed external key id '{keyId}'; expected '<name>:<version>' from GetKeyVersionsAsync.");
     }
 
     // Imports a Transit public key PEM (SubjectPublicKeyInfo) into a public-only JWK of the matching type.

--- a/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -156,6 +156,19 @@ public record OidcOptions
 	public IReadOnlyCollection<JsonWebKey> EncryptionKeys { get; set; } = [];
 
 	/// <summary>
+	/// The key-rollover propagation window: how long a newly published signing or encryption key is served at the
+	/// JWKS endpoint before the server begins producing tokens with it, giving client JWKS caches time to pick it
+	/// up so a rotation never causes a verification or decryption failure. This single value is the server's
+	/// source of truth for rollover timing: the JWKS endpoint derives its <c>Cache-Control</c> max-age from it
+	/// (so a client honouring the header is never staler than this window), and a key provider that rotates keys
+	/// dynamically (for example the external-custodian provider addressing a versioned HSM/KMS key) holds a freshly
+	/// rotated key as announced-but-not-yet-signing for this long. Size it to at least the longest a client may
+	/// cache the JWKS. A static, non-rotating key set is unaffected by the activation gate but still gets this as
+	/// the advertised JWKS cache lifetime. Defaults to one hour.
+	/// </summary>
+	public TimeSpan KeyRolloverPropagation { get; set; } = TimeSpan.FromHours(1);
+
+	/// <summary>
 	/// The default content encryption algorithm used for encrypting JWT tokens.
 	/// Per RFC 7518 Section 5, specifies how the JWT payload is encrypted using the Content Encryption Key (CEK).
 	/// Common values: A256CBC-HS512, A128CBC-HS256, A256GCM, A128GCM.

--- a/Abblix.Oidc.Server/Features/ExternalKeys/ExternalKeysProvider.cs
+++ b/Abblix.Oidc.Server/Features/ExternalKeys/ExternalKeysProvider.cs
@@ -94,14 +94,17 @@ public sealed class ExternalKeysProvider(
         var now = timeProvider.GetUtcNow();
         var propagation = options.Value.KeyRolloverPropagation;
 
-        var active = versions
-            .Where(version => now - version.CreatedAt >= propagation)
-            .OrderByDescending(version => version.CreatedAt)
-            .FirstOrDefault()
-            ?? versions.OrderByDescending(version => version.CreatedAt).First();
+        // Sort newest-first, then lead with the active version: the newest one already past the propagation
+        // window, or the newest overall if none has cleared it yet (bootstrap, the very first rollover). The rest
+        // keep newest-first order. Selection is index-based rather than by reference, since KeyVersion is a value
+        // type for which ReferenceEquals is meaningless.
+        var byNewest = versions.OrderByDescending(version => version.CreatedAt).ToList();
+        var activeIndex = byNewest.FindIndex(version => propagation <= now - version.CreatedAt);
+        if (activeIndex < 0)
+            activeIndex = 0;
 
-        return versions
-            .OrderByDescending(version => ReferenceEquals(version, active))
-            .ThenByDescending(version => version.CreatedAt);
+        return byNewest.Skip(activeIndex).Take(1)
+            .Concat(byNewest.Take(activeIndex))
+            .Concat(byNewest.Skip(activeIndex + 1));
     }
 }

--- a/Abblix.Oidc.Server/Features/ExternalKeys/ExternalKeysProvider.cs
+++ b/Abblix.Oidc.Server/Features/ExternalKeys/ExternalKeysProvider.cs
@@ -20,58 +20,88 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Runtime.CompilerServices;
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Interfaces;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.ExternalKeys;
 
 /// <summary>
 /// Publishes the public halves of an <see cref="IKeyCustodian"/>'s signing and encryption keys to the OIDC
-/// pipeline. It never returns private material: each key is public-only, which is precisely the signal the crypto
-/// seam reads to route the private operation to the custodian by <c>kid</c>. The same public keys back the
-/// <c>/jwks</c> endpoint and local signature verification. One provider serves any custodian, so the Vault and Azure
-/// packages carry no key provider of their own.
+/// pipeline, one entry per current key version. It never returns private material: each key is public-only, which
+/// is the signal the crypto seam reads to route the private operation to the custodian by <c>kid</c>.
+/// Version-awareness rides the produce/publish split of <see cref="IAuthServiceKeysProvider"/>: every version is
+/// published (so a client can verify a signature or encrypt a JWE to any of them, and a rotation overlaps), while
+/// the ACTIVE version - the newest one past the server's <see cref="OidcOptions.KeyRolloverPropagation"/> window -
+/// leads the set, so the produce role signs and encrypts with it. A freshly rotated version stays announced
+/// (published, trailing) until it clears the window, so a client that has not refreshed its JWKS cache never sees
+/// a token produced with a version it lacks. One provider serves any custodian, so the Vault and Azure packages
+/// carry no key provider of their own.
 /// </summary>
-public sealed class ExternalKeysProvider(IKeyCustodian custodian, IExternalKeyConfiguration configuration)
+public sealed class ExternalKeysProvider(
+    IKeyCustodian custodian,
+    IExternalKeyConfiguration configuration,
+    IOptions<OidcOptions> options,
+    TimeProvider timeProvider)
     : IAuthServiceKeysProvider
 {
-    private JsonWebKey? _signingKey;
+    /// <inheritdoc />
+    public IAsyncEnumerable<JsonWebKey> GetSigningKeys(bool includePrivateKeys = false)
+        => PublishAsync(configuration.SigningKeyName, PublicKeyUsages.Signature, configuration.SigningAlgorithm);
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<JsonWebKey> GetSigningKeys(bool includePrivateKeys = false)
+    public IAsyncEnumerable<JsonWebKey> GetEncryptionKeys(bool includePrivateKeys = false)
+        => PublishAsync(configuration.EncryptionKeyName, PublicKeyUsages.Encryption, configuration.EncryptionAlgorithm);
+
+    // Note: this lists the custodian's key versions on every call. Versions change on human timescales (a
+    // rotation), so a production deployment caches the enumeration for a short lifetime and recomputes only the
+    // produce-first ordering (cheap and time-dependent) per call. It is left uncached here to keep the seam
+    // obvious; a host layers its own caching over this provider.
+    private async IAsyncEnumerable<JsonWebKey> PublishAsync(
+        string keyName,
+        string usage,
+        string algorithm,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var publicKey = await custodian.GetPublicKeyAsync(configuration.SigningKeyName, CancellationToken.None);
+        var versions = await custodian.GetKeyVersionsAsync(keyName, cancellationToken).ToListAsync(cancellationToken);
 
-        // The custodian returns bare public-key material (RSA or EC); stamp the kid (= the store key name, the
-        // custodian's handle), the use and the configured algorithm. record `with` keeps the runtime key type, so
-        // this is correct for both RsaJsonWebKey and EllipticCurveJsonWebKey.
-        _signingKey ??= publicKey with
+        // Stamp the use and the configured algorithm on each version's bare public key (RSA or EC); keep the
+        // version-specific kid the custodian set, falling back to the configured key name for a single-version
+        // custodian that leaves the kid unset. record `with` keeps the runtime key type, so this is correct for
+        // both RsaJsonWebKey and EllipticCurveJsonWebKey.
+        var published = OrderProduceFirst(versions).Select(version => version.PublicKey with
         {
-            Usage = PublicKeyUsages.Signature,
-            KeyId = configuration.SigningKeyName,
-            Algorithm = configuration.SigningAlgorithm,
-        };
+            Usage = usage,
+            KeyId = version.PublicKey.KeyId ?? keyName,
+            Algorithm = algorithm,
+        });
 
-        yield return _signingKey;
+        foreach (var key in published)
+            yield return key;
     }
 
-    private JsonWebKey? _encryptionKey;
-
-    /// <inheritdoc />
-    public async IAsyncEnumerable<JsonWebKey> GetEncryptionKeys(bool includePrivateKeys = false)
+    // Order the versions produce-first: the active version leads (the produce role uses FirstByAlgorithm), the
+    // rest trail for verification/decryption and rotation overlap. The active version is the newest one already
+    // past the propagation window; if none has passed yet (bootstrap: the very first version is still fresh), the
+    // newest overall leads, since there is no older version a client could be holding instead.
+    private IEnumerable<KeyVersion> OrderProduceFirst(IReadOnlyList<KeyVersion> versions)
     {
-        var publicKey = await custodian.GetPublicKeyAsync(configuration.EncryptionKeyName, CancellationToken.None);
+        if (versions.Count <= 1)
+            return versions;
 
-        // The custodian returns bare public-key material (RSA or EC); stamp the kid (= the store key name, the
-        // custodian's handle), the use and the configured algorithm. record `with` keeps the runtime key type, so
-        // this is correct for both RsaJsonWebKey and EllipticCurveJsonWebKey.
-        _encryptionKey ??= publicKey with
-        {
-            Usage = PublicKeyUsages.Encryption,
-            KeyId = configuration.EncryptionKeyName,
-            Algorithm = configuration.EncryptionAlgorithm,
-        };
+        var now = timeProvider.GetUtcNow();
+        var propagation = options.Value.KeyRolloverPropagation;
 
-        yield return _encryptionKey;
+        var active = versions
+            .Where(version => now - version.CreatedAt >= propagation)
+            .OrderByDescending(version => version.CreatedAt)
+            .FirstOrDefault()
+            ?? versions.OrderByDescending(version => version.CreatedAt).First();
+
+        return versions
+            .OrderByDescending(version => ReferenceEquals(version, active))
+            .ThenByDescending(version => version.CreatedAt);
     }
 }

--- a/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
+++ b/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
@@ -98,11 +98,15 @@ public class AuthServiceJwtFormatter(
 		if (!encryption.Encrypt)
 			return await jwtCreator.IssueAsync(token, signingCredentials);
 
-		// Encrypt when a server encryption key is available, otherwise fall back to a signed-only JWS (the
-		// behavior of prior versions a host keeps by leaving Encrypt on). A pinned key id that matches no
-		// configured key still fails loudly inside the selector.
+		// Select the encryption key symmetrically with signing: by the policy's key-management algorithm (and
+		// any pinned key id), exactly as the signing key is selected by the token's 'alg'. An algorithm-agnostic
+		// key (no declared 'alg') matches any algorithm per RFC 7517 Section 4.4; when the policy pins no
+		// algorithm, selection falls back to the first available encryption key. No key available at all means
+		// encryption is not configured, so fall back to a signed-only JWS (the behavior of prior versions a host
+		// keeps by leaving Encrypt on); a pinned key id or a required algorithm that matches nothing fails
+		// loudly inside the selector.
 		var encryptingCredentials = await serviceKeysProvider.GetEncryptionKeys()
-			.FirstByAlgorithmAsync(algorithm: null, encryption.KeyId);
+			.FirstByAlgorithmAsync(encryption.KeyManagementAlgorithm, encryption.KeyId);
 
 		if (encryptingCredentials is null)
 			return await jwtCreator.IssueAsync(token, signingCredentials);


### PR DESCRIPTION
Version-aware external key rotation for the HSM/KMS/Vault custodian integration, plus a symmetric key-selection fix that applies to every deployment.

## What changed

- **Symmetric service-token key selection.** Encryption now selects the key by the key-management algorithm, mirroring signing; decryption already resolved by `kid`, so produce-by-alg / consume-by-kid is symmetric on both the signing and encryption sides.
- **The external-key provider publishes every version** of a custodian key (not just the latest) and produces with the active one, the newest past the server-level `OidcOptions.KeyRolloverPropagation` window. A freshly rotated version stays announced until client JWKS caches catch up, so a rotation overlaps with no verification failure.
- **`IKeyCustodian` consolidated and on `Task`.** A single `GetKeyVersionsAsync` replaces `GetPublicKeyAsync`; every operation is a network round-trip, so the contract and the `IDataSigner` / `IContentKeyDecryptor` crypto seams return `Task`, not `ValueTask`. `KeyVersion` is a `readonly record struct`.
- **JWKS is cacheable.** `Cache-Control: max-age` is derived from the same `KeyRolloverPropagation` window (a shared `SetCacheableHeaders` helper in both the MVC and Minimal API adapters), so `max-age <= propagation` holds by construction, the caching model OpenID Connect Core 10.1.1 relies on. Discovery metadata stays no-store.
- **Vault Transit and Azure Key Vault adapters enumerate all versions** with version-specific kids and creation times. Vault pins `key_version` on sign and frames the version into the decrypt envelope; Azure uses the versioned key identifier, so sign and unwrap are version-pinned by construction.

The custodian-as-KEK (envelope) mode is a separate follow-up.
