### PR TITLE
fix: four spec gaps in the JWT validator

### DIFF
--- a/src/Abblix.Jwt/CriticalHeaderValidation.cs
+++ b/src/Abblix.Jwt/CriticalHeaderValidation.cs
@@ -1,0 +1,149 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+
+namespace Abblix.Jwt;
+
+/// <summary>
+/// The structural half of the <c>crit</c> rules from RFC 7515 Section 4.1.11, shared by the two
+/// header kinds that can carry one.
+/// </summary>
+/// <remarks>
+/// RFC 7516 Section 4.1.13 defines <c>crit</c> for a JWE by pointing straight back at the JWS
+/// definition - "This Header Parameter MUST be understood and processed as defined in Section
+/// 4.1.11 of [JWS]" - so the rules are literally the same rules, and duplicating them per header
+/// kind would be duplicating a specification reference. Only the set of names a producer must not
+/// list differs, because the registered parameters differ between a JWS and a JWE header.
+/// </remarks>
+internal static class CriticalHeaderValidation
+{
+    /// <summary>
+    /// Header parameter names registered by RFC 7515 Section 4.1 (plus <c>crit</c> itself). Per
+    /// Section 4.1.11 a producer MUST NOT list any of these in <c>crit</c>, which exists to name
+    /// extensions.
+    /// </summary>
+    public static readonly IReadOnlySet<string> JwsReservedNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        JwtClaimTypes.Algorithm,
+        JwtClaimTypes.KeyId,
+        JwtClaimTypes.Type,
+        JwtClaimTypes.ContentType,
+        JwtClaimTypes.EncryptionAlgorithm,
+        JwtClaimTypes.Critical,
+        JwtClaimTypes.JwkSetUrl,
+        JwtClaimTypes.JsonWebKeyHeader,
+        JwtClaimTypes.X509Url,
+        JwtClaimTypes.X509CertificateChain,
+        JwtClaimTypes.X509Sha1Thumbprint,
+        JwtClaimTypes.X509Sha256Thumbprint,
+    };
+
+    /// <summary>
+    /// The same prohibition for a JWE protected header: everything RFC 7516 Section 4.1 registers,
+    /// which adds <c>zip</c>, plus the algorithm-specific parameters RFC 7518 Sections 4.6 to 4.8
+    /// register for ECDH-ES, AES GCM key wrapping and PBES2. None of these is an extension, so
+    /// none may appear in <c>crit</c>.
+    /// </summary>
+    public static readonly IReadOnlySet<string> JweReservedNames = new HashSet<string>(JwsReservedNames, StringComparer.Ordinal)
+    {
+        JwtClaimTypes.CompressionAlgorithm,
+        JwtClaimTypes.EphemeralPublicKey,
+        JwtClaimTypes.AgreementPartyUInfo,
+        JwtClaimTypes.AgreementPartyVInfo,
+        JwtClaimTypes.KeyWrapInitializationVector,
+        JwtClaimTypes.KeyWrapAuthenticationTag,
+        JwtClaimTypes.Pbes2SaltInput,
+        JwtClaimTypes.Pbes2IterationCount,
+    };
+
+    /// <summary>
+    /// Reads <c>crit</c> from <paramref name="header"/> and applies every rule that does not depend
+    /// on which extensions the host has registered: the parameter must parse, must not be the empty
+    /// array, must not repeat a name, must not name a registered parameter, and every name it lists
+    /// must actually be present in the header.
+    /// </summary>
+    /// <param name="header">The JOSE header to inspect.</param>
+    /// <param name="reservedNames">The registered names for this header kind: <see cref="JwsReservedNames"/>
+    /// or <see cref="JweReservedNames"/>.</param>
+    /// <param name="crit">The declared names when the header carries a well-formed <c>crit</c>,
+    /// otherwise <see langword="null"/> - which covers both "no <c>crit</c>" and "rejected", so
+    /// callers must check the return value first.</param>
+    /// <returns><see langword="null"/> when there is nothing to reject, otherwise the first
+    /// violation in declaration order, so the message names the offending parameter rather than
+    /// reporting that something somewhere was wrong.</returns>
+    public static JwtValidationError? ValidateStructure(
+        JsonWebTokenHeader header,
+        IReadOnlySet<string> reservedNames,
+        out IReadOnlyList<string>? crit)
+    {
+        crit = null;
+
+        IReadOnlyList<string>? declared;
+        try
+        {
+            // The accessor throws on a crit that is not an array of strings; that is a token defect,
+            // not a programming error, so it becomes a validation verdict here.
+            declared = header.Critical;
+        }
+        catch (JsonException)
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                "Invalid 'crit' header: must be a JSON array of strings");
+        }
+
+        if (declared is null)
+            return null;
+
+        if (declared.Count == 0)
+        {
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                "'crit' header must not be the empty array (RFC 7515 §4.1.11)");
+        }
+
+        var distinctNames = new HashSet<string>(declared, StringComparer.Ordinal);
+        if (distinctNames.Count != declared.Count)
+            return new JwtValidationError(JwtError.InvalidToken, "'crit' header contains duplicate names");
+
+        foreach (var name in declared)
+        {
+            if (reservedNames.Contains(name))
+            {
+                return new JwtValidationError(
+                    JwtError.InvalidToken,
+                    $"'crit' header must not list standard JOSE header name: {name}");
+            }
+
+            if (!header.Json.ContainsKey(name))
+            {
+                return new JwtValidationError(
+                    JwtError.InvalidToken,
+                    $"'crit' lists header name '{name}' that is not present in the JOSE header");
+            }
+        }
+
+        crit = declared;
+        return null;
+    }
+}

--- a/src/Abblix.Jwt/JsonWebTokenEncryptor.cs
+++ b/src/Abblix.Jwt/JsonWebTokenEncryptor.cs
@@ -180,6 +180,32 @@ internal class JsonWebTokenEncryptor(
         if (algorithm == null)
             return new JwtValidationError(JwtError.InvalidToken, "Missing 'alg' algorithm in JWE header");
 
+        // RFC 7516 Section 4.1.13 gives a JWE the same 'crit' parameter as a JWS, by reference:
+        // "This Header Parameter MUST be understood and processed as defined in Section 4.1.11 of
+        // [JWS]." That section is unambiguous about the consequence of not understanding a listed
+        // name: "If any of the listed extension Header Parameters are not understood and supported
+        // by the recipient, then the JWS is invalid." This library understands no JWE extensions,
+        // so any well-formed 'crit' here is a rejection.
+        // The check sits ahead of key selection deliberately, per the RFC 7516 Section 5.2 order:
+        // a critical extension may change what the following steps are supposed to mean, so nothing
+        // may touch key material while its meaning is still unknown.
+        if (CriticalHeaderValidation.ValidateStructure(
+                header, CriticalHeaderValidation.JweReservedNames, out var crit) is { } criticalError)
+        {
+            return criticalError;
+        }
+
+        if (crit is { Count: > 0 })
+        {
+            // Deliberately NOT routed to the keyed ICriticalHeaderHandler registry that serves JWS.
+            // That keyspace is keyed by bare parameter name, so a host registering a handler for a
+            // JWS extension would silently make the same name acceptable on a JWE envelope, where
+            // it means something else and where the handler was never written to run.
+            return new JwtValidationError(
+                JwtError.InvalidToken,
+                $"Unknown critical header parameter in JWE header: {crit[0]}");
+        }
+
         // Per RFC 7517 Section 4.4, 'alg' parameter in JWK is OPTIONAL
         // Filter only by kid when present - algorithm compatibility is validated during decryption attempt
         if (header.KeyId.HasValue())

--- a/src/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/src/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -143,10 +143,22 @@ public class JsonWebTokenPayload(JsonObject json)
 	}
 
 	/// <summary>
-	/// The authorized party (azp) the JWT was issued to. OpenID Connect Core mandates this claim
-	/// in an id_token when there is a single audience that differs from the issuer, and whenever
-	/// the token has more than one audience, naming the party the token was minted for.
+	/// The authorized party (azp): the party the token was issued to. OpenID Connect Core 1.0
+	/// section 2 defines it in one sentence - "OPTIONAL. Authorized party - the party to which
+	/// the ID Token was issued. If present, it MUST contain the OAuth 2.0 Client ID of this
+	/// party." So the claim is optional, and the only obligation attaches to its value.
 	/// </summary>
+	/// <remarks>
+	/// This described the claim as mandated, and as keyed to the issuer, until 2026-07-20. Both
+	/// were wrong, and the second inverts what the claim is for: azp names the recipient, not
+	/// the sender. The conditions the old text carried - a single audience differing from
+	/// something, or more than one audience - come from wording that errata set 2 replaced.
+	/// A recipient's duty is correspondingly weak: section 3.1.3.7 step 4 says a client using
+	/// extensions that produce azp "SHOULD validate the azp value as specified by those
+	/// extensions", and step 5 that this "MAY include that when an azp Claim is present, the
+	/// Client SHOULD verify that its client_id is the Claim Value". Nothing here is a MUST, and
+	/// a validator that rejects on a missing azp will refuse conformant issuers.
+	/// </remarks>
 	public string? AuthorizedParty
 	{
 		get => Json.GetProperty<string>(IanaClaimTypes.Azp);

--- a/src/Abblix.Jwt/JsonWebTokenSigner.cs
+++ b/src/Abblix.Jwt/JsonWebTokenSigner.cs
@@ -128,11 +128,16 @@ internal partial class JsonWebTokenSigner(
                 "No signing keys configured for issuer (RFC 7515 §6: cannot verify signature without keys)");
         }
 
-        // Per RFC 7517 Section 4.4, 'alg' parameter in JWK is OPTIONAL but binding when present:
-        // a key declaring its alg MUST NOT be used with any other algorithm. Filter such keys out
-        // before reaching crypto so a key registered for (say) RS256 cannot be misused to verify
-        // PS256 or RS384 tokens, closing within-family algorithm-confusion alongside the
-        // cross-family protection already provided by the generic keyed-DI dispatch.
+        // The binding a key declares over its algorithm comes from RFC 8725 Section 3.1, not from
+        // the JWK spec: "each key MUST be used with exactly one algorithm, and this MUST be
+        // checked when the cryptographic operation is performed". RFC 7517 Section 4.4 only
+        // introduces the parameter - it says 'alg' "identifies the algorithm intended for use
+        // with the key" and that "Use of this member is OPTIONAL", with no MUST NOT anywhere in
+        // it, so citing it for the prohibition (as this comment did until 2026-07-20) overstates
+        // it. Filtering here keeps a key registered for, say, RS256 from verifying a PS256 or
+        // RS384 token, closing within-family algorithm confusion alongside the cross-family
+        // protection the keyed-DI dispatch already gives. A key that declares no 'alg' stays a
+        // candidate, which is what makes the parameter's optionality workable.
         // Per RFC 7515 Section 4.1.4, 'kid' parameter helps select the key.
         var candidates = allKeys
             .Where(key =>

--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -540,14 +540,36 @@ internal class JsonWebTokenValidator(
     /// <summary>
     /// Validates the lifetime claims (nbf and exp) according to validation parameters.
     /// </summary>
+    /// <remarks>
+    /// Presence and value are two separate questions here, gated by two separate flags, the same
+    /// way <see cref="ValidationOptions.RequireIssuer"/> and <see cref="ValidationOptions.ValidateIssuer"/>
+    /// split them. The distinction is not academic: a token carrying neither <c>nbf</c> nor
+    /// <c>exp</c> has no instant at which it is expired, so a pure lifetime comparison finds
+    /// nothing wrong with it and lets it through forever. Whether that is correct depends
+    /// entirely on the token class, which only the caller knows -
+    /// <see cref="ValidationOptions.RequireExpirationTime"/> is how it says so.
+    /// </remarks>
     private Result<JsonWebToken, JwtValidationError> ValidateLifetime(
         JsonWebToken token, ValidationParameters parameters)
     {
-        if (!parameters.Options.HasFlag(ValidationOptions.ValidateLifetime))
+        var requireExpiration = parameters.Options.HasFlag(ValidationOptions.RequireExpirationTime);
+        var validateLifetime = parameters.Options.HasFlag(ValidationOptions.ValidateLifetime);
+
+        // Neither flag set means the claims are not this caller's business, and reading them is
+        // not free of consequence: the accessors throw on a timestamp outside DateTimeOffset's
+        // range, which a caller who opted out of time handling should never have to meet.
+        if (!requireExpiration && !validateLifetime)
             return token;
 
         var notBefore = token.Payload.NotBefore;
         var expiresAt = token.Payload.ExpiresAt;
+
+        if (requireExpiration && !expiresAt.HasValue)
+            return new JwtValidationError(JwtError.InvalidToken, "Missing expiration time in JWT payload");
+
+        if (!validateLifetime)
+            return token;
+
         if (!notBefore.HasValue && !expiresAt.HasValue)
             return token;
 

--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -55,27 +55,6 @@ internal class JsonWebTokenValidator(
     IServiceProvider serviceProvider) : IJsonWebTokenValidator
 {
     /// <summary>
-    /// Header parameter names defined by RFC 7515 §4.1 (and 'crit' itself). Per RFC 7515 §4.1.11
-    /// a producer MUST NOT list any of these in 'crit'; we reject as recipient-MAY because
-    /// strict input parsing for security-critical formats is the right default.
-    /// </summary>
-    private static readonly IReadOnlySet<string> ReservedCriticalHeaderNames = new HashSet<string>(StringComparer.Ordinal)
-    {
-        JwtClaimTypes.Algorithm,
-        JwtClaimTypes.KeyId,
-        JwtClaimTypes.Type,
-        JwtClaimTypes.ContentType,
-        JwtClaimTypes.EncryptionAlgorithm,
-        JwtClaimTypes.Critical,
-        JwtClaimTypes.JwkSetUrl,
-        JwtClaimTypes.JsonWebKeyHeader,
-        JwtClaimTypes.X509Url,
-        JwtClaimTypes.X509CertificateChain,
-        JwtClaimTypes.X509Sha1Thumbprint,
-        JwtClaimTypes.X509Sha256Thumbprint,
-    };
-
-    /// <summary>
     /// Provides a collection of signing algorithms supported by the validator.
     /// Dynamically determined from registered signers in the dependency injection container.
     /// </summary>
@@ -356,68 +335,17 @@ internal class JsonWebTokenValidator(
         JsonWebToken token,
         ValidationParameters parameters)
     {
-        var header = token.Header;
+        var structuralError = CriticalHeaderValidation.ValidateStructure(
+            token.Header, CriticalHeaderValidation.JwsReservedNames, out var crit);
 
-        IReadOnlyList<string>? crit;
-        try
-        {
-            crit = header.Critical;
-        }
-        catch (JsonException)
-        {
-            return new JwtValidationError(
-                JwtError.InvalidToken,
-                "Invalid 'crit' header: must be a JSON array of strings");
-        }
+        if (structuralError is not null)
+            return structuralError;
 
+        // No 'crit' at all is the ordinary case and needs no handler pass.
         if (crit is null)
             return token;
 
-        if (ValidateCritStructure(crit, header) is { } structuralError)
-            return structuralError;
-
         return await DispatchCritHandlersAsync(token, parameters, crit);
-    }
-
-    /// <summary>
-    /// Runs the structural guards from RFC 7515 §4.1.11 (empty array, duplicates, reserved
-    /// standard names, dangling references), all independent of the handler registry. Returns
-    /// <see langword="null"/> when every name in <paramref name="crit"/> is well-formed;
-    /// otherwise the first rejection in declaration order so the diagnostic pinpoints the
-    /// specific violating name. Routability (whether a handler is registered for a surviving
-    /// name) is decided in <see cref="DispatchCritHandlersAsync"/>.
-    /// </summary>
-    private static JwtValidationError? ValidateCritStructure(IReadOnlyList<string> crit, JsonWebTokenHeader header)
-    {
-        if (crit.Count == 0)
-        {
-            return new JwtValidationError(
-                JwtError.InvalidToken,
-                "'crit' header must not be the empty array (RFC 7515 §4.1.11)");
-        }
-
-        var distinctNames = new HashSet<string>(crit, StringComparer.Ordinal);
-        if (distinctNames.Count != crit.Count)
-            return new JwtValidationError(JwtError.InvalidToken, "'crit' header contains duplicate names");
-
-        foreach (var name in crit)
-        {
-            if (ReservedCriticalHeaderNames.Contains(name))
-            {
-                return new JwtValidationError(
-                    JwtError.InvalidToken,
-                    $"'crit' header must not list standard JOSE header name: {name}");
-            }
-
-            if (!header.Json.ContainsKey(name))
-            {
-                return new JwtValidationError(
-                    JwtError.InvalidToken,
-                    $"'crit' lists header name '{name}' that is not present in the JOSE header");
-            }
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -491,11 +491,29 @@ internal class JsonWebTokenValidator(
     /// Pins the JWT's <c>typ</c> header (RFC 7515 §4.1.9) to the set the caller expects, per
     /// the RFC 8725 §3.11 token-class-confusion guidance. When
     /// <see cref="ValidationParameters.ExpectedTokenTypes"/> is null or empty the check is
-    /// skipped (backward-compatible default for callers that have not opted in). Comparison
-    /// is case-sensitive per RFC 7515 §5.3, with the <c>application/</c> prefix stripped
-    /// before lookup per the §4.1.9 convention so <c>typ=at+jwt</c> and
-    /// <c>typ=application/at+jwt</c> both match a registered <c>at+jwt</c> expectation.
+    /// skipped (backward-compatible default for callers that have not opted in).
     /// </summary>
+    /// <remarks>
+    /// Matching is case-insensitive, and the <c>application/</c> prefix is stripped from the
+    /// expectation as well as from the token, so either form may be written on either side.
+    /// A <c>typ</c> is a media type: RFC 7515 §4.1.9 says "Per RFC 2045, all media type values,
+    /// subtype values, and parameter names are case insensitive", and RFC 2045 §5.1 puts it
+    /// flatly - "Matching of media type and subtype is ALWAYS case-insensitive". The same
+    /// §4.1.9 requires a recipient to treat a value without a '/' as if <c>application/</c>
+    /// were prepended, which makes the short and long forms one name rather than two.
+    /// Note that RFC 7515 §5.3 does NOT apply here despite defining the library's general
+    /// string-comparison rules: it ends by exempting exactly this parameter, "Only the 'typ'
+    /// and 'cty' member values defined in this specification do not use these comparison
+    /// rules". This code cited §5.3 for the opposite conclusion until 2026-07-20.
+    /// Folding costs no separation between the classes actually pinned here (<c>dpop+jwt</c>,
+    /// <c>at+jwt</c>, <c>logout+jwt</c>, <c>id_token</c>): they differ in their letters, not
+    /// their casing. The one place RFC 2045 keeps case significant is the value of a
+    /// <c>;parameter=</c> tail, which no <c>typ</c> in these specifications carries; should one
+    /// ever appear, this whole-string fold would be more permissive than the RFC on that tail.
+    /// The comparison deliberately does not use <see cref="IReadOnlySet{T}.Contains"/>: the set
+    /// arrives from the caller with a comparer of their choosing, which would quietly hand a
+    /// security decision to host configuration this validator can neither see nor vouch for.
+    /// </remarks>
     private static Result<JsonWebToken, JwtValidationError> ValidateTokenType(
         JsonWebToken token, ValidationParameters parameters)
     {
@@ -511,7 +529,10 @@ internal class JsonWebTokenValidator(
         }
 
         var normalized = StripApplicationPrefix(typ);
-        if (!expected.Contains(normalized))
+        var matched = expected.Any(expectedTyp => string.Equals(
+            StripApplicationPrefix(expectedTyp), normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (!matched)
         {
             return new JwtValidationError(
                 JwtError.InvalidTokenType,
@@ -522,14 +543,21 @@ internal class JsonWebTokenValidator(
     }
 
     /// <summary>
-    /// Implements RFC 7515 §4.1.9's prefix-stripping convention: when <c>typ</c> contains no
-    /// '/' the recipient SHOULD treat it as if <c>application/</c> were prepended; symmetric
-    /// stripping of the literal prefix lets either form match.
+    /// Implements RFC 7515 §4.1.9's prefix convention: "A recipient using the media type value
+    /// MUST treat it as if 'application/' were prepended to any 'typ' value not containing a
+    /// '/'." Stripping the literal prefix instead of prepending it reaches the same equivalence
+    /// from either form, and is applied to both sides of the comparison so a caller may write
+    /// whichever they prefer.
     /// </summary>
+    /// <remarks>
+    /// The prefix match ignores case because it is the media type portion, which RFC 2045 §5.1
+    /// declares case-insensitive; matching it ordinally would leave <c>Application/at+jwt</c>
+    /// unstripped and therefore unmatchable.
+    /// </remarks>
     private static string StripApplicationPrefix(string typ)
     {
         const string prefix = "application/";
-        return typ.StartsWith(prefix, StringComparison.Ordinal) ? typ[prefix.Length..] : typ;
+        return typ.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ? typ[prefix.Length..] : typ;
     }
 
     /// <summary>

--- a/src/Abblix.Jwt/JwtClaimTypes.cs
+++ b/src/Abblix.Jwt/JwtClaimTypes.cs
@@ -56,6 +56,13 @@ public static class JwtClaimTypes
     public const string EncryptionAlgorithm = "enc";
 
     /// <summary>
+    /// "zip" header parameter (RFC 7516 Section 4.1.3): the compression algorithm applied to the
+    /// plaintext before encryption. Registered as a JWE header parameter, so a producer must not
+    /// list it in "crit" - it is not an extension.
+    /// </summary>
+    public const string CompressionAlgorithm = "zip";
+
+    /// <summary>
     /// "crit" header parameter (RFC 7515 Section 4.1.11): a JSON array of JOSE header parameter
     /// names that the recipient MUST understand and process. The parameter itself MUST be
     /// understood by JWS implementations, even when no extensions are in use.

--- a/src/Abblix.Jwt/ValidationOptions.cs
+++ b/src/Abblix.Jwt/ValidationOptions.cs
@@ -87,6 +87,30 @@ public enum ValidationOptions
 	UseEmbeddedVerificationKey = 1 << 7,
 
 	/// <summary>
+	/// Requires the token to carry an expiration time. Pairs with <see cref="ValidateLifetime"/>
+	/// the way <see cref="RequireIssuer"/> pairs with <see cref="ValidateIssuer"/>: the Validate
+	/// flag checks a claim that is there, the Require flag says it has to be there.
+	/// </summary>
+	/// <remarks>
+	/// Without this, <see cref="ValidateLifetime"/> alone accepts a token carrying neither
+	/// <c>nbf</c> nor <c>exp</c> - there is no instant at which such a token is expired, so
+	/// checking its lifetime finds nothing wrong. That is right for the token classes whose
+	/// specifications leave expiry out, and wrong for the ones that make it REQUIRED, which is
+	/// why the two are separate flags rather than one stricter check.
+	/// Set it wherever the governing specification demands <c>exp</c>: an ID Token (OpenID
+	/// Connect Core 1.0 section 2, "REQUIRED"), a JWT access token (RFC 9068 section 2.2,
+	/// "exp REQUIRED"), a client assertion or JWT bearer grant (RFC 7523 section 3, "The JWT
+	/// MUST contain an 'exp' claim"). Leave it clear where the specification is silent, and
+	/// note that silence is not an oversight in at least one case: RFC 7592 section 5 says a
+	/// registration access token "SHOULD NOT expire while a client is still actively
+	/// registered", and this library issues those without an expiry accordingly.
+	/// Deliberately absent from <see cref="Default"/>, because several call sites derive their
+	/// options from Default by subtraction and would inherit a requirement their tokens do not
+	/// meet - including tokens this library itself mints.
+	/// </remarks>
+	RequireExpirationTime = 1 << 8,
+
+	/// <summary>
 	/// Requires and validates the issuer claim (iss).
 	/// Combines RequireIssuer and ValidateIssuer flags.
 	/// </summary>

--- a/src/Abblix.Jwt/ValidationParameters.cs
+++ b/src/Abblix.Jwt/ValidationParameters.cs
@@ -65,9 +65,15 @@ public record ValidationParameters
 	/// as another by relying parties that trust the same issuer for several classes.
 	/// </summary>
 	/// <remarks>
-	/// Comparison follows the spec rules: case-sensitive (RFC 7515 §5.3), with the
-	/// <c>application/</c>-prefix-stripping convention from §4.1.9 applied before lookup
-	/// — <c>typ=at+jwt</c> and <c>typ=application/at+jwt</c> are accepted equivalently.
+	/// Matching is case-insensitive and accepts either spelling of the <c>application/</c>
+	/// prefix on either side, so <c>at+jwt</c> and <c>application/AT+JWT</c> name the same
+	/// class. A <c>typ</c> is a media type, and RFC 7515 §4.1.9 adopts RFC 2045 §5.1 for it:
+	/// "Matching of media type and subtype is ALWAYS case-insensitive". The general
+	/// string-comparison rules of RFC 7515 §5.3 do not govern this parameter; that section
+	/// ends by exempting it by name.
+	/// The comparer carried by the set is NOT what produces this behaviour and is not consulted
+	/// for matching - the validator compares explicitly, so that its rules cannot be widened or
+	/// narrowed by how a host happened to construct the collection. Supply any comparer, or none.
 	/// When this property is null or empty the validator skips the check, preserving
 	/// historical behaviour for callers that have not opted in.
 	/// </remarks>

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -164,7 +164,11 @@ public partial class JwtBearerGrantHandler(
 			assertion,
 			new()
 			{
-				Options = ValidationOptions.Default,
+				// RFC 7523 Section 3 item 4 is explicit that the assertion must bound its own
+				// window: "The JWT MUST contain an 'exp' (expiration time) claim that limits the
+				// time window during which the JWT can be used." Without the flag, an assertion
+				// omitting exp would be treated as having nothing to check rather than as invalid.
+				Options = ValidationOptions.Default | ValidationOptions.RequireExpirationTime,
 				ValidateIssuer = ValidateIssuer,
 				ValidateAudience = ValidateAudience,
 				ResolveIssuerSigningKeys = issuerProvider.GetSigningKeysAsync,

--- a/src/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
@@ -75,7 +75,12 @@ public class UserInfoRequestValidator(
 
 		var jwtAccessToken = tokenResult.GetSuccess();
 
-		var result = await jwtValidator.ValidateAsync(jwtAccessToken, ValidationOptions.Default & ~ValidationOptions.RequireValidAudience);
+		// RFC 9068 Section 2.2 lists exp among the REQUIRED claims of a JWT access token, and
+		// Section 4 makes the consequence explicit: "The current time MUST be before the time
+		// represented by the exp claim." An access token without one would otherwise never expire.
+		var result = await jwtValidator.ValidateAsync(
+			jwtAccessToken,
+			(ValidationOptions.Default & ~ValidationOptions.RequireValidAudience) | ValidationOptions.RequireExpirationTime);
 
 		if (result.TryGetFailure(out var error))
 			return new OidcError(ErrorCodes.InvalidToken, error.ToString());

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
@@ -78,7 +78,10 @@ public partial class ClientSecretJwtAuthenticator(
             jwt,
             new ValidationParameters
             {
-                Options = ValidationOptions.Default,
+                // A client assertion must carry its own expiry: RFC 7521 Section 5.2 requires an
+                // "Expires At entity that limits the time window during which the assertion can be
+                // used", and RFC 7523 Section 3 item 4 states it as a MUST on the exp claim.
+                Options = ValidationOptions.Default | ValidationOptions.RequireExpirationTime,
                 ValidateAudience = ValidateAudience,
                 ValidateIssuer = issuer => ValidateIssuer(issuer, context),
                 ResolveIssuerSigningKeys = issuer => ResolveIssuerSigningKeys(issuer, context),

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
@@ -64,6 +64,12 @@ public class PrivateKeyJwtAuthenticator(
     {
         using var scope = serviceProvider.CreateScope();
         var tokenValidator = scope.ServiceProvider.GetRequiredService<IClientJwtValidator>();
-        return await tokenValidator.ValidateAsync(jwt);
+
+        // Stated rather than left to the default, because the requirement is this grant's and not
+        // the validator's: RFC 7521 Section 5.2 requires the assertion to carry an "Expires At
+        // entity that limits the time window during which the assertion can be used", which
+        // RFC 7523 Section 3 item 4 spells as a MUST on exp.
+        return await tokenValidator.ValidateAsync(
+            jwt, ValidationOptions.Default | ValidationOptions.RequireExpirationTime);
     }
 }

--- a/tests/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -969,6 +969,97 @@ public class JsonWebTokenValidationTests
     }
 
     /// <summary>
+    /// The same token, with <see cref="ValidationOptions.RequireExpirationTime"/> set, is rejected.
+    /// That flag is the caller saying its token class makes <c>exp</c> REQUIRED - an ID Token
+    /// (OpenID Connect Core 1.0 section 2), a JWT access token (RFC 9068 section 2.2), a client
+    /// assertion (RFC 7523 section 3).
+    /// </summary>
+    [Fact]
+    public async Task TokenWithoutExp_WithRequireExpirationTime_Rejected()
+    {
+        var token = CreateValidToken();
+        token.Payload.NotBefore = null;
+        token.Payload.ExpiresAt = null;
+
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(
+            SigningKey, options: ValidationOptions.Default | ValidationOptions.RequireExpirationTime);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+    }
+
+    /// <summary>
+    /// An <c>nbf</c> is not a substitute: it bounds when the token starts being usable, not when
+    /// it stops, so a token carrying only <c>nbf</c> still never expires.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithNbfOnly_WithRequireExpirationTime_Rejected()
+    {
+        var token = CreateValidToken();
+        token.Payload.ExpiresAt = null;
+        token.Payload.NotBefore = TimeProvider.System.GetUtcNow().AddMinutes(-5);
+
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(
+            SigningKey, options: ValidationOptions.Default | ValidationOptions.RequireExpirationTime);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out _));
+    }
+
+    /// <summary>
+    /// With the flag set and an <c>exp</c> present, nothing changes.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithExp_WithRequireExpirationTime_Validates()
+    {
+        var token = CreateValidToken();
+        token.Payload.ExpiresAt = TimeProvider.System.GetUtcNow().AddHours(1);
+
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(
+            SigningKey, options: ValidationOptions.Default | ValidationOptions.RequireExpirationTime);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// Presence is asked separately from validity, so the flag works on its own. This is the shape
+    /// <see cref="ValidationOptions.RequireIssuer"/> already has next to
+    /// <see cref="ValidationOptions.ValidateIssuer"/>.
+    /// </summary>
+    [Fact]
+    public async Task TokenWithoutExp_WithRequireExpirationTimeButNoLifetimeValidation_Rejected()
+    {
+        var token = CreateValidToken();
+        token.Payload.NotBefore = null;
+        token.Payload.ExpiresAt = null;
+
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var options = (ValidationOptions.Default & ~ValidationOptions.ValidateLifetime)
+                      | ValidationOptions.RequireExpirationTime;
+        var parameters = CreateValidationParameters(SigningKey, options: options);
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out _));
+    }
+
+    /// <summary>
     /// Verifies that JWTs with only exp claim (no nbf) validate successfully.
     /// Tests that nbf is optional even when ValidateLifetime is enabled.
     /// Only validates exp when present.

--- a/tests/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/JsonWebTokenValidationTests.cs
@@ -1341,12 +1341,19 @@ public class JsonWebTokenValidationTests
     }
 
     /// <summary>
-    /// RFC 7515 §5.3: the <c>typ</c> header is case-sensitive. <c>At+JWT</c> does NOT match
-    /// the canonical <c>at+jwt</c>; the validator rejects the mismatched casing instead of
-    /// silently coercing to the spec value.
+    /// A <c>typ</c> is a media type, and RFC 2045 section 5.1 makes the type and subtype
+    /// case-insensitive ("Matching of media type and subtype is ALWAYS case-insensitive"),
+    /// which RFC 7515 section 4.1.9 adopts by reference. So <c>At+JWT</c> names the same token
+    /// class as <c>at+jwt</c> and must be accepted.
     /// </summary>
+    /// <remarks>
+    /// This test asserted the opposite until 2026-07-20, citing RFC 7515 section 5.3 - which is
+    /// the section that ends "Only the 'typ' and 'cty' member values defined in this
+    /// specification do not use these comparison rules", exempting <c>typ</c> rather than
+    /// governing it. The assertion was holding the wrong behaviour in place.
+    /// </remarks>
     [Fact]
-    public async Task ExpectedTokenTypes_TypIsCaseSensitive()
+    public async Task ExpectedTokenTypes_TypMatchesCaseInsensitively()
     {
         var token = CreateValidToken();
         token.Header.Type = "At+JWT";
@@ -1360,7 +1367,64 @@ public class JsonWebTokenValidationTests
 
         var result = await validator.ValidateAsync(jwt, parameters);
 
-        Assert.True(result.TryGetFailure(out _));
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// The <c>application/</c> prefix is stripped from the expectation as well as from the token,
+    /// so a caller may register either form. RFC 7515 section 4.1.9 recommends producers omit the
+    /// prefix but requires recipients to treat a prefix-less value as if it were prepended, which
+    /// makes the two forms the same name and leaves the caller free to write either.
+    /// </summary>
+    /// <remarks>
+    /// Stripping used to be applied to the token's own <c>typ</c> only, which made the long form
+    /// unusable as an expectation in both directions: it matched neither <c>at+jwt</c> nor
+    /// <c>application/at+jwt</c>, since both reach the lookup already stripped.
+    /// </remarks>
+    [Theory]
+    [InlineData("at+jwt", "application/at+jwt")]
+    [InlineData("application/at+jwt", "at+jwt")]
+    [InlineData("application/at+jwt", "application/at+jwt")]
+    [InlineData("Application/AT+JWT", "at+jwt")]
+    public async Task ExpectedTokenTypes_ApplicationPrefixStrippedOnBothSides(string typ, string expected)
+    {
+        var token = CreateValidToken();
+        token.Header.Type = typ;
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { expected },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// Case folding must not blur the classes apart from each other: a logout token still fails
+    /// an id_token expectation. The names this library pins differ in more than casing, so the
+    /// RFC 2045 rule costs nothing in separation.
+    /// </summary>
+    [Fact]
+    public async Task ExpectedTokenTypes_DifferentClassStillRejected()
+    {
+        var token = CreateValidToken();
+        token.Header.Type = "Logout+JWT";
+        var jwt = await IssueToken(token, SigningKey);
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        var parameters = CreateValidationParameters(SigningKey) with
+        {
+            ExpectedTokenTypes = new HashSet<string>(StringComparer.Ordinal) { "at+jwt" },
+        };
+
+        var result = await validator.ValidateAsync(jwt, parameters);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidTokenType, error.Error);
     }
 
     /// <summary>

--- a/tests/Abblix.Jwt.UnitTests/JweCriticalHeaderTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/JweCriticalHeaderTests.cs
@@ -1,0 +1,222 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json.Nodes;
+using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// The <c>crit</c> parameter on the OUTER protected header of a JWE. RFC 7516 Section 4.1.13
+/// defines it by pointing at the JWS definition, so the rules are the same rules, but until
+/// 2026-07-20 the library checked only the inner JWS header after decryption and a critical
+/// extension declared on the envelope was silently ignored.
+/// </summary>
+/// <remarks>
+/// The outer header is built inside the encryptor with no injection point, so these tests issue a
+/// real JWE and then rewrite its first part. That also changes the AEAD associated data, which is
+/// exactly why every assertion here names <c>crit</c> in the message rather than merely checking
+/// the error category: without the check under test, the same tokens are rejected too, but for the
+/// wrong reason and only after key material has been touched. The control at the end proves the
+/// unmodified token still decrypts, so the splicing is not what these tests are measuring.
+/// </remarks>
+public class JweCriticalHeaderTests
+{
+    private const string IssuerUri = "https://issuer.example.com";
+    private const string TestAudience = "test-audience";
+    private const string ExtensionName = "my-ext";
+
+    private static readonly JsonWebKey SigningKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
+    private static readonly JsonWebKey EncryptionKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Encryption);
+
+    private static readonly IServiceProvider ServiceProvider = CreateServiceProvider();
+
+    private static IServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<string> IssueJwe()
+    {
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithms.RS256 },
+            Payload =
+            {
+                Issuer = IssuerUri,
+                Audiences = [TestAudience],
+                ExpiresAt = TimeProvider.System.GetUtcNow().AddHours(1),
+            },
+        };
+
+        var creator = ServiceProvider.GetRequiredService<IJsonWebTokenCreator>();
+        return await creator.IssueAsync(token, SigningKey, EncryptionKey);
+    }
+
+    /// <summary>
+    /// Rewrites the JWE protected header, applying <paramref name="edit"/> to the parsed object.
+    /// </summary>
+    private static async Task<string> IssueJweWithHeader(Action<JsonObject> edit)
+    {
+        var parts = (await IssueJwe()).Split('.');
+        var header = JsonNode.Parse(
+            Encoding.UTF8.GetString(Base64Url.DecodeFromChars(parts[0])))!.AsObject();
+
+        edit(header);
+
+        parts[0] = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(header.ToJsonString()));
+        return string.Join('.', parts);
+    }
+
+    private static Task<Result<JsonWebToken, JwtValidationError>> Validate(string jwt)
+    {
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        return validator.ValidateAsync(jwt, new ValidationParameters
+        {
+            ValidateAudience = _ => Task.FromResult(true),
+            ValidateIssuer = _ => Task.FromResult(true),
+            ResolveIssuerSigningKeys = _ => SigningKey.ToAsync(),
+            ResolveTokenDecryptionKeys = _ => EncryptionKey.ToAsync(),
+        });
+    }
+
+    private static async Task AssertRejectedForCrit(string jwt)
+    {
+        var result = await Validate(jwt);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Contains("crit", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The headline case: an extension nobody registered, declared critical on the envelope.
+    /// RFC 7515 Section 4.1.11, which RFC 7516 Section 4.1.13 adopts, says the token is invalid
+    /// if a listed parameter is not understood - and this library understands none.
+    /// </summary>
+    [Fact]
+    public async Task UnknownCriticalExtension_Rejected()
+    {
+        var jwt = await IssueJweWithHeader(header =>
+        {
+            header[JwtClaimTypes.Critical] = new JsonArray(ExtensionName);
+            header[ExtensionName] = "whatever";
+        });
+
+        await AssertRejectedForCrit(jwt);
+    }
+
+    /// <summary>
+    /// "Producers MUST NOT use the empty list" (RFC 7515 Section 4.1.11).
+    /// </summary>
+    [Fact]
+    public async Task EmptyCriticalList_Rejected()
+    {
+        var jwt = await IssueJweWithHeader(header => header[JwtClaimTypes.Critical] = new JsonArray());
+
+        await AssertRejectedForCrit(jwt);
+    }
+
+    /// <summary>
+    /// A name listed twice.
+    /// </summary>
+    [Fact]
+    public async Task DuplicateCriticalName_Rejected()
+    {
+        var jwt = await IssueJweWithHeader(header =>
+        {
+            header[JwtClaimTypes.Critical] = new JsonArray(ExtensionName, ExtensionName);
+            header[ExtensionName] = "whatever";
+        });
+
+        await AssertRejectedForCrit(jwt);
+    }
+
+    /// <summary>
+    /// A name declared critical but absent from the header it points into.
+    /// </summary>
+    [Fact]
+    public async Task DanglingCriticalName_Rejected()
+    {
+        var jwt = await IssueJweWithHeader(header => header[JwtClaimTypes.Critical] = new JsonArray(ExtensionName));
+
+        await AssertRejectedForCrit(jwt);
+    }
+
+    /// <summary>
+    /// A registered JWE parameter may not be declared critical: <c>crit</c> names extensions, and
+    /// these are not extensions. <c>zip</c> is registered by RFC 7516 Section 4.1.3 and belongs to
+    /// the JWE set specifically, so it also proves the JWE list is wider than the JWS one.
+    /// </summary>
+    [Theory]
+    [InlineData(JwtClaimTypes.CompressionAlgorithm)]
+    [InlineData(JwtClaimTypes.EphemeralPublicKey)]
+    [InlineData(JwtClaimTypes.Pbes2SaltInput)]
+    [InlineData(JwtClaimTypes.Algorithm)]
+    public async Task RegisteredParameterDeclaredCritical_Rejected(string reservedName)
+    {
+        var jwt = await IssueJweWithHeader(header =>
+        {
+            header[JwtClaimTypes.Critical] = new JsonArray(reservedName);
+            header[reservedName] = "whatever";
+        });
+
+        await AssertRejectedForCrit(jwt);
+    }
+
+    /// <summary>
+    /// A <c>crit</c> that is not an array of strings must come back as a verdict, not as an
+    /// exception escaping the validator on attacker-supplied input.
+    /// </summary>
+    [Theory]
+    [InlineData("42")]
+    [InlineData("\"my-ext\"")]
+    [InlineData("[\"a\", 42]")]
+    [InlineData("{}")]
+    public async Task MalformedCritical_RejectedWithoutThrowing(string criticalJson)
+    {
+        var jwt = await IssueJweWithHeader(header => header[JwtClaimTypes.Critical] = JsonNode.Parse(criticalJson));
+
+        await AssertRejectedForCrit(jwt);
+    }
+
+    /// <summary>
+    /// The control. An untouched JWE still round-trips, so the rejections above are about
+    /// <c>crit</c> and not about the envelope being rewritten.
+    /// </summary>
+    [Fact]
+    public async Task JweWithoutCritical_Validates()
+    {
+        var result = await Validate(await IssueJwe());
+
+        Assert.True(result.TryGetSuccess(out var token));
+        Assert.Equal(IssuerUri, token.Payload.Issuer);
+    }
+}


### PR DESCRIPTION
Four defects found while building the `id_token` validation spec for the client. Three are behaviour, one is documentation, and they share a cause worth naming: a rule attributed to the wrong clause. A citation looks checkable, so the next reader does not check it.

**`typ` was compared by the rules of the section that exempts it.** The code cited RFC 7515 section 5.3 for case-sensitive matching. That section ends "Only the 'typ' and 'cty' member values defined in this specification do not use these comparison rules". The rule that applies is section 4.1.9, which adopts RFC 2045, where "Matching of media type and subtype is ALWAYS case-insensitive". So `At+JWT` was rejected though it names the same class as `at+jwt`. Separately, the `application/` prefix was stripped from the token's own `typ` but never from the expectation, which made the long form unusable as an expectation in both directions. A test asserted the case-sensitive behaviour, citing the exempting section - it was holding the defect in place rather than catching it. Nothing here could let one token class pass as another; the classes pinned differ in their letters, not their casing.

**`crit` on a JWE envelope was read by nobody.** RFC 7516 section 4.1.13 defines it by pointing at the JWS definition, but the check ran only on the inner JWS header after decryption, so a critical extension declared on the envelope was silently ignored - the one outcome `crit` exists to prevent. The structural rules move to a shared helper, since they are literally the same rules; only the reserved-name list differs, because a JWE header registers `zip` and the key-management algorithms register `epk`, `apu`, `apv`, `iv`, `tag`, `p2s`, `p2c`. The check sits ahead of key selection, per the RFC 7516 section 5.2 order. JWE names are deliberately not routed to the keyed handler registry that serves JWS: it is keyed by bare parameter name, so a host registering a JWS handler would silently make that name acceptable on an envelope too. There was no coverage at all; thirteen cases added, verified red first.

**A token with no `exp` passed lifetime validation.** It has no instant at which it is expired, so the check found nothing wrong. Making `ValidateLifetime` itself stricter would have been wrong: RFC 7592 section 5 says a registration access token "SHOULD NOT expire while a client is still actively registered", and this library issues those without an expiry on purpose, while RFC 9101 and RFC 7591 section 2.3 say nothing about `exp` at all. So presence becomes its own opt-in flag, beside `ValidateLifetime` the way `RequireIssuer` sits beside `ValidateIssuer`, kept out of `Default` because several call sites build their options by subtracting from it. Set on the four sites whose text demands `exp`, left clear on the five where it does not. DPoP was the one thing that could have ruled this out and turns out not to enable lifetime validation at all.

**Two comments cited clauses that do not contain their rule.** The signer's key filter was attributed to RFC 7517 section 4.4, four sentences that call the JWK `alg` parameter OPTIONAL and "intended for use" and contain no MUST NOT; the prohibition is RFC 8725 section 3.1. The `azp` accessor described a claim OpenID Connect mandates when a single audience differs from the issuer - it is OPTIONAL, it names the party the token was issued to rather than the issuer, and the audience conditions come from wording errata set 2 replaced. Behaviour unchanged in both. Every quote was read out of the published document.

The remaining RFC 7515 section 5.3 citations, on `alg` and on `crit`, were checked and are correct.

No release note: none of this shipped as broken behaviour a host must migrate from, and the `exp` flag changes no existing configuration.
