### PR TITLE
fix(discovery): sign the metadata document with an algorithm the key supports

### DIFF
--- a/src/Abblix.Oidc.Server.MinimalApi/Formatters/ConfigurationResultFormatter.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/Formatters/ConfigurationResultFormatter.cs
@@ -20,14 +20,9 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Text.Json.Serialization.Metadata;
-using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
-using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Utils;
-using Abblix.Utils.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
@@ -44,21 +39,8 @@ public class ConfigurationResultFormatter(
     IOptionsSnapshot<OidcOptions> options,
     IHttpContextAccessor httpContextAccessor,
     LinkGenerator linkGenerator,
-    IJsonWebTokenCreator jwtCreator,
-    IAuthServiceKeysProvider serviceKeysProvider,
-    TimeProvider clock) : IConfigurationResultFormatter
+    ISignedMetadataProvider signedMetadataProvider) : IConfigurationResultFormatter
 {
-    /// <summary>
-    /// Serializes the metadata into the <c>signed_metadata</c> JWS payload with the same null-omission semantics the
-    /// wire JSON uses. Without re-attaching the modifier here the signed copy would carry <c>"field": null</c> entries
-    /// the plain JSON omits, and RFC 8414 §2.1 "signed values take precedence" would then assert those nulls onto
-    /// clients.
-    /// </summary>
-    private static readonly JsonSerializerOptions SignedMetadataSerializerOptions = new()
-    {
-        TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(JsonIgnoreNullsModifier.Apply),
-    };
-
     /// <inheritdoc />
     public async Task<IResult> FormatResponseAsync(EndpointResponse response)
     {
@@ -160,50 +142,10 @@ public class ConfigurationResultFormatter(
 
         if (options.Value.Discovery.SignedMetadata)
         {
-            modelResponse = modelResponse with { SignedMetadata = await SignAsync(modelResponse) };
+            modelResponse = modelResponse with { SignedMetadata = await signedMetadataProvider.SignAsync(modelResponse) };
         }
 
         return Results.Json(modelResponse);
-    }
-
-    /// <summary>
-    /// Produces the RFC 8414 §2.1 <c>signed_metadata</c> value: a compact JWS whose payload restates the supplied
-    /// metadata plus a mandatory <c>iss</c> claim. The result is always a pure JWS, so a deployment that also issues
-    /// JWE access tokens does not turn this into a JWE the client cannot verify against <c>jwks_uri</c>.
-    /// </summary>
-    private async Task<string> SignAsync(ModelResponse metadata)
-    {
-        var signingKey = await serviceKeysProvider.GetSigningKeys(true).FirstOrDefaultAsync();
-        if (signingKey is null)
-        {
-            throw new InvalidOperationException(
-                $"{nameof(DiscoveryOptions)}.{nameof(DiscoveryOptions.SignedMetadata)} is enabled but no signing keys are configured. " +
-                "Configure signing certificates so the discovery document can be signed (RFC 8414 §2.1).");
-        }
-
-        // Serialized before signed_metadata is set on the outer object, so the signed payload never contains
-        // signed_metadata itself (RFC 8414 §2.1).
-        var payload = JsonSerializer.SerializeToNode(metadata, SignedMetadataSerializerOptions) switch
-        {
-            JsonObject jsonObject => jsonObject,
-
-            _ => throw new InvalidOperationException(
-                "Discovery metadata serialized to a non-object JSON node. The metadata must serialize to a JSON object so it " +
-                "can form the signed_metadata JWS payload (RFC 8414 §2.1); " +
-                "a different node kind indicates a broken serializer or type-info resolver."),
-        };
-
-        var token = new JsonWebToken
-        {
-            Header = { Algorithm = signingKey.Algorithm },
-            Payload = new JsonWebTokenPayload(payload)
-            {
-                Issuer = metadata.Issuer,
-                IssuedAt = clock.GetUtcNow(),
-            },
-        };
-
-        return await jwtCreator.IssueAsync(token, signingKey);
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Formatters/ConfigurationResponseFormatter.cs
@@ -20,16 +20,11 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Text.Json.Serialization.Metadata;
-using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
-using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
 using Abblix.Oidc.Server.Mvc.Controllers;
 using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
 using Abblix.Oidc.Server.Mvc.Formatters.Interfaces;
-using Abblix.Utils.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using EndpointResponse = Abblix.Oidc.Server.Endpoints.Configuration.Interfaces.ConfigurationResponse;
@@ -43,21 +38,8 @@ namespace Abblix.Oidc.Server.Mvc.Formatters;
 public class ConfigurationResponseFormatter(
 	IOptionsSnapshot<OidcOptions> options,
 	IEndpointResolver endpointResolver,
-	IJsonWebTokenCreator jwtCreator,
-	IAuthServiceKeysProvider serviceKeysProvider,
-	TimeProvider clock) : IConfigurationResponseFormatter
+	ISignedMetadataProvider signedMetadataProvider) : IConfigurationResponseFormatter
 {
-	/// <summary>
-	/// Serializes the metadata into the <c>signed_metadata</c> JWS payload with the same
-	/// null-omission semantics the wire JSON uses (see <see cref="JsonIgnoreNullsModifier"/>
-	/// wired in <c>AddOidcControllers</c>). Without re-attaching the modifier here the signed
-	/// copy would carry <c>"field": null</c> entries the plain JSON omits, and RFC 8414 §2.1
-	/// "signed values take precedence" would then assert those nulls onto clients.
-	/// </summary>
-	private static readonly JsonSerializerOptions SignedMetadataSerializerOptions = new()
-	{
-		TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(JsonIgnoreNullsModifier.Apply),
-	};
 	/// <summary>
 	/// Formats the configuration response by mapping metadata and adding endpoint URLs.
 	/// </summary>
@@ -164,55 +146,10 @@ public class ConfigurationResponseFormatter(
 
 		if (options.Value.Discovery.SignedMetadata)
 		{
-			mvcResponse = mvcResponse with { SignedMetadata = await SignAsync(mvcResponse) };
+			mvcResponse = mvcResponse with { SignedMetadata = await signedMetadataProvider.SignAsync(mvcResponse) };
 		}
 
 		return mvcResponse;
-	}
-
-	/// <summary>
-	/// Produces the RFC 8414 §2.1 <c>signed_metadata</c> value: a compact JWS whose payload
-	/// restates the supplied metadata plus a mandatory <c>iss</c> claim. The result is always
-	/// a pure JWS — <see cref="IJsonWebTokenCreator.IssueAsync"/> is called without an
-	/// encryption key, so a deployment that also issues JWE access tokens does not turn this
-	/// into a JWE the client cannot verify against <c>jwks_uri</c>.
-	/// </summary>
-	/// <param name="metadata">The fully assembled metadata, including resolved endpoint URLs
-	/// and mTLS aliases, but without <c>signed_metadata</c> itself.</param>
-	/// <returns>The compact-serialized JWS string.</returns>
-	private async Task<string> SignAsync(ModelResponse metadata)
-	{
-		var signingKey = await serviceKeysProvider.GetSigningKeys(true).FirstOrDefaultAsync();
-		if (signingKey is null)
-		{
-			throw new InvalidOperationException(
-				$"{nameof(DiscoveryOptions)}.{nameof(DiscoveryOptions.SignedMetadata)} is enabled but no signing keys are configured. " +
-				"Configure signing certificates so the discovery document can be signed (RFC 8414 §2.1).");
-		}
-
-		// Serialized before signed_metadata is set on the outer object, so the signed payload
-		// never contains signed_metadata itself (RFC 8414 §2.1).
-		var payload = JsonSerializer.SerializeToNode(metadata, SignedMetadataSerializerOptions) switch
-		{
-			JsonObject jsonObject => jsonObject,
-
-			_ => throw new InvalidOperationException(
-				"Discovery metadata serialized to a non-object JSON node. The metadata must serialize to a JSON object so it " +
-				"can form the signed_metadata JWS payload (RFC 8414 §2.1); " +
-				"a different node kind indicates a broken serializer or type-info resolver."),
-		};
-
-		var token = new JsonWebToken
-		{
-			Header = { Algorithm = signingKey.Algorithm },
-			Payload = new JsonWebTokenPayload(payload)
-			{
-				Issuer = metadata.Issuer,
-				IssuedAt = clock.GetUtcNow(),
-			},
-		};
-
-		return await jwtCreator.IssueAsync(token, signingKey);
 	}
 
 	/// <summary>

--- a/src/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ISignedMetadataProvider.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Configuration/Interfaces/ISignedMetadataProvider.cs
@@ -1,0 +1,45 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
+
+/// <summary>
+/// Produces the RFC 8414 §2.1 <c>signed_metadata</c> value for a discovery document.
+/// </summary>
+/// <remarks>
+/// Lives in the core rather than in an adapter because the value is a property of the metadata, not of the
+/// framework that serves it: both the MVC and the Minimal API adapters assemble the same
+/// <see cref="Model.ConfigurationResponse"/> and owe their clients the same signature over it.
+/// </remarks>
+public interface ISignedMetadataProvider
+{
+    /// <summary>
+    /// Signs <paramref name="metadata"/> and returns the compact JWS.
+    /// </summary>
+    /// <param name="metadata">
+    /// The fully assembled metadata, including resolved endpoint URLs and any mTLS aliases, and without
+    /// <c>signed_metadata</c> itself: RFC 8414 §2.1 has the bundle assert the metadata, not restate its own
+    /// signature.
+    /// </param>
+    /// <returns>The compact-serialized JWS.</returns>
+    Task<string> SignAsync(Model.ConfigurationResponse metadata);
+}

--- a/src/Abblix.Oidc.Server/Endpoints/Configuration/SignedMetadataProvider.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Configuration/SignedMetadataProvider.cs
@@ -1,0 +1,132 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Configuration.Interfaces;
+using Abblix.Utils.Json;
+
+namespace Abblix.Oidc.Server.Endpoints.Configuration;
+
+/// <summary>
+/// Signs the discovery document with one of this provider's own signing keys, per RFC 8414 §2.1.
+/// </summary>
+/// <param name="jwtCreator">Issues the JWS.</param>
+/// <param name="serviceKeysProvider">Supplies this provider's signing keys.</param>
+/// <param name="clock">Stamps <c>iat</c>.</param>
+public class SignedMetadataProvider(
+    IJsonWebTokenCreator jwtCreator,
+    IAuthServiceKeysProvider serviceKeysProvider,
+    TimeProvider clock) : ISignedMetadataProvider
+{
+    /// <summary>
+    /// Serializes the metadata into the <c>signed_metadata</c> JWS payload with the same null-omission
+    /// semantics the wire JSON uses (see <see cref="JsonIgnoreNullsModifier"/>, wired by each adapter).
+    /// Without re-attaching the modifier here the signed copy would carry <c>"field": null</c> entries the
+    /// plain JSON omits, and RFC 8414 §2.1 "signed values take precedence" would then assert those nulls
+    /// onto clients.
+    /// </summary>
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(JsonIgnoreNullsModifier.Apply),
+    };
+
+    /// <inheritdoc />
+    public async Task<string> SignAsync(Model.ConfigurationResponse metadata)
+    {
+        var signingKey = await serviceKeysProvider.GetSigningKeys(true).FirstOrDefaultAsync();
+        if (signingKey is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(DiscoveryOptions)}.{nameof(DiscoveryOptions.SignedMetadata)} is enabled but no signing keys are configured. " +
+                "Configure signing certificates so the discovery document can be signed (RFC 8414 §2.1).");
+        }
+
+        var payload = JsonSerializer.SerializeToNode(metadata, SerializerOptions) switch
+        {
+            JsonObject jsonObject => jsonObject,
+
+            _ => throw new InvalidOperationException(
+                "Discovery metadata serialized to a non-object JSON node. The metadata must serialize to a JSON object so it " +
+                "can form the signed_metadata JWS payload (RFC 8414 §2.1); " +
+                "a different node kind indicates a broken serializer or type-info resolver."),
+        };
+
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithmFor(signingKey) },
+            Payload = new JsonWebTokenPayload(payload)
+            {
+                Issuer = metadata.Issuer,
+                IssuedAt = clock.GetUtcNow(),
+            },
+        };
+
+        // No encryption key is passed, so the result is always a pure JWS: a deployment that also issues JWE
+        // access tokens must not turn this into a JWE, which no client could verify against jwks_uri.
+        return await jwtCreator.IssueAsync(token, signingKey);
+    }
+
+    /// <summary>
+    /// Names the algorithm to sign with: the one the key declares, or the standard one for its kind.
+    /// </summary>
+    /// <remarks>
+    /// RFC 7517 §4.4 makes <c>alg</c> OPTIONAL on a key, and the rest of this server honours that - a key
+    /// declaring no algorithm is usable with any compatible one (see
+    /// <c>JsonWebKeyExtensions.FirstByAlgorithmAsync</c>). Reading the algorithm straight off the key
+    /// inverted that rule here, and since a key imported from an RSA certificate declares none, every such
+    /// deployment answered its discovery endpoint with an error once signed metadata was switched on.
+    /// The fallback for elliptic-curve keys follows the curve, the same pairing
+    /// <c>JsonWebKeyExtensions.Apply</c> uses when it imports one.
+    /// </remarks>
+    private static string SigningAlgorithmFor(JsonWebKey signingKey)
+    {
+        if (signingKey.Algorithm is { } declared)
+            return declared;
+
+        return signingKey switch
+        {
+            RsaJsonWebKey => SigningAlgorithms.RS256,
+
+            EllipticCurveJsonWebKey { Curve: var curve } => curve switch
+            {
+                EllipticCurveTypes.P256 => SigningAlgorithms.ES256,
+                EllipticCurveTypes.P384 => SigningAlgorithms.ES384,
+                EllipticCurveTypes.P521 => SigningAlgorithms.ES512,
+
+                _ => throw new InvalidOperationException(
+                    $"The signing key names the curve '{curve}', which this server has no signing algorithm "
+                    + "for. Set the alg parameter on the key to say how the discovery document is to be "
+                    + "signed (RFC 7517 section 4.4)."),
+            },
+
+            _ => throw new InvalidOperationException(
+                $"The signing key is a {signingKey.GetType().Name} and declares no alg parameter, so there "
+                + "is no algorithm to sign the discovery document with. Set the alg parameter on the key "
+                + "(RFC 7517 section 4.4)."),
+        };
+    }
+}

--- a/src/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -101,6 +101,9 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IJwtAlgorithmsProvider, JwtAlgorithmsProvider>();
         services.TryAddScoped<IAcrMetadataProvider, AcrMetadataProvider>();
         services.TryAddScoped<IConfigurationHandler, ConfigurationHandler>();
+        // Scoped to match the adapters' response formatters, which are the only consumers and are themselves
+        // scoped: the signature is produced per request over that request's resolved endpoint URLs.
+        services.TryAddScoped<ISignedMetadataProvider, SignedMetadataProvider>();
         return services;
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoveryControllerMtlsTests.cs
@@ -65,14 +65,12 @@ public class DiscoveryControllerMtlsTests
 
         SetupEndpointResolver();
 
-        // SignedMetadata defaults off in these fixtures, so the signing collaborators are
+        // SignedMetadata defaults off in these fixtures, so the signing collaborator is
         // never exercised - supplied only to satisfy the constructor.
         _formatter = new ConfigurationResponseFormatter(
             _optionsMock.Object,
             _endpointResolverMock.Object,
-            Mock.Of<IJsonWebTokenCreator>(),
-            Mock.Of<IAuthServiceKeysProvider>(),
-            new FakeTimeProvider());
+            Mock.Of<ISignedMetadataProvider>());
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Mvc/Controllers/DiscoverySignedMetadataTests.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Configuration;
 using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;
 using Abblix.Oidc.Server.Mvc.Formatters;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -75,9 +76,7 @@ public class DiscoverySignedMetadataTests
         _formatter = new ConfigurationResponseFormatter(
             _optionsMock.Object,
             _endpointResolverMock.Object,
-            _jwtCreatorMock.Object,
-            _keysProviderMock.Object,
-            _clock);
+            new SignedMetadataProvider(_jwtCreatorMock.Object, _keysProviderMock.Object, _clock));
     }
 
     /// <summary>
@@ -182,5 +181,36 @@ public class DiscoverySignedMetadataTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => _formatter.FormatResponseAsync(MinimalResponse()));
+    }
+
+    /// <summary>
+    /// A signing key that declares no <c>alg</c> is signed with the standard algorithm for its kind, rather
+    /// than with none.
+    /// </summary>
+    /// <remarks>
+    /// RFC 7517 section 4.4 makes <c>alg</c> OPTIONAL, and a key imported from an RSA certificate carries
+    /// none - the ordinary case for a deployment that signs with a certificate. Taking the algorithm off the
+    /// key left the header empty, the signer then resolved nothing for the key's type, and the discovery
+    /// endpoint answered with an error instead of a document. Every other case in this class hands over a key
+    /// that names RS256, which is why the one shape that actually ships was the one never exercised.
+    /// </remarks>
+    [Fact]
+    public async Task SignedMetadataEnabled_KeyWithoutAlgorithm_SignsWithTheStandardOneForItsKind()
+    {
+        _oidcOptions.Discovery.SignedMetadata = true;
+        _keysProviderMock
+            .Setup(p => p.GetSigningKeys(true))
+            .Returns(new JsonWebKey[] { new RsaJsonWebKey { KeyId = "sig" } }.ToAsyncEnumerable());
+
+        JsonWebToken? capturedToken = null;
+        _jwtCreatorMock
+            .Setup(c => c.IssueAsync(It.IsAny<JsonWebToken>(), It.IsAny<JsonWebKey?>(), It.IsAny<JsonWebKey?>(),
+                It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey?, JsonWebKey?, string, string>((t, _, _, _, _) => capturedToken = t)
+            .ReturnsAsync(SignedJws);
+
+        await _formatter.FormatResponseAsync(MinimalResponse());
+
+        Assert.Equal(SigningAlgorithms.RS256, capturedToken!.Header.Algorithm);
     }
 }


### PR DESCRIPTION
A signing key is not obliged to name an algorithm: RFC 7517 section 4.4 makes `alg` OPTIONAL, and a key built from an RSA certificate carries none. Both integration adapters read the algorithm straight off the key, so such a deployment produced a JWS header naming nothing, the signer resolved no implementation for the key type, and the discovery endpoint answered 500 as soon as `DiscoveryOptions.SignedMetadata` was switched on. This has been the behaviour since the feature shipped in 2.3.

The rest of the server already treats a key's `alg` as a hint rather than an instruction: the caller names the algorithm, and `JsonWebKeyExtensions.FirstByAlgorithmAsync` documents that a key declaring none is usable with any compatible one. Signing the discovery document was the one place that inverted the rule.

The algorithm is now derived from the key's kind when the key is silent, RSA to RS256 and elliptic curve by its curve, which is the pairing the key import already uses. An unknown kind throws with a message naming the remedy.

The two adapters carried the same forty lines of signing code, so the fix would have had to land twice and then drift. It now lives in the core behind `ISignedMetadataProvider`, registered next to the other configuration-endpoint services, and each adapter asks for it.

Found by an end-to-end test of the client library against this server: the test host configures its signing key exactly the way a host would, and reproduced the 500 on the first run. The four existing unit tests all handed the formatter a key that named RS256, which is why the shape that actually ships was the one never exercised; the new test covers it.
