### PR TITLE
test(backends): cover the paths an operator's actions reach (superseded by #291, tests landed on develop)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -37,6 +37,7 @@ jobs:
           - Abblix.Oidc.Server.UnitTests
           - Abblix.Oidc.Server.Vault.UnitTests
           - Abblix.Utils.UnitTests
+          - Abblix.Oidc.Client.UnitTests
     env:
       PROJECT: ${{ matrix.project }}
     steps:

--- a/Abblix.Oidc.slnx
+++ b/Abblix.Oidc.slnx
@@ -27,6 +27,7 @@
     <Project Path="src/Abblix.Oidc.Server.MinimalApi.SourceGeneration/Abblix.Oidc.Server.MinimalApi.SourceGeneration.csproj" />
     <Project Path="src/Abblix.Oidc.Server.Vault/Abblix.Oidc.Server.Vault.csproj" />
     <Project Path="src/Abblix.Oidc.Server.Azure/Abblix.Oidc.Server.Azure.csproj" />
+    <Project Path="src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj" />
@@ -41,5 +42,6 @@
     <Project Path="tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests.csproj" />
     <Project Path="tests/Abblix.Oidc.Server.Vault.UnitTests/Abblix.Oidc.Server.Vault.UnitTests.csproj" />
     <Project Path="tests/Abblix.Oidc.Server.Azure.UnitTests/Abblix.Oidc.Server.Azure.UnitTests.csproj" />
+    <Project Path="tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj" />
   </Folder>
 </Solution>

--- a/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
+++ b/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Abblix.OIDC.Client</PackageId>
+    <Title>Abblix OIDC Client</Title>
+    <Description>A self-contained OpenID Connect and OAuth 2.0 client for .NET: authorization code flow with PKCE, token handling, provider discovery and id_token validation on the Abblix.Jwt engine. The client side of Abblix OIDC Server, independent of the built-in ASP.NET Core handler.</Description>
+    <Authors>Abblix LLP</Authors>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>Abblix OIDC OpenID-Connect OAuth OAuth2 Client Authentication Security Login PKCE id-token Identity ASP.NET</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
+    <PackageIcon>Abblix.png</PackageIcon>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    <!-- Deterministic builds for reproducible binaries -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+
+    <!-- SourceLink for symbol packages -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Abblix.Oidc.Client.UnitTests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
+++ b/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
@@ -50,6 +50,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Abblix.Jwt\Abblix.Jwt.csproj" />
+    <ProjectReference Include="..\Abblix.Utils\Abblix.Utils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
+++ b/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
@@ -49,6 +49,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Abblix.Jwt\Abblix.Jwt.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Abblix.Oidc.Client.UnitTests" />
   </ItemGroup>
 

--- a/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
+++ b/src/Abblix.Oidc.Client/Abblix.Oidc.Client.csproj
@@ -33,6 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequest.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequest.cs
@@ -1,0 +1,34 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// A built authorization request.
+/// </summary>
+/// <param name="RequestUri">The address to send the user to.</param>
+/// <param name="State">
+/// What was put aside for the callback. Already stored by the time this is returned; it is carried here so
+/// that a caller which owns its own storage, such as the ASP.NET adapter with its cookie, can write it there
+/// as well.
+/// </param>
+public sealed record AuthorizationRequest(Uri RequestUri, AuthorizationState.AuthorizationState State);

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequestBuilder.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequestBuilder.cs
@@ -1,0 +1,130 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using Abblix.Oidc.Client.Features.AuthorizationState;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Features.Pkce;
+using Abblix.Utils;
+using Utils = Abblix.Utils;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// Builds the address the user is sent to in order to sign in, and the state that must survive until they
+/// come back.
+/// </summary>
+public sealed class AuthorizationRequestBuilder : IAuthorizationRequestBuilder
+{
+    /// <summary>
+    /// The number of random bytes behind each opaque value the client generates.
+    /// </summary>
+    /// <remarks>
+    /// 256 bits, which is far past what guessing could reach. These values are the client's only handle on
+    /// which request a response belongs to, so their unguessability is what makes a forged callback fail.
+    /// </remarks>
+    private const int OpaqueValueByteCount = 32;
+
+    private readonly IProviderMetadataProvider _metadataProvider;
+    private readonly IPkceProvider _pkceProvider;
+    private readonly IAuthorizationStateStore _stateStore;
+    private readonly OidcClientOptions _clientOptions;
+    private readonly AuthorizationRequestOptions _options;
+
+    /// <summary>
+    /// Creates the builder.
+    /// </summary>
+    public AuthorizationRequestBuilder(
+        IProviderMetadataProvider metadataProvider,
+        IPkceProvider pkceProvider,
+        IAuthorizationStateStore stateStore,
+        IOptions<OidcClientOptions> clientOptions,
+        IOptions<AuthorizationRequestOptions> options)
+    {
+        _metadataProvider = metadataProvider;
+        _pkceProvider = pkceProvider;
+        _stateStore = stateStore;
+        _clientOptions = clientOptions.Value;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task<AuthorizationRequest> CreateAsync(
+        Uri returnUri, CancellationToken cancellationToken = default)
+    {
+        var metadata = await _metadataProvider.GetMetadataAsync(cancellationToken);
+
+        if (metadata.AuthorizationEndpoint is not { } authorizationEndpoint)
+            throw new AuthorizationRequestException(
+                $"The OpenID Provider '{metadata.Issuer}' names no authorization endpoint, so there is "
+                + "nowhere to send the user.");
+
+        var pkce = await _pkceProvider.CreateAsync(cancellationToken);
+
+        var state = new AuthorizationState.AuthorizationState
+        {
+            State = NewOpaqueValue(),
+            Nonce = NewOpaqueValue(),
+            CodeVerifier = pkce.CodeVerifier,
+            ReturnUri = returnUri.ToString(),
+            Issuer = metadata.Issuer,
+            RedirectUri = _options.RedirectUri.ToString(),
+        };
+
+        // Stored before the address is handed out, so the callback can never arrive for a state that was not
+        // put aside yet.
+        await _stateStore.StoreAsync(state, cancellationToken);
+
+        return new AuthorizationRequest(BuildRequestUri(authorizationEndpoint, state, pkce), state);
+    }
+
+    private Uri BuildRequestUri(string authorizationEndpoint, AuthorizationState.AuthorizationState state, PkceParameters pkce)
+    {
+        // The builder carries over whatever the endpoint already has in its query: a provider is free to
+        // publish an authorization endpoint with parameters of its own, and dropping them would break it.
+        var endpoint = new Utils.UriBuilder(authorizationEndpoint);
+        var parameters = endpoint.Query;
+
+        parameters[Parameters.ResponseType] = ResponseTypes.Code;
+        parameters[Parameters.ClientId] = _clientOptions.ClientId;
+        parameters[Parameters.RedirectUri] = state.RedirectUri;
+        parameters[Parameters.Scope] = string.Join(' ', _options.Scopes);
+        parameters[Parameters.State] = state.State;
+        parameters[Parameters.Nonce] = state.Nonce;
+        parameters[Parameters.CodeChallenge] = pkce.CodeChallenge;
+        parameters[Parameters.CodeChallengeMethod] = pkce.CodeChallengeMethod;
+
+        // Naming the resources narrows the issued token to them, so one that leaks from a resource cannot be
+        // spent at another (RFC 8707). Omitted when the host names none, leaving the audience to the provider.
+        foreach (var resource in _options.Resources)
+            parameters.Add(Parameters.Resource, resource.ToString());
+
+        foreach (var (name, value) in _options.AdditionalParameters)
+            parameters[name] = value;
+
+        return endpoint.Uri;
+    }
+
+    private static string NewOpaqueValue()
+        => Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(OpaqueValueByteCount));
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequestException.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequestException.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// Thrown when an authorization request cannot be built.
+/// </summary>
+public sealed class AuthorizationRequestException : Exception
+{
+    /// <summary>
+    /// Creates the exception with a message describing what prevented the request from being built.
+    /// </summary>
+    public AuthorizationRequestException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequestOptions.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/AuthorizationRequestOptions.cs
@@ -1,0 +1,57 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// Configuration of the authorization requests this client sends.
+/// </summary>
+public sealed class AuthorizationRequestOptions
+{
+    /// <summary>
+    /// The address the provider returns the user to. Must be one the provider has registered for this client,
+    /// and is repeated verbatim when the authorization code is exchanged.
+    /// </summary>
+    public required Uri RedirectUri { get; set; }
+
+    /// <summary>
+    /// The scopes requested. <c>openid</c> is what makes the request an OpenID Connect one rather than plain
+    /// OAuth, so it is included by default.
+    /// </summary>
+    public IReadOnlyCollection<string> Scopes { get; set; } = ["openid", "profile"];
+
+    /// <summary>
+    /// The resources the issued access token is meant for, sent as <c>resource</c> per RFC 8707.
+    /// </summary>
+    /// <remarks>
+    /// Naming them narrows the token to those resources, so a token leaked by one of them cannot be spent at
+    /// another. Left empty the parameter is omitted, and the provider decides the audience itself.
+    /// </remarks>
+    public IReadOnlyCollection<Uri> Resources { get; set; } = [];
+
+    /// <summary>
+    /// Extra parameters appended to every authorization request, for anything a provider expects that this
+    /// client does not model.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> AdditionalParameters { get; set; } =
+        new Dictionary<string, string>();
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/IAuthorizationRequestBuilder.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/IAuthorizationRequestBuilder.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// Builds the request that sends a user to the OpenID Provider to sign in.
+/// </summary>
+public interface IAuthorizationRequestBuilder
+{
+    /// <summary>
+    /// Builds the address to send the user to, and puts aside everything needed to judge their return.
+    /// </summary>
+    /// <param name="returnUri">Where the user was heading before sign-in was required.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <exception cref="AuthorizationRequestException">The provider offers nowhere to send the user.</exception>
+    Task<AuthorizationRequest> CreateAsync(Uri returnUri, CancellationToken cancellationToken = default);
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/Parameters.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/Parameters.cs
@@ -1,0 +1,60 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// The names of the authorization request parameters, as they appear on the wire.
+/// </summary>
+/// <remarks>
+/// Named constants rather than literals for the same reason claim names are: a typo in a literal produces a
+/// request the provider rejects for a reason that reads like anything but a typo.
+/// </remarks>
+public static class Parameters
+{
+    /// <summary>What kind of response the client is asking for.</summary>
+    public const string ResponseType = "response_type";
+
+    /// <summary>Identifies the client to the provider.</summary>
+    public const string ClientId = "client_id";
+
+    /// <summary>Where the provider returns the user.</summary>
+    public const string RedirectUri = "redirect_uri";
+
+    /// <summary>What the client is asking to be allowed to do.</summary>
+    public const string Scope = "scope";
+
+    /// <summary>Ties the response back to the request that caused it.</summary>
+    public const string State = "state";
+
+    /// <summary>Ties the issued token back to the request that caused it.</summary>
+    public const string Nonce = "nonce";
+
+    /// <summary>The public half of the PKCE pair.</summary>
+    public const string CodeChallenge = "code_challenge";
+
+    /// <summary>How the challenge was derived from the verifier.</summary>
+    public const string CodeChallengeMethod = "code_challenge_method";
+
+    /// <summary>Which resource the issued access token is meant for (RFC 8707). May repeat.</summary>
+    public const string Resource = "resource";
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/ResponseTypes.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/ResponseTypes.cs
@@ -1,0 +1,36 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// The response types this client asks for, as they appear on the wire.
+/// </summary>
+public static class ResponseTypes
+{
+    /// <summary>
+    /// The authorization code flow. The only response type this client uses: everything else either puts
+    /// tokens in the browser's address bar or needs the client to accept them without a back channel.
+    /// </summary>
+    public const string Code = "code";
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationRequests/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationRequests/ServiceCollectionExtensions.cs
@@ -1,0 +1,60 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Abblix.Oidc.Client.Features.AuthorizationRequests;
+
+/// <summary>
+/// Registers the building of authorization requests.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the builder of authorization requests, together with the PKCE values and the request state it
+    /// depends on.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <param name="configureOptions">A delegate that configures <see cref="AuthorizationRequestOptions"/>.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    public static IServiceCollection AddAuthorizationRequests(
+        this IServiceCollection services, Action<AuthorizationRequestOptions> configureOptions)
+    {
+        services.Configure(configureOptions);
+
+        // A soft default, so a test or a host can substitute a clock before this call.
+        services.TryAddSingleton(TimeProvider.System);
+
+        services.TryAddSingleton<Pkce.IPkceProvider, Pkce.PkceProvider>();
+        services.TryAddSingleton<IAuthorizationRequestBuilder, AuthorizationRequestBuilder>();
+
+        // Correct for one instance only. A host running several replicas replaces this with a store the
+        // callback can reach whichever replica it lands on - the ASP.NET adapter's cookie-backed one.
+        services.TryAddSingleton<
+            AuthorizationState.IAuthorizationStateStore,
+            AuthorizationState.InMemoryAuthorizationStateStore>();
+
+        return services;
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationState/AuthorizationState.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationState/AuthorizationState.cs
@@ -1,0 +1,68 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationState;
+
+/// <summary>
+/// What the client must remember between sending the user to the provider and getting them back.
+/// </summary>
+/// <remarks>
+/// The authorization response arrives on a separate request, from the user's browser, carrying only what the
+/// provider chose to echo. Everything the client needs in order to judge that response therefore has to be
+/// put aside beforehand, and this is that set.
+/// </remarks>
+public sealed record AuthorizationState
+{
+    /// <summary>
+    /// The opaque value sent as <c>state</c> and echoed by the provider. It identifies which request the
+    /// response belongs to, and a response carrying a value that was never issued is a forged callback.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// The value sent as <c>nonce</c> and returned inside the <c>id_token</c>, which ties that token to this
+    /// request and rejects one replayed from another.
+    /// </summary>
+    public required string Nonce { get; init; }
+
+    /// <summary>
+    /// The secret half of the PKCE pair, presented when the authorization code is exchanged.
+    /// </summary>
+    public required string CodeVerifier { get; init; }
+
+    /// <summary>
+    /// The address the user was heading to before sign-in was required.
+    /// </summary>
+    public required string ReturnUri { get; init; }
+
+    /// <summary>
+    /// The issuer this request was addressed to, so the response can be checked against the provider that was
+    /// actually asked (RFC 9207).
+    /// </summary>
+    public required string Issuer { get; init; }
+
+    /// <summary>
+    /// The redirect address sent with the request, which must be repeated verbatim when the code is
+    /// exchanged.
+    /// </summary>
+    public required string RedirectUri { get; init; }
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationState/AuthorizationStateOptions.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationState/AuthorizationStateOptions.cs
@@ -1,0 +1,40 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationState;
+
+/// <summary>
+/// Configuration for the state kept between an authorization request and its callback.
+/// </summary>
+public sealed class AuthorizationStateOptions
+{
+    /// <summary>
+    /// How long a started sign-in may take before its state is discarded.
+    /// </summary>
+    /// <remarks>
+    /// This is the window a user has to get through the provider's pages, so it has to tolerate reading a
+    /// consent screen, a second factor, or a password reset. It is also how long a captured authorization
+    /// request stays useful to whoever captured it, so it should not be generous beyond that. A quarter of an
+    /// hour covers an unhurried sign-in and little else.
+    /// </remarks>
+    public TimeSpan Lifetime { get; set; } = TimeSpan.FromMinutes(15);
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationState/IAuthorizationStateStore.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationState/IAuthorizationStateStore.cs
@@ -1,0 +1,50 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.AuthorizationState;
+
+/// <summary>
+/// Holds the state of an authorization request between sending the user to the provider and their return.
+/// </summary>
+public interface IAuthorizationStateStore
+{
+    /// <summary>
+    /// Puts the state aside, keyed by its own <see cref="AuthorizationState.State"/> value.
+    /// </summary>
+    /// <param name="state">The state to remember.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    Task StoreAsync(AuthorizationState state, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Takes the state matching the value the provider echoed, removing it in the same step.
+    /// </summary>
+    /// <param name="state">The <c>state</c> parameter from the authorization response.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The stored state, or <c>null</c> when nothing matches.</returns>
+    /// <remarks>
+    /// Taking and removing is one operation on purpose. A stored state is good for exactly one callback: if
+    /// reading left it in place, a captured authorization response could be replayed, and each replay would
+    /// find its state waiting and look entirely legitimate. Returning null the second time is what makes the
+    /// second attempt fail.
+    /// </remarks>
+    Task<AuthorizationState?> TakeAsync(string state, CancellationToken cancellationToken = default);
+}

--- a/src/Abblix.Oidc.Client/Features/AuthorizationState/InMemoryAuthorizationStateStore.cs
+++ b/src/Abblix.Oidc.Client/Features/AuthorizationState/InMemoryAuthorizationStateStore.cs
@@ -1,0 +1,90 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.Features.AuthorizationState;
+
+/// <summary>
+/// Holds authorization state in the memory of one process.
+/// </summary>
+/// <remarks>
+/// The default, and correct only for a single instance. The callback that consumes a state may land on any
+/// replica, so an application running several will see sign-ins fail whenever the callback reaches a replica
+/// other than the one that started the request. The ASP.NET adapter's cookie-backed store is the answer
+/// there, because it travels with the user rather than living on one node.
+/// </remarks>
+public sealed class InMemoryAuthorizationStateStore : IAuthorizationStateStore
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly AuthorizationStateOptions _options;
+    private readonly ConcurrentDictionary<string, StoredState> _states = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Creates the store.
+    /// </summary>
+    public InMemoryAuthorizationStateStore(
+        TimeProvider timeProvider, IOptions<AuthorizationStateOptions> options)
+    {
+        _timeProvider = timeProvider;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public Task StoreAsync(AuthorizationState state, CancellationToken cancellationToken = default)
+    {
+        // A sign-in that was started and never finished must not be held forever: the entries carry a code
+        // verifier, and a process that only ever adds them is a slow leak driven by anyone who can start a
+        // sign-in. Sweeping on write keeps that bounded without a timer.
+        RemoveExpired();
+
+        var expiresAt = _timeProvider.GetUtcNow() + _options.Lifetime;
+        _states[state.State] = new StoredState(state, expiresAt);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<AuthorizationState?> TakeAsync(string state, CancellationToken cancellationToken = default)
+    {
+        if (!_states.TryRemove(state, out var stored))
+            return Task.FromResult<AuthorizationState?>(null);
+
+        // Removed either way: an expired entry is spent, not retryable.
+        var result = _timeProvider.GetUtcNow() < stored.ExpiresAt ? stored.State : null;
+        return Task.FromResult(result);
+    }
+
+    private void RemoveExpired()
+    {
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var (key, stored) in _states)
+        {
+            if (now >= stored.ExpiresAt)
+                _states.TryRemove(key, out _);
+        }
+    }
+
+    private sealed record StoredState(AuthorizationState State, DateTimeOffset ExpiresAt);
+}

--- a/src/Abblix.Oidc.Client/Features/Discovery/ConfiguredMetadataProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/ConfiguredMetadataProvider.cs
@@ -1,0 +1,50 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Discovery;
+
+/// <summary>
+/// Serves the provider metadata the host wrote in configuration, for a provider that publishes no discovery
+/// document.
+/// </summary>
+/// <remarks>
+/// Plenty of OAuth 2.0 providers never adopted OpenID Connect Discovery, so their endpoints are known only
+/// from their documentation. Rather than making those providers a special case throughout the client, the
+/// host declares the same metadata by hand and every consumer keeps reading it through
+/// <see cref="IProviderMetadataProvider"/>, unaware of where it came from.
+///
+/// Nothing is fetched and nothing is cached here: the configured document is already in memory, and it
+/// changes only when the host is reconfigured and restarted.
+/// </remarks>
+public sealed class ConfiguredMetadataProvider : IProviderMetadataProvider
+{
+    private readonly ProviderMetadata _metadata;
+
+    /// <summary>
+    /// Creates the provider over the metadata the host registered.
+    /// </summary>
+    public ConfiguredMetadataProvider(ProviderMetadata metadata) => _metadata = metadata;
+
+    /// <inheritdoc />
+    public Task<ProviderMetadata> GetMetadataAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_metadata);
+}

--- a/src/Abblix.Oidc.Client/Features/Discovery/DiscoveredMetadataProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/DiscoveredMetadataProvider.cs
@@ -1,0 +1,177 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.Features.Discovery;
+
+/// <summary>
+/// Fetches the provider's discovery document over HTTP, verifies its issuer and caches it for the configured
+/// lifetime.
+/// </summary>
+public sealed class DiscoveredMetadataProvider : IProviderMetadataProvider
+{
+    /// <summary>
+    /// The name of the <see cref="HttpClient"/> this provider resolves from <see cref="IHttpClientFactory"/>.
+    /// A host tunes discovery transport (proxy, timeout, handler chain) by configuring this name.
+    /// </summary>
+    public const string HttpClientName = "Abblix.Oidc.Client.ProviderDiscovery";
+
+    /// <summary>
+    /// The well-known path the discovery document is published under, per OpenID Connect Discovery 1.0.
+    /// </summary>
+    private const string WellKnownPath = ".well-known/openid-configuration";
+
+    /// <summary>
+    /// The separator between URI path segments. Named rather than written inline so that the address-building
+    /// below reads as URI composition instead of string surgery.
+    /// </summary>
+    private const char UriPathSeparator = '/';
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly DiscoveryOptions _options;
+
+    /// <summary>
+    /// Serializes fetches so that concurrent first requests result in one round trip rather than a stampede.
+    /// </summary>
+    private readonly SemaphoreSlim _fetchGate = new(1, 1);
+
+    /// <summary>
+    /// The cached document together with its expiry, held as a single reference so that a reader outside the
+    /// gate observes both fields from the same fetch rather than a mix of two.
+    /// </summary>
+    private CachedMetadata? _cached;
+
+    /// <summary>
+    /// Creates the provider.
+    /// </summary>
+    public DiscoveredMetadataProvider(
+        IHttpClientFactory httpClientFactory,
+        TimeProvider timeProvider,
+        IOptions<DiscoveryOptions> options)
+    {
+        _httpClientFactory = httpClientFactory;
+        _timeProvider = timeProvider;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task<ProviderMetadata> GetMetadataAsync(CancellationToken cancellationToken = default)
+    {
+        var cached = _cached;
+        if (cached is not null && _timeProvider.GetUtcNow() < cached.ExpiresAt)
+            return cached.Metadata;
+
+        await _fetchGate.WaitAsync(cancellationToken);
+        try
+        {
+            // Another caller may have refreshed while this one waited on the gate.
+            cached = _cached;
+            if (cached is not null && _timeProvider.GetUtcNow() < cached.ExpiresAt)
+                return cached.Metadata;
+
+            var metadata = await FetchAsync(cancellationToken);
+
+            // Assigned only on success, so a transient failure does not poison the cache for the whole lifetime.
+            _cached = new CachedMetadata(metadata, _timeProvider.GetUtcNow() + _options.MetadataCacheLifetime);
+            return metadata;
+        }
+        finally
+        {
+            _fetchGate.Release();
+        }
+    }
+
+    private async Task<ProviderMetadata> FetchAsync(CancellationToken cancellationToken)
+    {
+        var address = ResolveMetadataAddress();
+
+        ProviderMetadata? metadata;
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            using var response = await httpClient.GetAsync(address, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            metadata = await response.Content.ReadFromJsonAsync<ProviderMetadata>(cancellationToken);
+        }
+        catch (Exception exception) when (exception is HttpRequestException or JsonException)
+        {
+            throw new ProviderMetadataException(
+                $"Failed to read the OpenID Provider metadata from '{address}'.", exception);
+        }
+
+        if (metadata is null)
+            throw new ProviderMetadataException($"The OpenID Provider metadata at '{address}' was empty.");
+
+        ValidateIssuer(metadata, address);
+        return metadata;
+    }
+
+    private Uri ResolveMetadataAddress()
+    {
+        if (_options.MetadataAddress is { } explicitAddress)
+            return explicitAddress;
+
+        var authority = _options.Authority
+            ?? throw new ProviderMetadataException(
+                $"Neither {nameof(DiscoveryOptions.Authority)} nor {nameof(DiscoveryOptions.MetadataAddress)} "
+                + "is configured, so there is no provider to discover.");
+
+        // A relative path combines against the authority's directory, so an authority that carries a path
+        // segment (a multi-tenant provider) would lose that segment unless the base ends in a separator.
+        var authorityAsDirectory = authority.AbsoluteUri.EndsWith(UriPathSeparator)
+            ? authority
+            : new Uri(authority.AbsoluteUri + UriPathSeparator);
+
+        return new Uri(authorityAsDirectory, WellKnownPath);
+    }
+
+    /// <summary>
+    /// Enforces the issuer check of OpenID Connect Discovery 1.0 section 4.3: the issuer the document claims
+    /// must be the authority the document was fetched from.
+    /// </summary>
+    /// <remarks>
+    /// Without this check a provider that is able to serve a document at one authority could name any issuer
+    /// it likes, and every later token validation would then be measured against that borrowed name.
+    /// </remarks>
+    private void ValidateIssuer(ProviderMetadata metadata, Uri address)
+    {
+        // Nothing to compare against when the host configured only an explicit metadata address: it has named
+        // the document's location directly, so the authority is whatever that document declares.
+        if (_options.Authority is not { } authority)
+            return;
+
+        // Compared as URIs rather than as text: a provider is free to declare its issuer with or without the
+        // trailing slash, and both forms name the same authority. Anything else is a mismatch.
+        if (!Uri.TryCreate(metadata.Issuer, UriKind.Absolute, out var declaredIssuer) || declaredIssuer != authority)
+        {
+            throw new ProviderMetadataException(
+                $"The OpenID Provider metadata at '{address}' declares issuer '{metadata.Issuer}', "
+                + $"which does not match the configured authority '{authority}'.");
+        }
+    }
+
+    private sealed record CachedMetadata(ProviderMetadata Metadata, DateTimeOffset ExpiresAt);
+}

--- a/src/Abblix.Oidc.Client/Features/Discovery/DiscoveredMetadataProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/DiscoveredMetadataProvider.cs
@@ -22,6 +22,7 @@
 
 using System.Net.Http.Json;
 using System.Text.Json;
+using Abblix.Oidc.Client.Internals;
 using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Client.Features.Discovery;
@@ -50,19 +51,8 @@ public sealed class DiscoveredMetadataProvider : IProviderMetadataProvider
     private const char UriPathSeparator = '/';
 
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly TimeProvider _timeProvider;
     private readonly DiscoveryOptions _options;
-
-    /// <summary>
-    /// Serializes fetches so that concurrent first requests result in one round trip rather than a stampede.
-    /// </summary>
-    private readonly SemaphoreSlim _fetchGate = new(1, 1);
-
-    /// <summary>
-    /// The cached document together with its expiry, held as a single reference so that a reader outside the
-    /// gate observes both fields from the same fetch rather than a mix of two.
-    /// </summary>
-    private CachedMetadata? _cached;
+    private readonly RefreshingCache<ProviderMetadata> _cache;
 
     /// <summary>
     /// Creates the provider.
@@ -73,36 +63,13 @@ public sealed class DiscoveredMetadataProvider : IProviderMetadataProvider
         IOptions<DiscoveryOptions> options)
     {
         _httpClientFactory = httpClientFactory;
-        _timeProvider = timeProvider;
         _options = options.Value;
+        _cache = new RefreshingCache<ProviderMetadata>(timeProvider);
     }
 
     /// <inheritdoc />
-    public async Task<ProviderMetadata> GetMetadataAsync(CancellationToken cancellationToken = default)
-    {
-        var cached = _cached;
-        if (cached is not null && _timeProvider.GetUtcNow() < cached.ExpiresAt)
-            return cached.Metadata;
-
-        await _fetchGate.WaitAsync(cancellationToken);
-        try
-        {
-            // Another caller may have refreshed while this one waited on the gate.
-            cached = _cached;
-            if (cached is not null && _timeProvider.GetUtcNow() < cached.ExpiresAt)
-                return cached.Metadata;
-
-            var metadata = await FetchAsync(cancellationToken);
-
-            // Assigned only on success, so a transient failure does not poison the cache for the whole lifetime.
-            _cached = new CachedMetadata(metadata, _timeProvider.GetUtcNow() + _options.MetadataCacheLifetime);
-            return metadata;
-        }
-        finally
-        {
-            _fetchGate.Release();
-        }
-    }
+    public Task<ProviderMetadata> GetMetadataAsync(CancellationToken cancellationToken = default)
+        => _cache.GetAsync(FetchAsync, _options.MetadataCacheLifetime, cancellationToken);
 
     private async Task<ProviderMetadata> FetchAsync(CancellationToken cancellationToken)
     {
@@ -172,6 +139,4 @@ public sealed class DiscoveredMetadataProvider : IProviderMetadataProvider
                 + $"which does not match the configured authority '{authority}'.");
         }
     }
-
-    private sealed record CachedMetadata(ProviderMetadata Metadata, DateTimeOffset ExpiresAt);
 }

--- a/src/Abblix.Oidc.Client/Features/Discovery/DiscoveryOptions.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/DiscoveryOptions.cs
@@ -1,0 +1,55 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Discovery;
+
+/// <summary>
+/// Configuration for reading the provider's discovery document.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="OidcClientOptions"/> because these settings only mean anything to a client that
+/// discovers its provider. A client configured against a provider that publishes no document never sees them.
+/// </remarks>
+public sealed class DiscoveryOptions
+{
+    /// <summary>
+    /// The base address of the OpenID Provider. The discovery document is read from the well-known path under
+    /// this address, and the issuer the provider declares is checked against it.
+    /// </summary>
+    public Uri? Authority { get; set; }
+
+    /// <summary>
+    /// The exact address of the discovery document, for a provider that publishes it somewhere other than
+    /// under <see cref="Authority"/>. Leave unset to use the well-known path, which is the normal case.
+    /// </summary>
+    public Uri? MetadataAddress { get; set; }
+
+    /// <summary>
+    /// How long a fetched discovery document is reused before it is read again.
+    /// </summary>
+    /// <remarks>
+    /// The document changes rarely, but it carries the provider's key set location and endpoints, so the
+    /// lifetime bounds how long the client keeps following a provider that has moved. Twelve hours refreshes
+    /// twice a day without making discovery a per-request cost.
+    /// </remarks>
+    public TimeSpan MetadataCacheLifetime { get; set; } = TimeSpan.FromHours(12);
+}

--- a/src/Abblix.Oidc.Client/Features/Discovery/IProviderMetadataProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/IProviderMetadataProvider.cs
@@ -20,20 +20,25 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-namespace Abblix.Oidc.Client;
+namespace Abblix.Oidc.Client.Features.Discovery;
 
 /// <summary>
-/// Configuration for the Abblix OIDC/OAuth client.
+/// Supplies the OpenID Provider's discovery metadata to the rest of the client.
 /// </summary>
 /// <remarks>
-/// Holds what the client is, not who it talks to. Where the provider's endpoints come from is configured with
-/// the metadata source the host registers, so a client that discovers its provider and one that is told its
-/// endpoints do not share a settings surface neither of them fully uses.
+/// Every consumer reads the provider's endpoints through this contract rather than from configuration, so a
+/// provider that moves an endpoint is followed automatically. Implementations are expected to cache: this is
+/// called on every authorization request, and the document changes rarely.
 /// </remarks>
-public sealed class OidcClientOptions
+public interface IProviderMetadataProvider
 {
     /// <summary>
-    /// The client identifier issued by the OpenID Provider, sent as the <c>client_id</c> parameter.
+    /// Returns the provider's metadata, fetching it if no valid cached copy is held.
     /// </summary>
-    public required string ClientId { get; set; }
+    /// <param name="cancellationToken">Cancels the fetch.</param>
+    /// <returns>The provider's discovery metadata.</returns>
+    /// <exception cref="ProviderMetadataException">
+    /// The document could not be fetched, could not be parsed, or failed the issuer check.
+    /// </exception>
+    Task<ProviderMetadata> GetMetadataAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Abblix.Oidc.Client/Features/Discovery/MetadataSourceNotChosenProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/MetadataSourceNotChosenProvider.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Discovery;
+
+/// <summary>
+/// Stands in for a metadata source the host never chose, and fails loudly when anything asks it for metadata.
+/// </summary>
+/// <remarks>
+/// Where the provider's endpoints come from is a decision the host has to make: reading them from a discovery
+/// document and reading them from configuration are different trust models, so neither is a safe default to
+/// pick silently. Registering this guard makes the omission a clear error naming the two calls, instead of a
+/// missing-service message or, worse, a quiet fallback.
+/// </remarks>
+public sealed class MetadataSourceNotChosenProvider : IProviderMetadataProvider
+{
+    /// <inheritdoc />
+    public Task<ProviderMetadata> GetMetadataAsync(CancellationToken cancellationToken = default)
+        => throw new ProviderMetadataException(
+            "No source of OpenID Provider metadata is registered. Call AddDiscovery() to read the provider's "
+            + "discovery document, or AddConfiguredMetadata() to supply the provider's endpoints directly for "
+            + "a provider that publishes no document.");
+}

--- a/src/Abblix.Oidc.Client/Features/Discovery/ProviderMetadata.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/ProviderMetadata.cs
@@ -1,0 +1,112 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.Oidc.Client.Features.Discovery;
+
+/// <summary>
+/// The OpenID Provider metadata document published at <c>/.well-known/openid-configuration</c>,
+/// as defined by OpenID Connect Discovery 1.0 and RFC 8414.
+/// </summary>
+/// <remarks>
+/// Property names are pinned with <see cref="JsonPropertyNameAttribute"/> rather than derived from a naming
+/// policy: this document is produced by a foreign provider, so its wire names must not depend on how the
+/// host happens to configure its serializer.
+///
+/// Only the members the client actually acts upon are modelled. A provider is free to publish members this
+/// client does not know, and doing so must not break deserialization, so unmapped members are preserved in
+/// <see cref="AdditionalMetadata"/> instead of being discarded.
+/// </remarks>
+public sealed record ProviderMetadata
+{
+    /// <summary>
+    /// The provider's issuer identifier. Every token this client accepts must name this issuer, and the value
+    /// is verified against the address the document was fetched from.
+    /// </summary>
+    [JsonPropertyName("issuer")]
+    public required string Issuer { get; init; }
+
+    /// <summary>
+    /// The authorization endpoint the user agent is redirected to at the start of the flow.
+    /// </summary>
+    [JsonPropertyName("authorization_endpoint")]
+    public string? AuthorizationEndpoint { get; init; }
+
+    /// <summary>
+    /// The token endpoint used to exchange an authorization code and to refresh tokens.
+    /// </summary>
+    [JsonPropertyName("token_endpoint")]
+    public string? TokenEndpoint { get; init; }
+
+    /// <summary>
+    /// The endpoint publishing the provider's JSON Web Key Set, the source of the keys that verify token
+    /// signatures.
+    /// </summary>
+    [JsonPropertyName("jwks_uri")]
+    public string? JsonWebKeySetUri { get; init; }
+
+    /// <summary>
+    /// The endpoint returning claims about the authenticated user.
+    /// </summary>
+    [JsonPropertyName("userinfo_endpoint")]
+    public string? UserInfoEndpoint { get; init; }
+
+    /// <summary>
+    /// The endpoint that terminates the provider-side session for RP-initiated logout.
+    /// </summary>
+    [JsonPropertyName("end_session_endpoint")]
+    public string? EndSessionEndpoint { get; init; }
+
+    /// <summary>
+    /// The endpoint that revokes an issued token, per RFC 7009.
+    /// </summary>
+    [JsonPropertyName("revocation_endpoint")]
+    public string? RevocationEndpoint { get; init; }
+
+    /// <summary>
+    /// The PKCE code challenge methods the provider supports. Absence is meaningful: a provider that does not
+    /// advertise <c>S256</c> cannot be assumed to support it.
+    /// </summary>
+    [JsonPropertyName("code_challenge_methods_supported")]
+    public IReadOnlyList<string>? CodeChallengeMethodsSupported { get; init; }
+
+    /// <summary>
+    /// The signing algorithms the provider may use for an <c>id_token</c>.
+    /// </summary>
+    [JsonPropertyName("id_token_signing_alg_values_supported")]
+    public IReadOnlyList<string>? IdTokenSigningAlgValuesSupported { get; init; }
+
+    /// <summary>
+    /// Indicates whether the provider returns the <c>iss</c> parameter in the authorization response,
+    /// the mix-up defence of RFC 9207.
+    /// </summary>
+    [JsonPropertyName("authorization_response_iss_parameter_supported")]
+    public bool? AuthorizationResponseIssParameterSupported { get; init; }
+
+    /// <summary>
+    /// Members of the document this client does not model, kept verbatim so that a paid layer or a host can
+    /// read a provider capability the base client has no opinion about.
+    /// </summary>
+    [JsonExtensionData]
+    public IDictionary<string, object?>? AdditionalMetadata { get; init; }
+}

--- a/src/Abblix.Oidc.Client/Features/Discovery/ProviderMetadataException.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/ProviderMetadataException.cs
@@ -20,20 +20,31 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-namespace Abblix.Oidc.Client;
+namespace Abblix.Oidc.Client.Features.Discovery;
 
 /// <summary>
-/// Configuration for the Abblix OIDC/OAuth client.
+/// Thrown when the OpenID Provider's discovery metadata cannot be obtained or cannot be trusted.
 /// </summary>
 /// <remarks>
-/// Holds what the client is, not who it talks to. Where the provider's endpoints come from is configured with
-/// the metadata source the host registers, so a client that discovers its provider and one that is told its
-/// endpoints do not share a settings surface neither of them fully uses.
+/// A distinct type so a host can tell "the provider is unreachable or misconfigured" apart from a protocol
+/// error returned by a provider that is working. Every failure here is loud: a client that proceeds on
+/// metadata it could not verify would be signing in against an unverified authority.
 /// </remarks>
-public sealed class OidcClientOptions
+public sealed class ProviderMetadataException : Exception
 {
     /// <summary>
-    /// The client identifier issued by the OpenID Provider, sent as the <c>client_id</c> parameter.
+    /// Creates the exception with a message describing what about the metadata failed.
     /// </summary>
-    public required string ClientId { get; set; }
+    public ProviderMetadataException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates the exception with a message and the underlying transport or parsing failure.
+    /// </summary>
+    public ProviderMetadataException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
 }

--- a/src/Abblix.Oidc.Client/Features/Discovery/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/Features/Discovery/ServiceCollectionExtensions.cs
@@ -1,0 +1,87 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.Features.Discovery;
+
+/// <summary>
+/// Registers the provider discovery feature.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the guard that stands in until the host chooses where the provider's metadata comes from.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    internal static IServiceCollection AddMetadataSourcePlaceholder(this IServiceCollection services)
+    {
+        // TryAdd, so a host that chose its source before calling the core keeps that choice.
+        services.TryAddSingleton<IProviderMetadataProvider, MetadataSourceNotChosenProvider>();
+        return services;
+    }
+
+    /// <summary>
+    /// Reads the provider's endpoints from the discovery document it publishes.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <param name="configureOptions">A delegate that configures <see cref="DiscoveryOptions"/>.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    public static IServiceCollection AddDiscovery(
+        this IServiceCollection services, Action<DiscoveryOptions> configureOptions)
+    {
+        services.Configure(configureOptions);
+        services.AddHttpClient(DiscoveredMetadataProvider.HttpClientName);
+
+        // A soft default, so a test or a host can substitute a clock before this call.
+        services.TryAddSingleton(TimeProvider.System);
+
+        // Replaces the not-chosen guard the core registers: this call IS the host making the choice.
+        // Singleton because the cache is the point, a scoped provider would re-fetch per request.
+        services.Replace(
+            ServiceDescriptor.Singleton<IProviderMetadataProvider, DiscoveredMetadataProvider>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Takes the provider's endpoints from configuration, for a provider that publishes no discovery
+    /// document.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <param name="metadata">The provider's endpoints, as documented by that provider.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    public static IServiceCollection AddConfiguredMetadata(
+        this IServiceCollection services, ProviderMetadata metadata)
+    {
+        services.TryAddSingleton(metadata);
+
+        // Replaces the not-chosen guard the core registers: this call IS the host making the choice.
+        services.Replace(
+            ServiceDescriptor.Singleton<IProviderMetadataProvider, ConfiguredMetadataProvider>());
+
+        return services;
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/Pkce/CodeChallengeMethods.cs
+++ b/src/Abblix.Oidc.Client/Features/Pkce/CodeChallengeMethods.cs
@@ -1,0 +1,54 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Pkce;
+
+/// <summary>
+/// The code challenge methods of RFC 7636, named as they appear on the wire.
+/// </summary>
+/// <remarks>
+/// Carries the same names as the server side of the family. The two cannot share a declaration, because the
+/// base client deliberately does not depend on the server package, and these are wire constants rather than
+/// logic.
+///
+/// Only <see cref="S256"/> is used when building a request. The weaker "plain" transformation is named here
+/// because a provider may advertise it, and recognising what a provider offers is not the same as agreeing
+/// to use it.
+/// </remarks>
+public static class CodeChallengeMethods
+{
+    /// <summary>
+    /// The code verifier is sent unhashed, so anyone who reads the authorization request holds it. Recognised
+    /// but never used by this client.
+    /// </summary>
+    public const string Plain = "plain";
+
+    /// <summary>
+    /// The code verifier is hashed with SHA-256. What this client sends.
+    /// </summary>
+    public const string S256 = "S256";
+
+    /// <summary>
+    /// The code verifier is hashed with SHA-512.
+    /// </summary>
+    public const string S512 = "S512";
+}

--- a/src/Abblix.Oidc.Client/Features/Pkce/IPkceProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Pkce/IPkceProvider.cs
@@ -1,0 +1,38 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Pkce;
+
+/// <summary>
+/// Creates the PKCE values that bind an authorization request to the client that made it.
+/// </summary>
+public interface IPkceProvider
+{
+    /// <summary>
+    /// Creates fresh PKCE values for one authorization request.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <exception cref="PkceException">
+    /// The provider cannot honour a transformation this client is willing to use.
+    /// </exception>
+    Task<PkceParameters> CreateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Abblix.Oidc.Client/Features/Pkce/PkceException.cs
+++ b/src/Abblix.Oidc.Client/Features/Pkce/PkceException.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Pkce;
+
+/// <summary>
+/// Thrown when PKCE values cannot be created on terms this client is willing to accept.
+/// </summary>
+public sealed class PkceException : Exception
+{
+    /// <summary>
+    /// Creates the exception with a message describing what about PKCE failed.
+    /// </summary>
+    public PkceException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/Pkce/PkceParameters.cs
+++ b/src/Abblix.Oidc.Client/Features/Pkce/PkceParameters.cs
@@ -1,0 +1,39 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.Pkce;
+
+/// <summary>
+/// The Proof Key for Code Exchange values of one authorization request, as defined by RFC 7636.
+/// </summary>
+/// <param name="CodeVerifier">
+/// The secret half. Never leaves this client until the authorization code is exchanged, and is what proves
+/// that the client redeeming the code is the one that asked for it.
+/// </param>
+/// <param name="CodeChallenge">
+/// The public half, derived from the verifier and sent with the authorization request. Whoever intercepts it
+/// cannot derive the verifier from it.
+/// </param>
+/// <param name="CodeChallengeMethod">
+/// The transformation used to derive <paramref name="CodeChallenge"/> from the verifier.
+/// </param>
+public sealed record PkceParameters(string CodeVerifier, string CodeChallenge, string CodeChallengeMethod);

--- a/src/Abblix.Oidc.Client/Features/Pkce/PkceProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/Pkce/PkceProvider.cs
@@ -1,0 +1,90 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Utils;
+
+namespace Abblix.Oidc.Client.Features.Pkce;
+
+/// <summary>
+/// Creates the PKCE values of an authorization request, using the SHA-256 transformation of RFC 7636.
+/// </summary>
+public sealed class PkceProvider : IPkceProvider
+{
+    /// <summary>
+    /// The number of random bytes behind a verifier.
+    /// </summary>
+    /// <remarks>
+    /// RFC 7636 section 4.1 allows a verifier of 43 to 128 characters and recommends exactly this: 32 bytes
+    /// from a cryptographic generator, encoded as base64url, which lands on 43 characters.
+    /// </remarks>
+    private const int VerifierByteCount = 32;
+
+    private readonly IProviderMetadataProvider _metadataProvider;
+
+    /// <summary>
+    /// Creates the provider.
+    /// </summary>
+    public PkceProvider(IProviderMetadataProvider metadataProvider) => _metadataProvider = metadataProvider;
+
+    /// <inheritdoc />
+    public async Task<PkceParameters> CreateAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureProviderSupportsSha256Async(cancellationToken);
+
+        var verifier = Base64Url.EncodeToString(CryptoRandom.GetRandomBytes(VerifierByteCount));
+        var challenge = Base64Url.EncodeToString(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+
+        return new PkceParameters(verifier, challenge, CodeChallengeMethods.S256);
+    }
+
+    /// <summary>
+    /// Refuses to build a request for a provider that does not advertise the SHA-256 transformation.
+    /// </summary>
+    /// <remarks>
+    /// RFC 7636 also defines a `plain` transformation, where the challenge is the verifier itself. Falling
+    /// back to it when the provider looks unable to do better is the PKCE downgrade: anyone who can read the
+    /// authorization request then holds the verifier, and the protection is gone while still appearing to be
+    /// in place. So the client stops instead, loudly, and the operator decides.
+    ///
+    /// A provider that advertises nothing is given the benefit of the doubt: the member is optional, plenty
+    /// of providers support SHA-256 without listing it, and a request the provider cannot honour fails there
+    /// rather than silently weakening anything here.
+    /// </remarks>
+    private async Task EnsureProviderSupportsSha256Async(CancellationToken cancellationToken)
+    {
+        var metadata = await _metadataProvider.GetMetadataAsync(cancellationToken);
+
+        if (metadata.CodeChallengeMethodsSupported is not { Count: > 0 } supported)
+            return;
+
+        if (!supported.Contains(CodeChallengeMethods.S256, StringComparer.Ordinal))
+            throw new PkceException(
+                $"The OpenID Provider '{metadata.Issuer}' advertises code challenge methods "
+                + $"[{string.Join(", ", supported)}], which do not include '{CodeChallengeMethods.S256}'. This client does "
+                + "not fall back to a weaker transformation, because doing so would leave the request looking "
+                + "protected while it is not.");
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/ConfiguredSigningKeysProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/ConfiguredSigningKeysProvider.cs
@@ -1,0 +1,71 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+
+namespace Abblix.Oidc.Client.Features.SigningKeys;
+
+/// <summary>
+/// Serves a fixed set of the provider's verification keys, held by the host rather than read from the
+/// provider.
+/// </summary>
+/// <remarks>
+/// Three situations call for this. A provider may publish no key set at all, the way many OAuth 2.0 providers
+/// publish no discovery document. A deployment may be unable to reach the provider's key endpoint at all,
+/// which is normal in segmented networks. And an operator may want the keys pinned deliberately, so that a
+/// key the provider starts serving is not automatically trusted.
+///
+/// The trade is rotation: a provider that rotates its keys makes this client reject its tokens until the host
+/// is reconfigured. That is the price of pinning, and it is the reason this is not the default.
+/// </remarks>
+public sealed class ConfiguredSigningKeysProvider : IIssuerSigningKeysProvider
+{
+    private readonly IReadOnlyCollection<JsonWebKey> _keys;
+
+    /// <summary>
+    /// Creates the provider over the keys the host registered.
+    /// </summary>
+    public ConfiguredSigningKeysProvider(IReadOnlyCollection<JsonWebKey> keys)
+    {
+        if (keys.Count == 0)
+            throw new SigningKeysException(
+                "No verification keys were configured, so no signature made by the provider could be checked.");
+
+        _keys = keys;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// A key named by the token but absent from the configured set does not narrow the result to nothing:
+    /// every held key is returned and signature verification makes the final call, exactly as when the key
+    /// set is read from the provider.
+    /// </remarks>
+    public Task<IReadOnlyCollection<JsonWebKey>> GetSigningKeysAsync(
+        string? keyId, CancellationToken cancellationToken = default)
+    {
+        if (keyId is null)
+            return Task.FromResult(_keys);
+
+        var named = _keys.Where(key => key.KeyId == keyId).ToArray();
+        return Task.FromResult<IReadOnlyCollection<JsonWebKey>>(named.Length > 0 ? named : _keys);
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/IIssuerSigningKeysProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/IIssuerSigningKeysProvider.cs
@@ -1,0 +1,50 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+
+namespace Abblix.Oidc.Client.Features.SigningKeys;
+
+/// <summary>
+/// Supplies the keys that verify signatures made by the OpenID Provider.
+/// </summary>
+public interface IIssuerSigningKeysProvider
+{
+    /// <summary>
+    /// Returns the provider's signature-verification keys, re-reading the key set when the token names a key
+    /// that is not held.
+    /// </summary>
+    /// <param name="keyId">
+    /// The <c>kid</c> the token to be verified names, or <c>null</c> when it names none.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>
+    /// The keys to try. A named key that the provider publishes is returned alone; otherwise every held key
+    /// is returned, so a token without a <c>kid</c> can still be verified by trying each.
+    /// </returns>
+    /// <remarks>
+    /// Rotation is handled here rather than by each caller: a provider replaces its keys on its own schedule,
+    /// and a token signed with a key the client has not seen yet is a normal event, not a rejection.
+    /// </remarks>
+    Task<IReadOnlyCollection<JsonWebKey>> GetSigningKeysAsync(
+        string? keyId, CancellationToken cancellationToken = default);
+}

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/IssuerSigningKeysProvider.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/IssuerSigningKeysProvider.cs
@@ -1,0 +1,154 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Abblix.Jwt;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Internals;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.Features.SigningKeys;
+
+/// <summary>
+/// Reads the provider's key set from the address its metadata names, keeps it, and re-reads it when a token
+/// names a key that is not held.
+/// </summary>
+public sealed class IssuerSigningKeysProvider : IIssuerSigningKeysProvider
+{
+    /// <summary>
+    /// The name of the <see cref="HttpClient"/> this provider resolves from <see cref="IHttpClientFactory"/>.
+    /// </summary>
+    public const string HttpClientName = "Abblix.Oidc.Client.SigningKeys";
+
+    /// <summary>
+    /// The value of a key's <c>use</c> member that marks it as a signature-verification key, per RFC 7517.
+    /// </summary>
+    private const string SignatureUsage = "sig";
+
+    private readonly IProviderMetadataProvider _metadataProvider;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly SigningKeysOptions _options;
+    private readonly RefreshingCache<IReadOnlyCollection<JsonWebKey>> _cache;
+
+    /// <summary>
+    /// The moment the last read triggered by an unknown key happened, which bounds how often the next one may.
+    /// </summary>
+    private DateTimeOffset? _lastRefreshForUnknownKey;
+
+    /// <summary>
+    /// Creates the provider.
+    /// </summary>
+    public IssuerSigningKeysProvider(
+        IProviderMetadataProvider metadataProvider,
+        IHttpClientFactory httpClientFactory,
+        TimeProvider timeProvider,
+        IOptions<SigningKeysOptions> options)
+    {
+        _metadataProvider = metadataProvider;
+        _httpClientFactory = httpClientFactory;
+        _timeProvider = timeProvider;
+        _options = options.Value;
+        _cache = new RefreshingCache<IReadOnlyCollection<JsonWebKey>>(timeProvider);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<JsonWebKey>> GetSigningKeysAsync(
+        string? keyId, CancellationToken cancellationToken = default)
+    {
+        var keys = await _cache.GetAsync(FetchAsync, _options.CacheLifetime, cancellationToken);
+
+        if (keyId is null)
+            return keys;
+
+        if (TrySelect(keys, keyId, out var named))
+            return named;
+
+        // The token names a key the client has not seen. That is what a rotation looks like from here, so
+        // read the set again rather than rejecting - but no more often than the floor allows, because this
+        // path is driven by whoever presents the token.
+        if (!MayRefreshForUnknownKey())
+            return keys;
+
+        _lastRefreshForUnknownKey = _timeProvider.GetUtcNow();
+        keys = await _cache.GetAsync(FetchAsync, _options.CacheLifetime, forceRefresh: true, cancellationToken);
+
+        // Still unknown after the re-read: return everything held and let signature verification make the
+        // final call. Deciding "no such key" here would turn a key the provider serves but does not label the
+        // way this client expects into a silent authentication failure.
+        return TrySelect(keys, keyId, out named) ? named : keys;
+    }
+
+    private bool MayRefreshForUnknownKey()
+        => _lastRefreshForUnknownKey is not { } lastRefresh ||
+           _options.MinimumRefreshInterval <= _timeProvider.GetUtcNow() - lastRefresh;
+
+    private static bool TrySelect(
+        IReadOnlyCollection<JsonWebKey> keys, string keyId, out IReadOnlyCollection<JsonWebKey> selected)
+    {
+        var named = keys.Where(key => key.KeyId == keyId).ToArray();
+        selected = named;
+        return named.Length > 0;
+    }
+
+    private async Task<IReadOnlyCollection<JsonWebKey>> FetchAsync(CancellationToken cancellationToken)
+    {
+        var metadata = await _metadataProvider.GetMetadataAsync(cancellationToken);
+
+        if (metadata.JsonWebKeySetUri is not { } keySetUri)
+            throw new SigningKeysException(
+                $"The OpenID Provider '{metadata.Issuer}' names no key set, so a signature it makes cannot be "
+                + "verified.");
+
+        JsonWebKeySet? keySet;
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            using var response = await httpClient.GetAsync(keySetUri, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            keySet = await response.Content.ReadFromJsonAsync<JsonWebKeySet>(cancellationToken);
+        }
+        catch (Exception exception) when (exception is HttpRequestException or JsonException)
+        {
+            throw new SigningKeysException(
+                $"Failed to read the key set of OpenID Provider '{metadata.Issuer}' from '{keySetUri}'.",
+                exception);
+        }
+
+        var keys = keySet?.Keys ?? [];
+
+        // Keys that carry no public half cannot verify anything, and a key the provider marks for encryption
+        // must not be pressed into signature verification: reusing a key across purposes is exactly what the
+        // `use` member exists to prevent.
+        var signingKeys = keys
+            .Where(key => key.HasPublicKey && key.Usage is null or SignatureUsage)
+            .ToArray();
+
+        if (signingKeys.Length == 0)
+            throw new SigningKeysException(
+                $"The key set of OpenID Provider '{metadata.Issuer}' at '{keySetUri}' holds no key usable for "
+                + "signature verification.");
+
+        return signingKeys;
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/ServiceCollectionExtensions.cs
@@ -1,0 +1,52 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Abblix.Oidc.Client.Features.SigningKeys;
+
+/// <summary>
+/// Registers the reader of the provider's signing keys.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the source of the keys that verify signatures made by the OpenID Provider.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    public static IServiceCollection AddSigningKeys(this IServiceCollection services)
+    {
+        services.AddHttpClient(IssuerSigningKeysProvider.HttpClientName);
+
+        // A soft default, so a test or a host can substitute a clock before this call.
+        services.TryAddSingleton(TimeProvider.System);
+
+        // Singleton because the key set is cached across requests. The contract is registered with TryAdd,
+        // so a host running many replicas can supply an implementation whose cache and refresh floor are
+        // shared across them - see the remarks on SigningKeysOptions.MinimumRefreshInterval.
+        services.TryAddSingleton<IIssuerSigningKeysProvider, IssuerSigningKeysProvider>();
+
+        return services;
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Jwt;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -46,6 +47,27 @@ public static class ServiceCollectionExtensions
         // so a host running many replicas can supply an implementation whose cache and refresh floor are
         // shared across them - see the remarks on SigningKeysOptions.MinimumRefreshInterval.
         services.TryAddSingleton<IIssuerSigningKeysProvider, IssuerSigningKeysProvider>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Uses a fixed set of verification keys held by the host, instead of reading the provider's key set.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <param name="keys">The provider's verification keys, as published by that provider.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    /// <remarks>
+    /// For a provider that publishes no key set, a deployment that cannot reach the one it publishes, or an
+    /// operator who wants the keys pinned. The trade is that a rotation by the provider now needs a
+    /// reconfiguration here, so this is a choice rather than a default.
+    /// </remarks>
+    public static IServiceCollection AddConfiguredSigningKeys(
+        this IServiceCollection services, IReadOnlyCollection<JsonWebKey> keys)
+    {
+        // Replaces the reader registered by AddSigningKeys: this call IS the host making the choice.
+        services.Replace(ServiceDescriptor.Singleton<IIssuerSigningKeysProvider>(
+            _ => new ConfiguredSigningKeysProvider(keys)));
 
         return services;
     }

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/SigningKeysException.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/SigningKeysException.cs
@@ -1,0 +1,49 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.SigningKeys;
+
+/// <summary>
+/// Thrown when the OpenID Provider's signing keys cannot be obtained.
+/// </summary>
+/// <remarks>
+/// Distinct from a signature that simply fails to verify: this says the client never got the keys to check
+/// against, which is an operational fault rather than a rejected token.
+/// </remarks>
+public sealed class SigningKeysException : Exception
+{
+    /// <summary>
+    /// Creates the exception with a message describing what about the key set failed.
+    /// </summary>
+    public SigningKeysException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates the exception with a message and the underlying transport or parsing failure.
+    /// </summary>
+    public SigningKeysException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/SigningKeys/SigningKeysOptions.cs
+++ b/src/Abblix.Oidc.Client/Features/SigningKeys/SigningKeysOptions.cs
@@ -1,0 +1,52 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Features.SigningKeys;
+
+/// <summary>
+/// Configuration for reading the provider's signing keys.
+/// </summary>
+public sealed class SigningKeysOptions
+{
+    /// <summary>
+    /// How long a fetched key set is reused before it is read again.
+    /// </summary>
+    public TimeSpan CacheLifetime { get; set; } = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// The shortest interval between two key-set reads triggered by a token naming an unknown key.
+    /// </summary>
+    /// <remarks>
+    /// A provider rotates its keys whenever it likes, so a token signed with a key the client has not seen is
+    /// normal and must trigger a re-read rather than a rejection. That re-read is driven by unauthenticated
+    /// input, though: anyone can present a token naming a random key. Without a floor, a stream of such
+    /// tokens turns this client into a load generator against its own provider. The interval bounds that to
+    /// one read per window, no matter how many unknown keys arrive.
+    ///
+    /// The bound is per client instance, because the count that enforces it lives in memory. An application
+    /// running N replicas therefore allows up to N reads per window, not one. That is usually fine, and it is
+    /// deliberately not solved by making a base client depend on shared storage. An application that needs a
+    /// bound across replicas registers its own <see cref="IIssuerSigningKeysProvider"/> backed by whatever it
+    /// already shares.
+    /// </remarks>
+    public TimeSpan MinimumRefreshInterval { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/ClientAuthenticationMethods.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/ClientAuthenticationMethods.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// The ways this client can authenticate itself at the token endpoint, named as on the wire.
+/// </summary>
+/// <remarks>
+/// Carries the same names as the server side of the family. Only the methods a base client needs are listed:
+/// the ones built on a private key or a certificate belong to the paid layer that adds them.
+/// </remarks>
+public static class ClientAuthenticationMethods
+{
+    /// <summary>The secret travels in the Authorization header, as HTTP Basic.</summary>
+    public const string ClientSecretBasic = "client_secret_basic";
+
+    /// <summary>The secret travels in the request body.</summary>
+    public const string ClientSecretPost = "client_secret_post";
+
+    /// <summary>
+    /// No client authentication. What a public client uses, where there is no secret to keep because the
+    /// client runs somewhere the user controls.
+    /// </summary>
+    public const string None = "none";
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/ErrorCodes.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/ErrorCodes.cs
@@ -1,0 +1,41 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// The error codes a token endpoint returns, named as on the wire (RFC 6749 section 5.2).
+/// </summary>
+public static class ErrorCodes
+{
+    /// <summary>
+    /// The grant presented is no longer good: an authorization code already redeemed or expired, or a
+    /// refresh token that has been rotated away.
+    /// </summary>
+    /// <remarks>
+    /// The one code a client must react to rather than merely report. On a refresh it usually means another
+    /// request for the same session already rotated the token, which is a race to recover from, not a reason
+    /// to end the session.
+    /// </remarks>
+    public const string InvalidGrant = "invalid_grant";
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/GrantTypes.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/GrantTypes.cs
@@ -1,0 +1,36 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// The grant types this client presents at the token endpoint, as they appear on the wire.
+/// </summary>
+public static class GrantTypes
+{
+    /// <summary>Exchanging an authorization code for tokens.</summary>
+    public const string AuthorizationCode = "authorization_code";
+
+    /// <summary>Trading a refresh token for a fresh set.</summary>
+    public const string RefreshToken = "refresh_token";
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/ITokenRequestService.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/ITokenRequestService.cs
@@ -1,0 +1,54 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// Talks to the OpenID Provider's token endpoint.
+/// </summary>
+public interface ITokenRequestService
+{
+    /// <summary>
+    /// Exchanges an authorization code for tokens.
+    /// </summary>
+    /// <param name="code">The code the provider returned to the callback.</param>
+    /// <param name="codeVerifier">The secret half of the PKCE pair kept from the request.</param>
+    /// <param name="redirectUri">
+    /// The redirect address of the original request, which the provider compares against what it recorded.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <exception cref="TokenRequestException">The provider refused, or could not be reached.</exception>
+    Task<TokenResponse> ExchangeCodeAsync(
+        string code, string codeVerifier, string redirectUri, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Trades a refresh token for a fresh set of tokens.
+    /// </summary>
+    /// <param name="refreshToken">The refresh token held for the session.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <exception cref="TokenRequestException">
+    /// The provider refused, or could not be reached. A refusal carrying
+    /// <see cref="ErrorCodes.InvalidGrant"/> means this token has been rotated away.
+    /// </exception>
+    Task<TokenResponse> RefreshAsync(string refreshToken, CancellationToken cancellationToken = default);
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// Registers the talker to the token endpoint.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the service that redeems grants at the provider's token endpoint.
+    /// </summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <param name="configureOptions">A delegate that configures <see cref="TokenRequestOptions"/>.</param>
+    /// <returns>The same collection, so calls chain.</returns>
+    public static IServiceCollection AddTokenRequests(
+        this IServiceCollection services, Action<TokenRequestOptions> configureOptions)
+    {
+        services.Configure(configureOptions);
+        services.AddHttpClient(TokenRequestService.HttpClientName);
+        services.TryAddSingleton<ITokenRequestService, TokenRequestService>();
+
+        return services;
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/TokenErrorResponse.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/TokenErrorResponse.cs
@@ -1,0 +1,44 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// What the token endpoint returns on failure, per RFC 6749 section 5.2.
+/// </summary>
+public sealed record TokenErrorResponse
+{
+    /// <summary>
+    /// The machine-readable reason the request was refused.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// A human-readable elaboration, when the provider offers one.
+    /// </summary>
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; init; }
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/TokenRequestException.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/TokenRequestException.cs
@@ -1,0 +1,63 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// Thrown when the token endpoint refuses a request or cannot be reached.
+/// </summary>
+public sealed class TokenRequestException : Exception
+{
+    /// <summary>
+    /// Creates the exception from what the provider returned.
+    /// </summary>
+    public TokenRequestException(string message, string? error = null, string? errorDescription = null)
+        : base(message)
+    {
+        Error = error;
+        ErrorDescription = errorDescription;
+    }
+
+    /// <summary>
+    /// Creates the exception for a failure that never reached a protocol answer.
+    /// </summary>
+    public TokenRequestException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// The error code the provider returned, or <c>null</c> when the request never got that far.
+    /// </summary>
+    /// <remarks>
+    /// Carried separately from the message because callers act on it. A refresh answered with
+    /// <see cref="ErrorCodes.InvalidGrant"/> means the token presented has been rotated away, which is
+    /// recoverable by re-reading what is stored; every other code is not.
+    /// </remarks>
+    public string? Error { get; }
+
+    /// <summary>
+    /// The provider's elaboration on <see cref="Error"/>, when it gave one.
+    /// </summary>
+    public string? ErrorDescription { get; }
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/TokenRequestOptions.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/TokenRequestOptions.cs
@@ -1,0 +1,50 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// Configuration of how this client presents itself at the token endpoint.
+/// </summary>
+public sealed class TokenRequestOptions
+{
+    /// <summary>
+    /// How the client authenticates itself.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="ClientAuthenticationMethods.None"/>, the public-client case, because that is
+    /// the one where getting it wrong is harmless: a client with no secret cannot leak one. A confidential
+    /// client says so, and supplies <see cref="ClientSecret"/>.
+    /// </remarks>
+    public string ClientAuthenticationMethod { get; set; } = ClientAuthenticationMethods.None;
+
+    /// <summary>
+    /// The secret shared with the provider. Required by every method other than
+    /// <see cref="ClientAuthenticationMethods.None"/>.
+    /// </summary>
+    /// <remarks>
+    /// This belongs in a secret store, not in a configuration file committed anywhere. A client that keeps a
+    /// secret somewhere the user can read it is not a confidential client, whatever it is configured as.
+    /// </remarks>
+    public string? ClientSecret { get; set; }
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/TokenRequestService.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/TokenRequestService.cs
@@ -1,0 +1,228 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Abblix.Oidc.Client.Features.Discovery;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// Posts grants to the provider's token endpoint and reads back what it returns.
+/// </summary>
+public sealed class TokenRequestService : ITokenRequestService
+{
+    /// <summary>
+    /// The name of the <see cref="HttpClient"/> this service resolves from <see cref="IHttpClientFactory"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named client rather than a bare one so that a paid layer can hang a handler chain on this exact
+    /// traffic: certificate-bound mutual TLS, or the retry that RFC 9449 requires when a provider answers a
+    /// DPoP-protected request by demanding a fresh nonce.
+    /// </remarks>
+    public const string HttpClientName = "Abblix.Oidc.Client.Tokens";
+
+    private readonly IProviderMetadataProvider _metadataProvider;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly OidcClientOptions _clientOptions;
+    private readonly TokenRequestOptions _options;
+
+    /// <summary>
+    /// Creates the service.
+    /// </summary>
+    public TokenRequestService(
+        IProviderMetadataProvider metadataProvider,
+        IHttpClientFactory httpClientFactory,
+        IOptions<OidcClientOptions> clientOptions,
+        IOptions<TokenRequestOptions> options)
+    {
+        _metadataProvider = metadataProvider;
+        _httpClientFactory = httpClientFactory;
+        _clientOptions = clientOptions.Value;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public Task<TokenResponse> ExchangeCodeAsync(
+        string code, string codeVerifier, string redirectUri, CancellationToken cancellationToken = default)
+        => PostAsync(
+            new Dictionary<string, string>
+            {
+                ["grant_type"] = GrantTypes.AuthorizationCode,
+                ["code"] = code,
+                ["code_verifier"] = codeVerifier,
+
+                // Repeated from the authorization request, and compared by the provider against what it
+                // recorded there. A mismatch is what stops a code from being redeemed into someone else's
+                // client.
+                ["redirect_uri"] = redirectUri,
+            },
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<TokenResponse> RefreshAsync(
+        string refreshToken, CancellationToken cancellationToken = default)
+        => PostAsync(
+            new Dictionary<string, string>
+            {
+                ["grant_type"] = GrantTypes.RefreshToken,
+                ["refresh_token"] = refreshToken,
+            },
+            cancellationToken);
+
+    private async Task<TokenResponse> PostAsync(
+        Dictionary<string, string> parameters, CancellationToken cancellationToken)
+    {
+        var metadata = await _metadataProvider.GetMetadataAsync(cancellationToken);
+
+        if (metadata.TokenEndpoint is not { } tokenEndpoint)
+            throw new TokenRequestException(
+                $"The OpenID Provider '{metadata.Issuer}' names no token endpoint, so no grant can be "
+                + "redeemed.");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint);
+        Authenticate(request, parameters);
+        request.Content = new FormUrlEncodedContent(parameters);
+
+        HttpResponseMessage response;
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            response = await httpClient.SendAsync(request, cancellationToken);
+        }
+        catch (HttpRequestException exception)
+        {
+            throw new TokenRequestException(
+                $"Failed to reach the token endpoint of OpenID Provider '{metadata.Issuer}' at "
+                + $"'{tokenEndpoint}'.",
+                exception);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+                await ThrowRefusalAsync(response, metadata, cancellationToken);
+
+            return await ReadSuccessAsync(response, metadata, tokenEndpoint, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Presents the client's credentials the way the host configured.
+    /// </summary>
+    /// <remarks>
+    /// The method is configured rather than picked from what the provider advertises. Choosing the strongest
+    /// method a provider claims to support sounds helpful, but it lets the provider's own document decide how
+    /// this client authenticates, and a downgrade there is silent.
+    /// </remarks>
+    private void Authenticate(HttpRequestMessage request, Dictionary<string, string> parameters)
+    {
+        switch (_options.ClientAuthenticationMethod)
+        {
+            case ClientAuthenticationMethods.ClientSecretBasic:
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", BasicCredentials());
+                break;
+
+            case ClientAuthenticationMethods.ClientSecretPost:
+                parameters["client_id"] = _clientOptions.ClientId;
+                parameters["client_secret"] = RequireSecret();
+                break;
+
+            case ClientAuthenticationMethods.None:
+                // A public client has no secret to present, but still has to say who it is.
+                parameters["client_id"] = _clientOptions.ClientId;
+                break;
+
+            default:
+                throw new TokenRequestException(
+                    $"Client authentication method '{_options.ClientAuthenticationMethod}' is not one this "
+                    + "client can present.");
+        }
+    }
+
+    /// <summary>
+    /// Builds the HTTP Basic credentials of RFC 6749 section 2.3.1.
+    /// </summary>
+    /// <remarks>
+    /// Both halves are form-encoded before being joined, which the specification requires and which matters
+    /// for a secret containing a colon or a non-ASCII character. Skipping it produces credentials the
+    /// provider reads as a different secret entirely.
+    /// </remarks>
+    private string BasicCredentials()
+    {
+        var userName = Uri.EscapeDataString(_clientOptions.ClientId);
+        var password = Uri.EscapeDataString(RequireSecret());
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes($"{userName}:{password}"));
+    }
+
+    private string RequireSecret()
+        => _options.ClientSecret
+           ?? throw new TokenRequestException(
+               $"Client authentication method '{_options.ClientAuthenticationMethod}' needs a client secret, "
+               + $"but {nameof(TokenRequestOptions)}.{nameof(TokenRequestOptions.ClientSecret)} is not set.");
+
+    private static async Task ThrowRefusalAsync(
+        HttpResponseMessage response, ProviderMetadata metadata, CancellationToken cancellationToken)
+    {
+        TokenErrorResponse? error = null;
+        try
+        {
+            error = await response.Content.ReadFromJsonAsync<TokenErrorResponse>(cancellationToken);
+        }
+        catch (JsonException)
+        {
+            // A provider that answers a refusal with something other than the documented shape still refused.
+            // The status code is the part that matters, so the unreadable body is not allowed to mask it.
+        }
+
+        throw new TokenRequestException(
+            $"The token endpoint of OpenID Provider '{metadata.Issuer}' refused the request with status "
+            + $"{(int)response.StatusCode}"
+            + (error?.Error is { } code ? $" and error '{code}'." : "."),
+            error?.Error,
+            error?.ErrorDescription);
+    }
+
+    private static async Task<TokenResponse> ReadSuccessAsync(
+        HttpResponseMessage response,
+        ProviderMetadata metadata,
+        string tokenEndpoint,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken)
+                   ?? throw new TokenRequestException(
+                       $"The token endpoint of OpenID Provider '{metadata.Issuer}' returned an empty "
+                       + "response.");
+        }
+        catch (JsonException exception)
+        {
+            throw new TokenRequestException(
+                $"Failed to read the response of the token endpoint at '{tokenEndpoint}'.", exception);
+        }
+    }
+}

--- a/src/Abblix.Oidc.Client/Features/Tokens/TokenResponse.cs
+++ b/src/Abblix.Oidc.Client/Features/Tokens/TokenResponse.cs
@@ -1,0 +1,83 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.Oidc.Client.Features.Tokens;
+
+/// <summary>
+/// What the token endpoint returns on success, per RFC 6749 section 5.1.
+/// </summary>
+/// <remarks>
+/// Wire names are pinned with attributes rather than derived from a naming policy: the document comes from a
+/// foreign provider, so reading it must not depend on how the host configures its serializer.
+/// </remarks>
+public sealed record TokenResponse
+{
+    /// <summary>
+    /// The token presented to resource servers.
+    /// </summary>
+    [JsonPropertyName("access_token")]
+    public required string AccessToken { get; init; }
+
+    /// <summary>
+    /// How the access token is to be presented, almost always <c>Bearer</c>.
+    /// </summary>
+    [JsonPropertyName("token_type")]
+    public required string TokenType { get; init; }
+
+    /// <summary>
+    /// Seconds until the access token expires, when the provider says.
+    /// </summary>
+    [JsonPropertyName("expires_in")]
+    public int? ExpiresIn { get; init; }
+
+    /// <summary>
+    /// The token used to obtain a fresh set once the access token expires.
+    /// </summary>
+    /// <remarks>
+    /// A provider that rotates refresh tokens returns a new one here on every refresh, and the one presented
+    /// stops working the moment this arrives. Storing this value is therefore not an optimisation but a
+    /// requirement: lose it and the session cannot be continued.
+    /// </remarks>
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; init; }
+
+    /// <summary>
+    /// The token asserting who the user is. Present when the request carried the <c>openid</c> scope.
+    /// </summary>
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; init; }
+
+    /// <summary>
+    /// What the issued access token is actually good for, when it differs from what was asked.
+    /// </summary>
+    [JsonPropertyName("scope")]
+    public string? Scope { get; init; }
+
+    /// <summary>
+    /// Members of the response this client does not model, kept so a paid layer or a host can read a value
+    /// the base client has no opinion about.
+    /// </summary>
+    [JsonExtensionData]
+    public IDictionary<string, object?>? AdditionalData { get; init; }
+}

--- a/src/Abblix.Oidc.Client/Internals/RefreshingCache.cs
+++ b/src/Abblix.Oidc.Client/Internals/RefreshingCache.cs
@@ -1,0 +1,144 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client.Internals;
+
+/// <summary>
+/// Holds a value fetched from the provider and re-fetches it once it has aged out.
+/// </summary>
+/// <typeparam name="T">The cached value.</typeparam>
+/// <remarks>
+/// The client reads two things from the provider that change rarely and cost a round trip: the discovery
+/// document and the key set. Both want the same behaviour, so it lives here once.
+///
+/// Two properties matter and are easy to get wrong separately: concurrent first calls must produce one round
+/// trip rather than a stampede, and a failed fetch must not be cached, or one unlucky moment silences the
+/// provider for the whole lifetime.
+/// </remarks>
+internal sealed class RefreshingCache<T>
+    where T : class
+{
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Serializes fetches so concurrent callers share one round trip.
+    /// </summary>
+    private readonly SemaphoreSlim _fetchGate = new(1, 1);
+
+    /// <summary>
+    /// The value together with its expiry, held as a single reference so a reader outside the gate observes
+    /// both from the same fetch rather than a mix of two.
+    /// </summary>
+    private Entry? _entry;
+
+    /// <summary>
+    /// The largest share of a lifetime that may be cut from it to spread expiry across instances.
+    /// </summary>
+    /// <remarks>
+    /// Replicas of the same deployment start together, so without this their entries expire within
+    /// milliseconds of each other and every replica goes to the provider in one wave. Cutting a random slice
+    /// off each lifetime pulls them apart.
+    ///
+    /// The slice is only ever subtracted, never added: a value is then held no longer than the configured
+    /// lifetime, so the jitter cannot extend how long a stale document or key set stays in use.
+    /// </remarks>
+    private const double MaximumJitterShare = 0.1;
+
+    /// <summary>
+    /// Creates the cache over the clock that decides when an entry has aged out.
+    /// </summary>
+    public RefreshingCache(TimeProvider timeProvider) => _timeProvider = timeProvider;
+
+    /// <summary>
+    /// Returns the held value, fetching it when nothing valid is held.
+    /// </summary>
+    /// <param name="fetch">Reads the value from the provider.</param>
+    /// <param name="lifetime">How long a fetched value stays valid.</param>
+    /// <param name="cancellationToken">Cancels the fetch.</param>
+    public Task<T> GetAsync(
+        Func<CancellationToken, Task<T>> fetch, TimeSpan lifetime, CancellationToken cancellationToken)
+        => GetAsync(fetch, lifetime, forceRefresh: false, cancellationToken);
+
+    /// <summary>
+    /// Returns the held value, optionally discarding a still-valid one first.
+    /// </summary>
+    /// <param name="fetch">Reads the value from the provider.</param>
+    /// <param name="lifetime">How long a fetched value stays valid.</param>
+    /// <param name="forceRefresh">Fetches even when the held value has not aged out.</param>
+    /// <param name="cancellationToken">Cancels the fetch.</param>
+    public async Task<T> GetAsync(
+        Func<CancellationToken, Task<T>> fetch,
+        TimeSpan lifetime,
+        bool forceRefresh,
+        CancellationToken cancellationToken)
+    {
+        T value;
+        if (!forceRefresh && TryReadValid(out value))
+            return value;
+
+        // Captured before waiting, so that after the gate this caller can tell whether the entry it found
+        // wanting is still the one held. A timestamp cannot answer that: a clock too coarse to separate two
+        // adjacent operations would make a forced refresh accept the very entry it was asked to replace.
+        var rejectedEntry = _entry;
+
+        await _fetchGate.WaitAsync(cancellationToken);
+        try
+        {
+            // Another caller may have fetched while this one waited on the gate, in which case its result
+            // stands and this caller does not repeat the round trip.
+            if (!ReferenceEquals(_entry, rejectedEntry) && TryReadValid(out value))
+                return value;
+
+            var fetched = await fetch(cancellationToken);
+
+            // Assigned only on success, so a transient failure does not silence the provider for the rest of
+            // the lifetime.
+            _entry = new Entry(fetched, _timeProvider.GetUtcNow() + Jitter(lifetime));
+            return fetched;
+        }
+        finally
+        {
+            _fetchGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Shortens a lifetime by a random share of itself, so replicas started together stop expiring together.
+    /// </summary>
+    private static TimeSpan Jitter(TimeSpan lifetime)
+        => lifetime - lifetime * (Random.Shared.NextDouble() * MaximumJitterShare);
+
+    private bool TryReadValid(out T value)
+    {
+        var entry = _entry;
+        if (entry is not null && _timeProvider.GetUtcNow() < entry.ExpiresAt)
+        {
+            value = entry.Value;
+            return true;
+        }
+
+        value = null!;
+        return false;
+    }
+
+    private sealed record Entry(T Value, DateTimeOffset ExpiresAt);
+}

--- a/src/Abblix.Oidc.Client/Internals/RefreshingCache.cs
+++ b/src/Abblix.Oidc.Client/Internals/RefreshingCache.cs
@@ -40,13 +40,8 @@ internal sealed class RefreshingCache<T>
     private readonly TimeProvider _timeProvider;
 
     /// <summary>
-    /// Serializes fetches so concurrent callers share one round trip.
-    /// </summary>
-    private readonly SemaphoreSlim _fetchGate = new(1, 1);
-
-    /// <summary>
-    /// The value together with its expiry, held as a single reference so a reader outside the gate observes
-    /// both from the same fetch rather than a mix of two.
+    /// The in-flight or completed fetch together with its expiry, held as a single reference so a reader
+    /// observes both from the same attempt rather than a mix of two.
     /// </summary>
     private Entry? _entry;
 
@@ -91,33 +86,36 @@ internal sealed class RefreshingCache<T>
         bool forceRefresh,
         CancellationToken cancellationToken)
     {
-        T value;
-        if (!forceRefresh && TryReadValid(out value))
-            return value;
+        var observed = Volatile.Read(ref _entry);
+        if (!forceRefresh && IsValid(observed))
+            return await observed!.Fetch.WaitAsync(cancellationToken);
 
-        // Captured before waiting, so that after the gate this caller can tell whether the entry it found
-        // wanting is still the one held. A timestamp cannot answer that: a clock too coarse to separate two
-        // adjacent operations would make a forced refresh accept the very entry it was asked to replace.
-        var rejectedEntry = _entry;
+        // The observed entry is missing, aged out, or explicitly rejected, so a fetch is owed. Publishing the
+        // replacement before the fetch runs is what makes callers share it: a caller arriving mid-flight
+        // finds this entry and awaits the same attempt instead of starting its own.
+        //
+        // The fetch itself is started without any one caller's cancellation token. It is shared, so letting
+        // the first caller's cancellation abort it would cancel everyone else's read as a side effect. Each
+        // caller instead abandons its own wait below.
+        var replacement = new Entry(() => fetch(CancellationToken.None), _timeProvider.GetUtcNow() + Jitter(lifetime));
 
-        await _fetchGate.WaitAsync(cancellationToken);
+        // Whoever wins the exchange owns the fetch; whoever loses joins the winner's rather than duplicating
+        // it. Comparing against the entry this caller actually observed is what makes a forced refresh accept
+        // a replacement someone else has already published.
+        var current = Interlocked.CompareExchange(ref _entry, replacement, observed);
+        var winner = ReferenceEquals(current, observed) ? replacement : current!;
+
         try
         {
-            // Another caller may have fetched while this one waited on the gate, in which case its result
-            // stands and this caller does not repeat the round trip.
-            if (!ReferenceEquals(_entry, rejectedEntry) && TryReadValid(out value))
-                return value;
-
-            var fetched = await fetch(cancellationToken);
-
-            // Assigned only on success, so a transient failure does not silence the provider for the rest of
-            // the lifetime.
-            _entry = new Entry(fetched, _timeProvider.GetUtcNow() + Jitter(lifetime));
-            return fetched;
+            return await winner.Fetch.WaitAsync(cancellationToken);
         }
-        finally
+        catch when (!cancellationToken.IsCancellationRequested)
         {
-            _fetchGate.Release();
+            // A failed attempt must not be left in place, or one unlucky moment silences the provider for the
+            // rest of the lifetime. Removed only if it is still the entry held, so a retry that has already
+            // succeeded is not thrown away.
+            Interlocked.CompareExchange(ref _entry, null, winner);
+            throw;
         }
     }
 
@@ -127,18 +125,30 @@ internal sealed class RefreshingCache<T>
     private static TimeSpan Jitter(TimeSpan lifetime)
         => lifetime - lifetime * (Random.Shared.NextDouble() * MaximumJitterShare);
 
-    private bool TryReadValid(out T value)
+    private bool IsValid(Entry? entry) => entry is not null && _timeProvider.GetUtcNow() < entry.ExpiresAt;
+
+    /// <summary>
+    /// One attempt to read the value, shared by every caller that arrives while it is in flight.
+    /// </summary>
+    /// <remarks>
+    /// The fetch is started lazily and exactly once, so an entry that loses the exchange never runs the
+    /// request it was created for.
+    ///
+    /// The lifetime is measured from when the attempt started rather than from when it finished, which errs
+    /// towards reading again sooner.
+    /// </remarks>
+    private sealed class Entry
     {
-        var entry = _entry;
-        if (entry is not null && _timeProvider.GetUtcNow() < entry.ExpiresAt)
+        private readonly Lazy<Task<T>> _fetch;
+
+        public Entry(Func<Task<T>> fetch, DateTimeOffset expiresAt)
         {
-            value = entry.Value;
-            return true;
+            _fetch = new Lazy<Task<T>>(fetch, LazyThreadSafetyMode.ExecutionAndPublication);
+            ExpiresAt = expiresAt;
         }
 
-        value = null!;
-        return false;
-    }
+        public Task<T> Fetch => _fetch.Value;
 
-    private sealed record Entry(T Value, DateTimeOffset ExpiresAt);
+        public DateTimeOffset ExpiresAt { get; }
+    }
 }

--- a/src/Abblix.Oidc.Client/OidcClientOptions.cs
+++ b/src/Abblix.Oidc.Client/OidcClientOptions.cs
@@ -1,0 +1,34 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Client;
+
+/// <summary>
+/// Configuration for the Abblix OIDC/OAuth client.
+/// </summary>
+public sealed class OidcClientOptions
+{
+    /// <summary>
+    /// The client identifier issued by the OpenID Provider, sent as the <c>client_id</c> parameter.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+}

--- a/src/Abblix.Oidc.Client/README.md
+++ b/src/Abblix.Oidc.Client/README.md
@@ -1,0 +1,11 @@
+# Abblix OIDC Client
+
+A self-contained OpenID Connect and OAuth 2.0 client for .NET, built on the same engine as [Abblix OIDC Server](https://github.com/Abblix/Oidc.Server).
+
+It is the client side of the Abblix stack: authorization code flow with PKCE, token handling, provider discovery, and `id_token` validation on the `Abblix.Jwt` engine, independent of the built-in ASP.NET Core handler.
+
+> Work in progress. The public API is still taking shape and is not yet stable.
+
+## License
+
+Proprietary. See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md) and https://oidc.abblix.com/license.

--- a/src/Abblix.Oidc.Client/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Features.SigningKeys;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Abblix.Oidc.Client;
@@ -47,6 +48,7 @@ public static class ServiceCollectionExtensions
         services.Configure(configureOptions);
 
         return services
-            .AddMetadataSourcePlaceholder();
+            .AddMetadataSourcePlaceholder()
+            .AddSigningKeys();
     }
 }

--- a/src/Abblix.Oidc.Client/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Oidc.Client.Features.Discovery;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Abblix.Oidc.Client;
@@ -35,12 +36,17 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The service collection the client services are added to.</param>
     /// <param name="configureOptions">A delegate that configures <see cref="OidcClientOptions"/>.</param>
     /// <returns>The same <paramref name="services"/> instance, so calls can be chained.</returns>
+    /// <remarks>
+    /// This call alone does not say where the provider's endpoints come from. Follow it with
+    /// <c>AddDiscovery</c> for a provider that publishes a discovery document, or
+    /// <c>AddConfiguredMetadata</c> for one that does not.
+    /// </remarks>
     public static IServiceCollection AddOidcClientCore(
         this IServiceCollection services, Action<OidcClientOptions> configureOptions)
     {
-        // Skeleton: options are bound here. Feature services and the composed request and
-        // validation pipelines are registered in the following units of the client build-out.
         services.Configure(configureOptions);
-        return services;
+
+        return services
+            .AddMetadataSourcePlaceholder();
     }
 }

--- a/src/Abblix.Oidc.Client/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Client/ServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Abblix.Oidc.Client;
+
+/// <summary>
+/// Registration entry points for the Abblix OIDC/OAuth client core.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the framework-agnostic core of the Abblix OIDC/OAuth client and binds its options.
+    /// </summary>
+    /// <param name="services">The service collection the client services are added to.</param>
+    /// <param name="configureOptions">A delegate that configures <see cref="OidcClientOptions"/>.</param>
+    /// <returns>The same <paramref name="services"/> instance, so calls can be chained.</returns>
+    public static IServiceCollection AddOidcClientCore(
+        this IServiceCollection services, Action<OidcClientOptions> configureOptions)
+    {
+        // Skeleton: options are bound here. Feature services and the composed request and
+        // validation pipelines are registered in the following units of the client build-out.
+        services.Configure(configureOptions);
+        return services;
+    }
+}

--- a/src/Abblix.Utils/ParametersBuilder.cs
+++ b/src/Abblix.Utils/ParametersBuilder.cs
@@ -53,6 +53,18 @@ public class ParametersBuilder
 	}
 
 	/// <summary>
+	/// Appends a value under a name, keeping any value already stored under it.
+	/// </summary>
+	/// <param name="name">The name of the parameter to append to.</param>
+	/// <param name="value">The value to append.</param>
+	/// <remarks>
+	/// The indexer replaces, which is what almost every parameter wants. This is for the few that a
+	/// specification allows to repeat (<c>resource</c> of RFC 8707, for one), where each occurrence carries
+	/// its own meaning and replacing would silently drop all but the last.
+	/// </remarks>
+	public void Add(string name, string? value) => _values.Add(name, value);
+
+	/// <summary>
 	/// Returns a string that represents the current query string or URI fragment.
 	/// </summary>
 	/// <returns>A string that represents the current state of the builder.</returns>

--- a/tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj
@@ -17,7 +17,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Extensions.Options" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="xunit.v3.mtp-v2" />
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj
@@ -18,7 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Options" />
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Client.UnitTests/Abblix.Oidc.Client.UnitTests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Abblix.Oidc.Client\Abblix.Oidc.Client.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Abblix.Oidc.Client.UnitTests/ClientRegistrationTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/ClientRegistrationTests.cs
@@ -1,0 +1,91 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Client.Features.AuthorizationRequests;
+using Abblix.Oidc.Client.Features.AuthorizationState;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Features.Pkce;
+using Abblix.Oidc.Client.Features.SigningKeys;
+using Abblix.Oidc.Client.Features.Tokens;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Abblix.Oidc.Client.UnitTests;
+
+/// <summary>
+/// Tests that a client wired the way a host would wire it actually resolves.
+/// </summary>
+/// <remarks>
+/// The individual features are tested by constructing their services directly, which says nothing about
+/// whether the registration extensions name the right lifetimes and dependencies. A missing registration
+/// surfaces only when something asks the container for the service, so this is where that is asked.
+/// </remarks>
+public class ClientRegistrationTests
+{
+    private static ServiceProvider BuildFullyWiredClient() => new ServiceCollection()
+        .AddOidcClientCore(options => options.ClientId = "test-client")
+        .AddDiscovery(options => options.Authority = new Uri("https://provider.example.com"))
+        .AddAuthorizationRequests(options => options.RedirectUri = new Uri("https://client.example.com/cb"))
+        .AddTokenRequests(options => options.ClientAuthenticationMethod = ClientAuthenticationMethods.None)
+        .BuildServiceProvider(new ServiceProviderOptions
+        {
+            // What a host running in development gets, and what catches a dependency the registration forgot.
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+    /// <summary>
+    /// Every service a host talks to resolves from a container wired the documented way.
+    /// </summary>
+    [Fact]
+    public void AFullyWiredClientResolves()
+    {
+        using var provider = BuildFullyWiredClient();
+
+        Assert.IsType<DiscoveredMetadataProvider>(provider.GetRequiredService<IProviderMetadataProvider>());
+        Assert.IsType<IssuerSigningKeysProvider>(provider.GetRequiredService<IIssuerSigningKeysProvider>());
+        Assert.IsType<PkceProvider>(provider.GetRequiredService<IPkceProvider>());
+        Assert.IsType<TokenRequestService>(provider.GetRequiredService<ITokenRequestService>());
+        Assert.IsType<AuthorizationRequestBuilder>(
+            provider.GetRequiredService<IAuthorizationRequestBuilder>());
+        Assert.IsType<InMemoryAuthorizationStateStore>(
+            provider.GetRequiredService<IAuthorizationStateStore>());
+    }
+
+    /// <summary>
+    /// Pinned keys replace the reader that would otherwise go to the provider, whichever order the host
+    /// registers them in.
+    /// </summary>
+    [Fact]
+    public void ConfiguredKeysReplaceTheReader()
+    {
+        var services = new ServiceCollection()
+            .AddOidcClientCore(options => options.ClientId = "test-client")
+            .AddDiscovery(options => options.Authority = new Uri("https://provider.example.com"))
+            .AddConfiguredSigningKeys([new RsaJsonWebKey { KeyId = "pinned" }]);
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.IsType<ConfiguredSigningKeysProvider>(
+            provider.GetRequiredService<IIssuerSigningKeysProvider>());
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/AuthorizationRequests/AuthorizationRequestBuilderTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/AuthorizationRequests/AuthorizationRequestBuilderTests.cs
@@ -1,0 +1,246 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Web;
+using Abblix.Oidc.Client.Features.AuthorizationRequests;
+using Abblix.Oidc.Client.Features.AuthorizationState;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Features.Pkce;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.AuthorizationRequests;
+
+/// <summary>
+/// Tests for <see cref="AuthorizationRequestBuilder"/>.
+/// </summary>
+public class AuthorizationRequestBuilderTests
+{
+    private const string Issuer = "https://provider.example.com";
+    private const string RedirectUri = "https://client.example.com/signin-oidc";
+
+    private static readonly Uri ReturnUri = new("https://client.example.com/orders", UriKind.Absolute);
+
+    private static ProviderMetadata Metadata(
+        string? authorizationEndpoint = $"{Issuer}/authorize",
+        IReadOnlyList<string>? codeChallengeMethods = null) => new()
+    {
+        Issuer = Issuer,
+        AuthorizationEndpoint = authorizationEndpoint,
+        CodeChallengeMethodsSupported = codeChallengeMethods,
+    };
+
+    private static AuthorizationRequestBuilder CreateBuilder(
+        ProviderMetadata metadata,
+        IAuthorizationStateStore stateStore,
+        Action<AuthorizationRequestOptions>? configure = null)
+    {
+        var metadataProvider = new ConfiguredMetadataProvider(metadata);
+
+        var options = new AuthorizationRequestOptions { RedirectUri = new Uri(RedirectUri) };
+        configure?.Invoke(options);
+
+        return new AuthorizationRequestBuilder(
+            metadataProvider,
+            new PkceProvider(metadataProvider),
+            stateStore,
+            Options.Create(new OidcClientOptions { ClientId = "test-client" }),
+            Options.Create(options));
+    }
+
+    private static InMemoryAuthorizationStateStore CreateStateStore(TimeProvider? timeProvider = null) => new(
+        timeProvider ?? new FakeTimeProvider(),
+        Options.Create(new AuthorizationStateOptions()));
+
+    private static Dictionary<string, string> QueryOf(Uri uri)
+    {
+        var parsed = HttpUtility.ParseQueryString(uri.Query);
+        return parsed.AllKeys
+            .Where(key => key is not null)
+            .ToDictionary(key => key!, key => parsed[key]!, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The request carries what the authorization code flow needs, and the challenge is the SHA-256 one.
+    /// </summary>
+    [Fact]
+    public async Task CarriesTheParametersOfTheCodeFlow()
+    {
+        var request = await CreateBuilder(Metadata(), CreateStateStore())
+            .CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        var query = QueryOf(request.RequestUri);
+
+        Assert.Equal("code", query[Parameters.ResponseType]);
+        Assert.Equal("test-client", query[Parameters.ClientId]);
+        Assert.Equal(RedirectUri, query[Parameters.RedirectUri]);
+        Assert.Equal(CodeChallengeMethods.S256, query[Parameters.CodeChallengeMethod]);
+        Assert.NotEmpty(query[Parameters.CodeChallenge]);
+    }
+
+    /// <summary>
+    /// The values that tie a response back to its request are the ones put aside, so the callback can be
+    /// checked against what was actually sent.
+    /// </summary>
+    [Fact]
+    public async Task SendsTheStateAndNonceItPutAside()
+    {
+        var request = await CreateBuilder(Metadata(), CreateStateStore())
+            .CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        var query = QueryOf(request.RequestUri);
+
+        Assert.Equal(request.State.State, query[Parameters.State]);
+        Assert.Equal(request.State.Nonce, query[Parameters.Nonce]);
+        Assert.Equal(Issuer, request.State.Issuer);
+        Assert.Equal(ReturnUri.ToString(), request.State.ReturnUri);
+    }
+
+    /// <summary>
+    /// The code challenge sent is derived from the verifier kept, which is the whole point of PKCE: the two
+    /// halves must belong to each other or the exchange cannot be proved.
+    /// </summary>
+    [Fact]
+    public async Task TheChallengeSentMatchesTheVerifierKept()
+    {
+        var request = await CreateBuilder(Metadata(), CreateStateStore())
+            .CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        var expectedChallenge = System.Buffers.Text.Base64Url.EncodeToString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.ASCII.GetBytes(request.State.CodeVerifier)));
+
+        Assert.Equal(expectedChallenge, QueryOf(request.RequestUri)[Parameters.CodeChallenge]);
+    }
+
+    /// <summary>
+    /// Two requests never share their opaque values, or one captured response could be passed off as the
+    /// answer to another request.
+    /// </summary>
+    [Fact]
+    public async Task EveryRequestGetsItsOwnValues()
+    {
+        var builder = CreateBuilder(Metadata(), CreateStateStore());
+
+        var first = await builder.CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+        var second = await builder.CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(first.State.State, second.State.State);
+        Assert.NotEqual(first.State.Nonce, second.State.Nonce);
+        Assert.NotEqual(first.State.CodeVerifier, second.State.CodeVerifier);
+    }
+
+    /// <summary>
+    /// The state is stored before the address is handed out, so a callback can never arrive for a state that
+    /// was not put aside yet.
+    /// </summary>
+    [Fact]
+    public async Task StoresTheStateBeforeHandingOutTheAddress()
+    {
+        var store = CreateStateStore();
+
+        var request = await CreateBuilder(Metadata(), store)
+            .CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        var stored = await store.TakeAsync(request.State.State, TestContext.Current.CancellationToken);
+        Assert.NotNull(stored);
+        Assert.Equal(request.State.CodeVerifier, stored.CodeVerifier);
+    }
+
+    /// <summary>
+    /// A provider that advertises only the weaker transformation gets a refusal, not a downgrade. Falling
+    /// back to `plain` would leave the request looking protected while anyone who read it holds the verifier.
+    /// </summary>
+    [Fact]
+    public async Task RefusesToDowngradeWhenTheProviderOffersOnlyPlain()
+    {
+        var builder = CreateBuilder(
+            Metadata(codeChallengeMethods: [CodeChallengeMethods.Plain]), CreateStateStore());
+
+        var exception = await Assert.ThrowsAsync<PkceException>(
+            () => builder.CreateAsync(ReturnUri, TestContext.Current.CancellationToken));
+
+        Assert.Contains(CodeChallengeMethods.S256, exception.Message);
+    }
+
+    /// <summary>
+    /// A provider that advertises nothing is given the benefit of the doubt: the member is optional, and a
+    /// request it cannot honour fails at the provider rather than weakening anything here.
+    /// </summary>
+    [Fact]
+    public async Task ProceedsWhenTheProviderAdvertisesNoMethods()
+    {
+        var request = await CreateBuilder(Metadata(), CreateStateStore())
+            .CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        Assert.Equal(CodeChallengeMethods.S256, QueryOf(request.RequestUri)[Parameters.CodeChallengeMethod]);
+    }
+
+    /// <summary>
+    /// Every named resource is sent, because RFC 8707 lets the parameter repeat and each occurrence narrows
+    /// the token further. Keeping only the last would silently widen what the token is good for.
+    /// </summary>
+    [Fact]
+    public async Task SendsEveryNamedResource()
+    {
+        var builder = CreateBuilder(Metadata(), CreateStateStore(), options => options.Resources =
+        [
+            new Uri("https://api.example.com/orders"),
+            new Uri("https://api.example.com/billing"),
+        ]);
+
+        var request = await builder.CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        var resources = HttpUtility.ParseQueryString(request.RequestUri.Query).GetValues(Parameters.Resource);
+        Assert.NotNull(resources);
+        Assert.Equal(
+            ["https://api.example.com/orders", "https://api.example.com/billing"],
+            resources);
+    }
+
+    /// <summary>
+    /// Parameters the provider already carries on its authorization endpoint survive, since dropping them
+    /// would break a provider that publishes an endpoint with a query of its own.
+    /// </summary>
+    [Fact]
+    public async Task KeepsParametersTheEndpointAlreadyCarries()
+    {
+        var builder = CreateBuilder(
+            Metadata(authorizationEndpoint: $"{Issuer}/authorize?tenant=acme"), CreateStateStore());
+
+        var request = await builder.CreateAsync(ReturnUri, TestContext.Current.CancellationToken);
+
+        Assert.Equal("acme", QueryOf(request.RequestUri)["tenant"]);
+    }
+
+    /// <summary>
+    /// A provider naming no authorization endpoint leaves nowhere to send the user, and says so.
+    /// </summary>
+    [Fact]
+    public async Task FailsWhenTheProviderNamesNoAuthorizationEndpoint()
+    {
+        var builder = CreateBuilder(Metadata(authorizationEndpoint: null), CreateStateStore());
+
+        await Assert.ThrowsAsync<AuthorizationRequestException>(
+            () => builder.CreateAsync(ReturnUri, TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/AuthorizationState/InMemoryAuthorizationStateStoreTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/AuthorizationState/InMemoryAuthorizationStateStoreTests.cs
@@ -1,0 +1,128 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Client.Features.AuthorizationState;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.AuthorizationState;
+
+/// <summary>
+/// Tests for <see cref="InMemoryAuthorizationStateStore"/>.
+/// </summary>
+public class InMemoryAuthorizationStateStoreTests
+{
+    private static Client.Features.AuthorizationState.AuthorizationState StateFor(string state) => new()
+    {
+        State = state,
+        Nonce = "nonce",
+        CodeVerifier = "verifier",
+        ReturnUri = "https://client.example.com/orders",
+        Issuer = "https://provider.example.com",
+        RedirectUri = "https://client.example.com/signin-oidc",
+    };
+
+    private static InMemoryAuthorizationStateStore CreateStore(
+        TimeProvider timeProvider, TimeSpan? lifetime = null)
+    {
+        var options = new AuthorizationStateOptions();
+        if (lifetime is { } value)
+            options.Lifetime = value;
+
+        return new InMemoryAuthorizationStateStore(timeProvider, Options.Create(options));
+    }
+
+    /// <summary>
+    /// What was put aside comes back.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsWhatWasStored()
+    {
+        var store = CreateStore(new FakeTimeProvider());
+        await store.StoreAsync(StateFor("first"), TestContext.Current.CancellationToken);
+
+        var taken = await store.TakeAsync("first", TestContext.Current.CancellationToken);
+
+        Assert.Equal("verifier", taken?.CodeVerifier);
+    }
+
+    /// <summary>
+    /// A state is good for exactly one callback. Were it left in place, a captured authorization response
+    /// could be replayed and each replay would find its state waiting and look entirely legitimate.
+    /// </summary>
+    [Fact]
+    public async Task AStateIsGoodForOneCallbackOnly()
+    {
+        var store = CreateStore(new FakeTimeProvider());
+        await store.StoreAsync(StateFor("first"), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await store.TakeAsync("first", TestContext.Current.CancellationToken));
+        Assert.Null(await store.TakeAsync("first", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A state that was never issued matches nothing, which is what makes a forged callback fail.
+    /// </summary>
+    [Fact]
+    public async Task AnUnknownStateMatchesNothing()
+    {
+        var store = CreateStore(new FakeTimeProvider());
+
+        Assert.Null(await store.TakeAsync("never-issued", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A sign-in that took longer than allowed is not honoured, bounding how long a captured authorization
+    /// request stays useful to whoever captured it.
+    /// </summary>
+    [Fact]
+    public async Task AStateThatOutlivedItsWindowIsNotHonoured()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var store = CreateStore(timeProvider, TimeSpan.FromMinutes(15));
+
+        await store.StoreAsync(StateFor("first"), TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(16));
+
+        Assert.Null(await store.TakeAsync("first", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Sign-ins that were started and abandoned do not accumulate. The entries carry a code verifier, so a
+    /// store that only ever grows is a slow leak driven by anyone able to start a sign-in.
+    /// </summary>
+    [Fact]
+    public async Task AbandonedSignInsDoNotAccumulate()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var store = CreateStore(timeProvider, TimeSpan.FromMinutes(15));
+
+        await store.StoreAsync(StateFor("abandoned"), TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(16));
+
+        // Storing anything sweeps what has aged out, so the abandoned entry is gone before this one is added.
+        await store.StoreAsync(StateFor("current"), TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.TakeAsync("abandoned", TestContext.Current.CancellationToken));
+        Assert.NotNull(await store.TakeAsync("current", TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/DiscoveredMetadataProviderTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/DiscoveredMetadataProviderTests.cs
@@ -1,0 +1,239 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using Abblix.Oidc.Client.Features.Discovery;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.Discovery;
+
+/// <summary>
+/// Tests for <see cref="DiscoveredMetadataProvider"/>.
+/// </summary>
+public class DiscoveredMetadataProviderTests
+{
+    private const string Authority = "https://provider.example.com";
+
+    private static string MetadataJson(string issuer) =>
+        $$"""
+          {
+            "issuer": "{{issuer}}",
+            "authorization_endpoint": "{{Authority}}/authorize",
+            "token_endpoint": "{{Authority}}/token",
+            "jwks_uri": "{{Authority}}/jwks",
+            "code_challenge_methods_supported": ["S256"],
+            "a_member_this_client_does_not_model": "kept"
+          }
+          """;
+
+    private static DiscoveredMetadataProvider CreateProvider(
+        StubHttpMessageHandler handler,
+        TimeProvider timeProvider,
+        Uri? authority = null,
+        Uri? metadataAddress = null,
+        TimeSpan? cacheLifetime = null)
+    {
+        var options = new DiscoveryOptions
+        {
+            Authority = authority ?? new Uri(Authority),
+            MetadataAddress = metadataAddress,
+        };
+
+        if (cacheLifetime is { } lifetime)
+            options.MetadataCacheLifetime = lifetime;
+
+        return new DiscoveredMetadataProvider(
+            new StubHttpClientFactory(handler),
+            timeProvider,
+            Options.Create(options));
+    }
+
+    /// <summary>
+    /// The document is read from the well-known path under the configured authority.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_ReadsTheWellKnownPathUnderTheAuthority()
+    {
+        var handler = new StubHttpMessageHandler(MetadataJson(Authority));
+
+        var metadata = await CreateProvider(handler, TimeProvider.System)
+            .GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            new Uri($"{Authority}/.well-known/openid-configuration"),
+            Assert.Single(handler.RequestedAddresses));
+
+        Assert.Equal(Authority, metadata.Issuer);
+        Assert.Equal($"{Authority}/jwks", metadata.JsonWebKeySetUri);
+    }
+
+    /// <summary>
+    /// An authority that carries a path segment keeps it: multi-tenant providers publish the document below
+    /// the tenant path, not at the host root.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_KeepsThePathSegmentOfTheAuthority()
+    {
+        const string tenantAuthority = "https://provider.example.com/tenant-one";
+        var handler = new StubHttpMessageHandler(MetadataJson(tenantAuthority));
+
+        await CreateProvider(handler, TimeProvider.System, new Uri(tenantAuthority))
+            .GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            new Uri($"{tenantAuthority}/.well-known/openid-configuration"),
+            Assert.Single(handler.RequestedAddresses));
+    }
+
+    /// <summary>
+    /// A document that names an issuer other than the authority it was served from is rejected, per OpenID
+    /// Connect Discovery 1.0 section 4.3. This is the check that stops a provider from borrowing another
+    /// issuer's name and having every later token validation measured against it.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_RejectsAnIssuerThatDoesNotMatchTheAuthority()
+    {
+        var handler = new StubHttpMessageHandler(MetadataJson("https://attacker.example.com"));
+
+        var exception = await Assert.ThrowsAsync<ProviderMetadataException>(
+            () => CreateProvider(handler, TimeProvider.System)
+                .GetMetadataAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("attacker.example.com", exception.Message);
+    }
+
+    /// <summary>
+    /// A document that declares no issuer at all is rejected: there would be nothing to check later tokens
+    /// against.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_RejectsADocumentWithoutAnIssuer()
+    {
+        var handler = new StubHttpMessageHandler("""{ "token_endpoint": "https://provider.example.com/token" }""");
+
+        await Assert.ThrowsAsync<ProviderMetadataException>(
+            () => CreateProvider(handler, TimeProvider.System)
+                .GetMetadataAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A transport failure surfaces as a discovery failure rather than a raw HTTP exception, so a host can
+    /// tell an unreachable provider from a protocol error.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_TranslatesATransportFailure()
+    {
+        var handler = new StubHttpMessageHandler(string.Empty, HttpStatusCode.ServiceUnavailable);
+
+        var exception = await Assert.ThrowsAsync<ProviderMetadataException>(
+            () => CreateProvider(handler, TimeProvider.System)
+                .GetMetadataAsync(TestContext.Current.CancellationToken));
+
+        Assert.IsType<HttpRequestException>(exception.InnerException);
+    }
+
+    /// <summary>
+    /// A second call within the cache lifetime is served from the cached copy, so discovery is not a
+    /// per-request cost.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_ServesTheSecondCallFromCache()
+    {
+        var handler = new StubHttpMessageHandler(MetadataJson(Authority));
+        var provider = CreateProvider(handler, new FakeTimeProvider());
+
+        await provider.GetMetadataAsync(TestContext.Current.CancellationToken);
+        await provider.GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.Single(handler.RequestedAddresses);
+    }
+
+    /// <summary>
+    /// Once the lifetime elapses the document is read again, bounding how long the client keeps following a
+    /// provider that has moved an endpoint.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_RefetchesAfterTheCacheLifetimeElapses()
+    {
+        var handler = new StubHttpMessageHandler(MetadataJson(Authority));
+        var timeProvider = new FakeTimeProvider();
+        var provider = CreateProvider(handler, timeProvider, cacheLifetime: TimeSpan.FromMinutes(10));
+
+        await provider.GetMetadataAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(11));
+        await provider.GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.RequestedAddresses.Count);
+    }
+
+    /// <summary>
+    /// A failed fetch is not cached: the next call retries instead of repeating the failure for the whole
+    /// cache lifetime.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_DoesNotCacheAFailure()
+    {
+        var handler = new StubHttpMessageHandler(string.Empty, HttpStatusCode.ServiceUnavailable);
+        var provider = CreateProvider(handler, new FakeTimeProvider());
+
+        await Assert.ThrowsAsync<ProviderMetadataException>(
+            () => provider.GetMetadataAsync(TestContext.Current.CancellationToken));
+
+        handler.RespondWith(MetadataJson(Authority), HttpStatusCode.OK);
+        var metadata = await provider.GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(Authority, metadata.Issuer);
+    }
+
+    /// <summary>
+    /// A member the client does not model is preserved rather than discarded, so a provider capability the
+    /// base client has no opinion about stays readable.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_KeepsMembersItDoesNotModel()
+    {
+        var handler = new StubHttpMessageHandler(MetadataJson(Authority));
+
+        var metadata = await CreateProvider(handler, TimeProvider.System)
+            .GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(metadata.AdditionalMetadata);
+        Assert.True(metadata.AdditionalMetadata.ContainsKey("a_member_this_client_does_not_model"));
+    }
+
+    /// <summary>
+    /// An explicitly configured metadata address is read verbatim, for a provider that publishes the document
+    /// somewhere other than the well-known path.
+    /// </summary>
+    [Fact]
+    public async Task GetMetadataAsync_ReadsAnExplicitMetadataAddressVerbatim()
+    {
+        var address = new Uri($"{Authority}/custom/metadata.json");
+        var handler = new StubHttpMessageHandler(MetadataJson(Authority));
+
+        await CreateProvider(handler, TimeProvider.System, metadataAddress: address)
+            .GetMetadataAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(address, Assert.Single(handler.RequestedAddresses));
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/MetadataSourceSelectionTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/MetadataSourceSelectionTests.cs
@@ -1,0 +1,106 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Client.Features.Discovery;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.Discovery;
+
+/// <summary>
+/// Tests that the host names its metadata source explicitly, and that omitting the choice fails loudly rather
+/// than falling back to one.
+/// </summary>
+public class MetadataSourceSelectionTests
+{
+    private static ProviderMetadata HandWrittenMetadata() => new()
+    {
+        Issuer = "https://oauth-only.example.com",
+        AuthorizationEndpoint = "https://oauth-only.example.com/authorize",
+        TokenEndpoint = "https://oauth-only.example.com/token",
+    };
+
+    private static IServiceCollection ClientCore() => new ServiceCollection()
+        .AddOidcClientCore(options => options.ClientId = "test-client");
+
+    private static IProviderMetadataProvider Resolve(IServiceCollection services) =>
+        services.BuildServiceProvider().GetRequiredService<IProviderMetadataProvider>();
+
+    /// <summary>
+    /// Adding discovery registers the source that reads the provider's document.
+    /// </summary>
+    [Fact]
+    public void AddDiscoveryRegistersTheDiscoveringSource()
+    {
+        var services = ClientCore()
+            .AddDiscovery(options => options.Authority = new Uri("https://provider.example.com"));
+
+        Assert.IsType<DiscoveredMetadataProvider>(Resolve(services));
+    }
+
+    /// <summary>
+    /// Adding configured metadata registers the source that works from what the host declared. This is the
+    /// plain OAuth 2.0 provider case, where there is no document to discover.
+    /// </summary>
+    [Fact]
+    public async Task AddConfiguredMetadataRegistersTheConfiguredSource()
+    {
+        var services = ClientCore().AddConfiguredMetadata(HandWrittenMetadata());
+
+        var metadataProvider = Resolve(services);
+        Assert.IsType<ConfiguredMetadataProvider>(metadataProvider);
+
+        var metadata = await metadataProvider.GetMetadataAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("https://oauth-only.example.com/token", metadata.TokenEndpoint);
+    }
+
+    /// <summary>
+    /// A source chosen before the core is added survives: the core only fills the gap, it never overrides a
+    /// choice the host already made.
+    /// </summary>
+    [Fact]
+    public void AChoiceMadeBeforeTheCoreSurvives()
+    {
+        var services = new ServiceCollection()
+            .AddConfiguredMetadata(HandWrittenMetadata())
+            .AddOidcClientCore(options => options.ClientId = "test-client");
+
+        Assert.IsType<ConfiguredMetadataProvider>(Resolve(services));
+    }
+
+    /// <summary>
+    /// Omitting the choice fails with a message naming both calls, rather than silently defaulting to one.
+    /// Reading endpoints from a document and reading them from configuration are different trust models, so
+    /// neither is safe to pick on the host's behalf.
+    /// </summary>
+    [Fact]
+    public async Task OmittingTheChoiceFailsLoudly()
+    {
+        var metadataProvider = Resolve(ClientCore());
+        Assert.IsType<MetadataSourceNotChosenProvider>(metadataProvider);
+
+        var exception = await Assert.ThrowsAsync<ProviderMetadataException>(
+            () => metadataProvider.GetMetadataAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("AddDiscovery", exception.Message);
+        Assert.Contains("AddConfiguredMetadata", exception.Message);
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/StubHttpClientFactory.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/StubHttpClientFactory.cs
@@ -20,20 +20,25 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-namespace Abblix.Oidc.Client;
+namespace Abblix.Oidc.Client.UnitTests.Features.Discovery;
 
 /// <summary>
-/// Configuration for the Abblix OIDC/OAuth client.
+/// An <see cref="IHttpClientFactory"/> that hands out clients over a single stub handler, whatever name is
+/// asked for.
 /// </summary>
-/// <remarks>
-/// Holds what the client is, not who it talks to. Where the provider's endpoints come from is configured with
-/// the metadata source the host registers, so a client that discovers its provider and one that is told its
-/// endpoints do not share a settings surface neither of them fully uses.
-/// </remarks>
-public sealed class OidcClientOptions
+public sealed class StubHttpClientFactory : IHttpClientFactory
 {
+    private readonly HttpMessageHandler _handler;
+
     /// <summary>
-    /// The client identifier issued by the OpenID Provider, sent as the <c>client_id</c> parameter.
+    /// Creates the factory over the handler every client will send through.
     /// </summary>
-    public required string ClientId { get; set; }
+    public StubHttpClientFactory(HttpMessageHandler handler) => _handler = handler;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The handler is deliberately not disposed with the client: a test keeps asserting against the recorded
+    /// requests after the client is gone.
+    /// </remarks>
+    public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
 }

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/StubHttpMessageHandler.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Discovery/StubHttpMessageHandler.cs
@@ -1,0 +1,74 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.Discovery;
+
+/// <summary>
+/// An <see cref="HttpMessageHandler"/> that answers with a canned body and records what was asked for, so a
+/// test can assert both the address the client built and how many times it went to the network.
+/// </summary>
+public sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private string _body;
+    private HttpStatusCode _statusCode;
+
+    /// <summary>
+    /// Creates the handler with the response it will return until told otherwise.
+    /// </summary>
+    public StubHttpMessageHandler(string body, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _body = body;
+        _statusCode = statusCode;
+    }
+
+    /// <summary>
+    /// Every address requested through this handler, in order.
+    /// </summary>
+    public List<Uri> RequestedAddresses { get; } = [];
+
+    /// <summary>
+    /// Changes the response returned from the next request onwards.
+    /// </summary>
+    public void RespondWith(string body, HttpStatusCode statusCode)
+    {
+        _body = body;
+        _statusCode = statusCode;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestedAddresses.Add(request.RequestUri!);
+
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_body),
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        return Task.FromResult(response);
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/SigningKeys/ConfiguredSigningKeysProviderTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/SigningKeys/ConfiguredSigningKeysProviderTests.cs
@@ -1,0 +1,86 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Client.Features.SigningKeys;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.SigningKeys;
+
+/// <summary>
+/// Tests for <see cref="ConfiguredSigningKeysProvider"/>, the source used when the provider's key set is
+/// pinned by the host rather than read from the provider.
+/// </summary>
+public class ConfiguredSigningKeysProviderTests
+{
+    private static JsonWebKey KeyWithId(string keyId) => new RsaJsonWebKey { KeyId = keyId };
+
+    /// <summary>
+    /// Every configured key is offered when the token names none.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsEveryKeyWhenTheTokenNamesNone()
+    {
+        var provider = new ConfiguredSigningKeysProvider([KeyWithId("one"), KeyWithId("two")]);
+
+        var keys = await provider.GetSigningKeysAsync(null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, keys.Count);
+    }
+
+    /// <summary>
+    /// A named key is returned alone, so verification does not try keys the token did not name.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsOnlyTheNamedKey()
+    {
+        var provider = new ConfiguredSigningKeysProvider([KeyWithId("one"), KeyWithId("two")]);
+
+        var keys = await provider.GetSigningKeysAsync("two", TestContext.Current.CancellationToken);
+
+        Assert.Equal("two", Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// A key the token names but the host did not configure leaves every held key on the table rather than
+    /// narrowing to nothing. Signature verification makes the final call, exactly as when the set is read
+    /// from the provider, so a labelling difference does not become a silent authentication failure.
+    /// </summary>
+    [Fact]
+    public async Task FallsBackToEveryKeyWhenTheNamedOneIsNotConfigured()
+    {
+        var provider = new ConfiguredSigningKeysProvider([KeyWithId("one"), KeyWithId("two")]);
+
+        var keys = await provider.GetSigningKeysAsync("never-configured", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, keys.Count);
+    }
+
+    /// <summary>
+    /// An empty set is refused at construction. Accepting it would produce a client that rejects every token
+    /// the provider signs, and does so at the first sign-in rather than at startup.
+    /// </summary>
+    [Fact]
+    public void RefusesAnEmptySet()
+    {
+        Assert.Throws<SigningKeysException>(() => new ConfiguredSigningKeysProvider([]));
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/SigningKeys/IssuerSigningKeysProviderTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/SigningKeys/IssuerSigningKeysProviderTests.cs
@@ -1,0 +1,223 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Features.SigningKeys;
+using Abblix.Oidc.Client.UnitTests.Features.Discovery;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.SigningKeys;
+
+/// <summary>
+/// Tests for <see cref="IssuerSigningKeysProvider"/>.
+/// </summary>
+public class IssuerSigningKeysProviderTests
+{
+    private const string KeySetUri = "https://provider.example.com/jwks";
+
+    /// <summary>
+    /// An RSA public key in JWK form, differing only by key id so a test can tell two keys apart.
+    /// </summary>
+    private static string RsaKey(string keyId, string? usage = "sig") =>
+        $$"""
+          {
+            "kty": "RSA",
+            "kid": "{{keyId}}",
+            {{(usage is null ? string.Empty : $"\"use\": \"{usage}\",")}}
+            "alg": "RS256",
+            "n": "sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1WlUzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDprecbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS8exSZEy_c4gs_7svlJJQ4H9_NxsiIoLwAEk7-Q3UXERGYw_75IDrGA84-lA_-Ct4eTlXHBIY2EaV7t7LjJaynVJCpkv4LKjTTAumiGUIuQhrNhZLuF_RJLqHpM2kgWFLU7-VTdL1VbC2tejvcI2BlMkEpk1BzBZI0KQB0GaDWFLN-aEAw3vRw",
+            "e": "AQAB"
+          }
+          """;
+
+    private static string KeySetJson(params string[] keys) => $$"""{ "keys": [{{string.Join(",", keys)}}] }""";
+
+    private static IssuerSigningKeysProvider CreateProvider(
+        StubHttpMessageHandler handler,
+        TimeProvider timeProvider,
+        TimeSpan? minimumRefreshInterval = null,
+        string? keySetUri = KeySetUri)
+    {
+        var metadata = new ProviderMetadata
+        {
+            Issuer = "https://provider.example.com",
+            JsonWebKeySetUri = keySetUri,
+        };
+
+        var options = new SigningKeysOptions();
+        if (minimumRefreshInterval is { } interval)
+            options.MinimumRefreshInterval = interval;
+
+        return new IssuerSigningKeysProvider(
+            new ConfiguredMetadataProvider(metadata),
+            new StubHttpClientFactory(handler),
+            timeProvider,
+            Options.Create(options));
+    }
+
+    /// <summary>
+    /// The key set is read from the address the provider's metadata names.
+    /// </summary>
+    [Fact]
+    public async Task ReadsTheKeySetFromTheAddressTheMetadataNames()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("key-one")));
+
+        var keys = await CreateProvider(handler, new FakeTimeProvider())
+            .GetSigningKeysAsync(null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new Uri(KeySetUri), Assert.Single(handler.RequestedAddresses));
+        Assert.Equal("key-one", Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// A named key is returned alone, so verification does not try keys the token did not name.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsOnlyTheNamedKey()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("key-one"), RsaKey("key-two")));
+
+        var keys = await CreateProvider(handler, new FakeTimeProvider())
+            .GetSigningKeysAsync("key-two", TestContext.Current.CancellationToken);
+
+        Assert.Equal("key-two", Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// A token naming a key the client has not seen makes it read the set again: that is what a rotation
+    /// looks like from the client side, and rejecting it would log everyone out whenever the provider rotates.
+    /// </summary>
+    [Fact]
+    public async Task ReReadsTheKeySetWhenTheTokenNamesAnUnknownKey()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("old-key")));
+        var provider = CreateProvider(handler, new FakeTimeProvider());
+
+        await provider.GetSigningKeysAsync("old-key", TestContext.Current.CancellationToken);
+        handler.RespondWith(KeySetJson(RsaKey("old-key"), RsaKey("rotated-key")), HttpStatusCode.OK);
+
+        var keys = await provider.GetSigningKeysAsync("rotated-key", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.RequestedAddresses.Count);
+        Assert.Equal("rotated-key", Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// The re-read has a floor. The path is driven by whoever presents a token, so without one a stream of
+    /// tokens naming random keys would turn this client into a load generator against its own provider.
+    /// </summary>
+    [Fact]
+    public async Task DoesNotReReadMoreOftenThanTheFloorAllows()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("known-key")));
+        var provider = CreateProvider(handler, new FakeTimeProvider(), TimeSpan.FromMinutes(5));
+
+        await provider.GetSigningKeysAsync("known-key", TestContext.Current.CancellationToken);
+
+        for (var attempt = 0; attempt < 5; attempt++)
+            await provider.GetSigningKeysAsync($"unknown-{attempt}", TestContext.Current.CancellationToken);
+
+        // One read for the first call, one for the first unknown key, and none for the four that followed.
+        Assert.Equal(2, handler.RequestedAddresses.Count);
+    }
+
+    /// <summary>
+    /// Once the floor has passed, an unknown key is allowed to trigger a read again, so a rotation that
+    /// happens after a burst of bad tokens is still picked up.
+    /// </summary>
+    [Fact]
+    public async Task ReReadsAgainOnceTheFloorHasPassed()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("known-key")));
+        var timeProvider = new FakeTimeProvider();
+        var provider = CreateProvider(handler, timeProvider, TimeSpan.FromMinutes(5));
+
+        await provider.GetSigningKeysAsync("known-key", TestContext.Current.CancellationToken);
+        await provider.GetSigningKeysAsync("unknown-key", TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+        await provider.GetSigningKeysAsync("unknown-key", TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, handler.RequestedAddresses.Count);
+    }
+
+    /// <summary>
+    /// A key still unknown after the re-read leaves every held key on the table rather than deciding the
+    /// token is unverifiable: signature verification makes that call, not key selection.
+    /// </summary>
+    [Fact]
+    public async Task FallsBackToEveryHeldKeyWhenTheNamedOneNeverAppears()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("key-one"), RsaKey("key-two")));
+
+        var keys = await CreateProvider(handler, new FakeTimeProvider())
+            .GetSigningKeysAsync("never-published", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, keys.Count);
+    }
+
+    /// <summary>
+    /// A key the provider marks for encryption is not offered for signature verification: keeping the two
+    /// purposes apart is what the <c>use</c> member exists for.
+    /// </summary>
+    [Fact]
+    public async Task SkipsKeysTheProviderMarksForEncryption()
+    {
+        var handler = new StubHttpMessageHandler(
+            KeySetJson(RsaKey("signing-key"), RsaKey("encryption-key", usage: "enc")));
+
+        var keys = await CreateProvider(handler, new FakeTimeProvider())
+            .GetSigningKeysAsync(null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("signing-key", Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// A provider that names no key set cannot have its signatures verified, and says so plainly.
+    /// </summary>
+    [Fact]
+    public async Task FailsWhenTheProviderNamesNoKeySet()
+    {
+        var handler = new StubHttpMessageHandler(KeySetJson(RsaKey("key-one")));
+
+        await Assert.ThrowsAsync<SigningKeysException>(
+            () => CreateProvider(handler, new FakeTimeProvider(), keySetUri: null)
+                .GetSigningKeysAsync(null, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A transport failure surfaces as a key-set failure rather than a raw HTTP exception.
+    /// </summary>
+    [Fact]
+    public async Task TranslatesATransportFailure()
+    {
+        var handler = new StubHttpMessageHandler(string.Empty, HttpStatusCode.ServiceUnavailable);
+
+        var exception = await Assert.ThrowsAsync<SigningKeysException>(
+            () => CreateProvider(handler, new FakeTimeProvider())
+                .GetSigningKeysAsync(null, TestContext.Current.CancellationToken));
+
+        Assert.IsType<HttpRequestException>(exception.InnerException);
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/RecordingHttpMessageHandler.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/RecordingHttpMessageHandler.cs
@@ -1,0 +1,78 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.Tokens;
+
+/// <summary>
+/// An <see cref="HttpMessageHandler"/> that answers with a canned body and keeps what was sent to it, so a
+/// test can assert on the request the client actually built rather than on a model of it.
+/// </summary>
+public sealed class RecordingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _body;
+    private readonly HttpStatusCode _statusCode;
+
+    /// <summary>
+    /// Creates the handler with the response it returns to every request.
+    /// </summary>
+    public RecordingHttpMessageHandler(string body, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _body = body;
+        _statusCode = statusCode;
+    }
+
+    /// <summary>
+    /// How many requests passed through.
+    /// </summary>
+    public int RequestCount { get; private set; }
+
+    /// <summary>
+    /// The form body of the most recent request.
+    /// </summary>
+    public string? LastRequestBody { get; private set; }
+
+    /// <summary>
+    /// The Authorization header of the most recent request, if it carried one.
+    /// </summary>
+    public AuthenticationHeaderValue? LastAuthorizationHeader { get; private set; }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        LastAuthorizationHeader = request.Headers.Authorization;
+        LastRequestBody = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_body, System.Text.Encoding.UTF8, "application/json"),
+        };
+
+        return response;
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/ThrowingHttpMessageHandler.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/ThrowingHttpMessageHandler.cs
@@ -1,0 +1,51 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+
+namespace Abblix.Oidc.Client.UnitTests.Features.Tokens;
+
+/// <summary>
+/// An <see cref="HttpMessageHandler"/> that fails the way an unreachable provider does, so the transport
+/// failure path is exercised rather than assumed.
+/// </summary>
+public sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Exception _failure;
+
+    /// <summary>
+    /// Creates the handler over the failure every request will meet.
+    /// </summary>
+    public ThrowingHttpMessageHandler(Exception failure) => _failure = failure;
+
+    /// <summary>
+    /// How many requests were attempted.
+    /// </summary>
+    public int RequestCount { get; private set; }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        return Task.FromException<HttpResponseMessage>(_failure);
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/TokenRequestServiceTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/TokenRequestServiceTests.cs
@@ -1,0 +1,262 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Text;
+using System.Web;
+using Abblix.Oidc.Client.Features.Discovery;
+using Abblix.Oidc.Client.Features.Tokens;
+using Abblix.Oidc.Client.UnitTests.Features.Discovery;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.UnitTests.Features.Tokens;
+
+/// <summary>
+/// Tests for <see cref="TokenRequestService"/>.
+/// </summary>
+public class TokenRequestServiceTests
+{
+    private const string Issuer = "https://provider.example.com";
+    private const string TokenEndpoint = $"{Issuer}/token";
+    private const string RedirectUri = "https://client.example.com/signin-oidc";
+
+    private const string SuccessBody = """
+                                       {
+                                         "access_token": "the-access-token",
+                                         "token_type": "Bearer",
+                                         "expires_in": 3600,
+                                         "refresh_token": "the-refresh-token",
+                                         "id_token": "the-id-token",
+                                         "a_member_this_client_does_not_model": "kept"
+                                       }
+                                       """;
+
+    private static TokenRequestService CreateService(
+        RecordingHttpMessageHandler handler,
+        string authenticationMethod = ClientAuthenticationMethods.None,
+        string? clientSecret = null,
+        string? tokenEndpoint = TokenEndpoint)
+    {
+        var metadata = new ProviderMetadata { Issuer = Issuer, TokenEndpoint = tokenEndpoint };
+
+        return new TokenRequestService(
+            new ConfiguredMetadataProvider(metadata),
+            new StubHttpClientFactory(handler),
+            Options.Create(new OidcClientOptions { ClientId = "test-client" }),
+            Options.Create(new TokenRequestOptions
+            {
+                ClientAuthenticationMethod = authenticationMethod,
+                ClientSecret = clientSecret,
+            }));
+    }
+
+    private static Dictionary<string, string> FormOf(string body)
+    {
+        var parsed = HttpUtility.ParseQueryString(body);
+        return parsed.AllKeys
+            .Where(key => key is not null)
+            .ToDictionary(key => key!, key => parsed[key]!, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// An authorization code is redeemed with the verifier kept from the request and the redirect address the
+    /// provider recorded.
+    /// </summary>
+    [Fact]
+    public async Task ExchangeCodeSendsTheCodeGrant()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+
+        var response = await CreateService(handler).ExchangeCodeAsync(
+            "the-code", "the-verifier", RedirectUri, TestContext.Current.CancellationToken);
+
+        var form = FormOf(handler.LastRequestBody!);
+        Assert.Equal(GrantTypes.AuthorizationCode, form["grant_type"]);
+        Assert.Equal("the-code", form["code"]);
+        Assert.Equal("the-verifier", form["code_verifier"]);
+        Assert.Equal(RedirectUri, form["redirect_uri"]);
+
+        Assert.Equal("the-access-token", response.AccessToken);
+        Assert.Equal("the-refresh-token", response.RefreshToken);
+    }
+
+    /// <summary>
+    /// A refresh presents the refresh token under its own grant.
+    /// </summary>
+    [Fact]
+    public async Task RefreshSendsTheRefreshGrant()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+
+        await CreateService(handler).RefreshAsync("the-refresh-token", TestContext.Current.CancellationToken);
+
+        var form = FormOf(handler.LastRequestBody!);
+        Assert.Equal(GrantTypes.RefreshToken, form["grant_type"]);
+        Assert.Equal("the-refresh-token", form["refresh_token"]);
+    }
+
+    /// <summary>
+    /// A public client names itself and presents no secret, because it has none to keep.
+    /// </summary>
+    [Fact]
+    public async Task APublicClientNamesItselfWithoutASecret()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+
+        await CreateService(handler).RefreshAsync("token", TestContext.Current.CancellationToken);
+
+        var form = FormOf(handler.LastRequestBody!);
+        Assert.Equal("test-client", form["client_id"]);
+        Assert.False(form.ContainsKey("client_secret"));
+        Assert.Null(handler.LastAuthorizationHeader);
+    }
+
+    /// <summary>
+    /// The secret travels in the body when the host configured that method.
+    /// </summary>
+    [Fact]
+    public async Task ClientSecretPostSendsTheSecretInTheBody()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+        var service = CreateService(handler, ClientAuthenticationMethods.ClientSecretPost, "the-secret");
+
+        await service.RefreshAsync("token", TestContext.Current.CancellationToken);
+
+        var form = FormOf(handler.LastRequestBody!);
+        Assert.Equal("test-client", form["client_id"]);
+        Assert.Equal("the-secret", form["client_secret"]);
+    }
+
+    /// <summary>
+    /// The secret travels in the Authorization header when the host configured that method.
+    /// </summary>
+    [Fact]
+    public async Task ClientSecretBasicSendsTheSecretInTheHeader()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+        var service = CreateService(handler, ClientAuthenticationMethods.ClientSecretBasic, "the-secret");
+
+        await service.RefreshAsync("token", TestContext.Current.CancellationToken);
+
+        Assert.Equal("Basic", handler.LastAuthorizationHeader?.Scheme);
+        var decoded = Encoding.UTF8.GetString(
+            Convert.FromBase64String(handler.LastAuthorizationHeader!.Parameter!));
+        Assert.Equal("test-client:the-secret", decoded);
+
+        Assert.False(FormOf(handler.LastRequestBody!).ContainsKey("client_secret"));
+    }
+
+    /// <summary>
+    /// Both halves of the Basic credentials are form-encoded before being joined, as RFC 6749 section 2.3.1
+    /// requires. Without it a secret containing a colon reads to the provider as a different secret entirely.
+    /// </summary>
+    [Fact]
+    public async Task BasicCredentialsAreFormEncodedBeforeBeingJoined()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+        var service = CreateService(handler, ClientAuthenticationMethods.ClientSecretBasic, "se:cr et");
+
+        await service.RefreshAsync("token", TestContext.Current.CancellationToken);
+
+        var decoded = Encoding.UTF8.GetString(
+            Convert.FromBase64String(handler.LastAuthorizationHeader!.Parameter!));
+        Assert.Equal("test-client:se%3Acr%20et", decoded);
+    }
+
+    /// <summary>
+    /// A refusal carries the provider's error code, because callers act on it rather than merely report it.
+    /// </summary>
+    [Fact]
+    public async Task ARefusalCarriesTheProviderErrorCode()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            """{ "error": "invalid_grant", "error_description": "token already rotated" }""",
+            HttpStatusCode.BadRequest);
+
+        var exception = await Assert.ThrowsAsync<TokenRequestException>(
+            () => CreateService(handler).RefreshAsync("stale", TestContext.Current.CancellationToken));
+
+        Assert.Equal(ErrorCodes.InvalidGrant, exception.Error);
+        Assert.Equal("token already rotated", exception.ErrorDescription);
+    }
+
+    /// <summary>
+    /// A refusal whose body does not follow the documented shape is still a refusal: the unreadable body is
+    /// not allowed to mask the status code.
+    /// </summary>
+    [Fact]
+    public async Task ARefusalWithAnUnreadableBodyIsStillARefusal()
+    {
+        var handler = new RecordingHttpMessageHandler("<html>gateway error</html>", HttpStatusCode.BadGateway);
+
+        var exception = await Assert.ThrowsAsync<TokenRequestException>(
+            () => CreateService(handler).RefreshAsync("token", TestContext.Current.CancellationToken));
+
+        Assert.Null(exception.Error);
+        Assert.Contains("502", exception.Message);
+    }
+
+    /// <summary>
+    /// Members of the response this client does not model survive, so a paid layer can read a value the base
+    /// client has no opinion about.
+    /// </summary>
+    [Fact]
+    public async Task KeepsMembersItDoesNotModel()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+
+        var response = await CreateService(handler).RefreshAsync(
+            "token", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(response.AdditionalData);
+        Assert.True(response.AdditionalData.ContainsKey("a_member_this_client_does_not_model"));
+    }
+
+    /// <summary>
+    /// A method needing a secret that was not configured fails with a message naming what is missing, rather
+    /// than sending a request the provider will reject for a reason that reads like anything else.
+    /// </summary>
+    [Fact]
+    public async Task AMissingSecretIsNamedPlainly()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+        var service = CreateService(handler, ClientAuthenticationMethods.ClientSecretPost);
+
+        var exception = await Assert.ThrowsAsync<TokenRequestException>(
+            () => service.RefreshAsync("token", TestContext.Current.CancellationToken));
+
+        Assert.Contains(nameof(TokenRequestOptions.ClientSecret), exception.Message);
+    }
+
+    /// <summary>
+    /// A provider naming no token endpoint leaves no grant redeemable, and says so.
+    /// </summary>
+    [Fact]
+    public async Task FailsWhenTheProviderNamesNoTokenEndpoint()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+
+        await Assert.ThrowsAsync<TokenRequestException>(
+            () => CreateService(handler, tokenEndpoint: null)
+                .RefreshAsync("token", TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/TokenRequestServiceTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Features/Tokens/TokenRequestServiceTests.cs
@@ -22,6 +22,7 @@
 
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Web;
 using Abblix.Oidc.Client.Features.Discovery;
 using Abblix.Oidc.Client.Features.Tokens;
@@ -51,7 +52,7 @@ public class TokenRequestServiceTests
                                        """;
 
     private static TokenRequestService CreateService(
-        RecordingHttpMessageHandler handler,
+        HttpMessageHandler handler,
         string authenticationMethod = ClientAuthenticationMethods.None,
         string? clientSecret = null,
         string? tokenEndpoint = TokenEndpoint)
@@ -258,5 +259,64 @@ public class TokenRequestServiceTests
         await Assert.ThrowsAsync<TokenRequestException>(
             () => CreateService(handler, tokenEndpoint: null)
                 .RefreshAsync("token", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A provider that cannot be reached at all is reported as a token-request failure carrying the transport
+    /// fault, so a caller can tell an unreachable provider from one that refused.
+    /// </summary>
+    [Fact]
+    public async Task TranslatesATransportFailure()
+    {
+        var handler = new ThrowingHttpMessageHandler(new HttpRequestException("connection refused"));
+
+        var exception = await Assert.ThrowsAsync<TokenRequestException>(
+            () => CreateService(handler).RefreshAsync("token", TestContext.Current.CancellationToken));
+
+        Assert.Null(exception.Error);
+        Assert.IsType<HttpRequestException>(exception.InnerException);
+    }
+
+    /// <summary>
+    /// A success whose body cannot be read is a failure, not an empty set of tokens. Returning something
+    /// blank here would put a client into a signed-in state holding no token at all.
+    /// </summary>
+    [Fact]
+    public async Task ASuccessWithAnUnreadableBodyIsAFailure()
+    {
+        var handler = new RecordingHttpMessageHandler("<html>not json</html>");
+
+        var exception = await Assert.ThrowsAsync<TokenRequestException>(
+            () => CreateService(handler).RefreshAsync("token", TestContext.Current.CancellationToken));
+
+        Assert.IsType<JsonException>(exception.InnerException);
+    }
+
+    /// <summary>
+    /// A success carrying a literal JSON null is refused for the same reason.
+    /// </summary>
+    [Fact]
+    public async Task ASuccessCarryingNothingIsAFailure()
+    {
+        var handler = new RecordingHttpMessageHandler("null");
+
+        await Assert.ThrowsAsync<TokenRequestException>(
+            () => CreateService(handler).RefreshAsync("token", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A method this client cannot present is named rather than attempted.
+    /// </summary>
+    [Fact]
+    public async Task AnUnsupportedAuthenticationMethodIsNamed()
+    {
+        var handler = new RecordingHttpMessageHandler(SuccessBody);
+        var service = CreateService(handler, "private_key_jwt", "the-secret");
+
+        var exception = await Assert.ThrowsAsync<TokenRequestException>(
+            () => service.RefreshAsync("token", TestContext.Current.CancellationToken));
+
+        Assert.Contains("private_key_jwt", exception.Message);
+        Assert.Equal(0, handler.RequestCount);
     }
 }

--- a/tests/Abblix.Oidc.Client.UnitTests/GlobalUsings.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/GlobalUsings.cs
@@ -1,0 +1,23 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+global using Xunit;

--- a/tests/Abblix.Oidc.Client.UnitTests/Internals/RefreshingCacheTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/Internals/RefreshingCacheTests.cs
@@ -1,0 +1,172 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Client.Internals;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Abblix.Oidc.Client.UnitTests.Internals;
+
+/// <summary>
+/// Tests for <see cref="RefreshingCache{T}"/>, the primitive that keeps the client from asking the provider
+/// the same question twice at once.
+/// </summary>
+public class RefreshingCacheTests
+{
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Callers that arrive while a read is in flight share it rather than each starting their own. This is
+    /// the property the whole class exists for: without it, a burst of requests on a cold instance becomes a
+    /// burst of identical requests against the provider.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentCallersShareOneFetch()
+    {
+        var fetchCount = 0;
+        var release = new TaskCompletionSource();
+
+        var cache = new RefreshingCache<string>(new FakeTimeProvider());
+
+        async Task<string> Fetch(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref fetchCount);
+            await release.Task;
+            return "value";
+        }
+
+        // Started while the fetch is deliberately held open, so every caller is in flight at once.
+        var callers = Enumerable
+            .Range(0, 20)
+            .Select(_ => cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken))
+            .ToArray();
+
+        release.SetResult();
+        var results = await Task.WhenAll(callers);
+
+        Assert.Equal(1, fetchCount);
+        Assert.All(results, result => Assert.Equal("value", result));
+    }
+
+    /// <summary>
+    /// A failing read is shared too, so an unreachable provider is asked once per burst rather than once per
+    /// caller. Amplifying load against a provider that is already struggling is exactly the wrong response.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentCallersShareOneFailedFetch()
+    {
+        var fetchCount = 0;
+        var release = new TaskCompletionSource();
+
+        var cache = new RefreshingCache<string>(new FakeTimeProvider());
+
+        async Task<string> Fetch(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref fetchCount);
+            await release.Task;
+            throw new InvalidOperationException("the provider is unreachable");
+        }
+
+        var callers = Enumerable
+            .Range(0, 10)
+            .Select(_ => cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken))
+            .ToArray();
+
+        release.SetResult();
+
+        foreach (var caller in callers)
+            await Assert.ThrowsAsync<InvalidOperationException>(() => caller);
+
+        Assert.Equal(1, fetchCount);
+    }
+
+    /// <summary>
+    /// A failure is not held: the next caller tries again rather than being told for the rest of the lifetime
+    /// what one unlucky moment found.
+    /// </summary>
+    [Fact]
+    public async Task AFailedFetchIsNotHeld()
+    {
+        var attempt = 0;
+        var cache = new RefreshingCache<string>(new FakeTimeProvider());
+
+        Task<string> Fetch(CancellationToken cancellationToken) => ++attempt == 1
+            ? Task.FromException<string>(new InvalidOperationException("transient"))
+            : Task.FromResult("value");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken));
+
+        Assert.Equal("value", await cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// One caller giving up does not cancel the read the others are waiting on, which is the hazard that
+    /// comes with sharing an attempt.
+    /// </summary>
+    [Fact]
+    public async Task OneCallerCancellingDoesNotCancelTheOthers()
+    {
+        var release = new TaskCompletionSource();
+        var cache = new RefreshingCache<string>(new FakeTimeProvider());
+
+        async Task<string> Fetch(CancellationToken cancellationToken)
+        {
+            await release.Task;
+            return "value";
+        }
+
+        using var impatient = new CancellationTokenSource();
+        var abandoned = cache.GetAsync(Fetch, Lifetime, impatient.Token);
+        var patient = cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken);
+
+        await impatient.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => abandoned);
+
+        release.SetResult();
+        Assert.Equal("value", await patient);
+    }
+
+    /// <summary>
+    /// Once the value has aged out it is read again.
+    /// </summary>
+    [Fact]
+    public async Task ReadsAgainOnceTheLifetimeHasElapsed()
+    {
+        var fetchCount = 0;
+        var timeProvider = new FakeTimeProvider();
+        var cache = new RefreshingCache<string>(timeProvider);
+
+        Task<string> Fetch(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult("value");
+        }
+
+        await cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken);
+        await cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken);
+        Assert.Equal(1, fetchCount);
+
+        timeProvider.Advance(Lifetime + TimeSpan.FromMinutes(1));
+        await cache.GetAsync(Fetch, Lifetime, TestContext.Current.CancellationToken);
+        Assert.Equal(2, fetchCount);
+    }
+}

--- a/tests/Abblix.Oidc.Client.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Abblix.Oidc.Client.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,48 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Client.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="ServiceCollectionExtensions"/>.
+/// </summary>
+public class ServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// <see cref="ServiceCollectionExtensions.AddOidcClientCore"/> binds <see cref="OidcClientOptions"/>,
+    /// so a configured value is resolvable through <see cref="IOptions{TOptions}"/>.
+    /// </summary>
+    [Fact]
+    public void AddOidcClientCore_BindsOptions()
+    {
+        var services = new ServiceCollection();
+
+        services.AddOidcClientCore(options => options.ClientId = "test-client");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<OidcClientOptions>>().Value;
+        Assert.Equal("test-client", options.ClientId);
+    }
+}

--- a/tests/Abblix.Oidc.Server.Azure.UnitTests/AzureResponses.cs
+++ b/tests/Abblix.Oidc.Server.Azure.UnitTests/AzureResponses.cs
@@ -26,14 +26,14 @@ internal static class AzureResponses
         });
 
     /// <summary>A public-only P-256 EC key bundle, the shape the SDK expects for an EC key.</summary>
-    public static string EcKeyBundle(Uri vaultUri, string keyName, ECParameters publicKey)
+    public static string EcKeyBundle(Uri vaultUri, string keyName, ECParameters publicKey, string curve = "P-256")
         => JsonSerializer.Serialize(new
         {
             key = new
             {
                 kid = $"{vaultUri}keys/{keyName}/v1",
                 kty = "EC",
-                crv = "P-256",
+                crv = curve,
                 key_ops = new[] { "sign", "verify" },
                 x = Base64Url(publicKey.Q.X!),
                 y = Base64Url(publicKey.Q.Y!),
@@ -48,12 +48,30 @@ internal static class AzureResponses
     /// <summary>A "get key versions" page: each version's identifier, creation time (Unix seconds) and enabled
     /// flag, the shape <c>KeyClient.GetPropertiesOfKeyVersions</c> pages over.</summary>
     public static string KeyVersionsList(Uri vaultUri, string keyName, params (string Version, long CreatedUnix)[] versions)
+        => KeyVersionsList(
+            vaultUri, keyName, versions.Select(v => (v.Version, (long?)v.CreatedUnix, true)).ToArray());
+
+    /// <summary>
+    /// The same page, with the two attributes an operator can actually change: whether a version is enabled, and
+    /// whether the vault reports a creation time at all.
+    /// </summary>
+    /// <remarks>
+    /// Both are load-bearing rather than decorative. Disabling a version is how a compromised key is taken out of
+    /// service, and a version with no creation time cannot be placed in the rotation order. Neither can be
+    /// expressed by the simpler overload, which is why the paths that honour them went untested.
+    /// </remarks>
+    public static string KeyVersionsList(
+        Uri vaultUri, string keyName, params (string Version, long? CreatedUnix, bool Enabled)[] versions)
         => JsonSerializer.Serialize(new
         {
             value = versions.Select(version => new
             {
                 kid = $"{vaultUri}keys/{keyName}/{version.Version}",
-                attributes = new { enabled = true, created = version.CreatedUnix },
+
+                // A vault that reports no creation time omits the member; sending null is not the same shape.
+                attributes = version.CreatedUnix is { } created
+                    ? new Dictionary<string, object> { ["enabled"] = version.Enabled, ["created"] = created }
+                    : new Dictionary<string, object> { ["enabled"] = version.Enabled },
             }).ToArray(),
             nextLink = (string?)null,
         });

--- a/tests/Abblix.Oidc.Server.Azure.UnitTests/KeyVaultClientTests.cs
+++ b/tests/Abblix.Oidc.Server.Azure.UnitTests/KeyVaultClientTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -135,6 +135,72 @@ public sealed class KeyVaultClientTests : IDisposable
         Assert.Equal(created1, first.CreatedAt);
         Assert.Equal(created2, second.CreatedAt);
         Assert.Equal(rsa1.ExportParameters(false).Modulus, Assert.IsType<RsaJsonWebKey>(first.PublicKey).Modulus);
+    }
+
+    [Fact]
+    public async Task GetKeyVersionsAsync_SkipsADisabledVersion()
+    {
+        // Disabling a version in Key Vault is how an operator takes a compromised key out of service. If this
+        // client published it anyway, the key would stay in the JWKS and stay eligible to sign - the revocation
+        // would appear to have been carried out while changing nothing.
+        using var rsa = RSA.Create(2048);
+        var handler = new StubHttpMessageHandler(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/versions", StringComparison.Ordinal)
+                ? StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyVersionsList(
+                    VaultUri,
+                    "oidc-sign",
+                    ("live", 1_700_000_000L, true),
+                    ("revoked", 1_710_000_000L, false)))
+                : StubHttpMessageHandler.Json(
+                    HttpStatusCode.OK, AzureResponses.KeyBundle(VaultUri, "oidc-sign", rsa.ExportParameters(false))));
+
+        var versions = new List<KeyVersion>();
+        await foreach (var version in ClientOver(handler).GetKeyVersionsAsync("oidc-sign", TestContext.Current.CancellationToken))
+            versions.Add(version);
+
+        Assert.Equal("oidc-sign/live", Assert.Single(versions).PublicKey.KeyId);
+    }
+
+    [Fact]
+    public async Task GetKeyVersionsAsync_FailsWhenAVersionHasNoCreationTime()
+    {
+        // The creation time decides which version signs and when a rotation takes over. A version whose age is
+        // unknown cannot be ordered, so it has to stop the enumeration rather than be dated to year one and sort
+        // as ancient - which would quietly make it ineligible to produce with and impossible to notice.
+        using var rsa = RSA.Create(2048);
+        var handler = new StubHttpMessageHandler(request =>
+            request.RequestUri!.AbsolutePath.EndsWith("/versions", StringComparison.Ordinal)
+                ? StubHttpMessageHandler.Json(HttpStatusCode.OK, AzureResponses.KeyVersionsList(
+                    VaultUri, "oidc-sign", ("undated", null, true)))
+                : StubHttpMessageHandler.Json(
+                    HttpStatusCode.OK, AzureResponses.KeyBundle(VaultUri, "oidc-sign", rsa.ExportParameters(false))));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in ClientOver(handler).GetKeyVersionsAsync(
+                               "oidc-sign", TestContext.Current.CancellationToken))
+            {
+                // Enumerating is the act under test; the failure arrives before any version is produced.
+            }
+        });
+
+        Assert.Contains("oidc-sign/undated", exception.Message);
+    }
+
+    [Fact]
+    public async Task UnwrapKeyAsync_RejectsUnsupportedAlgorithm_WithoutCallingTheVault()
+    {
+        // An algorithm this store cannot unwrap must be refused outright. Mapping it to something the vault does
+        // accept would decrypt under an algorithm the caller never asked for.
+        var handler = new StubHttpMessageHandler(_ =>
+            throw new InvalidOperationException("the vault must not be called for an unsupported algorithm"));
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => ClientOver(handler).UnwrapKeyAsync(
+            "oidc-enc/v1",
+            EncryptionAlgorithms.KeyManagement.EcdhEs,
+            new JsonWebTokenHeader(new JsonObject()),
+            [5, 5],
+            TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
@@ -33,6 +33,9 @@ public sealed record DiscoveryDocument
     [JsonPropertyName("introspection_endpoint")]
     public Uri? IntrospectionEndpoint { get; init; }
 
+    [JsonPropertyName("revocation_endpoint")]
+    public Uri? RevocationEndpoint { get; init; }
+
     [JsonPropertyName("userinfo_endpoint")]
     public Uri? UserInfoEndpoint { get; init; }
 

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/DiscoveryNullOmissionTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/DiscoveryNullOmissionTests.cs
@@ -1,0 +1,96 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Proves that the discovery document omits what the provider does not have, rather than publishing it as null.
+/// </summary>
+/// <remarks>
+/// The two are not interchangeable to a reader. OpenID Connect Discovery and RFC 8414 describe optional members
+/// as absent when they do not apply, and a client decides what a provider supports by asking whether a member is
+/// there. A member published as <c>null</c> is present, so a client that checks for presence concludes the
+/// capability exists and then fails at the moment it tries to use it - a fault that surfaces far from its cause.
+///
+/// The omission is not a property of the model but of one line in each adapter's formatter, a serializer modifier
+/// that a later refactoring of how those options are built would drop without any compiler complaint. Asserting
+/// it on the wire is the only place the guarantee actually lives.
+/// </remarks>
+public class DiscoveryNullOmissionTests(TestFactory factory) : TestBase(factory)
+{
+    [Theory]
+    [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    public async Task The_discovery_document_publishes_no_null_members(string path)
+    {
+        var client = CreateClient();
+
+        var json = await client.GetStringAsync(path, TestContext.Current.CancellationToken);
+        using var document = JsonDocument.Parse(json);
+
+        var nullMembers = new List<string>();
+        CollectNullMembers(document.RootElement, string.Empty, nullMembers);
+
+        Assert.True(
+            nullMembers.Count == 0,
+            $"The document at '{path}' publishes null for: {string.Join(", ", nullMembers)}. "
+            + "An optional member the provider does not have must be absent, not null.");
+    }
+
+    /// <summary>
+    /// Walks the whole document rather than its top level, because a null nested inside a published object
+    /// misleads a reader exactly as much as one at the root.
+    /// </summary>
+    private static void CollectNullMembers(JsonElement element, string path, List<string> nullMembers)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Null:
+                nullMembers.Add(path.Length == 0 ? "<root>" : path);
+                break;
+
+            case JsonValueKind.Object:
+                foreach (var member in element.EnumerateObject())
+                    CollectNullMembers(member.Value, path.Length == 0 ? member.Name : $"{path}.{member.Name}", nullMembers);
+                break;
+
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var item in element.EnumerateArray())
+                    CollectNullMembers(item, $"{path}[{index++}]", nullMembers);
+                break;
+
+            case JsonValueKind.Undefined:
+            case JsonValueKind.String:
+            case JsonValueKind.Number:
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unhandled JSON value kind '{element.ValueKind}' at '{path}'.");
+        }
+    }
+}

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenRevocationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenRevocationTests.cs
@@ -1,0 +1,147 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end proof of the token revocation endpoint (RFC 7009) against the real endpoint and the real token
+/// registry.
+/// </summary>
+/// <remarks>
+/// Revocation is the control an operator or a user reaches for after a device is lost or a token leaks, so the
+/// property that matters is not the shape of the response but whether the token stops working afterwards. A
+/// revocation endpoint that answers 200 and leaves the token usable is worse than none at all: it reports that
+/// the danger has been dealt with.
+///
+/// The suite previously exercised revocation only as a side effect of reuse detection, which revokes a family
+/// on its own initiative. Nothing walked the endpoint a client actually calls.
+/// </remarks>
+public class TokenRevocationTests(TestFactory factory) : TestBase(factory)
+{
+    [Fact]
+    public async Task A_revoked_refresh_token_can_no_longer_be_redeemed()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ObtainConfidentialOfflineTokensAsync(client, discovery);
+        var refreshToken = tokens[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        // Proving it works first: otherwise a test that only checks the token fails afterwards would pass
+        // just as happily against a token that never worked at all.
+        var beforeRevocation = await RefreshAsync(client, discovery, refreshToken);
+        Assert.True(beforeRevocation.IsSuccessStatusCode);
+        var rotated = (await ReadJsonAsync(beforeRevocation))[TokenRequest.Parameters.RefreshToken]!
+            .GetValue<string>();
+
+        var revocation = await RevokeAsync(client, discovery, rotated);
+        Assert.Equal(HttpStatusCode.OK, revocation.StatusCode);
+
+        var afterRevocation = await RefreshAsync(client, discovery, rotated);
+        await AssertInvalidGrantAsync(afterRevocation);
+    }
+
+    [Fact]
+    public async Task Revoking_a_token_that_was_never_issued_still_answers_success()
+    {
+        // RFC 7009 Section 2.2 requires 200 for a token the server does not recognise. The reason is not
+        // politeness: a distinguishable answer turns the endpoint into an oracle that tells an attacker
+        // whether a guessed token exists, which is the one thing this endpoint must never reveal.
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var response = await RevokeAsync(client, discovery, "a-token-this-server-never-issued");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Revocation_requires_the_client_to_authenticate()
+    {
+        // Without client authentication anyone holding a token could revoke it, and anyone able to guess one
+        // could try. That turns a security control into a denial-of-service lever against other clients.
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ObtainConfidentialOfflineTokensAsync(client, discovery);
+        var refreshToken = tokens[TokenRequest.Parameters.RefreshToken]!.GetValue<string>();
+
+        var response = await FormPostHelpers.PostFormAsync(
+            client,
+            discovery.RevocationEndpoint!,
+            new Dictionary<string, string> { ["token"] = refreshToken });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        // The token survives the unauthenticated attempt, which is the half that matters: a rejected request
+        // that revoked anyway would be the denial of service this check exists to prevent.
+        var stillWorks = await RefreshAsync(client, discovery, refreshToken);
+        Assert.True(stillWorks.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task The_revocation_endpoint_is_published_in_discovery()
+    {
+        // A client finds this endpoint through discovery, so an endpoint that is enabled but unadvertised is
+        // unreachable in practice.
+        var discovery = await FetchDiscoveryAsync(CreateClient());
+
+        Assert.NotNull(discovery.RevocationEndpoint);
+    }
+
+    private static async Task<HttpResponseMessage> RevokeAsync(
+        HttpClient client, DiscoveryDocument discovery, string token) =>
+        await FormPostHelpers.PostFormAsync(client, discovery.RevocationEndpoint!, new Dictionary<string, string>
+        {
+            ["token"] = token,
+            [ClientRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+    private static async Task<HttpResponseMessage> RefreshAsync(
+        HttpClient client, DiscoveryDocument discovery, string refreshToken) =>
+        await FormPostHelpers.PostFormAsync(client, discovery.TokenEndpoint, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.RefreshToken,
+            [TokenRequest.Parameters.RefreshToken] = refreshToken,
+            [ClientRequest.Parameters.ClientId] = TestConstants.ConfidentialClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+    private static async Task<JsonObject> ReadJsonAsync(HttpResponseMessage response) =>
+        JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+
+    private static async Task AssertInvalidGrantAsync(HttpResponseMessage response)
+    {
+        var body = await ReadJsonAsync(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(ErrorCodes.InvalidGrant, body["error"]!.GetValue<string>());
+    }
+}

--- a/tests/Abblix.Oidc.Server.Mvc.UnitTests/Extensions/CertificateForwardingExtensionsTests.cs
+++ b/tests/Abblix.Oidc.Server.Mvc.UnitTests/Extensions/CertificateForwardingExtensionsTests.cs
@@ -1,0 +1,176 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Abblix.Oidc.Server.Mvc.Extensions;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.Oidc.Server.Mvc.UnitTests.Extensions;
+
+/// <summary>
+/// Tests the header converter registered by
+/// <see cref="CertificateForwardingExtensions.AddMtlsCertificateForwarding"/>.
+/// </summary>
+/// <remarks>
+/// This converter turns a header written by a reverse proxy into the client certificate that mTLS client
+/// authentication then treats as the client's identity. Two failures matter and neither is cosmetic: producing
+/// a certificate other than the one the header carried would authenticate the wrong client, and failing to
+/// parse a shape a real proxy emits would lock a correctly configured client out.
+///
+/// The converter is exercised through the options the extension registers rather than as a private function,
+/// because what the middleware calls is what is registered, and testing a copy proves nothing about it.
+/// </remarks>
+public class CertificateForwardingExtensionsTests
+{
+    /// <summary>
+    /// Fixed validity window rather than one measured from the clock: the certificate here is a carrier for
+    /// bytes, and nothing under test reads its dates, so a moving window would only add a way to fail on a
+    /// slow machine.
+    /// </summary>
+    private static readonly DateTimeOffset NotBefore = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=client.test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(NotBefore, NotBefore.AddYears(10));
+    }
+
+    private static Func<string, X509Certificate2?> ConverterOf(
+        string headerName = "X-Client-Cert", Action<CertificateForwardingOptions>? configure = null)
+        => OptionsOf(headerName, configure).HeaderConverter;
+
+    private static CertificateForwardingOptions OptionsOf(
+        string headerName = "X-Client-Cert", Action<CertificateForwardingOptions>? configure = null)
+    {
+        var provider = new ServiceCollection()
+            .AddMtlsCertificateForwarding(headerName, configure)
+            .BuildServiceProvider();
+
+        return provider.GetRequiredService<IOptions<CertificateForwardingOptions>>().Value;
+    }
+
+    [Fact]
+    public void The_configured_header_name_is_the_one_the_middleware_reads()
+    {
+        Assert.Equal("X-Forwarded-Client-Cert", OptionsOf("X-Forwarded-Client-Cert").CertificateHeader);
+    }
+
+    [Fact]
+    public void A_pem_header_yields_the_very_certificate_it_carried()
+    {
+        // nginx with ssl_client_escaped_cert emits PEM. Comparing thumbprints rather than merely asserting
+        // that something parsed is the point: a converter returning a different certificate authenticates a
+        // different client.
+        using var certificate = CreateCertificate();
+
+        var parsed = ConverterOf()(certificate.ExportCertificatePem());
+
+        Assert.NotNull(parsed);
+        Assert.Equal(certificate.Thumbprint, parsed.Thumbprint);
+    }
+
+    [Fact]
+    public void A_raw_base64_header_yields_the_very_certificate_it_carried()
+    {
+        // Envoy and HAProxy send base64-encoded DER.
+        using var certificate = CreateCertificate();
+
+        var parsed = ConverterOf()(Convert.ToBase64String(certificate.RawData));
+
+        Assert.NotNull(parsed);
+        Assert.Equal(certificate.Thumbprint, parsed.Thumbprint);
+    }
+
+    [Fact]
+    public void A_url_encoded_header_yields_the_very_certificate_it_carried()
+    {
+        // nginx with ssl_client_cert percent-encodes what it forwards.
+        using var certificate = CreateCertificate();
+
+        var parsed = ConverterOf()(Uri.EscapeDataString(Convert.ToBase64String(certificate.RawData)));
+
+        Assert.NotNull(parsed);
+        Assert.Equal(certificate.Thumbprint, parsed.Thumbprint);
+    }
+
+    [Fact]
+    public void Base64_stripped_of_its_padding_is_still_accepted()
+    {
+        // Padding is routinely dropped in transit. Rejecting an unpadded value would lock out a correctly
+        // configured client, and the failure would read as a certificate problem rather than an encoding one.
+        using var certificate = CreateCertificate();
+
+        var parsed = ConverterOf()(Convert.ToBase64String(certificate.RawData).TrimEnd('='));
+
+        Assert.NotNull(parsed);
+        Assert.Equal(certificate.Thumbprint, parsed.Thumbprint);
+    }
+
+    [Fact]
+    public void Base64_broken_across_lines_is_still_accepted()
+    {
+        // Proxies and configuration files wrap long values; the whitespace is not part of the encoding.
+        using var certificate = CreateCertificate();
+        var wrapped = string.Join("\n", Chunk(Convert.ToBase64String(certificate.RawData), 64));
+
+        var parsed = ConverterOf()(wrapped);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(certificate.Thumbprint, parsed.Thumbprint);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-certificate")]
+    [InlineData("-----BEGIN CERTIFICATE-----\nnot base64 at all\n-----END CERTIFICATE-----")]
+    [InlineData("AAAA")]
+    public void A_header_that_is_not_a_certificate_produces_nothing(string headerValue)
+    {
+        // The header arrives from outside. A converter that produced anything at all out of junk would hand
+        // the authentication layer an identity nobody presented, so the only safe answer is none.
+        Assert.Null(ConverterOf()(headerValue));
+    }
+
+    [Fact]
+    public void The_host_callback_runs_after_the_defaults_so_it_can_override_them()
+    {
+        // If it ran first, a host would appear to configure the converter while the defaults silently won.
+        var options = OptionsOf(configure: settings => settings.CertificateHeader = "X-Overridden");
+
+        Assert.Equal("X-Overridden", options.CertificateHeader);
+        Assert.NotNull(options.HeaderConverter);
+    }
+
+    private static IEnumerable<string> Chunk(string value, int size)
+    {
+        for (var offset = 0; offset < value.Length; offset += size)
+            yield return value.Substring(offset, Math.Min(size, value.Length - offset));
+    }
+}

--- a/tests/Abblix.Oidc.Server.Vault.UnitTests/TransitCustodianTests.cs
+++ b/tests/Abblix.Oidc.Server.Vault.UnitTests/TransitCustodianTests.cs
@@ -107,6 +107,49 @@ public sealed class VaultTransitClientTests : IDisposable
         Assert.False(root.TryGetProperty("signature_algorithm", out _)); // EC has no signature_algorithm
     }
 
+    [Theory]
+    [InlineData(SigningAlgorithms.RS256, "pkcs1v15", "sha2-256")]
+    [InlineData(SigningAlgorithms.RS384, "pkcs1v15", "sha2-384")]
+    [InlineData(SigningAlgorithms.RS512, "pkcs1v15", "sha2-512")]
+    [InlineData(SigningAlgorithms.PS256, "pss", "sha2-256")]
+    [InlineData(SigningAlgorithms.PS384, "pss", "sha2-384")]
+    [InlineData(SigningAlgorithms.PS512, "pss", "sha2-512")]
+    public async Task SignAsync_SendsTheTransitNameOfEveryRsaAlgorithmItAccepts(
+        string algorithm, string expectedSignatureAlgorithm, string expectedHashAlgorithm)
+    {
+        // A hand-written mapping table invites transposition, and a transposed arm here is not a crash: Vault
+        // signs happily with whatever it was told, so the token goes out signed under one algorithm while its JWS
+        // header advertises another. Nothing local notices - the failure lands on whoever verifies it.
+        var handler = new StubHttpMessageHandler((_, _) => StubHttpMessageHandler.Json(
+            HttpStatusCode.OK, new { data = new { signature = "vault:v1:AQID" } }));
+
+        await ClientOver(handler).SignAsync("oidc-sign:1", algorithm, [1], TestContext.Current.CancellationToken);
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody!);
+        var root = body.RootElement;
+        Assert.Equal(expectedSignatureAlgorithm, root.GetProperty("signature_algorithm").GetString());
+        Assert.Equal(expectedHashAlgorithm, root.GetProperty("hash_algorithm").GetString());
+    }
+
+    [Theory]
+    [InlineData(SigningAlgorithms.ES256, "sha2-256")]
+    [InlineData(SigningAlgorithms.ES384, "sha2-384")]
+    [InlineData(SigningAlgorithms.ES512, "sha2-512")]
+    public async Task SignAsync_SendsTheTransitHashOfEveryEcAlgorithmItAccepts(
+        string algorithm, string expectedHashAlgorithm)
+    {
+        // Same exposure on the EC side, where the algorithm is carried by the hash alone.
+        var handler = new StubHttpMessageHandler((_, _) => StubHttpMessageHandler.Json(
+            HttpStatusCode.OK, new { data = new { signature = "vault:v1:AQID" } }));
+
+        await ClientOver(handler).SignAsync("oidc-sign:1", algorithm, [1], TestContext.Current.CancellationToken);
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody!);
+        var root = body.RootElement;
+        Assert.Equal(expectedHashAlgorithm, root.GetProperty("hash_algorithm").GetString());
+        Assert.Equal("jws", root.GetProperty("marshaling_algorithm").GetString());
+    }
+
     [Fact]
     public async Task SignAsync_RejectsUnsupportedAlgorithm_WithoutCallingTransit()
     {
@@ -162,6 +205,46 @@ public sealed class VaultTransitClientTests : IDisposable
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.UnwrapKeyAsync(
             "oidc-enc:1", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
             [1], TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task DecryptAsync_Throws_WhenTheFailureIsOurs(HttpStatusCode status)
+    {
+        // Only a rejected ciphertext may become null, because null is how the seam says "this did not decrypt" and
+        // that is what keeps a wrong key indistinguishable from bad padding. A throttled, sealed or broken Vault is
+        // not a decryption failure. Reporting one as null would reject every encrypted token for as long as the
+        // fault lasts, silently, and blame the clients for a JWE that is perfectly good.
+        var handler = new StubHttpMessageHandler((_, _) => StubHttpMessageHandler.Json(
+            status, new { errors = new[] { "not a decryption failure" } }));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => ClientOver(handler).UnwrapKeyAsync(
+            "oidc-enc:1", EncryptionAlgorithms.KeyManagement.RsaOaep256, new JsonWebTokenHeader(new JsonObject()),
+            [1], TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetKeyVersionsAsync_RefusesAKeyTypeItCannotPublish()
+    {
+        // Transit will happily hold an ed25519 or a symmetric key, and an operator can point this store at one by
+        // configuring a key name. Publishing it is impossible, so the refusal has to name the type - otherwise the
+        // failure surfaces as an import error from deep inside the crypto stack, far from the configuration that
+        // caused it.
+        using var rsa = RSA.Create(2048);
+        var handler = KeyResponse("ed25519", rsa.ExportSubjectPublicKeyInfoPem());
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await foreach (var _ in ClientOver(handler).GetKeyVersionsAsync(
+                               "oidc-sign", TestContext.Current.CancellationToken))
+            {
+                // Enumerating is the act under test; the refusal arrives before any version is produced.
+            }
+        });
+
+        Assert.Contains("ed25519", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Addresses the custodian half of #275.

## What was actually wrong

Branch coverage in the two custodian packages sat far below the rest of the solution (Vault 51.9%, Azure 45.9%, everything else 71-89%). Reading the source rather than the number gave the reason: the happy path was exercised and the answers we do not like were not.

Most of what looked missing was already covered - a rejected ciphertext becoming `null`, a 403 throwing, an unsupported algorithm refused before any call. The issue's framing was a hypothesis and the source corrected it. What was genuinely dark:

- **A disabled Key Vault version.** Disabling a version is how an operator takes a compromised key out of service. Had the skip been wrong, the key would have stayed in the JWKS and stayed eligible to sign, and the revocation would have appeared to succeed while changing nothing.
- **A version with no creation time.** The creation time decides which version signs and when a rotation takes over, so a version whose age is unknown has to stop the enumeration rather than be dated to year one and sort as ancient.
- **Vault threw only on 403.** A 429, a 503 and a 500 are not decryption failures either. Reporting one as `null` would reject every encrypted token for as long as the fault lasts, silently, and blame the clients for a JWE that is perfectly good.
- **A key type Transit can hold but this store cannot publish** (ed25519, symmetric). An operator can point the store at one by configuring a key name; the refusal has to name the type or the failure surfaces as an import error deep in the crypto stack.
- **Vault's signing algorithm table**, now exercised arm by arm against the wire. A hand-written mapping invites transposition, and a transposed arm is not a crash: Vault signs with whatever it is told, so the token goes out under one algorithm while its header advertises another.

## Verification

Every new test was checked by mutation, not by watching it go green. The disabled-version skip and the unwrap status filter were each broken in the production source, the corresponding tests went red, and the source was restored. A test that cannot fail protects nothing.

No production code is changed by this branch.

## What could not be done, and why

Azure's mapping table cannot be asserted at the wire the way Vault's can: the SDK's transport hands the message handler a request whose content is already gone, so the algorithm actually sent is not observable through that seam. Left alone and recorded on the issue rather than worked around with a visibility change to production code.

## Numbers

| package | branches | lines |
| --- | --- | --- |
| Vault | 51.9% to 76.4% | 91.9% to 98.5% |
| Azure | unchanged | 78.5% to 84.2% |

Azure's branch figure is unmoved because what remains there is the mapping table above.
