### PR TITLE
Rename the RSA log parameter off the shadowed Algorithm property

### DIFF
--- a/Abblix.Jwt/Encryption/RsaKeyEncryptor.Logging.cs
+++ b/Abblix.Jwt/Encryption/RsaKeyEncryptor.Logging.cs
@@ -29,6 +29,6 @@ partial class RsaKeyEncryptor
 	[LoggerMessage(
 		EventId = LogEvents.Jwt.RsaEncryptionFailed,
 		Level = LogLevel.Error,
-		Message = "RSA key encryption failed: Algorithm={Algorithm}, KeySize={KeySize} bits, CEK size={ContentEncryptionKeySize} bytes, Theoretical max CEK={MaxContentEncryptionKeySize} bytes")]
-	private partial void LogEncryptionFailed(string Algorithm, int KeySize, int ContentEncryptionKeySize, int MaxContentEncryptionKeySize);
+		Message = "RSA key encryption failed: Algorithm={EncryptionAlgorithm}, KeySize={KeySize} bits, CEK size={ContentEncryptionKeySize} bytes, Theoretical max CEK={MaxContentEncryptionKeySize} bytes")]
+	private partial void LogEncryptionFailed(string EncryptionAlgorithm, int KeySize, int ContentEncryptionKeySize, int MaxContentEncryptionKeySize);
 }


### PR DESCRIPTION
The `[LoggerMessage]` parameter on `RsaKeyEncryptor.LogEncryptionFailed` was named `Algorithm` to match its `{Algorithm}` placeholder, which shadowed the encryptor's own `public string Algorithm` property (flagged by the code-quality bot on #268). The logged value was always correct - the call site passes the `algorithm` field - but the collision is avoidable.

Renames the placeholder and the parameter to `EncryptionAlgorithm`, so nothing shadows the property. The human-readable label stays `Algorithm=`, the same way `CEK size=` already differs from its `{ContentEncryptionKeySize}` placeholder, and the call site is positional so it needs no change. The structured field key becomes `EncryptionAlgorithm`; the event is new in this cycle, so no consumer depends on the old key.
