### PR TITLE
Make the RFC 8693 token-exchange grant opt-in

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -145,7 +145,7 @@ public static class ServiceCollectionExtensions
         // AuthorizationHandler is no longer aliased as IGrantTypeInformer: each registered
         // IAuthorizationResponseBuilder now contributes its own grant types directly to the
         // IGrantTypeInformer set, so the IGrantTypeInformer chain stays Singleton-friendly
-        // (every contributor is Singleton — no captive-dep risk for Singleton consumers).
+        // (every contributor is Singleton - no captive-dep risk for Singleton consumers).
         // TryAddAlias keeps the host-first contract on this seam (issue #226).
         return services.TryAddAlias<IAuthorizationHandler, AuthorizationHandler>();
     }
@@ -240,9 +240,13 @@ public static class ServiceCollectionExtensions
             .AddAuthorizationCodeGrant()
             .AddRefreshTokenGrant()
             .AddClientCredentialsGrant()
-            .AddTokenExchangeGrant()
-            // BackChannelAuthenticationGrantHandler and DeviceCodeGrantHandler are registered
-            // in AddBackChannelAuthentication() and AddDeviceAuthorization() respectively
+            // TokenExchangeGrantHandler is registered in AddTokenExchangeGrant(), like
+            // BackChannelAuthenticationGrantHandler in AddBackChannelAuthentication() and
+            // DeviceCodeGrantHandler in AddDeviceAuthorization(). Token exchange is opt-in because
+            // registering it makes the OP advertise urn:ietf:params:oauth:grant-type:token-exchange
+            // in grant_types_supported, and a host that never intends to delegate authority should
+            // not publish that it does. It also brings four subject-token resolvers, one of which
+            // (RefreshTokenSubjectTokenResolver) reads the refresh-token store.
             // AddAuthorizationGrants() is called in AddOidcCore() after all handlers are registered
             .AddTokenContextValidators();
 
@@ -368,11 +372,18 @@ public static class ServiceCollectionExtensions
     /// <see cref="Features.TokenExchange.RefreshTokenSubjectTokenResolver"/> for refresh tokens).
     /// </summary>
     /// <remarks>
+    /// Opt-in: unlike the authorization-code, refresh-token and client-credentials grants, this one is
+    /// not registered by <c>AddTokenEndpoint</c>. Call it explicitly, and call it BEFORE
+    /// <c>AddOidcCore</c> / <c>AddOidcServices</c> / <c>AddOidcMinimalApi</c>, because
+    /// <c>AddAuthorizationGrants()</c> composes the registered handlers inside them - a handler added
+    /// afterwards lands beside the composite and the token endpoint resolves the wrong single
+    /// <see cref="Token.Grants.IAuthorizationGrantHandler"/>. A host that does not call this
+    /// neither serves the grant nor advertises it in <c>grant_types_supported</c>.
+    ///
     /// Subject-token resolvers are dispatched by keyed DI under the
     /// <c>urn:ietf:params:oauth:token-type:*</c> URI. Hosts may register additional resolvers
-    /// after this call (e.g. SAML 2.0 assertions in federation scenarios) -- the handler picks
-    /// them up automatically. The <c>actor_token</c>/delegation path and discovery / DCR
-    /// metadata land in subsequent slices (see #143).
+    /// after this call (e.g. SAML 2.0 assertions in federation scenarios) - the handler picks
+    /// them up automatically.
     /// </remarks>
     /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
     /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
@@ -469,7 +480,7 @@ public static class ServiceCollectionExtensions
     {
         // The IAuthorizationResponseBuilder / IGrantTypeInformer aliases inherit this lifetime
         // (BuildAliasDescriptor preserves the source lifetime), so a builder with scoped
-        // dependencies registers Scoped and its aliases follow — no captive dependency.
+        // dependencies registers Scoped and its aliases follow - no captive dependency.
         services.TryAdd(new ServiceDescriptor(typeof(TImpl), typeof(TImpl), lifetime));
         services.TryAddEnumerableAlias<IAuthorizationResponseBuilder, TImpl>();
         services.TryAddEnumerableAlias<IGrantTypeInformer, TImpl>();
@@ -719,7 +730,7 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers the Device Authorization Grant (RFC 8628) endpoint services — handler, request and context
+    /// Registers the Device Authorization Grant (RFC 8628) endpoint services - handler, request and context
     /// validators, and the <c>DeviceAuthorizationOptionsValidator</c>. Invoked by the public
     /// <c>AddDeviceAuthorization()</c> opt-in method, not by the unconditional endpoint wiring: device
     /// authorization is a single opt-in feature, so its validator only runs when a server opts in.

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -8,6 +8,7 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.TestHost.TestStubs;
+using Abblix.Oidc.Server.Endpoints;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Consents;
@@ -21,7 +22,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 // Load the embedded test license JWT before any OIDC service touches LicenseChecker.
 // The license is scoped to valid_issuers=["https://auth.example.com"] (TestConstants.Issuer)
-// with issuer_limit=1, so it physically cannot be lifted into a production host —
+// with issuer_limit=1, so it physically cannot be lifted into a production host -
 // LicenseChecker.CheckIssuer throws on a non-matching issuer at startup.
 await LoadEmbeddedTestLicenseAsync();
 
@@ -30,13 +31,14 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 
 // Opt into the endpoints that are no longer on by default (EnabledEndpoints now defaults to OidcEndpoints.Base).
-// The grant-bearing features — device authorization and CIBA — MUST be registered BEFORE AddOidcServices: their
-// grant handlers must exist before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or a
+// The grant-bearing features - device authorization, CIBA and token exchange - MUST be registered
+// BEFORE AddOidcServices: their grant handlers must exist before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or a
 // handler lands beside the composite and the token endpoint resolves the wrong single IAuthorizationGrantHandler.
 // The endpoint-only opt-ins have no ordering constraint but are grouped here so the host mirrors the previous
 // every-endpoint-on server the E2E suite expects.
 builder.Services.AddDeviceAuthorization();
 builder.Services.AddBackChannelAuthentication();
+builder.Services.AddTokenExchangeGrant();
 builder.Services.AddRevocation();
 builder.Services.AddIntrospection();
 builder.Services.AddCheckSession();

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarMetadataTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarMetadataTests.cs
@@ -26,9 +26,10 @@ public class RarMetadataTests(TestFactory factory) : RarTestBase(factory)
     public async Task Discovery_exposes_token_exchange_grant_type()
     {
         // RFC 8693 §5: AS that supports Token Exchange MUST advertise it in grant_types_supported.
-        // Automatic exposure via AddTokenExchangeGrant() -> AddAuthorizationGrant<TokenExchangeGrantHandler>,
-        // CompositeAuthorizationGrantHandler aggregates GrantTypesSupported across all registered
-        // handlers and the discovery pipeline reads from it.
+        // Exposure follows the host opting in: AddTokenExchangeGrant() -> AddAuthorizationGrant
+        // <TokenExchangeGrantHandler>, CompositeAuthorizationGrantHandler aggregates GrantTypesSupported
+        // across all registered handlers and the discovery pipeline reads from it. A host that never calls
+        // AddTokenExchangeGrant() therefore does not advertise the grant, which is the point of the opt-in.
         var client = CreateClient();
         var discovery = await FetchDiscoveryAsync(client);
 
@@ -73,7 +74,7 @@ public class RarMetadataTests(TestFactory factory) : RarTestBase(factory)
     {
         // The embedded test license declares valid_issuers = [TestConstants.Issuer] only.
         // Loading it at TestHost startup registers a permissive license, but
-        // LicenseChecker.CheckIssuer throws on any issuer that is not on that whitelist —
+        // LicenseChecker.CheckIssuer throws on any issuer that is not on that whitelist -
         // physically preventing the license from being lifted into a production host with
         // a different issuer URL. Touch a client first so the WebApplicationFactory bootstraps
         // the host (which is what triggers LicenseLoader.LoadAsync on the embedded JWT).

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Program.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Program.cs
@@ -8,6 +8,7 @@ using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.TestHost.TestStubs;
+using Abblix.Oidc.Server.Endpoints;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Consents;
@@ -21,20 +22,21 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 // Load the embedded test license JWT before any OIDC service touches LicenseChecker.
 // The license is scoped to valid_issuers=["https://auth.example.com"] (TestConstants.Issuer)
-// with issuer_limit=1, so it physically cannot be lifted into a production host —
+// with issuer_limit=1, so it physically cannot be lifted into a production host -
 // LicenseChecker.CheckIssuer throws on a non-matching issuer at startup.
 await LoadEmbeddedTestLicenseAsync();
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Opt into the endpoints that are no longer on by default (EnabledEndpoints now defaults to OidcEndpoints.Base).
-// The grant-bearing features — device authorization and CIBA — MUST be registered BEFORE AddOidcMinimalApi: their
-// grant handlers must exist before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or a
+// The grant-bearing features - device authorization, CIBA and token exchange - MUST be registered
+// BEFORE AddOidcMinimalApi: their grant handlers must exist before AddOidcCore's AddAuthorizationGrants() composes the grant handlers, or a
 // handler lands beside the composite and the token endpoint resolves the wrong single IAuthorizationGrantHandler.
 // The endpoint-only opt-ins have no ordering constraint but are grouped here so the host mirrors the previous
 // every-endpoint-on server the E2E suite expects.
 builder.Services.AddDeviceAuthorization();
 builder.Services.AddBackChannelAuthentication();
+builder.Services.AddTokenExchangeGrant();
 builder.Services.AddRevocation();
 builder.Services.AddIntrospection();
 builder.Services.AddCheckSession();


### PR DESCRIPTION
`AddTokenEndpoint` registered the token-exchange handler unconditionally, so every host advertised `urn:ietf:params:oauth:grant-type:token-exchange` in `grant_types_supported` whether or not any client was allowed to use it, and every host received the four subject-token resolvers, one of which reads the refresh-token store.

Token exchange delegates authority between parties. A deployment that never intends to should not publish that it can. Registration now follows the same shape as the other grant-bearing opt-ins, `AddBackChannelAuthentication` and `AddDeviceAuthorization`: the host calls `AddTokenExchangeGrant()` before `AddOidcCore`, or the grant does not exist for it.

Not a breaking change. The grant has never appeared in a published release, so no host has ever received it enabled.

Both E2E test hosts opt in explicitly, and `AddTokenExchangeGrant`'s XML doc now states the opt-in and the ordering requirement.