### PR TITLE
Make the JARM content-encryption fallback a setting

### DIFF
--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -177,6 +177,23 @@ public record OidcOptions
 	public string DefaultContentEncryptionAlgorithm { get; set; } = EncryptionAlgorithms.ContentEncryption.Aes256CbcHmacSha512;
 
 	/// <summary>
+	/// The content encryption algorithm used for an encrypted authorization response (JARM) when the client
+	/// registered <c>authorization_encrypted_response_alg</c> but omitted
+	/// <c>authorization_encrypted_response_enc</c>.
+	/// </summary>
+	/// <remarks>
+	/// Separate from <see cref="DefaultContentEncryptionAlgorithm"/> because the specification names a
+	/// different value for this one response: JWT Secured Authorization Response Mode section 3 says that
+	/// "if authorization_encrypted_response_alg is specified, the default for this value is A128CBC-HS256".
+	/// A client registering only the key-management algorithm expects that, so the server has to encrypt
+	/// with it or produce a response the client cannot read.
+	/// It is a setting rather than a constant so a deployment whose clients all understand a stronger
+	/// algorithm can raise the floor, the same way the general default can be raised.
+	/// </remarks>
+	public string DefaultAuthorizationResponseEncryptionAlgorithm { get; set; }
+		= EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256;
+
+	/// <summary>
 	/// Per-type signing and encryption settings for the JWTs the server issues for itself (access, refresh,
 	/// registration access and initial access tokens). Each type signs with RS256 and, when a server
 	/// <see cref="EncryptionKeys"/> entry is configured, is encrypted to it by default, as in prior versions.

--- a/src/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
+++ b/src/Abblix.Oidc.Server/Features/ResponseObject/ResponseJwtBuilder.cs
@@ -87,6 +87,6 @@ public class ResponseJwtBuilder(
         return await clientJwtFormatter.FormatAsync(
             token,
             clientInfo,
-            ClientJwtEncryption.ForJarm(clientInfo));
+            ClientJwtEncryption.ForJarm(clientInfo, options.Value));
     }
 }

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtEncryption.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtEncryption.cs
@@ -79,12 +79,19 @@ public sealed record ClientJwtEncryption(
 
 	/// <summary>
 	/// Policy for a JARM authorization response JWT: encrypts only when the client registered
-	/// <c>authorization_encrypted_response_alg</c> (JARM §2.2 / §3 opt-in), defaulting the content-encryption to
-	/// <c>A128CBC-HS256</c> when <c>authorization_encrypted_response_enc</c> is omitted (JARM §3).
+	/// <c>authorization_encrypted_response_alg</c> (JARM §2.2 / §3 opt-in), falling back to
+	/// <see cref="OidcOptions.DefaultAuthorizationResponseEncryptionAlgorithm"/> when
+	/// <c>authorization_encrypted_response_enc</c> is omitted.
 	/// </summary>
-	public static ClientJwtEncryption ForJarm(ClientInfo clientInfo) => new(
+	/// <remarks>
+	/// The fallback comes from its own setting rather than
+	/// <see cref="OidcOptions.DefaultContentEncryptionAlgorithm"/>, because JARM section 3 names a different
+	/// value for this response than the one the other client-addressed JWTs default to, and a client that
+	/// registered only the key-management algorithm is entitled to the one the specification named.
+	/// </remarks>
+	public static ClientJwtEncryption ForJarm(ClientInfo clientInfo, OidcOptions options) => new(
 		clientInfo.AuthorizationEncryptedResponseAlgorithm,
 		clientInfo.AuthorizationEncryptedResponseEncryption,
-		EncryptionAlgorithms.ContentEncryption.Aes128CbcHmacSha256,
+		options.DefaultAuthorizationResponseEncryptionAlgorithm,
 		RequireRegisteredAlgorithm: true);
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ResponseObject/ResponseJwtBuilderTests.cs
@@ -190,6 +190,44 @@ public class ResponseJwtBuilderTests
     }
 
     /// <summary>
+    /// The JARM fallback is a setting, so a deployment whose clients all understand a stronger algorithm can
+    /// raise it.
+    /// </summary>
+    /// <remarks>
+    /// The case above pins the value the specification names, which a client registering only
+    /// <c>authorization_encrypted_response_alg</c> is entitled to. This one pins that the value is reachable
+    /// at all: without it the setting could be read from nowhere and every test would still pass, because the
+    /// default it happens to carry is the same constant the code used to hold.
+    /// </remarks>
+    [Fact]
+    public async Task BuildAsync_WithEncryptionAlgorithmButNoEnc_HonoursTheConfiguredFallback()
+    {
+        var capture = CaptureIssue();
+        _clientKeys
+            .Setup(p => p.GetEncryptionKeys(It.IsAny<ClientInfo>()))
+            .Returns(new[] { _clientEncryptionKey }.ToAsyncEnumerable());
+
+        _client.AuthorizationEncryptedResponseAlgorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256;
+
+        var options = Options.Create(new OidcOptions
+        {
+            DefaultAuthorizationResponseEncryptionAlgorithm = EncryptionAlgorithms.ContentEncryption.Aes256Gcm,
+        });
+
+        var builder = new ResponseJwtBuilder(
+            _clientInfoProvider.Object,
+            new ClientJwtFormatter(
+                _jwtCreator.Object, _clientKeys.Object, _serviceKeys.Object, Options.Create(new OidcOptions())),
+            _issuerProvider.Object,
+            _timeProvider.Object,
+            options);
+
+        await builder.BuildAsync(ClientId, [("code", "auth-code")]);
+
+        Assert.Equal(EncryptionAlgorithms.ContentEncryption.Aes256Gcm, capture.ContentAlgorithm);
+    }
+
+    /// <summary>
     /// Characterizes the unified key-management algorithm selection shared by all client-addressed JWTs: when the
     /// client's encryption key declares its own <c>alg</c>, that algorithm is used in preference to the registered
     /// <c>authorization_encrypted_response_alg</c>. This is the long-standing UserInfo/ID-token rule, now applied to


### PR DESCRIPTION
The authorization response was the one client-addressed JWT whose fallback content-encryption algorithm was written into the code. UserInfo, the ID token and introspection all read theirs from `OidcOptions`, so a deployment could raise the floor for three of the four and not the fourth.

## Why its own setting

It does not share `DefaultContentEncryptionAlgorithm`, because the specification names a different value for this one response. JWT Secured Authorization Response Mode section 3: "if `authorization_encrypted_response_alg` is specified, the default for this value is `A128CBC-HS256`". A client that registered only the key-management algorithm is entitled to that, so collapsing the two into a single knob would either break such a client or weaken the other three.

`OidcOptions.DefaultAuthorizationResponseContentEncryptionAlgorithm` therefore carries the specification's value as its default, and a deployment whose clients all understand a stronger algorithm can raise it.

## On the test

The default is unchanged, so the existing case pinning `A128CBC-HS256` still passes and proves nothing new - it would pass just as well against a hardcoded constant. The added case moves the setting and requires the change to reach the encoder. Reverting the read to the old constant turns exactly that one case red and nothing else, which is what says it is load-bearing.