### PR TITLE
Let the polling interval bound the gap between polls, not the wait before the first

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -107,7 +107,15 @@ public class BackChannelAuthenticationRequestProcessor(
 		var backChannelRequest = new BackChannelAuthenticationRequest(authorizedGrant, expiresAt)
 		{
 			Status = BackChannelAuthenticationStatus.Pending,
-			NextPollAt = timeProvider.GetUtcNow() + pollingInterval,
+
+			// The client may poll from the moment it holds the request id, so the first allowed poll is
+			// now, matching the device flow. CIBA section 11 adopts RFC 8628's polling rules, and section
+			// 3.2 there defines the interval as the minimum to wait "between polling requests to the token
+			// endpoint" - it has nothing to sit after until a first poll exists. This used to read
+			// now + interval, which answered the first request with slow_down and cost every sign-in one
+			// interval for polling too fast when nothing had been polled.
+			NextPollAt = timeProvider.GetUtcNow(),
+
 			ClientNotificationEndpoint = request.ClientInfo.BackChannelClientNotificationEndpoint,
 			ClientNotificationToken = request.Model.ClientNotificationToken,
 		};

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/DeviceAuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/DeviceAuthorizationRequestProcessor.cs
@@ -66,7 +66,18 @@ public class DeviceAuthorizationRequestProcessor(
             userCode)
         {
             Status = DeviceAuthorizationStatus.Pending,
-            NextPollAt = timeProvider.GetUtcNow() + deviceAuthOptions.PollingInterval,
+
+            // The device may poll from the moment it holds the code, so the first allowed poll is now.
+            // RFC 8628 section 3.2 defines the interval as "the minimum amount of time in seconds that
+            // the client SHOULD wait between polling requests to the token endpoint" - it bounds the gap
+            // BETWEEN polls, and at issuance there is no earlier poll for it to sit after. This used to
+            // read now + interval, which answered the device's very first request with slow_down: not a
+            // violation, since slow_down is a variant of authorization_pending and a conforming device
+            // simply waits, but it charged every sign-in one interval of latency for polling too fast
+            // when nothing had been polled at all. The first poll stamps the interval, and the throttle
+            // governs every request after it.
+            NextPollAt = timeProvider.GetUtcNow(),
+
             // RFC 9396 §3: stash authorization_details on the persisted record so the
             // host's user-verification step can read it (via ValidUserCode) and thread it
             // onto the AuthorizedGrant's AuthorizationContext when approving.

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -23,7 +23,6 @@
 using System.Net;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common;
-using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
@@ -37,7 +36,6 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Xunit;
 using CibaParameters = Abblix.Oidc.Server.Model.BackChannelAuthenticationRequest.Parameters;
 using CibaResponse = Abblix.Oidc.Server.Model.BackChannelAuthenticationSuccess.Parameters;
@@ -273,27 +271,22 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         });
 
     /// <summary>
-    /// Builds an isolated host that can actually issue an auth_req_id: a device handler that reports the
-    /// canonical e2e user as reachable, and a zero polling interval.
+    /// Builds an isolated host that can actually issue an auth_req_id, by supplying the device interaction
+    /// the library leaves to the integrator: a handler that reports the canonical e2e user as reachable.
     /// </summary>
     /// <remarks>
-    /// The interval is flattened because the processor stamps <c>NextPollAt = now + PollingInterval</c> at
-    /// the moment the request is stored, so with the five-second default the very first poll is answered
-    /// with <c>slow_down</c> instead of <c>authorization_pending</c>. Waiting out five seconds of wall clock
-    /// would test the rate limiter, not the property under test - that a pending request yields no tokens.
+    /// The polling interval is the shipped default here, deliberately. These tests each poll once, and a
+    /// first poll is answered on its merits because the interval bounds the gap between polls - so what
+    /// they exercise is the configuration a deployment actually runs. This host used to flatten the
+    /// interval to zero, because the request was stamped with a next-poll time at issuance and the first
+    /// poll came back <c>slow_down</c> instead of <c>authorization_pending</c>; that is what #281 changed,
+    /// and the workaround left with it.
     /// </remarks>
     private WebApplicationFactory<Program> CreateCibaHost()
         => Factory.WithWebHostBuilder(builder =>
             builder.ConfigureTestServices(services =>
-            {
                 services.Replace(ServiceDescriptor
-                    .Scoped<IUserDeviceAuthenticationHandler, ReachableUserDeviceHandler>());
-
-                services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
-                    new PostConfigureOptions<OidcOptions>(
-                        Options.DefaultName,
-                        options => options.BackChannelAuthentication.PollingInterval = TimeSpan.Zero));
-            }));
+                    .Scoped<IUserDeviceAuthenticationHandler, ReachableUserDeviceHandler>())));
 
     private static HttpClient CreateClientFor(WebApplicationFactory<Program> host)
         => host.CreateClient(new WebApplicationFactoryClientOptions

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/DeviceAuthorizationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/DeviceAuthorizationTests.cs
@@ -179,10 +179,16 @@ public class DeviceAuthorizationTests(TestFactory factory) : TestBase(factory)
         var authorization = await StartDeviceFlowAsync(client, discovery, device);
         var deviceCode = authorization[DeviceResponse.Parameters.DeviceCode]!.GetValue<string>();
 
-        // The wait the server just told this device to observe. Enforcement starts at issuance, so the very
-        // first poll of a device that ignores the interval already lands inside the window.
+        // The wait the server just told this device to observe.
         Assert.True(authorization[DeviceResponse.Parameters.Interval]!.GetValue<int>() > 0);
 
+        // The first poll is the device doing what RFC 8628 section 3.4 describes - polling as soon as it
+        // holds the code - and it is answered on its merits, because the interval bounds the gap between
+        // polls and there is no earlier poll for this one to be too close to.
+        var first = await PollAsync(client, discovery, device, deviceCode);
+        await AssertRefusedAsync(first, ErrorCodes.AuthorizationPending);
+
+        // The second, sent immediately, is the one that ignores the interval.
         var response = await PollAsync(client, discovery, device, deviceCode);
 
         await AssertRefusedAsync(response, ErrorCodes.SlowDown);


### PR DESCRIPTION
Both polling flows stamped a next-poll time when they issued the code, so a device that started polling the moment it held one was answered with `slow_down` before it had polled twice. RFC 8628 section 3.4 describes starting at once as the normal thing to do, and section 3.2 defines the interval as the minimum a client should wait "between polling requests to the token endpoint" - at issuance there is no earlier poll for it to sit after.

Not a violation, since `slow_down` is a variant of `authorization_pending` and a conforming device simply waits. What it cost was one interval of latency on every device and CIBA sign-in, for polling too fast when nothing had been polled at all - and it left the `authorization_pending` branch unreachable on a host running the default interval.

The first allowed poll is now the moment of issuance. The first poll stamps the interval; the throttle governs every request after it, unchanged.

## What moved with it

The device throttle test polls twice: the first poll is answered on its merits, the second - sent immediately - is the one that ignores the interval. It now asserts what the throttle means rather than when enforcement happened to begin.

The CIBA host drops the zero-interval override it carried, and its three tests run against the shipped default. That override existed only because the first poll could not reach the pending branch; removing it and having the tests pass is the evidence the behaviour changed.

Closes #281.