### PR TITLE
Upgrade the test stack to Microsoft Testing Platform 2.x

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -80,13 +80,14 @@ jobs:
         # --no-restore reuses the cached restore; the project's dependency closure still builds here,
         # so allow more room than the 3-minute step baseline for the largest shard.
         run: |
-          dotnet test "tests/$PROJECT/$PROJECT.csproj" --configuration Release --no-restore -- \
+          dotnet test "tests/$PROJECT/$PROJECT.csproj" --configuration Release --no-restore \
             --report-trx --report-trx-filename test-results.trx \
             --coverage --coverage-output-format cobertura \
             --results-directory ./TestResults
 
-      # `dotnet test <project> -- --results-directory ./TestResults` resolves the relative path from
-      # the project working directory, so files land at tests/<Project>/TestResults/.
+      # The new dotnet test experience (Microsoft.Testing.Platform runner, opted in via global.json)
+      # takes MTP options directly, without the VSTest separator. --results-directory ./TestResults
+      # resolves from the working directory (repo root), so files land at ./TestResults/.
         timeout-minutes: 5
       - name: Upload test results
         if: always()

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,20 +27,18 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <!-- HOLD: Microsoft.Testing.Extensions.* 18.6.x / 2.2.x pull Microsoft.Testing.Platform 2.x,
-         which makes a breaking ABI change to ITestApplicationBuilder.AddSelfRegisteredExtensions
-         (and friends) that xunit.v3 3.2.2 (current stable) cannot consume — all test projects
-         fail to launch with "error run failed" from
-         Xunit.MicrosoftTestingPlatform.TestPlatformTestFramework. xunit.v3 4.x is pre-release
-         only; we stay on the 3.x stable line, so this HOLD stays until xunit.v3 ships a stable
-         release that targets MTP 2.x. -->
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
+    <!-- xunit.v3 picks the Microsoft Testing Platform major version by package variant: the plain
+         xunit.v3 metapackage targets MTP v1, while xunit.v3.mtp-v2 targets MTP v2. We reference the
+         mtp-v2 variant (below) so the current Microsoft.Testing.Extensions.*, which require MTP 2.x,
+         load cleanly. The test-authoring API is identical across variants; only the runner
+         integration differs, so test code is unaffected. -->
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.2" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestMinor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
+++ b/tests/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
+++ b/tests/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/Abblix.Oidc.Server.AspNetCore.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/Abblix.Oidc.Server.AspNetCore.UnitTests.csproj
@@ -20,7 +20,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Moq" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 		<PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.Azure.UnitTests/Abblix.Oidc.Server.Azure.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.Azure.UnitTests/Abblix.Oidc.Server.Azure.UnitTests.csproj
@@ -18,7 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Options" />
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Abblix.Oidc.Server.E2E.Tests.csproj
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Abblix.Oidc.Server.E2E.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests.csproj
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Moq" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 		<PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.Vault.UnitTests/Abblix.Oidc.Server.Vault.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.Vault.UnitTests/Abblix.Oidc.Server.Vault.UnitTests.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Extensions.Options" />
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -17,7 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Update="SonarAnalyzer.CSharp">


### PR DESCRIPTION
Upgrades the test stack to Microsoft.Testing.Platform 2.x, lifting the version hold that kept the `Microsoft.Testing.Extensions.*` frozen.

## What changed
- Test projects reference the `xunit.v3.mtp-v2` variant instead of the plain `xunit.v3` metapackage, so they run on MTP v2. The test-authoring API is identical; only the runner integration differs.
- `Microsoft.Testing.Extensions.CodeCoverage` 18.0.6 -> 18.9.0 and `Microsoft.Testing.Extensions.TrxReport` 1.9.1 -> 2.3.2.
- `global.json` opts into the new `dotnet test` experience (`test.runner`), required for the MTP runner on the .NET 10 SDK.
- The PR test workflow drops the VSTest argument separator, since the new experience passes MTP options directly.

The hold rested on a premise that no longer holds: xunit.v3 3.2.x can target either MTP major version through its variant packages, so the freeze was unnecessary.
