### PR TITLE
ci: run the workflow linters on every pull request

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -1,11 +1,12 @@
 name: Lint workflows
 
 on:
+  # Both jobs below are required status checks on the protected branches, so they must run on every
+  # pull request targeting one. A path filter here made them required-but-absent for any PR outside
+  # .github/, and a missing check can never be satisfied - the only way to merge was an admin bypass,
+  # on every such PR. A required check has to be one CI can actually produce.
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/scripts/lint-no-inline-secrets.py'
-      - '.github/codeql/**'
+    branches: [master, develop]
   push:
     branches: [master, develop]
   workflow_dispatch:


### PR DESCRIPTION
`actionlint (schema + shellcheck)` and `Block inline untrusted-input interpolation` are required status checks on the protected branches, but the `pull_request` trigger was filtered to `.github/**`. Any pull request outside those paths therefore left both checks required-but-absent, and a missing check can never be satisfied: the only way to merge was an admin bypass, which waives every other protection along with it.

This PR is its own test case in reverse: it touches `.github/`, so the checks fire either way. The real confirmation is the next PR that does not touch `.github/` - both checks should appear there and pass.

Checked: Inputs (no inline expression in `run:`), Permissions (top-level `contents: read`, per-job least-privilege), Pinning (every `uses:` a full SHA), Timeouts (5 per job, 3 per step), Failure semantics (no masked exits). N/A: Cross-repo, Secrets (this workflow holds none).
