### PR TITLE
Emit 303 on authorize redirects and anti-framing headers on form_post

### DIFF
--- a/Abblix.Oidc.Server.AspNetCore/AntiFramingHeaders.cs
+++ b/Abblix.Oidc.Server.AspNetCore/AntiFramingHeaders.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.AspNetCore;
+
+/// <summary>
+/// Header values that forbid a self-rendered HTML page (such as the form_post auto-submit page) from being
+/// embedded in another origin's frame, defending against clickjacking as required by the OAuth 2.0 Security
+/// Best Current Practice (RFC 9700, Section 4.16). Single source of truth shared by both transport adapters,
+/// paired with the framework's <c>HeaderNames</c> constants for the header names at the call site.
+/// </summary>
+public static class AntiFramingHeaders
+{
+    /// <summary>
+    /// Content-Security-Policy value that denies every framing ancestor. Covers modern user agents.
+    /// </summary>
+    public const string ContentSecurityPolicy = "frame-ancestors 'none'";
+
+    /// <summary>
+    /// X-Frame-Options value that denies all framing. Covers legacy user agents that predate CSP frame-ancestors.
+    /// </summary>
+    public const string XFrameOptions = "DENY";
+}

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/NoneResponseTypeTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/NoneResponseTypeTests.cs
@@ -12,7 +12,7 @@ namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 /// <summary>
 /// OAuth 2.0 Multiple Response Type Encoding Practices §4 (none response type) end-to-end: a
 /// <c>response_type=none</c> request authorizes the flow and redirects back to <c>redirect_uri</c>
-/// carrying only <c>state</c> and <c>iss</c> (RFC 9207) — no authorization code, access token, or
+/// carrying only <c>state</c> and <c>iss</c> (RFC 9207) - no authorization code, access token, or
 /// id_token. The host opts into the response type via <c>EnableNoneFlow()</c>.
 /// </summary>
 public class NoneResponseTypeTests(TestFactory factory) : TestBase(factory)
@@ -36,7 +36,7 @@ public class NoneResponseTypeTests(TestFactory factory) : TestBase(factory)
         var response = await client.GetAsync(uri, TestContext.Current.CancellationToken);
 
         Assert.True(
-            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.SeeOther,
             $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: " +
             await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
 

--- a/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResponseModeRestrictionTests.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResponseModeRestrictionTests.cs
@@ -51,7 +51,7 @@ public class ResponseModeRestrictionTests(TestFactory factory) : TestBase(factor
         var response = await client.GetAsync(uri, TestContext.Current.CancellationToken);
 
         Assert.True(
-            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.SeeOther,
             $"/authorize returned {(int)response.StatusCode}, expected an error redirect. Body: " +
             await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
 
@@ -98,5 +98,11 @@ public class ResponseModeRestrictionTests(TestFactory factory) : TestBase(factor
         // The auto-submitting form POSTs the authorization response back to the registered redirect_uri.
         Assert.Contains(TestConstants.RedirectUri, body);
         Assert.Contains(TokenRequest.Parameters.Code, body);
+
+        // The auto-submit page must never be framed by another origin (clickjacking defense, RFC 9700 §4.16).
+        Assert.True(response.Headers.TryGetValues("Content-Security-Policy", out var csp));
+        Assert.Contains("frame-ancestors 'none'", csp);
+        Assert.True(response.Headers.TryGetValues("X-Frame-Options", out var xFrameOptions));
+        Assert.Contains("DENY", xFrameOptions);
     }
 }

--- a/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -97,7 +97,7 @@ public abstract class TestBase(TestFactory factory)
 
     /// <summary>
     /// Drives /authorize for a JARM (JWT Secured Authorization Response Mode) request and returns the value of
-    /// the single <c>response</c> callback parameter — the signed (and optionally encrypted) response JWT.
+    /// the single <c>response</c> callback parameter - the signed (and optionally encrypted) response JWT.
     /// </summary>
     protected static async Task<string> AuthorizeAndExtractResponseJwtAsync(
         HttpClient client,
@@ -119,7 +119,7 @@ public abstract class TestBase(TestFactory factory)
         var uri = QueryHelpers.BuildUri(discovery.AuthorizationEndpoint, queryParams);
         var response = await client.GetAsync(uri);
         Assert.True(
-            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.SeeOther,
             $"/authorize returned {(int)response.StatusCode}, expected redirect. Body: {await response.Content.ReadAsStringAsync()}");
         var location = response.Headers.Location ?? throw new InvalidOperationException("/authorize did not set Location header");
         var query = System.Web.HttpUtility.ParseQueryString(location.Query);
@@ -141,7 +141,7 @@ public abstract class TestBase(TestFactory factory)
 
     /// <summary>
     /// Drives a plain auth-code flow with <c>offline_access</c> for the confidential test client and
-    /// returns the parsed token response — its <c>refresh_token</c> is the first member of a fresh
+    /// returns the parsed token response - its <c>refresh_token</c> is the first member of a fresh
     /// family. Shared by the refresh-token rotation and tampering scenarios so the flow lives in one place.
     /// </summary>
     protected static async Task<JsonObject> ObtainConfidentialOfflineTokensAsync(
@@ -187,7 +187,7 @@ public abstract class TestBase(TestFactory factory)
     /// <summary>
     /// Drives PAR -> /authorize -> /token for the supplied client and
     /// authorization_details payload. Returns the parsed token response
-    /// JsonObject. Throws on any non-success HTTP status — use the
+    /// JsonObject. Throws on any non-success HTTP status - use the
     /// lower-level helpers for negative scenarios.
     /// </summary>
     protected async Task<JsonObject> PerformParFlowAsync(

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BindingTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BindingTests.cs
@@ -62,7 +62,7 @@ public sealed class BindingTests(TestFactory factory) : IClassFixture<TestFactor
             OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.AuthorizationEndpoint), query, ResponseParameters.Code);
         Assert.False(string.IsNullOrEmpty(code));
 
-        // The code is real and redeemable — closes the loop that the bound request produced a usable grant.
+        // The code is real and redeemable - closes the loop that the bound request produced a usable grant.
         var token = await client.ExchangeCodeAsync(discovery, code, verifier, TestConstants.ConfidentialClientId, TestConstants.ConfidentialClientSecret);
         Assert.NotNull(token[ResponseParameters.AccessToken]);
     }
@@ -116,7 +116,7 @@ public sealed class BindingTests(TestFactory factory) : IClassFixture<TestFactor
             OidcFlows.BuildQuery(OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.EndSessionEndpoint), query),
             TestContext.Current.CancellationToken);
 
-        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.SeeOther,
             $"/endsession returned {(int)response.StatusCode}, expected a redirect to the post-logout URI");
         Assert.StartsWith(MinimalApiTestConstants.PostLogoutRedirectUri, response.Headers.Location!.ToString());
     }
@@ -230,7 +230,7 @@ public sealed class BindingTests(TestFactory factory) : IClassFixture<TestFactor
         var url = OidcFlows.BuildQuery(
             OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.AuthorizationEndpoint), query);
 
-        // Under TestServer a BindAsync throw does not translate to an HTTP status — it propagates out of the awaited
+        // Under TestServer a BindAsync throw does not translate to an HTTP status - it propagates out of the awaited
         // call. Pre-fix the converter throws JsonException / CultureNotFoundException / TimeSpan overflow; post-fix
         // FormValues shapes every one into a BadHttpRequestException carrying the 400 the MVC binder would have
         // produced. Asserting the thrown type is the genuine red (wrong exception) to green (BadHttpRequestException).

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/FormatterTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/FormatterTests.cs
@@ -20,7 +20,7 @@ using ResponseParameters = Abblix.Oidc.Server.Endpoints.Authorization.Interfaces
 namespace Abblix.Oidc.Server.MinimalApi.E2E.Tests;
 
 /// <summary>
-/// Coverage for the adapter's parallel <c>IResult</c> formatter set — the half that does not exist in the core and
+/// Coverage for the adapter's parallel <c>IResult</c> formatter set - the half that does not exist in the core and
 /// differs from the MVC <c>ActionResult</c> formatters: JARM response packaging, RFC 6749 cache headers, the JWT vs
 /// JSON introspection content negotiation, the form_post HTML response, the check-session document and the
 /// UserInfo challenge.
@@ -109,7 +109,7 @@ public sealed class FormatterTests(TestFactory factory) : IClassFixture<TestFact
         var state = Guid.NewGuid().ToString("N");
 
         // response_mode=form_post answers with a 200 text/html auto-submitting form that POSTs the authorization
-        // response back to redirect_uri — a custom IResult (the ported AutoPostFormatter), not a redirect.
+        // response back to redirect_uri - a custom IResult (the ported AutoPostFormatter), not a redirect.
         var response = await client.GetAsync(OidcFlows.BuildQuery(
             OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.AuthorizationEndpoint), new Dictionary<string, string>
             {
@@ -130,6 +130,12 @@ public sealed class FormatterTests(TestFactory factory) : IClassFixture<TestFact
         Assert.Contains("<form", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(TestConstants.RedirectUri, html);
         Assert.Contains(state, html);
+
+        // The auto-submit page must never be framed by another origin (clickjacking defense, RFC 9700 §4.16).
+        Assert.True(response.Headers.TryGetValues("Content-Security-Policy", out var csp));
+        Assert.Contains("frame-ancestors 'none'", csp);
+        Assert.True(response.Headers.TryGetValues("X-Frame-Options", out var xFrameOptions));
+        Assert.Contains("DENY", xFrameOptions);
     }
 
     [Fact]
@@ -144,7 +150,7 @@ public sealed class FormatterTests(TestFactory factory) : IClassFixture<TestFact
         var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        // The UserInfo formatter advertises both an RFC 6750 Bearer and an RFC 9449 DPoP challenge on a 401 —
+        // The UserInfo formatter advertises both an RFC 6750 Bearer and an RFC 9449 DPoP challenge on a 401 -
         // the dual-challenge OidcResults.Format overload that does not exist in the MVC formatter set.
         Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.Bearer);
         Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == TokenTypes.DPoP);

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/OidcFlows.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/OidcFlows.cs
@@ -74,7 +74,7 @@ internal static class OidcFlows
     {
         var response = await client.GetAsync(
             BuildQuery(authorizeEndpoint, query), TestContext.Current.CancellationToken);
-        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.SeeOther,
             $"/authorize returned {(int)response.StatusCode}, expected redirect");
         var location = response.Headers.Location
             ?? throw new InvalidOperationException("/authorize did not set Location");

--- a/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
+++ b/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
@@ -24,7 +24,7 @@ using ResponseParameters = Abblix.Oidc.Server.Endpoints.Authorization.Interfaces
 namespace Abblix.Oidc.Server.MinimalApi.E2E.Tests;
 
 /// <summary>
-/// Coverage for the adapter's routing and host-configuration surface — the parts that live in
+/// Coverage for the adapter's routing and host-configuration surface - the parts that live in
 /// <c>MapOidcEndpoints</c> rather than in the core: the optional route prefix, the per-endpoint enable flags, and the
 /// HTTP-method gating each <c>MapPost</c>/<c>MapMethods</c> produces.
 /// </summary>
@@ -95,7 +95,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
         var introspectPath = new Uri((await ClientOf(factory).FetchDiscoveryAsync())
             [ConfigurationResponse.Parameters.IntrospectionEndpoint]!.GetValue<string>()).AbsolutePath;
 
-        // Reset the host to the default OidcEndpoints.Base set — the state of a server that opts into nothing.
+        // Reset the host to the default OidcEndpoints.Base set - the state of a server that opts into nothing.
         using var baseHost = factory.WithWebHostBuilder(builder =>
             builder.ConfigureTestServices(services =>
                 services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
@@ -126,7 +126,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
         var (_, challenge) = OidcFlows.Pkce();
 
         // prompt has a spec-fixed value set; "bogus" is not one of them. The OAuth-shaped contract (matching the
-        // MVC adapter) is a 400 with {"error":"invalid_request"} served as application/json — not the framework
+        // MVC adapter) is a 400 with {"error":"invalid_request"} served as application/json - not the framework
         // default ValidationProblemDetails (application/problem+json), which omits the error code OIDC clients read.
         var response = await client.GetAsync(OidcFlows.BuildQuery(
             OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.AuthorizationEndpoint), new Dictionary<string, string>
@@ -151,7 +151,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
     public async Task Host_registered_formatter_overrides_the_adapter_default()
     {
         // The adapter registers every formatter via TryAdd, so a host that registers its own implementation is used
-        // instead of the default — this is the host-extensibility contract the adapter promises.
+        // instead of the default - this is the host-extensibility contract the adapter promises.
         using var overridden = factory.WithWebHostBuilder(builder =>
             builder.ConfigureTestServices(services =>
                 services.AddScoped<IConfigurationResultFormatter, MarkerConfigurationFormatter>()));
@@ -173,7 +173,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
         var client = ClientOf(prefixed);
 
         // MapOidcEndpoints(RoutePrefix) mounts the token endpoint at /oauth/connect/token, so discovery must advertise
-        // the prefixed URL — a bare /connect/token would 404 every discovery-driven client.
+        // the prefixed URL - a bare /connect/token would 404 every discovery-driven client.
         var discovery = await client.FetchDiscoveryAsync(RoutePrefix);
 
         foreach (var key in new[]
@@ -277,7 +277,7 @@ public sealed class RoutingTests(TestFactory factory) : IClassFixture<TestFactor
         using var content = new FormUrlEncodedContent(form);
         var response = await client.PostAsync(url, content, TestContext.Current.CancellationToken);
 
-        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found,
+        Assert.True(response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.SeeOther,
             $"/authorize returned {(int)response.StatusCode}, expected a redirect");
         var echoedState = System.Web.HttpUtility.ParseQueryString(response.Headers.Location!.Query)["state"];
         Assert.Equal(formState, echoedState);

--- a/Abblix.Oidc.Server.MinimalApi/Formatters/AuthorizationResultFormatter.cs
+++ b/Abblix.Oidc.Server.MinimalApi/Formatters/AuthorizationResultFormatter.cs
@@ -68,7 +68,7 @@ public class AuthorizationResultFormatter(
                 return await RedirectAsync(
                     options.Value.LoginUri.NotNull(nameof(OidcOptions.LoginUri)), response.Model);
 
-            // prompt=create: a dedicated registration UI when configured, otherwise the login UI — the original
+            // prompt=create: a dedicated registration UI when configured, otherwise the login UI - the original
             // request parameters travel in the redirect so a combined page can still branch on them.
             case RegistrationRequired:
                 return await RedirectAsync(
@@ -115,9 +115,9 @@ public class AuthorizationResultFormatter(
 
         IResult result = response.ResponseMode switch
         {
-            ResponseModes.FormPost => new FormPostResult(parametersProvider, dto, redirectUri),
-            ResponseModes.Query => Results.Redirect(redirectUri.AddToQuery(GetParametersFrom(dto))),
-            ResponseModes.Fragment => Results.Redirect(redirectUri.AddToFragment(GetParametersFrom(dto))),
+            ResponseModes.FormPost => new FormPostResult(parametersProvider, dto, redirectUri).WithAntiFramingHeaders(),
+            ResponseModes.Query => new SeeOtherResult(redirectUri.AddToQuery(GetParametersFrom(dto))),
+            ResponseModes.Fragment => new SeeOtherResult(redirectUri.AddToFragment(GetParametersFrom(dto))),
             _ => throw new InvalidOperationException($"Response mode '{response.ResponseMode}' is not supported"),
         };
 
@@ -173,7 +173,7 @@ public class AuthorizationResultFormatter(
         var stored = await authorizationRequestStorage.StoreAsync(request, options.Value.LoginSessionExpiresIn);
         var resolved = ResolveContent(uri);
         var target = resolved.AddToQuery([(options.Value.RequestUriParameterName, stored.RequestUri.OriginalString)]);
-        return Results.Redirect(target);
+        return new SeeOtherResult(target);
     }
 
     /// <summary>

--- a/Abblix.Oidc.Server.MinimalApi/Formatters/SeeOtherResult.cs
+++ b/Abblix.Oidc.Server.MinimalApi/Formatters/SeeOtherResult.cs
@@ -1,0 +1,52 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.AspNetCore.Http;
+
+namespace Abblix.Oidc.Server.MinimalApi.Formatters;
+
+/// <summary>
+/// Redirects the user agent with HTTP 303 See Other instead of the framework-default 302 Found.
+/// A 303 forces the follow-up request to use GET and never re-sends the original request body, so the
+/// authorization endpoint (which accepts POST and may carry the user's credentials) never leaks that body
+/// to the redirect target. This is why the OAuth 2.0 Security Best Current Practice mandates 303 here and
+/// forbids the body-preserving 307 (RFC 9700, Section 4.12).
+/// </summary>
+internal sealed class SeeOtherResult : IResult
+{
+    private readonly string _location;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeeOtherResult"/> class.
+    /// </summary>
+    /// <param name="location">The absolute URI to redirect the user agent to.</param>
+    public SeeOtherResult(string location) => _location = location;
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        var response = httpContext.Response;
+        response.StatusCode = StatusCodes.Status303SeeOther;
+        response.Headers.Location = _location;
+        return Task.CompletedTask;
+    }
+}

--- a/Abblix.Oidc.Server.MinimalApi/OidcResults.cs
+++ b/Abblix.Oidc.Server.MinimalApi/OidcResults.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Model;
@@ -122,6 +123,17 @@ public static class OidcResults
             foreach (var value in values)
                 response.Headers.Append(name, value);
         });
+
+    /// <summary>
+    /// Decorates a self-rendered HTML result (the form_post auto-submit page) with the anti-framing headers so it
+    /// can never be embedded in another origin's frame (clickjacking defense, RFC 9700 Section 4.16). The check_session
+    /// page cannot use this path: its CSP carries a per-request nonce generated inside the result, so it sets the
+    /// header itself.
+    /// </summary>
+    public static IResult WithAntiFramingHeaders(this IResult inner)
+        => inner
+            .WithHeader(HeaderNames.ContentSecurityPolicy, AntiFramingHeaders.ContentSecurityPolicy)
+            .WithHeader(HeaderNames.XFrameOptions, AntiFramingHeaders.XFrameOptions);
 
     /// <summary>Decorates a result to append a cookie to the response before the inner result executes.</summary>
     public static IResult WithAppendCookie(

--- a/Abblix.Oidc.Server.Mvc/ActionResults/ActionResultExtensions.cs
+++ b/Abblix.Oidc.Server.Mvc/ActionResults/ActionResultExtensions.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Model;
@@ -67,6 +68,19 @@ public static class ActionResultExtensions
 	/// <returns>A decorated <see cref="ActionResult"/> that appends the specified header.</returns>
 	public static ActionResult WithHeader(this ActionResult innerResult, string name, string value)
 		=> new ActionResultDecorator(innerResult, response => response.Headers[name] = value);
+
+	/// <summary>
+	/// Decorates a self-rendered HTML result (the form_post auto-submit page) with the anti-framing headers so it
+	/// can never be embedded in another origin's frame (clickjacking defense, RFC 9700 Section 4.16). The check_session
+	/// page cannot use this path: its CSP carries a per-request nonce generated inside the result, so it sets the
+	/// header itself.
+	/// </summary>
+	/// <param name="innerResult">The HTML-producing <see cref="ActionResult"/> to protect.</param>
+	/// <returns>A decorated <see cref="ActionResult"/> that emits the anti-framing headers.</returns>
+	public static ActionResult WithAntiFramingHeaders(this ActionResult innerResult)
+		=> innerResult
+			.WithHeader(HeaderNames.ContentSecurityPolicy, AntiFramingHeaders.ContentSecurityPolicy)
+			.WithHeader(HeaderNames.XFrameOptions, AntiFramingHeaders.XFrameOptions);
 
 	/// <summary>
 	/// Decorates an <see cref="ActionResult"/> to append each value as a separate header line.

--- a/Abblix.Oidc.Server.Mvc/ActionResults/SeeOtherResult.cs
+++ b/Abblix.Oidc.Server.Mvc/ActionResults/SeeOtherResult.cs
@@ -1,0 +1,52 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Abblix.Oidc.Server.Mvc.ActionResults;
+
+/// <summary>
+/// Redirects the user agent with HTTP 303 See Other instead of the framework-default 302 Found.
+/// A 303 forces the follow-up request to use GET and never re-sends the original request body, so the
+/// authorization endpoint (which accepts POST and may carry the user's credentials) never leaks that body
+/// to the redirect target. This is why the OAuth 2.0 Security Best Current Practice mandates 303 here and
+/// forbids the body-preserving 307 (RFC 9700, Section 4.12).
+/// </summary>
+internal sealed class SeeOtherResult : ActionResult
+{
+    private readonly string _location;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeeOtherResult"/> class.
+    /// </summary>
+    /// <param name="location">The absolute URI to redirect the user agent to.</param>
+    public SeeOtherResult(string location) => _location = location;
+
+    /// <inheritdoc />
+    public override void ExecuteResult(ActionContext context)
+    {
+        var response = context.HttpContext.Response;
+        response.StatusCode = StatusCodes.Status303SeeOther;
+        response.Headers.Location = _location;
+    }
+}

--- a/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/AuthorizationResponseFormatter.cs
@@ -41,7 +41,7 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 /// Handles the formatting of authorization responses in compliance with OpenID Connect and OAuth 2.0 protocols.
 /// Protocol-level decisions (parameter assembly, iss/scope gating, JARM packing) are made upstream by the core
 /// response encoder; this formatter maps the encoded response onto the MVC wire DTO and delivers it to the
-/// client's redirect URI via query, fragment or form_post — for both successful and error responses.
+/// client's redirect URI via query, fragment or form_post - for both successful and error responses.
 /// </summary>
 /// <param name="options">Provides the configured interaction URIs (login, consent, …) and request-uri
 /// parameter name used when redirecting the user agent to the authorization server's own UI.</param>
@@ -91,7 +91,7 @@ public class AuthorizationResponseFormatter(
                     options.Value.LoginUri.NotNull(nameof(OidcOptions.LoginUri)), response.Model);
 
             // prompt=create (Initiating User Registration via OpenID Connect 1.0): a dedicated
-            // registration UI when the host configured one, otherwise the login UI — the original
+            // registration UI when the host configured one, otherwise the login UI - the original
             // request parameters (including prompt=create) travel in the redirect, so a combined
             // login/registration page can still branch on them.
             case RegistrationRequired:
@@ -103,7 +103,7 @@ public class AuthorizationResponseFormatter(
             // iss/scope gating and JARM packing are applied upstream by the core response encoder (run from
             // the handler); here we only map the encoded response onto the MVC wire DTO and deliver it.
 
-            // JARM (*.jwt): success and error alike deliver an identical wire shape — the single `response`
+            // JARM (*.jwt): success and error alike deliver an identical wire shape - the single `response`
             // JWT packed by the encoder. Matched before the plaintext branches so any JWT-bearing response
             // (of either type) takes this path.
             case ClientDeliveredResponse { ResponseJwt: { } responseJwt } jarm:
@@ -151,15 +151,15 @@ public class AuthorizationResponseFormatter(
             ResponseModes.FormPost => new OkObjectResult(dto)
             {
                 Formatters = { new AutoPostFormatter(parametersProvider, redirectUri) },
-            },
+            }.WithAntiFramingHeaders(),
 
-            ResponseModes.Query => new RedirectResult(redirectUri.AddToQuery(GetParametersFrom(dto))),
-            ResponseModes.Fragment => new RedirectResult(redirectUri.AddToFragment(GetParametersFrom(dto))),
+            ResponseModes.Query => new SeeOtherResult(redirectUri.AddToQuery(GetParametersFrom(dto))),
+            ResponseModes.Fragment => new SeeOtherResult(redirectUri.AddToFragment(GetParametersFrom(dto))),
 
             _ => throw new InvalidOperationException($"Response mode '{response.ResponseMode}' is not supported"),
         };
 
-        // The session_state cookie is set for a successful authentication independent of JARM/plaintext —
+        // The session_state cookie is set for a successful authentication independent of JARM/plaintext -
         // keyed on the runtime type, so a JARM success (matched by the *.jwt branch above) still receives it.
         if (response is SuccessfullyAuthenticated authenticated &&
             sessionManagementService.Enabled &&
@@ -234,7 +234,7 @@ public class AuthorizationResponseFormatter(
             uri = uriResolver.Content(uri.OriginalString);
         }
 
-        return new RedirectResult(new UriBuilder(uri)
+        return new SeeOtherResult(new UriBuilder(uri)
         {
             Query =
             {

--- a/Abblix.Oidc.Server.Mvc/Formatters/CheckSessionResponseFormatter.cs
+++ b/Abblix.Oidc.Server.Mvc/Formatters/CheckSessionResponseFormatter.cs
@@ -62,7 +62,7 @@ public class CheckSessionResponseFormatter : ICheckSessionResponseFormatter
             var response = context.HttpContext.Response;
             response.StatusCode = StatusCodes.Status200OK;
             response.ContentType = MediaTypeNames.Text.Html;
-            response.Headers["Content-Security-Policy"] = $"default-src 'none'; script-src 'nonce-{nonce}'";
+            response.Headers.ContentSecurityPolicy = $"default-src 'none'; script-src 'nonce-{nonce}'";
 
             return response.WriteAsync(htmlContent);
         }


### PR DESCRIPTION
Two OAuth 2.0 Security Best Current Practice (RFC 9700) hardening changes to the authorization endpoint, surfaced by a source-level BCP conformance audit.

## 303 See Other on authorize redirects (Section 4.12)

Authorization-endpoint redirects previously used the framework-default 302 Found. They now emit 303 See Other via a new `SeeOtherResult` in both the MVC and Minimal API adapters, so the follow-up request is always a GET that carries no request body.

## Anti-framing headers on the form_post page (Section 4.16)

The form_post auto-submit page now sends `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY`, applied at its single composition site through a shared `WithAntiFramingHeaders()` helper, with the values single-sourced in `AntiFramingHeaders`. The `check_session` page keeps setting its CSP inline, because that value carries a per-request nonce shared with the HTML body and so cannot be known at composition time.

## Other

Response-header writes use the framework's typed accessors (`Headers.ContentSecurityPolicy`, `Headers.XFrameOptions`, ...) where the framework provides one.