### PR TITLE
fix(discovery): finish the server nullability audit and align the metadata records with the specification

### DIFF
--- a/src/Abblix.Oidc.Server/Common/Configuration/DeviceAuthorizationOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/DeviceAuthorizationOptions.cs
@@ -91,7 +91,15 @@ public record DeviceAuthorizationOptions
     /// </summary>
     public required Uri VerificationUri
     {
-        get => _verificationUri!;
+        // `required` is a compiler obligation on an object initialiser and nothing more: the configuration
+        // binder does not honour it, and for an absent reference-typed member it never calls the setter at
+        // all. A host binding a partial DeviceAuthorization section therefore reaches here with nothing set,
+        // and handing that null onwards produced an ArgumentNullException from a URI builder on every device
+        // authorization request - pointing at the plumbing rather than at the setting that was missed.
+        get => _verificationUri ?? throw new InvalidOperationException(
+            $"{nameof(VerificationUri)} is not configured. The device authorization endpoint cannot state "
+            + "where the user should enter their code, which RFC 8628 section 3.2 makes a required member "
+            + "of the response.");
         set
         {
             if (!string.Equals(value.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
@@ -39,7 +39,7 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization.Validation;
 /// <param name="logger">The logger to be used for logging purposes.</param>
 /// <param name="processors">The set of registered authorization response processors. The
 /// validator rejects requests whose <c>response_type</c> contains a part with no matching
-/// registered processor — this enforces OAuth 2.1 (draft) default-off Implicit Flow at the validation
+/// registered processor - this enforces OAuth 2.1 (draft) default-off Implicit Flow at the validation
 /// layer (without <c>EnableImplicitFlow()</c>, no <c>token</c> / <c>id_token</c> processors exist
 /// and any request asking for them gets <c>unsupported_response_type</c>).</param>
 /// <param name="options">Provides the server-wide default security profile a client inherits when it
@@ -68,7 +68,7 @@ public partial class FlowTypeValidator(
         var returnsTokenFromAuthorization = responseType.ReturnsTokenFromAuthorization();
 
         // RFC 6749 §4.1.2.1: response_type is REQUIRED, and a missing required parameter is
-        // invalid_request — not unsupported_response_type (no method was named at all) and not
+        // invalid_request - not unsupported_response_type (no method was named at all) and not
         // unauthorized_client (no client policy was consulted).
         if (responseType is not { Length: > 0 })
         {
@@ -78,7 +78,7 @@ public partial class FlowTypeValidator(
 
         // A code-only profile (FAPI 2.0) rejects any response type that returns a token or id_token
         // from the authorization endpoint, regardless of what the client's AllowedResponseTypes
-        // permits — the profile tightens, the granular whitelist cannot widen it. Checked before the
+        // permits - the profile tightens, the granular whitelist cannot widen it. Checked before the
         // server-support gate so a profiled client gets the profile-specific reason even on a server
         // where Implicit Flow is enabled for other clients.
         var profile = SecurityProfileRequirements.For(context.ClientInfo, options.Value.DefaultSecurityProfile);
@@ -107,7 +107,7 @@ public partial class FlowTypeValidator(
         {
             LogResponseTypeNotAllowed(responseType);
             // RFC 6749 §4.1.2.1 / §4.2.2.1: the server supports this response_type (the gate above
-            // passed), but this particular client is not registered to use it — that is
+            // passed), but this particular client is not registered to use it - that is
             // unauthorized_client. unsupported_response_type (returned before) is reserved for
             // methods the server itself cannot produce.
             return Error(ErrorCodes.UnauthorizedClient, "The response type is not allowed for the client");
@@ -174,25 +174,30 @@ public partial class FlowTypeValidator(
     private static bool TryDetectFlowType(
         [NotNullWhen(true)] string[]? responseType,
         out FlowTypes flowType,
-        out string responseMode)
+        [NotNullWhen(true)] out string? responseMode)
     {
         var none = responseType.HasFlag(ResponseTypes.None);
         var code = responseType.HasFlag(ResponseTypes.Code);
         var token = responseType.ReturnsTokenFromAuthorization();
 
-        // OAuth 2.0 Multiple Response Type Encoding Practices §4: `none` MUST stand alone — it cannot be
-        // combined with code, token or id_token. A none+anything request matches no case below, so
-        // detection fails and the caller returns unsupported_response_type. The none flow defaults to
-        // the query response mode (§4) and carries no credentials.
+        // OAuth 2.0 Multiple Response Type Encoding Practices section 4 says the `none` response type
+        // "SHOULD NOT be combined with other Response Types". We reject the combination outright rather
+        // than merely discouraging it: a none+anything request matches no case below, so detection fails
+        // and the caller returns unsupported_response_type. That is our choice, stricter than the text.
+        // The none flow defaults to the query response mode and carries no credentials.
         (var result, flowType, responseMode) = (none, code, token) switch
         {
             (none: true, code: false, token: false) => (true, FlowTypes.None, ResponseModes.Query),
             (none: false, code: true, token: false) => (true, FlowTypes.AuthorizationCode, ResponseModes.Query),
             (none: false, code: false, token: true) => (true, FlowTypes.Implicit, ResponseModes.Fragment),
             (none: false, code: true, token: true) => (true, FlowTypes.Hybrid, ResponseModes.Fragment),
-            _ => (false, default, null!)
+            _ => (false, default, null)
         };
 
-        return result;
+        // The postcondition is returned rather than asserted: the default arm above leaves the mode unset,
+        // and returning the test itself means no arm added later can claim success while leaving it so.
+        // The annotation alone would not catch that - Roslyn verifies a [NotNullWhen] postcondition on an
+        // out parameter, but only against what the method actually returns.
+        return result && responseMode is not null;
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
@@ -141,7 +141,9 @@ public record ConfigurationResponse
 
 	/// <summary>
 	/// Lists the prompt values supported by the OpenID Provider.
-	/// Optional: the field is defined by the prompt=create extension, not by the core metadata list.
+	/// OPTIONAL per Initiating User Registration via OpenID Connect 1.0 section 4.2, which defines the field
+	/// outside the core metadata list. That section also states the obligation that follows from stating it at
+	/// all: a provider listing this element must list every prompt value it supports, not only <c>create</c>.
 	/// </summary>
 	public IEnumerable<string>? PromptValuesSupported { init; get; }
 

--- a/src/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ConfigurationResponse.cs
@@ -27,12 +27,27 @@ namespace Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 /// Contains provider capabilities, supported features, and cryptographic algorithms,
 /// but excludes endpoint URLs which are framework-specific.
 /// </summary>
+/// <remarks>
+/// Each member's C# nullability mirrors what OpenID Connect Discovery 1.0 section 3 says about the corresponding
+/// metadata field, so that the compiler asks of a handler exactly what the specification asks of a provider.
+/// The four fields that section marks REQUIRED are <c>required</c> here; everything else is nullable, because
+/// RECOMMENDED and OPTIONAL fields are legitimately absent and <c>null</c> is how this type says "not stated"
+/// (the wire model omits nulls entirely). Several of the optional ones carry a default that applies precisely
+/// when the field is omitted, so omission is an answer rather than a gap: <c>grant_types_supported</c> defaults
+/// to authorization code and implicit, <c>response_modes_supported</c> to query and fragment, and
+/// <c>token_endpoint_auth_methods_supported</c> to client_secret_basic.
+/// Before this, all eleven were declared non-nullable with a null-forgiving initialiser, which swore they were
+/// always present while nothing enforced it. A custom <see cref="IConfigurationHandler"/> that left one out
+/// produced no error at all: the null travelled into the wire model, whose null-omitting serialisation dropped
+/// the field, so a discovery document could silently ship without a REQUIRED member and answer 200.
+/// </remarks>
 public record ConfigurationResponse
 {
 	/// <summary>
 	/// The issuer identifier, which uniquely identifies the OpenID Provider.
+	/// REQUIRED by OpenID Connect Discovery 1.0 section 3.
 	/// </summary>
-	public string Issuer { init; get; } = null!;
+	public required string Issuer { init; get; }
 
 	/// <summary>
 	/// Indicates whether the OpenID Provider supports front channel logout.
@@ -61,33 +76,40 @@ public record ConfigurationResponse
 
 	/// <summary>
 	/// Lists the scopes supported by the OpenID Provider.
+	/// RECOMMENDED by OpenID Connect Discovery 1.0 section 3.
 	/// </summary>
-	public IEnumerable<string> ScopesSupported { init; get; } = null!;
+	public IEnumerable<string>? ScopesSupported { init; get; }
 
 	/// <summary>
 	/// Lists the claims supported by the OpenID Provider.
+	/// RECOMMENDED by OpenID Connect Discovery 1.0 section 3.
 	/// </summary>
-	public IEnumerable<string> ClaimsSupported { init; get; } = null!;
+	public IEnumerable<string>? ClaimsSupported { init; get; }
 
 	/// <summary>
 	/// Lists the grant types supported by the OpenID Provider.
+	/// OPTIONAL per OpenID Connect Discovery 1.0 section 3, which defines the omitted case as
+	/// authorization code and implicit.
 	/// </summary>
-	public IEnumerable<string> GrantTypesSupported { init; get; } = null!;
+	public IEnumerable<string>? GrantTypesSupported { init; get; }
 
 	/// <summary>
 	/// Lists the response types supported by the OpenID Provider.
+	/// REQUIRED by OpenID Connect Discovery 1.0 section 3.
 	/// </summary>
-	public IEnumerable<string> ResponseTypesSupported { init; get; } = null!;
+	public required IEnumerable<string> ResponseTypesSupported { init; get; }
 
 	/// <summary>
 	/// Lists the response modes supported by the OpenID Provider.
+	/// OPTIONAL per OpenID Connect Discovery 1.0 section 3, which defines the omitted case as query and fragment.
 	/// </summary>
-	public IEnumerable<string> ResponseModesSupported { init; get; } = null!;
+	public IEnumerable<string>? ResponseModesSupported { init; get; }
 
 	/// <summary>
 	/// Lists the token endpoint authentication methods supported by the OpenID Provider.
+	/// OPTIONAL per OpenID Connect Discovery 1.0 section 3, which defines the omitted case as client_secret_basic.
 	/// </summary>
-	public IEnumerable<string> TokenEndpointAuthMethodsSupported { init; get; } = null!;
+	public IEnumerable<string>? TokenEndpointAuthMethodsSupported { init; get; }
 
 	/// <summary>
 	/// Lists the signing algorithms supported for authenticating clients at the token endpoint.
@@ -96,18 +118,21 @@ public record ConfigurationResponse
 
 	/// <summary>
 	/// Lists the ID token signing algorithm values supported by the OpenID Provider.
+	/// REQUIRED by OpenID Connect Discovery 1.0 section 3.
 	/// </summary>
-	public IEnumerable<string> IdTokenSigningAlgValuesSupported { init; get; } = null!;
+	public required IEnumerable<string> IdTokenSigningAlgValuesSupported { init; get; }
 
 	/// <summary>
 	/// Lists the subject types supported by the OpenID Provider.
+	/// REQUIRED by OpenID Connect Discovery 1.0 section 3.
 	/// </summary>
-	public IEnumerable<string> SubjectTypesSupported { init; get; } = null!;
+	public required IEnumerable<string> SubjectTypesSupported { init; get; }
 
 	/// <summary>
 	/// Lists the code challenge methods supported for PKCE.
+	/// OPTIONAL per RFC 8414 section 2.
 	/// </summary>
-	public IEnumerable<string> CodeChallengeMethodsSupported { init; get; } = null!;
+	public IEnumerable<string>? CodeChallengeMethodsSupported { init; get; }
 
 	/// <summary>
 	/// Indicates whether the OpenID Provider supports the use of the request parameter.
@@ -116,8 +141,9 @@ public record ConfigurationResponse
 
 	/// <summary>
 	/// Lists the prompt values supported by the OpenID Provider.
+	/// Optional: the field is defined by the prompt=create extension, not by the core metadata list.
 	/// </summary>
-	public IEnumerable<string> PromptValuesSupported { init; get; } = null!;
+	public IEnumerable<string>? PromptValuesSupported { init; get; }
 
 	/// <summary>
 	/// Specifies the signing algorithms supported for user information endpoints.

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/DPoPTokenEndpointValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/DPoPTokenEndpointValidator.cs
@@ -61,7 +61,7 @@ public partial class DPoPTokenEndpointValidator(
         if (ValidateCertificateBinding(context) is { } certificateError)
             return certificateError;
 
-        var committed = context.AuthorizedGrant?.Context.ProofKeyThumbprint;
+        var committed = context.AuthorizedGrant.Context.ProofKeyThumbprint;
 
         return context.ClientRequest is { DPoPProof: { } proofJwt }
             ? await ValidatePresentedProofAsync(context, proofJwt, committed)
@@ -78,7 +78,7 @@ public partial class DPoPTokenEndpointValidator(
     /// </summary>
     private static OidcError? ValidateCertificateBinding(TokenValidationContext context)
     {
-        var committedCertThumbprint = context.AuthorizedGrant?.Context.CertificateSha256Thumbprint;
+        var committedCertThumbprint = context.AuthorizedGrant.Context.CertificateSha256Thumbprint;
         if (committedCertThumbprint is null || AuthenticatesByMutualTls(context.ClientInfo))
             return null;
 

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/TokenValidationContext.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/TokenValidationContext.cs
@@ -34,6 +34,7 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Validation;
 public record TokenValidationContext(TokenRequest Request, ClientRequest ClientRequest)
 {
     private ClientInfo? _clientInfo;
+    private AuthorizedGrant? _authorizedGrant;
 
     /// <summary>
     /// Information about the client making the request, derived from the client authentication process.
@@ -48,7 +49,22 @@ public record TokenValidationContext(TokenRequest Request, ClientRequest ClientR
     /// This object is essential for ensuring that the grant is valid and for extracting any additional information
     /// needed for token generation.
     /// </summary>
-    public AuthorizedGrant AuthorizedGrant { get; set; } = null!;
+    /// <remarks>
+    /// Asserted by name rather than sworn to with a null-forgiving initialiser, the way <see cref="ClientInfo"/>
+    /// beside it already is. The two properties are filled by one pipeline and had been expressing the same fact
+    /// in opposite ways, and the readers did not believe the oath: the sender-constraining checks reached this
+    /// through a null-conditional, so an unset grant did not fail - it read as "no binding was committed" and
+    /// waved the request through. That is the wrong direction for a check whose whole purpose is to refuse a
+    /// token redeemed without the key or certificate it was bound to (RFC 9449 section 10, RFC 8705 section 4).
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when trying to access this property before it is set.
+    /// </exception>
+    public AuthorizedGrant AuthorizedGrant
+    {
+        get => _authorizedGrant.NotNull(nameof(AuthorizedGrant));
+        set => _authorizedGrant = value;
+    }
 
     /// <summary>
     /// Defines the scope of access requested or authorized. This array of scope definitions helps in determining

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -587,13 +587,13 @@ public static class ServiceCollectionExtensions
         // This service is optional - if not registered, long-polling will be disabled
         services.TryAddSingleton<IBackChannelLongPollingService>(sp =>
         {
-            var options = sp.GetRequiredService<IOptions<OidcOptions>>();
-            if (options.Value.BackChannelAuthentication.UseLongPolling)
-            {
-                var logger = sp.GetRequiredService<ILogger<InMemoryLongPollingService>>();
-                return new InMemoryLongPollingService(logger);
-            }
-            return null!;
+            // Registered whatever the long-polling setting says. A factory that answers null publishes a
+            // false non-null through the container: a consumer resolving it normally receives the null it
+            // was promised was absent, an enumeration yields a null element, and GetRequiredService reports
+            // the service as unregistered while a descriptor for it plainly exists. Constructing it when it
+            // will not be used costs one object; the alternative costs a diagnosis.
+            var logger = sp.GetRequiredService<ILogger<InMemoryLongPollingService>>();
+            return new InMemoryLongPollingService(logger);
         });
 
         // Register HTTP client for backchannel notifications (ping and push modes) with configurable handler lifetime

--- a/src/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
+++ b/src/Abblix.Oidc.Server/Model/ConfigurationResponse.cs
@@ -35,7 +35,7 @@ namespace Abblix.Oidc.Server.Model;
 /// <remarks>
 /// Decorated with <see cref="JsonIgnoreNullsAttribute"/> so that all nullable optional properties are omitted
 /// from the serialized JSON when <c>null</c>, rather than emitted as <c>"field": null</c>.
-/// RFC 8414 §2 requires that optional metadata fields be absent when not applicable — some OIDC client libraries
+/// RFC 8414 §2 requires that optional metadata fields be absent when not applicable - some OIDC client libraries
 /// (including <c>Microsoft.IdentityModel</c>) reject a discovery document that contains <c>null</c> values for
 /// fields they do not expect to be present.
 /// </remarks>
@@ -264,8 +264,15 @@ public record ConfigurationResponse
     /// The issuer identifier, which uniquely identifies the OpenID Provider. This value must be used by clients
     /// when issuing requests to the provider to ensure that the request is directed to the correct entity.
     /// </summary>
+    /// <remarks>
+    /// REQUIRED by OpenID Connect Discovery 1.0 section 3. Every member here mirrors that section's
+    /// REQUIRED/RECOMMENDED/OPTIONAL marker in its C# nullability, matching
+    /// <see cref="Endpoints.Configuration.Interfaces.ConfigurationResponse"/>, which this record is mapped from.
+    /// A nullable member means the field is legitimately absent, and <see cref="JsonIgnoreNullsAttribute"/> then
+    /// omits it from the document rather than writing a null.
+    /// </remarks>
     [JsonPropertyName(Parameters.Issuer)]
-    public string Issuer { init; get; } = null!;
+    public required string Issuer { init; get; }
 
     /// <summary>
     /// The URL of the OpenID Provider's JSON Web Key Set (JWKS) document. This document contains the provider's public
@@ -374,42 +381,42 @@ public record ConfigurationResponse
     /// Lists the scopes supported by the OpenID Provider, defining the extent of access granted by the authorization.
     /// </summary>
     [JsonPropertyName(Parameters.ScopesSupported)]
-    public IEnumerable<string> ScopesSupported { init; get; } = null!;
+    public IEnumerable<string>? ScopesSupported { init; get; }
 
     /// <summary>
     /// Lists the claims supported by the OpenID Provider, indicating the user information that can be included
     /// in the ID token or obtained from the UserInfo endpoint.
     /// </summary>
     [JsonPropertyName(Parameters.ClaimsSupported)]
-    public IEnumerable<string> ClaimsSupported { init; get; } = null!;
+    public IEnumerable<string>? ClaimsSupported { init; get; }
 
     /// <summary>
     /// Lists the grant types supported by the OpenID Provider, defining the methods through which
     /// clients can request tokens.
     /// </summary>
     [JsonPropertyName(Parameters.GrantTypesSupported)]
-    public IEnumerable<string> GrantTypesSupported { init; get; } = null!;
+    public IEnumerable<string>? GrantTypesSupported { init; get; }
 
     /// <summary>
     /// Lists the response types supported by the OpenID Provider, indicating the formats that can be used
     /// for the authorization response.
     /// </summary>
     [JsonPropertyName(Parameters.ResponseTypesSupported)]
-    public IEnumerable<string> ResponseTypesSupported { init; get; } = null!;
+    public required IEnumerable<string> ResponseTypesSupported { init; get; }
 
     /// <summary>
     /// Lists the response modes supported by the OpenID Provider, defining how the authorization response
     /// should be delivered to the client.
     /// </summary>
     [JsonPropertyName(Parameters.ResponseModesSupported)]
-    public IEnumerable<string> ResponseModesSupported { init; get; } = null!;
+    public IEnumerable<string>? ResponseModesSupported { init; get; }
 
     /// <summary>
     /// Lists the token endpoint authentication methods supported by the OpenID Provider,
     /// specifying how clients authenticate to the token endpoint.
     /// </summary>
     [JsonPropertyName(Parameters.TokenEndpointAuthMethodsSupported)]
-    public IEnumerable<string> TokenEndpointAuthMethodsSupported { init; get; } = null!;
+    public IEnumerable<string>? TokenEndpointAuthMethodsSupported { init; get; }
 
     /// <summary>
     /// Lists the signing algorithms supported by the OpenID Provider for authenticating clients at the token endpoint.
@@ -424,21 +431,21 @@ public record ConfigurationResponse
     /// indicating the algorithms that can be used to sign the ID token.
     /// </summary>
     [JsonPropertyName(Parameters.IdTokenSigningAlgValuesSupported)]
-    public IEnumerable<string> IdTokenSigningAlgValuesSupported { init; get; } = null!;
+    public required IEnumerable<string> IdTokenSigningAlgValuesSupported { init; get; }
 
     /// <summary>
     /// Lists the subject types supported by the OpenID Provider,
     /// defining how the subject's identifier is formatted and presented to the client.
     /// </summary>
     [JsonPropertyName(Parameters.SubjectTypesSupported)]
-    public IEnumerable<string> SubjectTypesSupported { init; get; } = null!;
+    public required IEnumerable<string> SubjectTypesSupported { init; get; }
 
     /// <summary>
     /// Lists the code challenge methods supported by the OpenID Provider for PKCE,
     /// enhancing the security of the authorization code flow.
     /// </summary>
     [JsonPropertyName(Parameters.CodeChallengeMethodsSupported)]
-    public IEnumerable<string> CodeChallengeMethodsSupported { init; get; } = null!;
+    public IEnumerable<string>? CodeChallengeMethodsSupported { init; get; }
 
     /// <summary>
     /// Indicates whether the OpenID Provider supports the use of the request parameter,
@@ -452,7 +459,7 @@ public record ConfigurationResponse
     /// specifying how the provider should prompt the user during authentication.
     /// </summary>
     [JsonPropertyName(Parameters.PromptValuesSupported)]
-    public IEnumerable<string> PromptValuesSupported { init; get; } = null!;
+    public IEnumerable<string>? PromptValuesSupported { init; get; }
 
     /// <summary>
     /// Specifies the signing algorithms supported by the OpenID Provider for user information endpoints.

--- a/src/Abblix.Utils/Result.cs
+++ b/src/Abblix.Utils/Result.cs
@@ -20,6 +20,8 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Abblix.Utils;
 
 /// <summary>
@@ -140,7 +142,7 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="value">When this method returns, contains the success value if the result is successful;
     /// otherwise, the default value.</param>
     /// <returns><c>true</c> if the result is a success; otherwise, <c>false</c>.</returns>
-    public abstract bool TryGetSuccess(out TSuccess value);
+    public abstract bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value);
 
     /// <summary>
     /// Gets the success value.
@@ -162,7 +164,7 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="value">When this method returns, contains the failure value if the result is a failure;
     /// otherwise, the default value.</param>
     /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
-    public abstract bool TryGetFailure(out TFailure value);
+    public abstract bool TryGetFailure([MaybeNullWhen(false)] out TFailure value);
 
     /// <summary>
     /// Binds the result to a function that returns a new result, allowing chaining of operations.
@@ -250,7 +252,7 @@ public abstract record Result<TSuccess, TFailure>
         /// <param name="value">When this method returns, contains the success value if the result is successful;
         /// otherwise, the default value.</param>
         /// <returns><c>true</c> if the result is a success; otherwise, <c>false</c>.</returns>
-        public override bool TryGetSuccess(out TSuccess value)
+        public override bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value)
         {
             value = Value;
             return true;
@@ -262,7 +264,7 @@ public abstract record Result<TSuccess, TFailure>
         /// <param name="value">When this method returns, contains the failure value if the result is a failure;
         /// otherwise, the default value.</param>
         /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
-        public override bool TryGetFailure(out TFailure value)
+        public override bool TryGetFailure([MaybeNullWhen(false)] out TFailure value)
         {
             value = default!;
             return false;
@@ -400,7 +402,7 @@ public abstract record Result<TSuccess, TFailure>
         /// <param name="value">When this method returns, contains the success value if the result is successful;
         /// otherwise, the default value.</param>
         /// <returns><c>true</c> if the result is a success; otherwise, <c>false</c>.</returns>
-        public override bool TryGetSuccess(out TSuccess value)
+        public override bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value)
         {
             value = default!;
             return false;
@@ -412,7 +414,7 @@ public abstract record Result<TSuccess, TFailure>
         /// <param name="value">When this method returns, contains the failure value if the result is a failure;
         /// otherwise, the default value.</param>
         /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
-        public override bool TryGetFailure(out TFailure value)
+        public override bool TryGetFailure([MaybeNullWhen(false)] out TFailure value)
         {
             value = Value;
             return true;

--- a/tests/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/ConfigurationResponseSerializationTests.cs
+++ b/tests/Abblix.Oidc.Server.Mvc.UnitTests/Formatters/ConfigurationResponseSerializationTests.cs
@@ -19,7 +19,7 @@ public class ConfigurationResponseSerializationTests
     public void ConfigurationResponse_NullableFieldsOmittedWhenNull()
     {
         // All nullable fields intentionally left at their default (null).
-        // RFC 8414 §2 requires absent optional fields — "null" is not compliant.
+        // RFC 8414 §2 requires absent optional fields - "null" is not compliant.
         var response = new ConfigurationResponse
         {
             Issuer = "https://example.com",
@@ -37,7 +37,7 @@ public class ConfigurationResponseSerializationTests
 
         var json = JsonSerializer.Serialize(response, BuildOptions());
 
-        // No field should appear as null — absent is correct, null is spec violation.
+        // No field should appear as null - absent is correct, null is spec violation.
         // System.Text.Json uses compact format: ":null" without spaces.
         Assert.DoesNotContain(":null", json);
     }
@@ -64,6 +64,44 @@ public class ConfigurationResponseSerializationTests
         var json = JsonSerializer.Serialize(response, BuildOptions());
 
         Assert.Contains("\"authorization_response_iss_parameter_supported\":true", json);
+    }
+
+    /// <summary>
+    /// A provider that states only what OpenID Connect Discovery 1.0 section 3 makes REQUIRED produces a document
+    /// carrying exactly those fields, with the optional ones absent rather than empty.
+    /// </summary>
+    /// <remarks>
+    /// This guards the choice made when the eleven always-present members were split by the specification's own
+    /// markers: the optional ones became nullable rather than defaulting to an empty collection. The difference is
+    /// visible on the wire and it changes meaning. An omitted <c>grant_types_supported</c> tells a client to apply
+    /// the default that section defines, authorization code and implicit; an empty array tells it this provider
+    /// accepts no grant at all. Give those members an empty-collection initialiser and this test goes red on the
+    /// field it would start emitting.
+    /// </remarks>
+    [Fact]
+    public void ConfigurationResponse_StatingOnlyTheRequiredFieldsOmitsTheOptionalOnes()
+    {
+        var response = new ConfigurationResponse
+        {
+            Issuer = "https://example.com",
+            ResponseTypesSupported = ["code"],
+            IdTokenSigningAlgValuesSupported = ["RS256"],
+            SubjectTypesSupported = ["public"],
+        };
+
+        var json = JsonSerializer.Serialize(response, BuildOptions());
+
+        Assert.DoesNotContain(":null", json);
+        Assert.DoesNotContain("[]", json);
+        Assert.DoesNotContain(ConfigurationResponse.Parameters.GrantTypesSupported, json);
+        Assert.DoesNotContain(ConfigurationResponse.Parameters.ScopesSupported, json);
+        Assert.DoesNotContain(ConfigurationResponse.Parameters.ResponseModesSupported, json);
+        Assert.DoesNotContain(ConfigurationResponse.Parameters.TokenEndpointAuthMethodsSupported, json);
+
+        Assert.Contains(ConfigurationResponse.Parameters.Issuer, json);
+        Assert.Contains(ConfigurationResponse.Parameters.ResponseTypesSupported, json);
+        Assert.Contains(ConfigurationResponse.Parameters.IdTokenSigningAlgValuesSupported, json);
+        Assert.Contains(ConfigurationResponse.Parameters.SubjectTypesSupported, json);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/LongPollingRegistrationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/LongPollingRegistrationTests.cs
@@ -1,0 +1,96 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
+using Abblix.Oidc.Server.Features.UserInfo;
+using Abblix.Oidc.Server.Mvc;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.BackChannelAuthentication;
+
+/// <summary>
+/// What the container hands back for the long-polling service when long polling is switched off, which is how
+/// every host starts out.
+/// </summary>
+public class LongPollingRegistrationTests
+{
+    /// <summary>
+    /// The service resolves to a real instance whether or not the feature is switched on.
+    /// </summary>
+    /// <remarks>
+    /// The registration used to be a factory that returned null on this path, and a factory answering null
+    /// publishes a false non-null through the container. Nothing in the type system marks the contract as
+    /// nullable, so a consumer that resolves it normally receives the null it was told could not be there; an
+    /// enumeration of the contract yields a null element; and <c>GetRequiredService</c> reports the service as
+    /// unregistered while a descriptor for it plainly exists, which sends the reader looking for a missing
+    /// registration that is right in front of them. Constructing the object when it will not be used costs one
+    /// allocation at startup.
+    /// The switch is read at request time by the grant handler, so this test also pins the two facts that make
+    /// the situation reachable rather than hypothetical: the switch defaults to off, and resolution succeeds
+    /// anyway.
+    /// </remarks>
+    [Fact]
+    public void TheLongPollingServiceResolvesWhileTheFeatureIsOff()
+    {
+        var provider = BuildProvider();
+
+        var options = provider.GetRequiredService<IOptions<OidcOptions>>();
+        Assert.False(options.Value.BackChannelAuthentication.UseLongPolling);
+
+        Assert.NotNull(provider.GetService<IBackChannelLongPollingService>());
+        Assert.NotNull(provider.GetRequiredService<IBackChannelLongPollingService>());
+    }
+
+    private static IServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+
+        // Host-level prerequisites every real ASP.NET host registers: memory-backed caches for the storages,
+        // and stubs for the host-supplied services the CIBA registration transitively touches.
+        services.AddDistributedMemoryCache();
+        services.AddMemoryCache();
+        services.AddSingleton(Mock.Of<IUserCredentialsAuthenticator>());
+        services.AddSingleton(Mock.Of<IUserInfoProvider>());
+
+        // CIBA is opt-in and carries a grant handler, so it registers before AddOidcServices composes them.
+        // UseLongPolling is left at its default, which is the state under test.
+        services.AddBackChannelAuthentication();
+
+        services.AddOidcServices(options =>
+        {
+            options.Issuer = TestConstants.DefaultIssuer.OriginalString;
+            options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)];
+            options.RequireInitialAccessToken = false;
+        });
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/TokenValidationContextTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/TokenValidationContextTests.cs
@@ -1,0 +1,73 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Endpoints.Token.Validation;
+using Abblix.Oidc.Server.Model;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token.Validation;
+
+/// <summary>
+/// The token pipeline's per-request context, and the two properties the pipeline fills in as it goes.
+/// </summary>
+public class TokenValidationContextTests
+{
+    private static TokenValidationContext Unfilled() => new(new TokenRequest(), new ClientRequest());
+
+    /// <summary>
+    /// Reading a grant that the pipeline has not established yet is a loud failure naming the property,
+    /// not a quiet null.
+    /// </summary>
+    /// <remarks>
+    /// The property is what the sender-constraining checks read to learn whether the grant was issued
+    /// bound to a proof key (RFC 9449) or to a client certificate (RFC 8705). While it was declared with a
+    /// null-forgiving initialiser those checks reached it through a null-conditional, so an unset grant did
+    /// not fail - it read as "nothing was committed", which is precisely the answer that lets a bound token
+    /// be redeemed without the key or certificate it was bound to.
+    /// The reordering that produces an unset grant is available to a host: the validator family is editable
+    /// through the supported composition API, and its ordering constraint is not written down anywhere the
+    /// editor would see it. That makes this the difference between a loud misconfiguration and a silent
+    /// hole, which is the whole point of asserting it here.
+    /// </remarks>
+    [Fact]
+    public void AnUnsetAuthorizedGrantIsRefusedByName()
+    {
+        var context = Unfilled();
+
+        var error = Assert.Throws<InvalidOperationException>(() => context.AuthorizedGrant);
+        Assert.Contains(nameof(TokenValidationContext.AuthorizedGrant), error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Its neighbour behaves the same way, which is the point: two properties of one context, filled by one
+    /// pipeline, expressing the same fact the same way.
+    /// </summary>
+    [Fact]
+    public void AnUnsetClientInfoIsRefusedByName()
+    {
+        var context = Unfilled();
+
+        var error = Assert.Throws<InvalidOperationException>(() => context.ClientInfo);
+        Assert.Contains(nameof(TokenValidationContext.ClientInfo), error.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Configuration/PartialConfigurationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Configuration/PartialConfigurationTests.cs
@@ -1,0 +1,78 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Abblix.Oidc.Server.Common.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.Configuration;
+
+/// <summary>
+/// What a host gets when it binds a configuration section that leaves a required setting out.
+/// </summary>
+public class PartialConfigurationTests
+{
+    /// <summary>
+    /// A verification URI that was never configured names itself when read.
+    /// </summary>
+    /// <remarks>
+    /// The C# <c>required</c> modifier is an obligation on an object initialiser and nothing more. The
+    /// configuration binder does not honour it, and for an absent reference-typed member it never calls the
+    /// setter at all - so a host that binds a partial section gets an options object the compiler believes
+    /// is complete. Before this was asserted here, the missing setting surfaced as an
+    /// ArgumentNullException out of a URI builder on every device authorization request, naming the
+    /// plumbing rather than the setting.
+    /// The instance is created the way the binder creates one, bypassing the initialiser, because that is
+    /// the only path on which this can happen. Writing the test with an object initialiser would not
+    /// compile without supplying the very value whose absence is under test.
+    /// </remarks>
+    [Fact]
+    public void AVerificationUriLeftOutOfConfigurationNamesItself()
+    {
+        var options = Activator.CreateInstance<DeviceAuthorizationOptions>();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // A section that is present and plausible, and simply does not mention the URI. A typo in
+                // the key name reaches here identically, since unknown keys are dropped without a word.
+                // The other settings carry values because their setters validate, which is itself the
+                // contrast worth seeing: a bad value is caught where it is written, an absent one is not.
+                ["DeviceCodeLength"] = "32",
+                ["UserCodeLength"] = "8",
+            })
+            .Build();
+
+        // The binder reads the property as well as writing it, so the refusal lands while the section is
+        // being bound rather than on the first request that needed the URI. That is the better end to fail
+        // at, and it is asserted here rather than assumed: a host learns at startup that its section is
+        // incomplete, with the setting named, instead of learning it from a request that blows up later.
+        // Wrapped by reflection on the way out of the binder, so the assertion reaches through it. What
+        // matters is the sentence a host reads, and it names the setting.
+        var wrapped = Assert.Throws<TargetInvocationException>(() => configuration.Bind(options));
+        var error = Assert.IsType<InvalidOperationException>(wrapped.InnerException);
+        Assert.Contains(nameof(DeviceAuthorizationOptions.VerificationUri), error.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
@@ -66,7 +66,7 @@ public class DiscoveryControllerMtlsTests
         SetupEndpointResolver();
 
         // SignedMetadata defaults off in these fixtures, so the signing collaborators are
-        // never exercised — supplied only to satisfy the constructor.
+        // never exercised - supplied only to satisfy the constructor.
         _formatter = new ConfigurationResponseFormatter(
             _optionsMock.Object,
             _endpointResolverMock.Object,
@@ -76,13 +76,26 @@ public class DiscoveryControllerMtlsTests
     }
 
     /// <summary>
+    /// The smallest handler output the formatter will accept: the four members OpenID Connect Discovery 1.0
+    /// section 3 marks REQUIRED, and nothing else. These tests are about mTLS aliases, so every other field is
+    /// left absent on purpose - which is now expressible, because absent and empty are different states.
+    /// </summary>
+    private static ConfigurationResponse MinimalResponse() => new()
+    {
+        Issuer = "https://example.com",
+        ResponseTypesSupported = ["code"],
+        IdTokenSigningAlgValuesSupported = ["RS256"],
+        SubjectTypesSupported = ["public"],
+    };
+
+    /// <summary>
     /// Verifies no mTLS aliases when neither MtlsEndpointAliases nor MtlsBaseUri configured.
     /// </summary>
     [Fact]
     public async Task ConfigurationAsync_WithNoMtlsConfiguration_ShouldNotIncludeMtlsAliases()
     {
         // Arrange - base response without URLs (simulating handler output)
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -101,7 +114,7 @@ public class DiscoveryControllerMtlsTests
     {
         // Arrange
         _oidcOptions.Discovery.MtlsBaseUri = new Uri("https://mtls.example.com");
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -129,7 +142,7 @@ public class DiscoveryControllerMtlsTests
             IntrospectionEndpoint = new Uri("https://mtls.example.com/custom-introspection"),
             UserInfoEndpoint = new Uri("https://mtls.example.com/custom-userinfo"),
         };
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -156,7 +169,7 @@ public class DiscoveryControllerMtlsTests
             TokenEndpoint = new Uri("https://custom.example.com/token"),
             // Others not set - should be auto-computed
         };
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -178,7 +191,7 @@ public class DiscoveryControllerMtlsTests
     {
         // Arrange
         _oidcOptions.Discovery.MtlsBaseUri = new Uri("https://mtls.example.com/oauth");
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -198,7 +211,7 @@ public class DiscoveryControllerMtlsTests
     {
         // Arrange
         _oidcOptions.Discovery.MtlsBaseUri = new Uri("https://mtls.example.com/oauth/");
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -218,7 +231,7 @@ public class DiscoveryControllerMtlsTests
         // Arrange
         _oidcOptions.Discovery.MtlsBaseUri = new Uri("https://mtls.example.com");
         _oidcOptions.EnabledEndpoints = 0; // Disable all endpoints
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -238,7 +251,7 @@ public class DiscoveryControllerMtlsTests
     {
         // Arrange
         _oidcOptions.Discovery.MtlsBaseUri = new Uri("https://mtls.example.com:8443");
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -264,7 +277,7 @@ public class DiscoveryControllerMtlsTests
             IntrospectionEndpoint = new Uri("https://custom2.example.com/introspect"),
             // RevocationEndpoint and UserInfoEndpoint will be auto-computed
         };
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -286,7 +299,7 @@ public class DiscoveryControllerMtlsTests
     public async Task ConfigurationAsync_WithCertificateBoundTokensSupported_ShouldSurfaceFlag()
     {
         // Arrange
-        var baseResponse = new ConfigurationResponse { TlsClientCertificateBoundAccessTokens = true };
+        var baseResponse = MinimalResponse() with { TlsClientCertificateBoundAccessTokens = true };
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);
@@ -304,7 +317,7 @@ public class DiscoveryControllerMtlsTests
     public async Task ConfigurationAsync_WithoutCertificateBoundTokens_ShouldOmitFlag()
     {
         // Arrange
-        var baseResponse = new ConfigurationResponse();
+        var baseResponse = MinimalResponse();
 
         // Act
         var result = await _formatter.FormatResponseAsync(baseResponse);

--- a/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
@@ -81,6 +81,19 @@ public class DiscoverySignedMetadataTests
     }
 
     /// <summary>
+    /// The smallest handler output the formatter will accept: the four members OpenID Connect Discovery 1.0
+    /// section 3 marks REQUIRED, and nothing else. These tests are about the signed_metadata field, so every
+    /// other field is left absent on purpose.
+    /// </summary>
+    private static EndpointResponse MinimalResponse() => new()
+    {
+        Issuer = Issuer,
+        ResponseTypesSupported = ["code"],
+        IdTokenSigningAlgValuesSupported = ["RS256"],
+        SubjectTypesSupported = ["public"],
+    };
+
+    /// <summary>
     /// When the opt-in flag is off, the discovery document carries no <c>signed_metadata</c>
     /// and the signing pipeline is never touched (safe-by-default).
     /// </summary>
@@ -89,7 +102,7 @@ public class DiscoverySignedMetadataTests
     {
         _oidcOptions.Discovery.SignedMetadata = false;
 
-        var result = await _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer });
+        var result = await _formatter.FormatResponseAsync(MinimalResponse());
 
         Assert.NotNull(result.Value);
         Assert.Null(result.Value.SignedMetadata);
@@ -101,7 +114,7 @@ public class DiscoverySignedMetadataTests
 
     /// <summary>
     /// When enabled, the field carries the JWS produced by the creator, and the token is
-    /// issued as a pure JWS — no encryption key is passed even though a deployment may have
+    /// issued as a pure JWS - no encryption key is passed even though a deployment may have
     /// encryption keys, so the result stays verifiable against <c>jwks_uri</c>.
     /// </summary>
     [Fact]
@@ -118,7 +131,7 @@ public class DiscoverySignedMetadataTests
                 (_, _, enc, _, _) => capturedEncryptionKey = enc)
             .ReturnsAsync(SignedJws);
 
-        var result = await _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer });
+        var result = await _formatter.FormatResponseAsync(MinimalResponse());
 
         Assert.Equal(SignedJws, result.Value!.SignedMetadata);
         Assert.Null(capturedEncryptionKey);
@@ -142,7 +155,7 @@ public class DiscoverySignedMetadataTests
             .Callback<JsonWebToken, JsonWebKey?, JsonWebKey?, string, string>((t, _, _, _, _) => capturedToken = t)
             .ReturnsAsync(SignedJws);
 
-        await _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer });
+        await _formatter.FormatResponseAsync(MinimalResponse());
 
         Assert.NotNull(capturedToken);
         var payload = capturedToken!.Payload.Json;
@@ -168,6 +181,6 @@ public class DiscoverySignedMetadataTests
         _keysProviderMock.Setup(p => p.GetSigningKeys(true)).Returns(AsyncEnumerable.Empty<JsonWebKey>());
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _formatter.FormatResponseAsync(new EndpointResponse { Issuer = Issuer }));
+            () => _formatter.FormatResponseAsync(MinimalResponse()));
     }
 }


### PR DESCRIPTION
Continues the server-side nullability audit. #287 auto-merged the moment its head went green, taking the first six commits; these five were pushed after that moment and never reached develop. Rebased onto develop as their own branch so the diff carries only what is missing.

## What is here

**The token pipeline's authorized grant is asserted by name.** It was declared with a null-forgiving initialiser while its neighbour on the same record used a named assertion, and the readers did not believe the oath: the sender-constraining checks reached it through a null-conditional, so an unset grant read as "no binding was committed" and waved the request through. That is the wrong direction for a check whose purpose is to refuse a token redeemed without the key or certificate it was bound to (RFC 9449 section 10, RFC 8705 section 4).

**Four remaining audit findings closed.** A long-polling service registered through a factory that returned null when the feature was off (its default); an `out` parameter falsified by a null-forgiving default arm, fixed on both halves so the compiler actually verifies it; two abstract methods writing null into a non-nullable `out`; and a configuration property that returned null to every request instead of naming the setting the host had not configured.

**The discovery metadata records now follow the specification's own markers.** Eleven members on both configuration records carried an always-present promise that nothing enforced. A host with its own `IConfigurationHandler` that left one out got no error at all: the null travelled into the wire model, whose null-omitting serialisation dropped the field, so a discovery document could ship without a REQUIRED member and still answer 200. Each member now mirrors what OpenID Connect Discovery 1.0 section 3 says about its field: the four it marks REQUIRED are `required`, the rest are nullable because RECOMMENDED and OPTIONAL fields are legitimately absent.

Nullable rather than an empty collection is deliberate. Three of those fields define a default that applies precisely when they are omitted, so an empty array would claim the provider accepts nothing where omission means the default.

## What the change costs a host

Nothing, unless its handler was already emitting a document without a REQUIRED field. Everything under `src` compiled unchanged, and every one of the eleven compile errors landed in test fixtures constructing a bare response.

## Verification

Full solution suite green at 3609. The device-configuration refusal and the discovery serialisation guard are new tests; the latter was mutation-proved by giving one optional member an empty-collection initialiser, which turns it red on the field it starts emitting. The compile-time contracts in the middle commit have a zero-warning solution build as their oracle.

Every specification marker cited here was read from the source document rather than recalled, including the one for `prompt_values_supported`, which the last commit corrects.
