### PR TITLE
fix: close four reachable crashes found by a server-side nullability audit

### DIFF
--- a/src/Abblix.Jwt/JsonObjectExtensions.cs
+++ b/src/Abblix.Jwt/JsonObjectExtensions.cs
@@ -52,8 +52,19 @@ public static class JsonObjectExtensions
     /// </remarks>
     public static T? GetProperty<T>(this JsonObject json, string name)
     {
-        return json.TryGetPropertyValue(name, out var value) && value != null
-            ? value.GetValue<T>()
+        // A member that is present but is not the JSON type asked for reads as absent, which is what the
+        // summary above has always promised and what every caller is written against. It matters because
+        // the objects this reads are shaped by whoever sent the request: a JWT payload and an
+        // authorization_details entry are both schemaless on the wire, so "type" can arrive as a number
+        // and "locations" as a string. GetValue<T> answers that with an InvalidOperationException thrown
+        // out of a property getter, which turns a request the specification answers with a named protocol
+        // error into an unhandled one, in library code and in the per-type validators hosts write against
+        // these same accessors.
+        // Reading it as absent is not the same as accepting it. The member is then unstated, and whatever
+        // requires it refuses the request in protocol language at the layer that owns that decision.
+        return json.TryGetPropertyValue(name, out var value) && value is JsonValue typed
+               && typed.TryGetValue<T>(out var result)
+            ? result
             : default;
     }
 

--- a/src/Abblix.Jwt/JsonWebTokenExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebTokenExtensions.cs
@@ -118,18 +118,29 @@ public static class JsonWebTokenExtensions
     /// </remarks>
     private static IEnumerable<string> GetArrayOfStrings(JsonNode? property)
     {
+        // A node that is not a string yields nothing rather than throwing. These members are read off
+        // objects shaped by whoever sent them - a JWT payload and an authorization_details entry are both
+        // schemaless on the wire - so a number or an object can arrive where a string was expected, and
+        // GetValue<string> answers that with an InvalidOperationException from inside a property getter.
+        // Yielding nothing leaves the member unstated, which whatever requires it then refuses in
+        // protocol language, at the layer that owns that decision.
         switch (property)
         {
             case null:
                 break;
 
             case JsonValue value:
-                yield return value.GetValue<string>();
+                if (value.TryGetValue<string>(out var single))
+                    yield return single;
                 break;
 
             case JsonArray array:
-                foreach (var node in array.OfType<JsonNode>())
-                    yield return node.GetValue<string>();
+                foreach (var node in array.OfType<JsonValue>())
+                {
+                    if (node.TryGetValue<string>(out var element))
+                        yield return element;
+                }
+
                 break;
         }
     }

--- a/src/Abblix.Oidc.Server.MinimalApi/FormValues.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/FormValues.cs
@@ -37,14 +37,31 @@ namespace Abblix.Oidc.Server.MinimalApi;
 internal static class FormValues
 {
     /// <summary>A single value, or null when absent or empty.</summary>
-    public static string? Value(StringValues values) => values is { Count: > 0 } ? values.ToString() : null;
+    /// <remarks>
+    /// RFC 6749 section 3.1 puts this in the request direction as a requirement rather than a preference:
+    /// "Parameters sent without a value MUST be treated as if they were omitted from the request." A query
+    /// string carries no way to say "present and empty" that differs from saying nothing, so binding
+    /// "state=" as an empty string invented a value the client never sent - and state is returned only if
+    /// it was present in the request, so the client got back one it never issued.
+    /// </remarks>
+    public static string? Value(StringValues values)
+        => values is { Count: > 0 } && values.ToString() is { Length: > 0 } value ? value : null;
 
     /// <summary>A single value read from the form by name.</summary>
     public static string? Value(IFormCollection form, string name) => Value(Get(form, name));
 
     /// <summary>A repeated field as an array (RFC 8707 <c>resource</c>/<c>audience</c>), or null.</summary>
+    /// <remarks>
+    /// Valueless entries are dropped for the reason given on <see cref="Value(StringValues)"/>, and a field
+    /// whose every entry was valueless is the field not being there. Repeating the reading here rather than
+    /// leaving it to the callers keeps one answer to "what does present-but-empty mean" for the whole
+    /// binding surface.
+    /// </remarks>
     public static string[]? Strings(StringValues values)
-        => values is { Count: > 0 } ? values.OfType<string>().ToArray() : null;
+        => values is { Count: > 0 }
+           && values.OfType<string>().Where(value => value.Length > 0).ToArray() is { Length: > 0 } strings
+            ? strings
+            : null;
 
     /// <summary>A repeated form field read by name as an array, or null.</summary>
     public static string[]? Strings(IFormCollection form, string name) => Strings(Get(form, name));

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/RedirectUrisValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/RedirectUrisValidator.cs
@@ -54,7 +54,16 @@ internal class RedirectUrisValidator : SyncClientRegistrationContextValidator
 
         if (request.GrantTypes.Intersect(RequiringRedirectUri, StringComparer.Ordinal).Any())
         {
-            if (request.RedirectUris.Length == 0)
+            // Absent, explicitly null, and empty are one answer: the client registered no redirect URI for
+            // a grant type that cannot deliver a response without one. The property is declared
+            // non-nullable, but a registration body is attacker-shaped JSON and the deserializer honours
+            // neither the annotation nor a member initialiser against an explicit null, so the null is
+            // real, and reading Length on it turned a rejected registration into an unhandled exception.
+            // The error code is the one this validator already returns for the empty case: RFC 7591
+            // section 3.2.2 defines invalid_redirect_uri as "The value of one or more redirection URIs is
+            // invalid", which names bad values rather than absent ones, so answering absence with it is
+            // this library's choice and not something the document requires.
+            if (request.RedirectUris is not { Length: > 0 })
                 return ErrorFactory.InvalidRedirectUri($"{Parameters.RedirectUris} is required");
 
             foreach (var uri in request.RedirectUris)

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -142,6 +142,18 @@ public partial class SubjectTypeValidator(
     {
         var redirectUris = context.Request.RedirectUris;
 
+        // Without a redirect URI there is no host, and the host is what a pairwise identifier is derived
+        // from when no sector identifier URI was registered - so this combination cannot be honoured and
+        // is refused rather than worked around. It is reachable: a client asking only for a grant type
+        // that needs no redirection registers none, which the redirect URI validator correctly permits,
+        // and it arrives here with the list absent or empty.
+        if (redirectUris is not { Length: > 0 })
+        {
+            return ErrorFactory.InvalidClientMetadata(
+                "The client specified pairwise subject type without a sector identifier URI, which needs "
+                + "a redirect URI to take the host from, and none was registered");
+        }
+
         if (redirectUris.Any(uri => uri.Scheme != Uri.UriSchemeHttps))
         {
             return ErrorFactory.InvalidClientMetadata("All schemes in the redirect URIs must be https");

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -106,10 +106,8 @@ public class BackChannelAuthenticationGrantHandler(
         // Try to retrieve the corresponding backchannel authentication request from storage
         var authenticationRequest = await storage.TryGetAsync(request.AuthenticationRequestId);
 
-        // Resolve mode-specific grant processor using keyed service
-        // Delivery mode is validated at backchannel authentication request time by ClientValidator
-        var processor = serviceProvider.GetRequiredKeyedService<IBackChannelGrantProcessor>(
-            clientInfo.BackChannelTokenDeliveryMode.NotNull(nameof(clientInfo.BackChannelTokenDeliveryMode)));
+        if (ResolveProcessor(clientInfo) is not { } processor)
+            return NotConfiguredForDelivery();
 
         // Validate that the client is allowed to access the token endpoint for this mode
         var accessError = processor.ValidateTokenEndpointAccess();
@@ -253,9 +251,8 @@ public class BackChannelAuthenticationGrantHandler(
             return new OidcError(ErrorCodes.InvalidGrant, "The authentication request was issued to another client");
         }
 
-        // Resolve mode-specific grant processor
-        var grantProcessor = serviceProvider.GetRequiredKeyedService<IBackChannelGrantProcessor>(
-            clientInfo.BackChannelTokenDeliveryMode);
+        if (ResolveProcessor(clientInfo) is not { } grantProcessor)
+            return NotConfiguredForDelivery();
 
         switch (updatedRequest)
         {
@@ -281,4 +278,35 @@ public class BackChannelAuthenticationGrantHandler(
                     "The polling interval must be increased by at least 5 seconds for all subsequent requests.");
         }
     }
+
+    /// <summary>
+    /// Resolves the processor for the client's registered delivery mode, or null when there is none to
+    /// resolve.
+    /// </summary>
+    /// <remarks>
+    /// Both ways of having no processor are one answer, and neither is an exception. The mode is optional
+    /// client metadata with nothing tying it to the grant types the client is allowed, so a client can be
+    /// registered for this grant carrying no mode at all; and a mode that names no registered processor is
+    /// a client configured for a delivery this deployment does not offer. GetRequiredKeyedService answers
+    /// both with an InvalidOperationException, which reaches the token endpoint as an unhandled failure -
+    /// while the backchannel authentication endpoint answers the identical client state with a named error
+    /// an operator can read (BackChannelAuthentication/Validation/ClientValidator.cs).
+    /// Keyed lookup with a null check is the dispatch convention this project documents for a value read
+    /// off a wire or off client metadata, precisely so an unknown discriminator is a rejection rather than
+    /// a throw.
+    /// </remarks>
+    private IBackChannelGrantProcessor? ResolveProcessor(ClientInfo clientInfo)
+        => clientInfo.BackChannelTokenDeliveryMode is { Length: > 0 } deliveryMode
+            ? serviceProvider.GetKeyedService<IBackChannelGrantProcessor>(deliveryMode)
+            : null;
+
+    /// <summary>
+    /// The refusal for a client whose backchannel token delivery mode is missing or unsupported, worded as
+    /// its sibling on the backchannel authentication endpoint words it.
+    /// </summary>
+    private static OidcError NotConfiguredForDelivery()
+        => new(
+            ErrorCodes.InvalidClient,
+            "The client is not properly configured for backchannel authentication. " +
+            "A token delivery mode (poll, ping, or push) must be specified.");
 }

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
@@ -58,9 +58,14 @@ internal sealed class AuthorizationDetailsPolicy(
         if (raw is not { Count: > 0 })
             return (JsonArray?)null;
 
-        var authorizationDetails = raw.ToTypedArray();
-        if (authorizationDetails is not { Length: > 0 })
-            return (JsonArray?)null;
+        // An entry that is not a JSON object is dropped by the conversion, so a count that shrank means the
+        // client sent authorization_details this server cannot read - ["payment"] or [1,2] rather than the
+        // objects RFC 9396 section 2 defines. Refused rather than quietly reduced: the null the conversion
+        // would otherwise produce is indistinguishable from the client having sent none, so the request
+        // would be authorized with its authorization_details silently discarded, which is the one outcome
+        // neither the client nor the resource server can detect.
+        if (raw.ToTypedArray() is not { } authorizationDetails || authorizationDetails.Length != raw.Count)
+            return Reject("Every authorization_details entry must be a JSON object.");
 
         var allowlist = client.AuthorizationDetailsTypes;
         if (allowlist is not null)

--- a/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
@@ -209,4 +209,59 @@ public class AuthorizationDetailTests
 
         Assert.Null(payload.AuthorizationDetails);
     }
+
+    /// <summary>
+    /// A member whose JSON type is not the one RFC 9396 section 2.2 gives it reads as unstated, rather
+    /// than throwing out of a property getter.
+    /// </summary>
+    /// <remarks>
+    /// The entry is attacker-shaped: <c>authorization_details</c> is carried as schemaless JSON, so
+    /// every member arrives as whatever the request said it was. A getter that throws on the mismatch
+    /// turns a request the specification answers with <c>invalid_authorization_details</c> into an
+    /// unhandled exception, and it does so inside the per-type validators hosts are asked to write,
+    /// where nothing is placed to catch it.
+    /// Reading it as unstated is not the same as accepting it: the entry then carries no type, and an
+    /// entry with no type is refused. What changes is which layer decides, and in which language.
+    /// </remarks>
+    [Theory]
+    [InlineData("""{ "type": 123 }""")]
+    [InlineData("""{ "type": true }""")]
+    [InlineData("""{ "type": ["payment_initiation"] }""")]
+    [InlineData("""{ "type": { "name": "payment_initiation" } }""")]
+    [InlineData("""{ "type": null }""")]
+    public void AuthorizationDetail_AMemberOfTheWrongJsonType_ReadsAsUnstated(string wire)
+    {
+        var detail = new AuthorizationDetail((JsonObject)JsonNode.Parse(wire)!);
+
+        Assert.Null(detail.Type);
+    }
+
+    /// <summary>
+    /// The same holds for the other common-data members, which the per-type validators read too, and a
+    /// single string still stands for a one-element list.
+    /// </summary>
+    /// <remarks>
+    /// The string-for-a-list reading is deliberate and long-standing across this library's JWT accessors,
+    /// so it is pinned here rather than treated as the same defect: it is a value the member can carry,
+    /// not a type it cannot be read as. What must not happen either way is a throw out of the getter.
+    /// </remarks>
+    [Fact]
+    public void AuthorizationDetail_MembersOfTheWrongJsonType_DoNotThrow()
+    {
+        var wire = """
+                   {
+                     "type": "payment_initiation",
+                     "locations": 7,
+                     "actions": "initiate",
+                     "identifier": 42
+                   }
+                   """;
+
+        var detail = new AuthorizationDetail((JsonObject)JsonNode.Parse(wire)!);
+
+        Assert.Equal(PaymentInitiationType, detail.Type);
+        Assert.Empty(detail.Locations ?? []);
+        Assert.Equal([InitiateAction], detail.Actions);
+        Assert.Null(detail.Identifier);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/RedirectUrisValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/RedirectUrisValidatorTests.cs
@@ -47,6 +47,29 @@ public class RedirectUrisValidatorTests
             nonPublic: true)!;
     }
 
+    /// <summary>
+    /// A registration body that carries no redirect_uris at all is refused, not crashed on.
+    /// </summary>
+    /// <remarks>
+    /// The regression test for an unhandled exception at the registration endpoint. The property is
+    /// declared non-nullable and the deserializer honours neither that annotation nor a member initialiser
+    /// against an explicit <c>"redirect_uris": null</c>, so a body shaped by whoever is registering could
+    /// leave it null and the length check dereferenced it. Both ways of saying nothing are covered: the
+    /// member omitted, which leaves the property at its declared default, and the member sent as null.
+    /// The grant type matters - it is what makes a redirect URI required at all, so the sibling case for a
+    /// client-credentials client (which needs none) stays green beside this.
+    /// </remarks>
+    [Fact]
+    public async Task ValidateAsync_WithNullRedirectUrisForAuthCode_ShouldReturnError()
+    {
+        var context = CreateContext(null!, [GrantTypes.AuthorizationCode]);
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRedirectUri, result.Error);
+    }
+
     private ClientRegistrationValidationContext CreateContext(
         Uri[] redirectUris,
         string[] grantTypes,

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
@@ -52,6 +52,30 @@ public class SubjectTypeValidatorTests
         _validator = new SubjectTypeValidator(_logger.Object, _secureHttpFetcher.Object);
     }
 
+    /// <summary>
+    /// A pairwise client that registered no redirect URI and no sector identifier URI is refused, not
+    /// crashed on.
+    /// </summary>
+    /// <remarks>
+    /// The sibling of the redirect URI validator's own null case, and reachable for the same reason from
+    /// the opposite direction: a client asking only for a grant type that needs no redirection registers
+    /// none, which that validator correctly permits, so this one receives an absent or empty list. It then
+    /// took the first host out of a list that has none. Both shapes are covered because they arrive by
+    /// different routes - the member omitted or sent as null, and the member sent as an empty array.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ValidateAsync_WithPairwiseAndNoRedirectUris_ShouldReturnError(bool nullRatherThanEmpty)
+    {
+        var context = CreateContext(nullRatherThanEmpty ? null! : [], SubjectTypes.Pairwise);
+
+        var result = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+    }
+
     private ClientRegistrationValidationContext CreateContext(
         Uri[] redirectUris,
         string? subjectType = SubjectTypes.Public,

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -131,6 +131,36 @@ public class BackChannelAuthenticationGrantHandlerTests
     }
 
     /// <summary>
+    /// A client registered for this grant but carrying no usable token delivery mode is refused in
+    /// protocol language, the way the backchannel authentication endpoint already refuses it.
+    /// </summary>
+    /// <remarks>
+    /// The mode is optional client metadata and nothing ties it to the grant types a client is allowed, so
+    /// this state is registrable, and a mode naming no registered processor is the same state reached by a
+    /// deployment that does not offer that delivery. Both used to resolve a required keyed service and
+    /// leave the token endpoint with an unhandled exception, while the sibling endpoint answered the
+    /// identical client with invalid_client and a sentence an operator can act on.
+    /// </remarks>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("carrier-pigeon")]
+    public async Task AuthorizeAsync_WithNoUsableDeliveryMode_ReturnsInvalidClient(string? deliveryMode)
+    {
+        // The storage read happens before the client's own configuration is looked at, so the mock has to
+        // answer it even though this request never gets as far as needing what it returns.
+        _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync((BackChannelAuthenticationRequest?)null);
+
+        var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
+        var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = deliveryMode };
+
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidClient, error.Error);
+    }
+
+    /// <summary>
     /// Verifies that the handler supports the CIBA grant type.
     /// </summary>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -87,6 +87,35 @@ public class AuthorizationDetailsPolicyTests
         Assert.Contains("type", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// A 'type' member carrying something other than a string is refused in protocol language, not by an
+    /// exception escaping the endpoint.
+    /// </summary>
+    /// <remarks>
+    /// The regression test for an HTTP 500 reachable before authentication: authorization_details is
+    /// carried as schemaless JSON, so this entry survives every earlier shape check, and reading its type
+    /// used to throw straight out of the accessor. RFC 9396 section 5 already names the answer, and the
+    /// entry ends up refused for the same reason a missing type is - it states none.
+    /// The assertion is the refusal rather than the absence of a throw. A test that only required "does
+    /// not throw" would pass just as well against a version that quietly authorized the request with the
+    /// authorization_details dropped, which is the other way this could have been got wrong.
+    /// </remarks>
+    [Theory]
+    [InlineData(123)]
+    [InlineData(true)]
+    public async Task Type_member_of_the_wrong_json_type_yields_failure(object value)
+    {
+        var sp = BuildProvider();
+        var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
+        var raw = new JsonArray(new JsonObject { ["type"] = JsonValue.Create(value) });
+
+        var result = await composite.ApplyAsync(raw, TestClient, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, error.Error);
+        Assert.Contains("type", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public async Task Single_validator_dispatched_by_type_returns_validated_detail()
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -88,6 +88,31 @@ public class AuthorizationDetailsPolicyTests
     }
 
     /// <summary>
+    /// An authorization_details array whose entries are not JSON objects is refused, not quietly reduced
+    /// to nothing.
+    /// </summary>
+    /// <remarks>
+    /// The conversion drops what it cannot read, and the emptiness it leaves behind is indistinguishable
+    /// from the client having sent no authorization_details at all - so the request used to be authorized
+    /// with its RAR grant discarded, which neither the client nor the resource server can detect. RFC 9396
+    /// section 2 defines the entries as JSON objects, so this is a malformed request and has a named answer.
+    /// </remarks>
+    [Theory]
+    [InlineData("payment_initiation")]
+    [InlineData(7)]
+    public async Task Entries_that_are_not_objects_yield_failure(object element)
+    {
+        var sp = BuildProvider();
+        var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
+        var raw = new JsonArray(JsonValue.Create(element));
+
+        var result = await composite.ApplyAsync(raw, TestClient, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, error.Error);
+    }
+
+    /// <summary>
     /// A 'type' member carrying something other than a string is refused in protocol language, not by an
     /// exception escaping the endpoint.
     /// </summary>


### PR DESCRIPTION
Nullability audit of the server-side projects: every null-forgiving operator and every
nullability annotation was traced back to whatever actually backed it. Four of the
findings were reachable crashes, and each fix is verified by mutation - the test fails
on the previous code with the exception that names the defect, not merely with a failed
assertion.

**A member of the wrong JSON type read as unstated instead of throwing.**
`authorization_details=[{"type":123}]` reached an accessor that answered a type mismatch
with an exception out of a property getter, ending the authorization request as an
unhandled failure - before authentication, with any registered `client_id`. The same
throw was reachable through the CIBA and device endpoints and through the per-type
validators hosts are asked to write. Both accessors already documented the behaviour
introduced here; only the implementation disagreed. The string-for-a-list reading stays
and is now pinned, since that is a value the member can carry rather than a type it
cannot be read as.

**A registration carrying no `redirect_uris` refused rather than crashed on.** The
property is declared non-nullable and carries an initialiser, and neither survives
contact with the wire. The error code is unchanged, and the comment says plainly that
answering absence with `invalid_redirect_uri` is this library's choice rather than
something RFC 7591 section 3.2.2 requires.

**Pairwise registration with no host to derive it from.** Two exceptions in four lines,
reachable from the opposite direction: a client asking only for a grant type that needs
no redirection registers no redirect URI, which the previous validator correctly permits.

**A CIBA client with no usable token delivery mode.** The token endpoint threw where the
backchannel authentication endpoint already answered with `invalid_client` and a sentence
an operator can act on. Resolution moves to keyed lookup with a null check, the dispatch
convention this project documents. The `.NotNull` guarding it is removed rather than
moved: it asserted an invariant that does not hold, so it converted a client state the
protocol has an answer for into a failure that has none.

**`authorization_details` entries that are not JSON objects.** `["payment"]` was
authorized with the RAR grant silently discarded, because the emptiness left by the
conversion is indistinguishable from the client having sent none. Neither the client nor
the resource server can detect that.

Also a hardening, labelled as such because no behavioural consequence was demonstrated:
the Minimal API binder now reads a valueless request parameter as absent, which RFC 6749
section 3.1 requires in this direction and which both helpers already promised in their
own summaries.

Not included, deliberately: turning the ten `= null!` members of the internal
configuration carrier into `required` members. That is a source break for hosts
implementing `IConfigurationHandler` and belongs on a release boundary. The remaining
audit findings are graded and recorded rather than swept in.
