### PR TITLE
Give Abblix.Utils tests of its own: Result and the validation attributes

### DIFF
--- a/tests/Abblix.Utils.UnitTests/ResultTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ResultTests.cs
@@ -1,0 +1,252 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Utils.UnitTests;
+
+/// <summary>
+/// The two arms of <see cref="Result{TSuccess,TFailure}"/>, member by member.
+/// </summary>
+/// <remarks>
+/// This type carries every protocol decision the server makes - a request is honoured or refused, and the
+/// refusal travels back as the failure arm rather than as an exception. It had no tests of its own: what
+/// coverage it showed came from the server exercising it in passing, which proves the paths that server
+/// happens to take and says nothing about the rest of the surface a consumer may call.
+///
+/// Every member below is asserted on both arms, because success and failure are two separate
+/// implementations of the same abstract member. A member that is right on one and wrong on the other reads
+/// as covered from a single call, and the wrong half is the one that only runs when something has already
+/// gone wrong - which is the worst moment to discover it.
+/// </remarks>
+public class ResultTests
+{
+    private static Result<int, string> Ok(int value = 42) => Result<int, string>.Success(value);
+    private static Result<int, string> No(string error = "refused") => Result<int, string>.Failure(error);
+
+    [Fact]
+    public void SuccessAndFailureAreTellable()
+    {
+        Assert.True(Ok().TryGetSuccess(out var value));
+        Assert.Equal(42, value);
+        Assert.False(Ok().TryGetFailure(out _));
+
+        Assert.True(No().TryGetFailure(out var error));
+        Assert.Equal("refused", error);
+        Assert.False(No().TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// A value or an error becomes a result without being wrapped by hand, which is what lets a method
+    /// body <c>return</c> either one.
+    /// </summary>
+    [Fact]
+    public void AValueOrAnErrorConvertsOnItsOwn()
+    {
+        Result<int, string> fromValue = 7;
+        Result<int, string> fromError = "denied";
+
+        Assert.True(fromValue.TryGetSuccess(out var value));
+        Assert.Equal(7, value);
+        Assert.True(fromError.TryGetFailure(out var error));
+        Assert.Equal("denied", error);
+    }
+
+    /// <summary>
+    /// Reading the arm that is not there is a programming mistake, not a value, so it throws rather than
+    /// answering with a default that would travel on as if it meant something.
+    /// </summary>
+    [Fact]
+    public void ReadingTheOtherArmThrows()
+    {
+        Assert.Equal(42, Ok().GetSuccess());
+        Assert.Throws<InvalidOperationException>(() => Ok().GetFailure());
+
+        Assert.Equal("refused", No().GetFailure());
+        Assert.Throws<InvalidOperationException>(() => No().GetSuccess());
+    }
+
+    [Fact]
+    public void TheExplicitConversionIsTheSuccessValue()
+    {
+        Assert.Equal(42, (int)Ok());
+        Assert.Throws<InvalidOperationException>(() => (int)No());
+    }
+
+    [Fact]
+    public void MatchPicksTheArmThatIsThere()
+    {
+        Assert.Equal("ok:42", Ok().Match(value => $"ok:{value}", error => $"no:{error}"));
+        Assert.Equal("no:refused", No().Match(value => $"ok:{value}", error => $"no:{error}"));
+    }
+
+    [Fact]
+    public async Task MatchAsyncPicksTheArmThatIsThere_WithASynchronousFailureArm()
+    {
+        Assert.Equal(
+            "ok:42",
+            await Ok().MatchAsync(value => Task.FromResult($"ok:{value}"), error => $"no:{error}"));
+
+        Assert.Equal(
+            "no:refused",
+            await No().MatchAsync(value => Task.FromResult($"ok:{value}"), error => $"no:{error}"));
+    }
+
+    [Fact]
+    public async Task MatchAsyncPicksTheArmThatIsThere_WithBothArmsAsynchronous()
+    {
+        Assert.Equal(
+            "ok:42",
+            await Ok().MatchAsync(
+                value => Task.FromResult($"ok:{value}"), error => Task.FromResult($"no:{error}")));
+
+        Assert.Equal(
+            "no:refused",
+            await No().MatchAsync(
+                value => Task.FromResult($"ok:{value}"), error => Task.FromResult($"no:{error}")));
+    }
+
+    /// <summary>
+    /// Mapping one arm leaves the other alone. That is the whole point: a pipeline transforms the value it
+    /// is carrying and a refusal travels through it untouched, arriving as the refusal that was made.
+    /// </summary>
+    [Fact]
+    public void MappingOneArmLeavesTheOther()
+    {
+        Assert.Equal(84, Ok().MapSuccess(value => value * 2).GetSuccess());
+        Assert.Equal("refused", No().MapSuccess(value => value * 2).GetFailure());
+
+        Assert.Equal("REFUSED", No().MapFailure(error => error.ToUpperInvariant()).GetFailure());
+        Assert.Equal(42, Ok().MapFailure(error => error.ToUpperInvariant()).GetSuccess());
+    }
+
+    [Fact]
+    public async Task MappingOneArmLeavesTheOther_Asynchronously()
+    {
+        Assert.Equal(84, (await Ok().MapSuccessAsync(value => Task.FromResult(value * 2))).GetSuccess());
+        Assert.Equal(
+            "refused", (await No().MapSuccessAsync(value => Task.FromResult(value * 2))).GetFailure());
+
+        Assert.Equal(
+            "REFUSED",
+            (await No().MapFailureAsync(error => Task.FromResult(error.ToUpperInvariant()))).GetFailure());
+        Assert.Equal(
+            42, (await Ok().MapFailureAsync(error => Task.FromResult(error.ToUpperInvariant()))).GetSuccess());
+    }
+
+    [Fact]
+    public void MapTransformsWhicheverArmIsThere()
+    {
+        var mappedSuccess = Ok().Map(value => value.ToString(), error => error.Length);
+        Assert.Equal("42", mappedSuccess.GetSuccess());
+
+        var mappedFailure = No().Map(value => value.ToString(), error => error.Length);
+        Assert.Equal("refused".Length, mappedFailure.GetFailure());
+    }
+
+    /// <summary>
+    /// Binding continues the chain on success and stops it on failure, which is what keeps a caller from
+    /// having to ask after every step whether it is still worth continuing.
+    /// </summary>
+    [Fact]
+    public void BindContinuesOnSuccessAndStopsOnFailure()
+    {
+        Assert.Equal(
+            "42", Ok().Bind(value => Result<string, string>.Success(value.ToString())).GetSuccess());
+
+        Assert.Equal(
+            "refused", No().Bind(value => Result<string, string>.Success(value.ToString())).GetFailure());
+
+        // A step that refuses turns the chain into that refusal.
+        Assert.Equal("second step said no", Ok().Bind(_ => Result<string, string>.Failure("second step said no"))
+            .GetFailure());
+    }
+
+    [Fact]
+    public void BindingAnActionRunsItOnlyOnSuccess()
+    {
+        var ran = 0;
+
+        Assert.Equal(42, Ok().Bind(_ => ran++).GetSuccess());
+        Assert.Equal(1, ran);
+
+        Assert.Equal("refused", No().Bind(_ => ran++).GetFailure());
+        Assert.Equal(1, ran);
+    }
+
+    [Fact]
+    public async Task BindingAsynchronouslyContinuesOnSuccessAndStopsOnFailure()
+    {
+        Assert.Equal(
+            "42",
+            (await Ok().BindAsync(value => Task.FromResult(Result<string, string>.Success(value.ToString()))))
+            .GetSuccess());
+
+        Assert.Equal(
+            "refused",
+            (await No().BindAsync(value => Task.FromResult(Result<string, string>.Success(value.ToString()))))
+            .GetFailure());
+    }
+
+    [Fact]
+    public async Task BindingAnAsynchronousActionRunsItOnlyOnSuccess()
+    {
+        var ran = 0;
+
+        Assert.Equal(42, (await Ok().BindAsync(_ => { ran++; return Task.CompletedTask; })).GetSuccess());
+        Assert.Equal(1, ran);
+
+        Assert.Equal("refused", (await No().BindAsync(_ => { ran++; return Task.CompletedTask; })).GetFailure());
+        Assert.Equal(1, ran);
+    }
+
+    /// <summary>
+    /// Ensure turns a condition on the carried value into a refusal, and leaves an existing refusal as it
+    /// is rather than replacing it with the new one.
+    /// </summary>
+    [Fact]
+    public void EnsureRefusesOnlyWhatItIsGiven()
+    {
+        Assert.Equal(42, Ok().Ensure(value => value > 0, "not positive").GetSuccess());
+        Assert.Equal("not positive", Ok().Ensure(value => value < 0, "not positive").GetFailure());
+
+        // The first refusal is the one that happened; the predicate never sees a value to judge.
+        Assert.Equal("refused", No().Ensure(value => value < 0, "not positive").GetFailure());
+    }
+
+    [Fact]
+    public void DeconstructionYieldsTheArmThatIsThere()
+    {
+        var (successValue, successError) = Ok();
+        Assert.Equal(42, successValue);
+        Assert.Null(successError);
+
+        var (failureValue, failureError) = No();
+        Assert.Equal(default, failureValue);
+        Assert.Equal("refused", failureError);
+    }
+
+    [Fact]
+    public void ToStringSpeaksForWhicheverArmIsThere()
+    {
+        Assert.Equal("42", Ok().ToString());
+        Assert.Equal("refused", No().ToString());
+    }
+}

--- a/tests/Abblix.Utils.UnitTests/ValidationAttributeTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ValidationAttributeTests.cs
@@ -1,0 +1,235 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Abblix.Utils.Validation;
+
+// Aliased because .NET ships its own AllowedValuesAttribute in System.ComponentModel.DataAnnotations, and
+// an unqualified name here binds to whichever is in scope. The two are not interchangeable: the framework's
+// judges a single value against a set of objects, this one also flattens arrays and arrays of arrays, which
+// is the shape a response_type or scope list arrives in.
+using AllowedValuesAttribute = Abblix.Utils.Validation.AllowedValuesAttribute;
+
+namespace Abblix.Utils.UnitTests;
+
+/// <summary>
+/// The three validation attributes, each on the shapes a request can actually carry.
+/// </summary>
+/// <remarks>
+/// These decide whether a value that arrived from outside is allowed to go further, and they had no tests
+/// of their own. An attribute that accepts what it should refuse fails silently by construction: the
+/// request proceeds, and whatever the value breaks does so somewhere else entirely.
+/// Each case below is a value shape a real request produces - a missing member, an empty string, a
+/// relative address, an array with a hole in it - rather than a sampling of the type system.
+/// </remarks>
+public class ValidationAttributeTests
+{
+    /// <summary>
+    /// A reflection target, not a subject: the attributes read the member's own metadata to name it in a
+    /// refusal, so the test needs one member carrying a wire name and one without. The values are never
+    /// read - what is validated is passed to the attribute directly.
+    /// </summary>
+    private sealed class Model
+    {
+        [JsonPropertyName("redirect_uri")]
+        public string? RedirectUri { get; init; } = null;
+
+        public string? Undecorated { get; init; } = null;
+    }
+
+    private static ValidationContext ContextFor(string memberName)
+        => new(new Model()) { MemberName = memberName, DisplayName = memberName };
+
+    private static ValidationResult? Validate(ValidationAttribute attribute, object? value, string member)
+        => attribute.GetValidationResult(value, ContextFor(member));
+
+    /// <summary>
+    /// An absent or empty value is not the concern of this attribute: whether a member is required is a
+    /// separate question, asked by a separate attribute, and answering it here would refuse a request that
+    /// simply left an optional member out.
+    /// </summary>
+    [Fact]
+    public void AnAbsoluteUri_TreatsAbsenceAsSomeoneElsesQuestion()
+    {
+        var attribute = new AbsoluteUriAttribute();
+
+        Assert.Null(Validate(attribute, null, nameof(Model.Undecorated)));
+        Assert.Null(Validate(attribute, string.Empty, nameof(Model.Undecorated)));
+        Assert.Null(Validate(attribute, new Uri(string.Empty, UriKind.Relative), nameof(Model.Undecorated)));
+    }
+
+    [Fact]
+    public void AnAbsoluteUri_AcceptsAnAbsoluteAddressAsStringOrUri()
+    {
+        var attribute = new AbsoluteUriAttribute();
+
+        Assert.Null(Validate(attribute, "https://client.example.com/cb", nameof(Model.Undecorated)));
+        Assert.Null(Validate(attribute, new Uri("https://client.example.com/cb"), nameof(Model.Undecorated)));
+    }
+
+    [Fact]
+    public void AnAbsoluteUri_RefusesARelativeAddress()
+    {
+        var attribute = new AbsoluteUriAttribute();
+
+        var result = Validate(attribute, "/callback", nameof(Model.Undecorated));
+
+        Assert.NotNull(result);
+        Assert.Contains("not absolute", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// When a scheme is demanded, another one is refused by name. This is the check behind "https only",
+    /// so the case that matters is the one where the address is perfectly well formed and simply plain.
+    /// </summary>
+    [Fact]
+    public void AnAbsoluteUri_RefusesAnotherSchemeWhenOneIsDemanded()
+    {
+        var attribute = new AbsoluteUriAttribute(Uri.UriSchemeHttps);
+
+        Assert.Null(Validate(attribute, "https://client.example.com/cb", nameof(Model.Undecorated)));
+
+        var result = Validate(attribute, "http://client.example.com/cb", nameof(Model.Undecorated));
+        Assert.NotNull(result);
+        Assert.Contains("https", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnAbsoluteUri_RefusesAValueThatIsNotAnAddressAtAll()
+    {
+        var attribute = new AbsoluteUriAttribute();
+
+        var result = Validate(attribute, 42, nameof(Model.Undecorated));
+
+        Assert.NotNull(result);
+        Assert.Contains(nameof(Int32), result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The message names the member as it appears on the wire, not as it is spelled in C#.
+    /// </summary>
+    /// <remarks>
+    /// A refusal is read by whoever sent the request, and they sent <c>redirect_uri</c>. Naming the
+    /// property instead would describe an object they have never seen.
+    /// </remarks>
+    [Fact]
+    public void AnAbsoluteUri_NamesTheMemberByItsWireName()
+    {
+        var result = Validate(new AbsoluteUriAttribute(), "/callback", nameof(Model.RedirectUri));
+
+        Assert.NotNull(result);
+        Assert.Contains("redirect_uri", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllowedValues_AcceptsWhatIsListed_RegardlessOfCase()
+    {
+        var attribute = new AllowedValuesAttribute("code", "id_token");
+
+        Assert.Null(Validate(attribute, "code", nameof(Model.Undecorated)));
+        Assert.Null(Validate(attribute, "CODE", nameof(Model.Undecorated)));
+        Assert.Null(Validate(attribute, null, nameof(Model.Undecorated)));
+    }
+
+    [Fact]
+    public void AllowedValues_RefusesWhatIsNot_AndSaysWhich()
+    {
+        var attribute = new AllowedValuesAttribute("code", "id_token");
+
+        var result = Validate(attribute, "token", nameof(Model.Undecorated));
+
+        Assert.NotNull(result);
+        Assert.Contains("token", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An array is judged element by element, and one disallowed entry refuses the whole value - a request
+    /// asking for two things gets neither when it may only have one of them.
+    /// </summary>
+    [Fact]
+    public void AllowedValues_JudgesEveryElementOfAnArray()
+    {
+        var attribute = new AllowedValuesAttribute("code", "id_token");
+
+        Assert.Null(Validate(attribute, new[] { "code", "id_token" }, nameof(Model.Undecorated)));
+        Assert.NotNull(Validate(attribute, new[] { "code", "token" }, nameof(Model.Undecorated)));
+    }
+
+    /// <summary>
+    /// The nested shape is the one a response_type list takes: several requests, each of several values.
+    /// </summary>
+    [Fact]
+    public void AllowedValues_FlattensAnArrayOfArrays()
+    {
+        var attribute = new AllowedValuesAttribute("code", "id_token");
+
+        Assert.Null(Validate(
+            attribute,
+            new[] { new[] { "code" }, new[] { "id_token", "code" } },
+            nameof(Model.Undecorated)));
+
+        Assert.NotNull(Validate(
+            attribute,
+            new[] { new[] { "code" }, new[] { "token" } },
+            nameof(Model.Undecorated)));
+    }
+
+    /// <summary>
+    /// A type the attribute cannot judge is a wiring mistake rather than a bad request, so it throws
+    /// instead of quietly reporting success on a value it never looked at.
+    /// </summary>
+    [Fact]
+    public void AllowedValues_ThrowsOnATypeItCannotJudge()
+        => Assert.Throws<InvalidOperationException>(
+            () => Validate(new AllowedValuesAttribute("code"), 42, nameof(Model.Undecorated)));
+
+    [Fact]
+    public void ElementsRequired_RefusesACollectionWithAHoleInIt()
+    {
+        var attribute = new ElementsRequiredAttribute();
+
+        Assert.True(attribute.IsValid(new[] { "a", "b" }));
+        Assert.False(attribute.IsValid(new[] { "a", null }));
+        Assert.True(attribute.IsValid(Array.Empty<string>()));
+    }
+
+    /// <summary>
+    /// Anything that is not a collection is not this attribute's business, including a bare value and an
+    /// absent one.
+    /// </summary>
+    [Fact]
+    public void ElementsRequired_LeavesANonCollectionAlone()
+    {
+        var attribute = new ElementsRequiredAttribute();
+
+        Assert.True(attribute.IsValid(42));
+        Assert.True(attribute.IsValid(null));
+    }
+
+    [Fact]
+    public void ElementsRequired_NamesTheMemberInItsMessage()
+        => Assert.Contains(
+            "redirect_uris",
+            new ElementsRequiredAttribute().FormatErrorMessage("redirect_uris"),
+            StringComparison.Ordinal);
+}


### PR DESCRIPTION
`Abblix.Utils` is a library other people call, so the question its coverage should answer is whether its own suite exercises its surface - not whether the server happens to reach it.

Measured that way it starts at **44.3% of lines, 50.2% of branches**, not the 66.6% #273 quotes from a merged solution run. The 22-point difference is coverage borrowed from `Abblix.Oidc.Server` exercising the library in passing, which proves the paths that consumer takes and says nothing about the rest.

After this change: **60.9% lines, 61.1% branches**, from its own tests alone.

## Result

The type every protocol decision travels on - honoured or refused - and it carried none of its own tests. Success and failure are two separate implementations of each abstract member, so a member correct on one and wrong on the other reads as covered from a single call, and the wrong half is the one that only runs once something has already gone wrong.

Both arms are asserted for each member: the factories and both implicit conversions, `Match` and its two async overloads, `MapSuccess`/`MapFailure` with their async pairs, `Map`, the try-get pair, the throwing reads of the absent arm, `Bind` in its four shapes, `Ensure` - including that it leaves an existing refusal alone rather than replacing it - `Deconstruct` and `ToString`.

## The validation attributes

These decide whether a value from outside may go further. An attribute that accepts what it should refuse fails silently by construction: the request proceeds and the damage appears elsewhere.

Each case is a shape a real request produces. `AbsoluteUriAttribute` treats absence as someone else's question, accepts a string or a `Uri`, refuses a relative address, refuses another scheme by name when one is demanded, refuses a value that is not an address, and names the member as the wire spells it - the refusal is read by whoever sent `redirect_uri` and has never seen the property. `AllowedValuesAttribute` judges a single value case-insensitively, every element of an array, and the array-of-arrays a `response_type` list arrives in, and throws on a type it cannot judge rather than reporting success on a value it never looked at. `ElementsRequiredAttribute` refuses a collection with a hole in it.

Worth knowing for a consumer: .NET ships its own `AllowedValuesAttribute` in `System.ComponentModel.DataAnnotations`, so an unqualified name binds to whichever is in scope, and the two are not interchangeable - ours also flattens arrays. The test file aliases it for that reason.

## Still dark

Recorded rather than left to be rediscovered: `EnumerableExtensions` (96 lines), `HttpServerUtility` (80), `ResultExtensions` (66), `ArrayExtensions` (60), `UriExtensions` (56), `Base64UrlTextEncoderConverter` (40), `JsonIgnoreNullsModifier` (28), `CultureInfoConverter` (26), `TimeSpanSecondsConverter` (20), `StringExtensions` (18), and a handful of smaller converters.

Part of #273.