### PR TITLE
fix(ciba): check the client before the store, and require what the response specifications require

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -103,9 +103,10 @@ public class BackChannelAuthenticationGrantHandler(
             return ErrorFactory.MissingParameter(TokenRequest.Parameters.AuthenticationRequestId);
         }
 
-        // Try to retrieve the corresponding backchannel authentication request from storage
-        var authenticationRequest = await storage.TryGetAsync(request.AuthenticationRequestId);
-
+        // Both of these decide from the client's own registered metadata and need nothing from storage, so they
+        // run before the lookup. Ordering them the other way let a request that is refused on configuration
+        // grounds alone still cost a storage round trip, which hands an authenticated client a cheap way to
+        // make the server work: the refusal is free to produce and the lookup is not.
         if (ResolveProcessor(clientInfo) is not { } processor)
             return NotConfiguredForDelivery();
 
@@ -115,6 +116,9 @@ public class BackChannelAuthenticationGrantHandler(
         {
             return accessError;
         }
+
+        // Try to retrieve the corresponding backchannel authentication request from storage
+        var authenticationRequest = await storage.TryGetAsync(request.AuthenticationRequestId);
 
         // Determine the outcome of the authorization based on the state of the backchannel authentication request
         return authenticationRequest switch

--- a/src/Abblix.Oidc.Server/Model/BackChannelAuthenticationSuccess.cs
+++ b/src/Abblix.Oidc.Server/Model/BackChannelAuthenticationSuccess.cs
@@ -37,7 +37,7 @@ public record BackChannelAuthenticationSuccess
     /// to poll the authorization server and check the status of the user's authentication.
     /// </summary>
     [JsonPropertyName(Parameters.AuthenticationRequestId)]
-    public string AuthenticationRequestId { get; set; } = null!;
+    public required string AuthenticationRequestId { get; set; }
 
     /// <summary>
     /// Specifies the time period (in seconds) after which the backchannel authentication request expires.

--- a/src/Abblix.Oidc.Server/Model/ClientRegistrationResponse.cs
+++ b/src/Abblix.Oidc.Server/Model/ClientRegistrationResponse.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 // 
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -41,7 +41,7 @@ public record ClientRegistrationResponse
     /// </summary>
     [Required]
     [JsonPropertyName(Parameters.ClientId)]
-    public string ClientId { get; init; } = null!;
+    public required string ClientId { get; init; }
 
     /// <summary>
     /// The client secret. This value must not be assigned to multiple clients and is used for authenticating the client with the server.
@@ -119,7 +119,7 @@ public record ClientRegistrationResponse
 
     /// <summary>
     /// The type of application for which the client is registered (<c>web</c>, <c>native</c>).
-    /// Optional — server may assign a default. Per RFC 7591 §2.
+    /// Optional - server may assign a default. Per RFC 7591 §2.
     /// </summary>
     [JsonPropertyName(Parameters.ApplicationType)]
     public string? ApplicationType { get; init; }

--- a/src/Abblix.Oidc.Server/Model/PushedAuthorizationResponse.cs
+++ b/src/Abblix.Oidc.Server/Model/PushedAuthorizationResponse.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -40,10 +40,14 @@ public record PushedAuthorizationResponse
         public const string ExpiresIn = "expires_in";
     }
 
-    /// <summary>The URI where the pushed authorization request is stored.</summary>
+    /// <summary>
+    /// The URI where the pushed authorization request is stored.
+    /// RFC 9126 section 2.2 states no REQUIRED marker for this member and instead says the server MUST
+    /// generate a request URI and provide it in the response, which binds just as tightly.
+    /// </summary>
     [JsonPropertyName(Parameters.RequestUri)]
     [JsonPropertyOrder(1)]
-    public Uri RequestUri { get; init; } = null!;
+    public required Uri RequestUri { get; init; }
 
     /// <summary>How long the stored request stays valid.</summary>
     [JsonPropertyName(Parameters.ExpiresIn)]

--- a/src/Abblix.Oidc.Server/Model/TokenResponse.cs
+++ b/src/Abblix.Oidc.Server/Model/TokenResponse.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -45,20 +45,27 @@ public record TokenResponse
         public const string AuthorizationDetails = "authorization_details";
     }
 
-    /// <summary>The access token issued by the authorization server.</summary>
+    /// <summary>
+    /// The access token issued by the authorization server.
+    /// REQUIRED by RFC 6749 section 5.1, so it is required here: a successful token response without it is
+    /// not a response this server is allowed to send, and the compiler can say so where the null could not.
+    /// </summary>
     [JsonPropertyName(Parameters.AccessToken)]
     [JsonPropertyOrder(1)]
-    public string AccessToken { get; init; } = null!;
+    public required string AccessToken { get; init; }
 
     /// <summary>The type of the issued token, typically an absolute URI identifying the token type.</summary>
     [JsonPropertyName(Parameters.IssuedTokenType)]
     [JsonPropertyOrder(2)]
     public Uri? IssuedTokenType { get; set; }
 
-    /// <summary>The type of token that is issued, usually 'Bearer'.</summary>
+    /// <summary>
+    /// The type of token that is issued, usually 'Bearer'.
+    /// REQUIRED by RFC 6749 section 5.1.
+    /// </summary>
     [JsonPropertyName(Parameters.TokenType)]
     [JsonPropertyOrder(3)]
-    public string TokenType { get; init; } = null!;
+    public required string TokenType { get; init; }
 
     /// <summary>The lifetime in seconds of the access token.</summary>
     [JsonPropertyName(Parameters.ExpiresIn)]

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -147,10 +147,10 @@ public class BackChannelAuthenticationGrantHandlerTests
     [InlineData("carrier-pigeon")]
     public async Task AuthorizeAsync_WithNoUsableDeliveryMode_ReturnsInvalidClient(string? deliveryMode)
     {
-        // The storage read happens before the client's own configuration is looked at, so the mock has to
-        // answer it even though this request never gets as far as needing what it returns.
-        _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync((BackChannelAuthenticationRequest?)null);
-
+        // Deliberately no storage stub. The refusal is decided from the client's registered metadata alone, so
+        // the lookup must not happen, and the strict mock turns any attempt into a failure by itself. The
+        // explicit verification below states the same thing as an intention rather than as a side effect of
+        // strictness, so the guarantee survives a future relaxation of the mock.
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = deliveryMode };
 
@@ -158,6 +158,7 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidClient, error.Error);
+        _storage.Verify(s => s.TryGetAsync(It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>
@@ -987,16 +988,10 @@ public class BackChannelAuthenticationGrantHandlerTests
         };
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
 
-        var expectedGrant = new AuthorizedGrant(
-            new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
-            new AuthorizationContext(ClientId, [Scopes.OpenId], null));
-
-        var authenticatedRequest = new BackChannelAuthenticationRequest(expectedGrant, DateTimeOffset.UtcNow.AddMinutes(5))
-        {
-            Status = BackChannelAuthenticationStatus.Authenticated
-        };
-
-        _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync(authenticatedRequest);
+        // No storage stub, deliberately. The delivery mode alone settles this, so the refusal is now
+        // independent of whatever is stored, which is a wider guarantee than the one this test used to make:
+        // it previously stubbed an authenticated request and asserted the lookup happened exactly once,
+        // pinning an ordering that made a refusable request pay for a storage round trip.
 
         // Act
         var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
@@ -1007,8 +1002,8 @@ public class BackChannelAuthenticationGrantHandlerTests
         Assert.Contains("push", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("must not poll", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
 
-        // Verify storage was checked but not removed (push mode clients shouldn't access token endpoint)
-        _storage.Verify(s => s.TryGetAsync(AuthReqId), Times.Once);
+        // The stored grant is neither read nor consumed: a client that must not poll cannot reach it at all.
+        _storage.Verify(s => s.TryGetAsync(It.IsAny<string>()), Times.Never);
         _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
     }
 }


### PR DESCRIPTION
Two small changes from the tail of the nullability audit. Both were on the queue as "open" and "judged not worth doing"; the second turned out to be half worth doing, and the half that is not is now written down with its reason.

## The CIBA handler asked storage before it asked the client

The token endpoint read the stored authentication request first and only then decided whether this client may use the endpoint at all. Both of those decisions come from the client's registered delivery mode and need nothing from the lookup, so a request that could only ever be refused still cost a storage round trip: cheap to send, expensive to serve, and available to any authenticated client by registering push delivery and then polling. The lookup now runs after both refusals; everything that genuinely needs the stored request still reads it.

Two tests were pinning the old order and both say more now. The delivery-mode test stubs nothing, so the strict mock fails on any lookup attempt by itself. The push-mode test used to stub an authenticated request and assert the lookup happened exactly once; it now asserts the lookup never happens, which is the wider statement: the refusal does not depend on what is stored, so a client that must not poll cannot reach the grant even when the grant is ready.

Mutation-proved: restoring the old order fails all four, each naming the storage call.

## Outbound responses require what their specifications require

Five members on four response models promised to be always present through a null-forgiving initialiser. These are built by this server, not bound from client input, so `required` costs nothing and states the contract the compiler can then check: `access_token` and `token_type` (RFC 6749 section 5.1), `client_id` (RFC 7591 section 3.2.1), `auth_req_id` (CIBA section 7.3) and `request_uri`, which RFC 9126 section 2.2 leaves unmarked while saying the server MUST generate and provide it.

The three request models beside them keep their initialisers on purpose, and the reason is now in the commit message rather than in someone's head: on an inbound model `required` converts a client's missing parameter into a deserialisation failure instead of the protocol error the endpoint owes it, model binding does not honour the modifier anyway, and the promise there is already made good by the validation attributes on those properties.

## Verification

Full solution suite green at 3610. The response-model change touches no caller, which is both its entire cost and its oracle, since what it buys is a compile-time guarantee.
