### PR TITLE
Stop demanding a redirect URI from clients that never redirect

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -147,7 +147,11 @@ public class RegisterClientRequestProcessor(
             TokenEndpointAuthMethod = model.TokenEndpointAuthMethod,
             AllowedResponseTypes = model.ResponseTypes,
             AllowedGrantTypes = model.GrantTypes,
-            RedirectUris = model.RedirectUris,
+            // A client that registers none has none: the flows that redirect are the ones that require
+            // them, and a device-flow or CIBA client runs neither. Empty rather than null so every reader
+            // downstream - the authorization endpoint's redirect check among them - sees a set to compare
+            // against instead of having to ask whether there is one.
+            RedirectUris = model.RedirectUris ?? [],
             Jwks = model.Jwks,
             JwksUri = model.JwksUri,
             PkceRequired = model.PkceRequired,

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -68,7 +68,10 @@ public class UpdateClientRequestProcessor(
             TokenEndpointAuthMethod = model.TokenEndpointAuthMethod,
             AllowedResponseTypes = model.ResponseTypes,
             AllowedGrantTypes = model.GrantTypes,
-            RedirectUris = model.RedirectUris,
+            // Empty rather than null when the client registers none, matching registration: RFC 7592 §2
+            // replaces the whole metadata set, so a client dropping its redirect URIs must end up with an
+            // empty set rather than an absent one.
+            RedirectUris = model.RedirectUris ?? [],
             Jwks = model.Jwks,
             JwksUri = model.JwksUri,
             PkceRequired = model.PkceRequired,

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -71,10 +71,13 @@ public partial class SubjectTypeValidator(
         if (contentResult.TryGetFailure(out var contentError))
             return contentError;
 
+        // A client registering no redirect URIs satisfies the subset check below with nothing to check:
+        // the rule is that everything it registered must appear in the sector document, and it registered
+        // nothing. Passing an empty set says that, where passing null would only ask the question again.
         var error = ValidateSectorIdentifierContent(
             sectorIdentifierUri,
             contentResult.GetSuccess(),
-            context.Request.RedirectUris);
+            context.Request.RedirectUris ?? []);
 
         if (error != null)
             return error;

--- a/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -46,12 +46,21 @@ public record ClientRegistrationRequest
 
     /// <summary>
     /// The <c>redirect_uris</c> array (RFC 7591 §2) listing every absolute URI the OP may use to deliver
-    /// authorization responses to this client. At least one entry is required, and authorization requests
-    /// must specify a redirect URI that exactly matches one of these values.
+    /// authorization responses to this client. An authorization request must then specify a redirect URI
+    /// that exactly matches one of these values.
     /// </summary>
+    /// <remarks>
+    /// Deliberately not required at the model layer, because whether it is required depends on another
+    /// member of the same request. RFC 7591 section 2 asks for it only for grant types that redirect, and
+    /// <c>RedirectUrisValidator</c> already applies exactly that rule - it demands at least one entry when
+    /// the requested grants include the authorization code, implicit or refresh token, and says nothing
+    /// otherwise. A declarative constraint here ran first and refused a device-flow or CIBA client, which
+    /// has no user agent to redirect, with a transport-level 400 naming a C# property rather than the
+    /// protocol error the endpoint owes the caller. This mirrors the repository rule that a declarative
+    /// value constraint belongs on a request model only when the specification fixes the rule outright.
+    /// </remarks>
     [JsonPropertyName(Parameters.RedirectUris)]
-    [ElementsRequired]
-    public Uri[] RedirectUris { get; init; } = null!;
+    public Uri[]? RedirectUris { get; init; }
 
     /// <summary>
     /// The <c>response_types</c> the client intends to use (RFC 7591 §2). Each entry is itself a

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -221,8 +221,10 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
     {
         var registered = await RegisterClientAsync(client, discovery, new JsonObject
         {
+            // No redirect_uris: CIBA moves the user interaction off the browser entirely, so there is no
+            // redirect to register. That this registration is accepted is itself part of what the suite
+            // proves.
             [RegistrationMembers.ClientName] = $"ciba-{Guid.NewGuid():N}",
-            [RegistrationMembers.RedirectUris] = new JsonArray(TestConstants.RedirectUri),
             [RegistrationMembers.ResponseTypes] = new JsonArray(),
             [RegistrationMembers.GrantTypes] = new JsonArray(GrantTypes.Ciba),
             [RegistrationMembers.TokenEndpointAuthMethod] = ClientAuthenticationMethods.ClientSecretPost,

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
@@ -81,6 +81,40 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
     private static async Task<JsonObject> ReadJsonAsync(HttpResponseMessage response) =>
         JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
 
+    /// <summary>
+    /// A client whose grants redirect still has to register a redirect URI, and is told so in the
+    /// protocol's own terms.
+    /// </summary>
+    /// <remarks>
+    /// The requirement lives in the validator that expresses it correctly - it applies when the requested
+    /// grants include one that redirects - rather than as a declarative constraint on the model, which ran
+    /// first and refused a device-flow or CIBA client that has no user agent to redirect. This case is the
+    /// other half of that change: the rule is still enforced where it applies, and the refusal carries
+    /// invalid_redirect_uri rather than a transport-level complaint naming a C# property.
+    /// </remarks>
+    [Fact]
+    public async Task A_redirecting_client_still_has_to_register_a_redirect_uri()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        Assert.NotNull(discovery.RegistrationEndpoint);
+        var response = await client.PostAsJsonAsync(
+            discovery.RegistrationEndpoint!,
+            new JsonObject
+            {
+                [RequestMembers.ClientName] = "redirecting-without-a-uri",
+                [RequestMembers.GrantTypes] = new JsonArray(GrantTypes.AuthorizationCode),
+                [RequestMembers.ResponseTypes] = new JsonArray(ResponseTypes.Code),
+            },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var body = await ReadJsonAsync(response);
+        Assert.Equal(ErrorCodes.InvalidRedirectUri, body["error"]!.GetValue<string>());
+    }
+
     [Fact]
     public async Task A_client_can_read_its_own_registration()
     {

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
@@ -98,21 +98,23 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
-        Assert.NotNull(discovery.RegistrationEndpoint);
+        // The metadata every other case here registers with, minus the one member under test - so what
+        // differs between an accepted registration and this one is exactly the redirect URI.
+        var metadata = NewClientMetadata("redirecting-without-a-uri");
+        metadata.Remove(RequestMembers.RedirectUris);
+
+        var registrationEndpoint = discovery.RegistrationEndpoint;
+        Assert.NotNull(registrationEndpoint);
+
         var response = await client.PostAsJsonAsync(
-            discovery.RegistrationEndpoint!,
-            new JsonObject
-            {
-                [RequestMembers.ClientName] = "redirecting-without-a-uri",
-                [RequestMembers.GrantTypes] = new JsonArray(GrantTypes.AuthorizationCode),
-                [RequestMembers.ResponseTypes] = new JsonArray(ResponseTypes.Code),
-            },
-            TestContext.Current.CancellationToken);
+            registrationEndpoint, metadata, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var body = await ReadJsonAsync(response);
-        Assert.Equal(ErrorCodes.InvalidRedirectUri, body["error"]!.GetValue<string>());
+        var error = body["error"];
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidRedirectUri, error.GetValue<string>());
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/DeviceAuthorizationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/DeviceAuthorizationTests.cs
@@ -234,11 +234,11 @@ public class DeviceAuthorizationTests(TestFactory factory) : TestBase(factory)
             [RegistrationRequest.ClientName] = clientName,
             [RegistrationRequest.GrantTypes] = new JsonArray(GrantTypes.DeviceAuthorization),
 
-            // A device client has no user agent to redirect, so it declares no response type. The MVC
-            // registration model still marks redirect_uris as required, so one is supplied and never used.
+            // A device client has no user agent to redirect, so it declares no response type and registers
+            // no redirect_uris at all - which is also the point: this registration is what proves the
+            // endpoint no longer demands one from a client that can never use it.
             // client_secret_post keeps the credentials in the same form body the other scenarios post.
             [RegistrationRequest.ResponseTypes] = new JsonArray(),
-            [RegistrationRequest.RedirectUris] = new JsonArray(TestConstants.RedirectUri),
             [RegistrationRequest.TokenEndpointAuthMethod] = ClientAuthenticationMethods.ClientSecretPost,
         });
 


### PR DESCRIPTION
A device-flow or CIBA client could not register. Both move the user interaction off the browser, so neither has a user agent to redirect, and RFC 7591 section 2 asks for `redirect_uris` only for grant types that use one.

The library already held that rule - `RedirectUrisValidator` requires at least one entry exactly when the requested grants include the authorization code, implicit or refresh token. It also held the wrong one: `ElementsRequired` on the model demanded the member unconditionally, and model binding runs first, so the request was refused with a transport-level 400 naming a C# property before the grant-aware validator could speak. Two rules, and the wrong one won on ordering.

## What the compiler found

The model member is now optional and nullable rather than merely optional. That was the useful part: it made the compiler name every consumer that had to decide what absence means, and it found four - including the sector-identifier check, which no grep for the assignment would have surfaced.

Absence normalises to an empty set at each. For the sector-identifier subset check that is the exact reading of the rule: everything a client registered must appear in the document, and a client that registered nothing has nothing that could be missing.

## Evidence

The device and CIBA suites each drop the dummy redirect URI they had been passing - one of them carried a comment saying why it was there - and their passing without it is what says the endpoint no longer demands one.

The other half is a new case in `ClientManagementTests`: a client whose grants do redirect still has to register one, and now hears `invalid_redirect_uri` instead of a complaint about a property name.

Closes #280.