### PR TITLE
Decouple the core from ASP.NET and carry a cancellation token through the token endpoint

### DIFF
--- a/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -408,11 +408,14 @@ public static class EndpointRouteBuilderExtensions
         TokenRequest tokenRequest,
         ClientRequest clientRequest,
         ITokenHandler handler,
-        ITokenResultFormatter formatter)
+        ITokenResultFormatter formatter,
+        CancellationToken cancellationToken)
     {
         Core.TokenRequest coreTokenRequest = tokenRequest;
         Core.ClientRequest coreClientRequest = clientRequest;
-        var response = await handler.HandleAsync(coreTokenRequest, coreClientRequest);
+        // Minimal API binds this parameter to the request's own RequestAborted. CIBA holds this call open for
+        // the long-polling window, so without it a client that disconnects leaves the server polling storage.
+        var response = await handler.HandleAsync(coreTokenRequest, coreClientRequest, cancellationToken);
         return await formatter.FormatResponseAsync(coreTokenRequest, response);
     }
 

--- a/src/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Controllers/TokenController.cs
@@ -81,7 +81,9 @@ public class TokenController : ControllerBase
         [FromForm] ClientRequest clientRequest)
     {
         Core.TokenRequest coreTokenRequest = tokenRequest;
-        var response = await handler.HandleAsync(coreTokenRequest, clientRequest);
+        // The request's own token: CIBA holds this call open for the long-polling window, and without it a
+        // client that disconnects leaves the server polling storage for an answer nobody is waiting for.
+        var response = await handler.HandleAsync(coreTokenRequest, clientRequest, HttpContext.RequestAborted);
         return await formatter.FormatResponseAsync(coreTokenRequest, response);
     }
 

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/AuthorizationCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/AuthorizationCodeGrantHandler.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -67,10 +67,11 @@ public class AuthorizationCodeGrantHandler(
     /// Information about the client, used to verify that the request is valid for this client.</param>
     /// <returns>A task that represents the asynchronous authorization operation.
     /// The result is either an authorized grant or an error indicating why the request failed.</returns>
-    public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
     {
         // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
-        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        // not a server fault - the previous throw-on-access surfaced it as HTTP 500.
         if (!request.Code.HasValue())
         {
             return ErrorFactory.MissingParameter(TokenRequest.Parameters.Code);
@@ -112,7 +113,7 @@ public class AuthorizationCodeGrantHandler(
 
             // Validates the code verifier against the stored code challenge using the appropriate method.
             // base64url challenges (S256/S512) and the plain verifier are case-sensitive per RFC 7636 §4.6,
-            // so the comparison is ordinal — case folding would widen the accepted set and weaken the plain method.
+            // so the comparison is ordinal - case folding would widen the accepted set and weaken the plain method.
             if (!string.Equals(
                     grant.Context.CodeChallenge,
                     CalculateChallenge(grant.Context.CodeChallengeMethod, request.CodeVerifier),

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -29,7 +29,6 @@ using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -47,14 +46,12 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// <param name="options">Configuration options for backchannel authentication including long-polling settings.</param>
 /// <param name="serviceProvider">Service provider for resolving mode-specific grant processors.</param>
 /// <param name="statusNotifier">Notifier for long-polling status changes (null if long-polling disabled).</param>
-/// <param name="httpContextAccessor">Accessor for HTTP context to retrieve cancellation token.</param>
 public class BackChannelAuthenticationGrantHandler(
     IBackChannelRequestStorage storage,
     TimeProvider timeProvider,
     IOptions<OidcOptions> options,
     IServiceProvider serviceProvider,
-    IBackChannelLongPollingService? statusNotifier = null,
-    IHttpContextAccessor? httpContextAccessor = null) : IAuthorizationGrantHandler
+    IBackChannelLongPollingService? statusNotifier = null) : IAuthorizationGrantHandler
 {
     /// <summary>
     /// Specifies the grant types supported by this handler, specifically the "CIBA" (Client-Initiated Backchannel
@@ -94,10 +91,11 @@ public class BackChannelAuthenticationGrantHandler(
     /// Either an authorized grant if authentication succeeded, or an error indicating why the request failed
     /// (authorization_pending, access_denied, expired_token, slow_down, or invalid_grant).
     /// </returns>
-    public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
     {
         // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
-        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        // not a server fault - the previous throw-on-access surfaced it as HTTP 500.
         if (!request.AuthenticationRequestId.HasValue())
         {
             return ErrorFactory.MissingParameter(TokenRequest.Parameters.AuthenticationRequestId);
@@ -143,7 +141,8 @@ public class BackChannelAuthenticationGrantHandler(
             // If the user has not yet been authenticated and the request is still pending,
             // either wait for status change (long-polling) or return immediately (short-polling)
             { Status: BackChannelAuthenticationStatus.Pending } pendingRequest
-                => await HandlePendingRequestAsync(request.AuthenticationRequestId, pendingRequest, clientInfo),
+                => await HandlePendingRequestAsync(
+                    request.AuthenticationRequestId, pendingRequest, clientInfo, cancellationToken),
 
             // If the user denied the authentication request, return an error indicating access is denied
             { Status: BackChannelAuthenticationStatus.Denied }
@@ -170,11 +169,13 @@ public class BackChannelAuthenticationGrantHandler(
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="authenticationRequest">The pending authentication request to update.</param>
     /// <param name="clientInfo">Client information for determining token delivery mode.</param>
+    /// <param name="cancellationToken">Abandons the wait when the caller stops waiting.</param>
     /// <returns>Either an authorized grant if authentication completed during long-polling, or authorization_pending error.</returns>
     private async Task<Result<AuthorizedGrant, OidcError>> HandlePendingRequestAsync(
         string authenticationRequestId,
         Features.BackChannelAuthentication.BackChannelAuthenticationRequest authenticationRequest,
-        ClientInfo clientInfo)
+        ClientInfo clientInfo,
+        CancellationToken cancellationToken)
     {
         // Calculate remaining time before expiration
         var expiresIn = authenticationRequest.ExpiresAt - timeProvider.GetUtcNow();
@@ -196,7 +197,7 @@ public class BackChannelAuthenticationGrantHandler(
 
         if (options.Value.BackChannelAuthentication.UseLongPolling && statusNotifier != null)
         {
-            var result = await TryLongPollingAsync(authenticationRequestId, clientInfo);
+            var result = await TryLongPollingAsync(authenticationRequestId, clientInfo, cancellationToken);
             if (result != null)
             {
                 return result;
@@ -214,18 +215,20 @@ public class BackChannelAuthenticationGrantHandler(
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="clientInfo">Client information for determining token delivery mode.</param>
+    /// <param name="cancellationToken">Abandons the wait when the caller stops waiting.</param>
     /// <returns>
     /// The result of processing the updated request if status changed, or null if timeout occurred.
     /// Null indicates the caller should return authorization_pending error.
     /// </returns>
     private async Task<Result<AuthorizedGrant, OidcError>?> TryLongPollingAsync(
         string authenticationRequestId,
-        ClientInfo clientInfo)
+        ClientInfo clientInfo,
+        CancellationToken cancellationToken)
     {
         var statusChanged = await statusNotifier!.WaitForStatusChangeAsync(
             authenticationRequestId,
             options.Value.BackChannelAuthentication.LongPollingTimeout,
-            httpContextAccessor?.HttpContext?.RequestAborted ?? CancellationToken.None);
+            cancellationToken);
 
         if (!statusChanged)
         {

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/ClientCredentialsGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/ClientCredentialsGrantHandler.cs
@@ -70,7 +70,8 @@ public class ClientCredentialsGrantHandler(
 	/// <param name="request">The token request containing the requested scope and other parameters.</param>
 	/// <param name="clientInfo">Information about the authenticated client making the request.</param>
 	/// <returns>A task that completes with an authorized grant containing the client session and context.</returns>
-	public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+	/// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+	public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
 	{
 		// Extract the requested scope from the request (may be null/empty)
 		var scope = request.Scope;

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/CompositeAuthorizationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/CompositeAuthorizationGrantHandler.cs
@@ -67,7 +67,8 @@ public class CompositeAuthorizationGrantHandler(IEnumerable<IAuthorizationGrantH
     /// <returns>A task that resolves to the result of the authorization process.
     /// If successful, it contains the granted authorization;
     /// otherwise, it contains an error explaining why the authorization failed.</returns>
-    public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
     {
         // Check if there is a handler for the requested grant type.
         // If no handler exists, return an error indicating that the grant type is unsupported.
@@ -79,6 +80,6 @@ public class CompositeAuthorizationGrantHandler(IEnumerable<IAuthorizationGrantH
         }
 
         // Delegate the authorization request to the handler that supports the specified grant type.
-        return await grantHandler.AuthorizeAsync(request, clientInfo);
+        return await grantHandler.AuthorizeAsync(request, clientInfo, cancellationToken);
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -55,10 +55,11 @@ public class DeviceCodeGrantHandler(
     /// <inheritdoc />
     public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(
         TokenRequest request,
-        ClientInfo clientInfo)
+        ClientInfo clientInfo,
+    CancellationToken cancellationToken)
     {
         // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
-        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        // not a server fault - the previous throw-on-access surfaced it as HTTP 500.
         if (!request.DeviceCode.HasValue())
         {
             return ErrorFactory.MissingParameter(TokenRequest.Parameters.DeviceCode);
@@ -116,7 +117,7 @@ public class DeviceCodeGrantHandler(
                 if (!await TryBumpNextPollAsync(
                         request.DeviceCode, nextPollAt + pollingInterval, deviceRequest.ExpiresAt - now))
                 {
-                    return await AuthorizeAsync(request, clientInfo);
+                    return await AuthorizeAsync(request, clientInfo, cancellationToken);
                 }
 
                 return new OidcError(
@@ -129,7 +130,7 @@ public class DeviceCodeGrantHandler(
                 if (!await TryBumpNextPollAsync(
                         request.DeviceCode, now + pollingInterval, deviceRequest.ExpiresAt - now))
                 {
-                    return await AuthorizeAsync(request, clientInfo);
+                    return await AuthorizeAsync(request, clientInfo, cancellationToken);
                 }
 
                 return new OidcError(

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/IAuthorizationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/IAuthorizationGrantHandler.cs
@@ -48,5 +48,24 @@ public interface IAuthorizationGrantHandler : IGrantTypeInformer
 	/// <param name="request">The token request (already authenticated against the client).</param>
 	/// <param name="clientInfo">The authenticated client; used to enforce that the grant was
 	/// issued to the same client that is now redeeming it.</param>
-	Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo);
+	[Obsolete("Implement and call the overload taking a CancellationToken. This one is kept so an existing " +
+	          "implementation keeps working, and will be removed in the next major version.")]
+	Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+		=> AuthorizeAsync(request, clientInfo, CancellationToken.None);
+
+	/// <inheritdoc cref="AuthorizeAsync(TokenRequest, ClientInfo)"/>
+	/// <param name="request">The token request (already authenticated against the client).</param>
+	/// <param name="clientInfo">The authenticated client.</param>
+	/// <param name="cancellationToken">
+	/// Abandons the resolution when the caller stops waiting. CIBA holds this call open for the configured
+	/// long-polling timeout, so a handler that never receives the token goes on polling storage for a client
+	/// that disconnected.
+	/// </param>
+	/// <remarks>
+	/// This is the member an implementation provides. The obsolete overload above defaults to forwarding here,
+	/// so a caller still holding the old signature keeps working, while an implementation that provided only
+	/// the old one fails to compile rather than silently never receiving the token.
+	/// </remarks>
+	Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(
+		TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -109,9 +109,11 @@ public partial class JwtBearerGrantHandler(
 	/// A task that completes with either an authorized grant containing the user session and context,
 	/// or an error indicating why the JWT assertion was rejected.
 	/// </returns>
+	/// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
 	public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(
 		TokenRequest request,
-		ClientInfo clientInfo)
+		ClientInfo clientInfo,
+		CancellationToken cancellationToken)
 	{
 		return ValidateAssertionParameter(request, clientInfo)
 			.BindAsync(assertion => ValidateJwtAsync(assertion, clientInfo))

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/PasswordGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/PasswordGrantHandler.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -62,10 +62,11 @@ public class PasswordGrantHandler(
     /// </param>
     /// <returns>A task that completes with the authorization result, which could be an error or successful grant.
     /// </returns>
-    public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
     {
         // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
-        // not a server fault — the previous throw-on-access surfaced it as HTTP 500.
+        // not a server fault - the previous throw-on-access surfaced it as HTTP 500.
         if (!request.UserName.HasValue())
         {
             return Task.FromResult<Result<AuthorizedGrant, OidcError>>(

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/RefreshTokenGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/RefreshTokenGrantHandler.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -65,7 +65,8 @@ public class RefreshTokenGrantHandler(
 	/// A task representing the outcome of the authorization process, either returning a successful grant with a new
 	/// access token or an error if the request is invalid or the refresh token is unauthorized.
 	/// </returns>
-	public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+	/// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+	public async Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
 	{
 		// RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
 		// not a server fault - the previous throw-on-access surfaced it as HTTP 500.

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -78,7 +78,8 @@ public class TokenExchangeGrantHandler(
     /// <inheritdoc/>
     public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(
         TokenRequest request,
-        ClientInfo clientInfo)
+        ClientInfo clientInfo,
+        CancellationToken cancellationToken)
     {
         Result<ValidationContext, OidcError> initial = new ValidationContext(request, clientInfo);
 
@@ -111,7 +112,7 @@ public class TokenExchangeGrantHandler(
     /// <summary>
     /// RFC 8693 §2.1: <c>subject_token</c> and <c>subject_token_type</c> are REQUIRED. A missing one
     /// is the caller's protocol error (<c>invalid_request</c> per RFC 6749 §5.2), not a server
-    /// fault — the previous throw-on-access surfaced it as HTTP 500.
+    /// fault - the previous throw-on-access surfaced it as HTTP 500.
     /// </summary>
     private static Result<ValidationContext, OidcError> ValidateRequiredParameters(ValidationContext ctx)
     {
@@ -334,12 +335,12 @@ public class TokenExchangeGrantHandler(
 
     /// <summary>
     /// Enforces the per-client <c>audience</c> allowlist (RFC 8693 §2.1). The requested audience is
-    /// written into the issued token's <c>aud</c> claim, so it must be constrained — otherwise a
+    /// written into the issued token's <c>aud</c> claim, so it must be constrained - otherwise a
     /// client could mint a token for any target service it names. The allowlist is default-deny: an
     /// <c>audience</c> is accepted only when the client declares a non-empty
     /// <see cref="ClientInfo.TokenExchangeAllowedAudiences"/> that contains every requested value.
     /// RFC 8707 <c>resource</c> values reach the <c>aud</c> claim through the exact same path
-    /// (see <c>AuthorizationContextExtensions.ApplyTo</c>), so a declared allowlist gates them too —
+    /// (see <c>AuthorizationContextExtensions.ApplyTo</c>), so a declared allowlist gates them too -
     /// otherwise renaming <c>audience</c> to <c>resource</c> would bypass the constraint entirely.
     /// A client without a declared allowlist keeps the asymmetric defaults: <c>audience</c> is
     /// default-deny because no other gate exists for logical service names, while <c>resource</c>
@@ -450,7 +451,7 @@ public class TokenExchangeGrantHandler(
         var clientInfo = ctx.ClientInfo;
 
         // RFC 8693 §4.1: issued token's subject is always the subject_token's subject (impersonation
-        // and delegation alike). Scope handling keeps the exchange least-privilege — the issued token
+        // and delegation alike). Scope handling keeps the exchange least-privilege - the issued token
         // never carries more authority than either the presented subject_token or the client's own
         // registration:
         //
@@ -460,7 +461,7 @@ public class TokenExchangeGrantHandler(
         //   the presented token. A subject token without a scope claim (e.g. an id_token) imposes no
         //   scope upper bound, so the RFC 8693 id_token -> access_token scenario keeps working.
         // - Fallback to the subject_token's scope (2b): the fallback path does not pass through
-        //   ScopeValidator, so it is filtered to the client's AllowedScopes here — otherwise a broker
+        //   ScopeValidator, so it is filtered to the client's AllowedScopes here - otherwise a broker
         //   client would obtain scopes it was never registered for (RFC 6749 §3.3).
         string[] scope;
         if (request.Scope is { Length: > 0 } requestedScope)

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ITokenHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ITokenHandler.cs
@@ -41,8 +41,8 @@ public interface ITokenHandler
     /// <param name="clientRequest">Supplementary information about the client making the request, necessary
     /// for performing contextual validation and ensuring the request complies with security policies.</param>
     /// <returns>
-    /// A <see cref="Task"/> resulting in a <see cref="TokenIssued"/> on success — which contains the issued tokens
-    /// (access token, refresh token, ID token, etc.) — or an <see cref="OidcError"/> describing the reason
+    /// A <see cref="Task"/> resulting in a <see cref="TokenIssued"/> on success, which contains the issued tokens
+    /// (access token, refresh token, ID token, etc.), or an <see cref="OidcError"/> describing the reason
     /// for request failure.
     /// </returns>
     /// <remarks>
@@ -50,5 +50,24 @@ public interface ITokenHandler
     /// authorization server. They must ensure that only valid and authorized requests lead to the issuance of tokens,
     /// thereby maintaining the integrity and security of the authentication and authorization process.
     /// </remarks>
-    Task<Result<TokenIssued, OidcError>> HandleAsync(TokenRequest tokenRequest, ClientRequest clientRequest);
+    [Obsolete("Implement and call the overload taking a CancellationToken. This one is kept so an existing " +
+              "implementation keeps working, and will be removed in the next major version.")]
+    Task<Result<TokenIssued, OidcError>> HandleAsync(TokenRequest tokenRequest, ClientRequest clientRequest)
+        => HandleAsync(tokenRequest, clientRequest, CancellationToken.None);
+
+    /// <inheritdoc cref="HandleAsync(TokenRequest, ClientRequest)"/>
+    /// <param name="tokenRequest">The token request.</param>
+    /// <param name="clientRequest">Supplementary information about the client making the request.</param>
+    /// <param name="cancellationToken">
+    /// Abandons the request when the caller stops waiting. The adapters pass the request's own token, so a
+    /// client that disconnects mid-request stops the work it started rather than leaving it to run out its
+    /// own timeout: CIBA holds this call open for the whole long-polling window.
+    /// </param>
+    /// <remarks>
+    /// This is the member an implementation provides. The obsolete overload above defaults to forwarding here,
+    /// so a caller still holding the old signature keeps working, while an implementation that provided only
+    /// the old one fails to compile rather than silently never receiving the token.
+    /// </remarks>
+    Task<Result<TokenIssued, OidcError>> HandleAsync(
+        TokenRequest tokenRequest, ClientRequest clientRequest, CancellationToken cancellationToken);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ITokenRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ITokenRequestValidator.cs
@@ -42,5 +42,20 @@ public interface ITokenRequestValidator
 	/// or an <see cref="OidcError"/> using one of the codes from RFC 6749 §5.2 (e.g. <c>invalid_grant</c>,
 	/// <c>invalid_client</c>, <c>unsupported_grant_type</c>).
 	/// </summary>
-	Task<Result<ValidTokenRequest, OidcError>> ValidateAsync(TokenRequest tokenRequest, ClientRequest clientRequest);
+	[Obsolete("Implement and call the overload taking a CancellationToken. This one is kept so an existing " +
+	          "implementation keeps working, and will be removed in the next major version.")]
+	Task<Result<ValidTokenRequest, OidcError>> ValidateAsync(TokenRequest tokenRequest, ClientRequest clientRequest)
+		=> ValidateAsync(tokenRequest, clientRequest, CancellationToken.None);
+
+	/// <inheritdoc cref="ValidateAsync(TokenRequest, ClientRequest)"/>
+	/// <param name="tokenRequest">The token request to validate.</param>
+	/// <param name="clientRequest">Supplementary information about the client making the request.</param>
+	/// <param name="cancellationToken">Abandons validation when the caller stops waiting.</param>
+	/// <remarks>
+	/// This is the member an implementation provides. The obsolete overload above defaults to forwarding here,
+	/// so a caller still holding the old signature keeps working, while an implementation that provided only
+	/// the old one fails to compile rather than silently never receiving the token.
+	/// </remarks>
+	Task<Result<ValidTokenRequest, OidcError>> ValidateAsync(
+		TokenRequest tokenRequest, ClientRequest clientRequest, CancellationToken cancellationToken);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/TokenHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/TokenHandler.cs
@@ -57,11 +57,13 @@ public class TokenHandler(ITokenRequestValidator validator, ITokenRequestProcess
     /// It employs rigorous validation to prevent unauthorized access and to maintain the integrity of the token
     /// lifecycle management process.
     /// </remarks>
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
     public async Task<Result<TokenIssued, OidcError>> HandleAsync(
         TokenRequest tokenRequest,
-        ClientRequest clientRequest)
+        ClientRequest clientRequest,
+        CancellationToken cancellationToken)
     {
-        var validationResult = await validator.ValidateAsync(tokenRequest, clientRequest);
+        var validationResult = await validator.ValidateAsync(tokenRequest, clientRequest, cancellationToken);
         return await validationResult.BindAsync(processor.ProcessAsync);
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -48,11 +48,13 @@ public class TokenRequestValidator(ITokenContextValidator validator) : ITokenReq
 	/// <returns>A <see cref="Task"/> that resolves to a <see cref="Result{ValidTokenRequest, AuthError}"/>,
 	/// indicating the outcome of the validation process. This result can either denote a successful validation
 	/// or contain error information specifying why the request was invalid.</returns>
-	public async Task<Result<ValidTokenRequest, OidcError>> ValidateAsync(TokenRequest tokenRequest, ClientRequest clientRequest)
+	/// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+	public async Task<Result<ValidTokenRequest, OidcError>> ValidateAsync(
+		TokenRequest tokenRequest, ClientRequest clientRequest, CancellationToken cancellationToken)
 	{
 		var context = new TokenValidationContext(tokenRequest, clientRequest);
 
-		var error = await validator.ValidateAsync(context);
+		var error = await validator.ValidateAsync(context, cancellationToken);
 		if (error != null)
 			return error;
 

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/AuthorizationGrantValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/AuthorizationGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -49,7 +49,8 @@ public class AuthorizationGrantValidator(IAuthorizationGrantHandler grantHandler
     /// including an error code and description;
     /// otherwise, null indicating that the grant is valid and the context has been updated.
     /// </returns>
-    public async Task<OidcError?> ValidateAsync(TokenValidationContext context)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public async Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken)
     {
         // Ensure the client is authorized to use the requested grant type
         if (!context.ClientInfo.AllowedGrantTypes.Contains(context.Request.GrantType))
@@ -59,7 +60,7 @@ public class AuthorizationGrantValidator(IAuthorizationGrantHandler grantHandler
                 "The grant type is not allowed for this client");
         }
 
-        var result = await grantHandler.AuthorizeAsync(context.Request, context.ClientInfo);
+        var result = await grantHandler.AuthorizeAsync(context.Request, context.ClientInfo, cancellationToken);
 
         if (result.TryGetFailure(out var error))
         {

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/ClientValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/ClientValidator.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -47,7 +47,8 @@ public class ClientValidator(IClientAuthenticator clientAuthenticator): ITokenCo
     /// A <see cref="OidcError"/> if the client cannot be authenticated,
     /// otherwise null indicating successful validation.
     /// </returns>
-    public async Task<OidcError?> ValidateAsync(TokenValidationContext context)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public async Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken)
     {
         var clientRequest = context.ClientRequest;
         var clientInfo = await clientAuthenticator.TryAuthenticateClientAsync(clientRequest);

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/DPoPTokenEndpointValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/DPoPTokenEndpointValidator.cs
@@ -41,7 +41,7 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Validation;
 /// token.
 /// </summary>
 /// <remarks>
-/// Sits AFTER <see cref="ClientValidator"/> in the composite — that ordering is
+/// Sits AFTER <see cref="ClientValidator"/> in the composite - that ordering is
 /// load-bearing because this step reads <see cref="TokenValidationContext.ClientInfo"/>
 /// to decide whether DPoP is mandatory (<see cref="ClientInfo.RequireDPoP"/>)
 /// or opportunistic. When the client opts in but the proof is missing, the request is
@@ -56,7 +56,7 @@ public partial class DPoPTokenEndpointValidator(
     IOptionsMonitor<OidcOptions> options) : DPoPNonceValidator(nonceService), ITokenContextValidator
 {
     /// <inheritdoc/>
-    public async Task<OidcError?> ValidateAsync(TokenValidationContext context)
+    public async Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken)
     {
         if (ValidateCertificateBinding(context) is { } certificateError)
             return certificateError;
@@ -70,7 +70,7 @@ public partial class DPoPTokenEndpointValidator(
 
     /// <summary>
     /// RFC 8705 §4: a grant issued with a certificate-bound token must be redeemed (e.g. on refresh) by
-    /// re-presenting the same certificate. Clients that authenticate via mutual TLS are skipped — their
+    /// re-presenting the same certificate. Clients that authenticate via mutual TLS are skipped - their
     /// authentication already proved certificate possession on this connection. For every other
     /// authentication method (including public 'none') the binding is otherwise never checked, so a stolen
     /// certificate-bound refresh token would be redeemable with no certificate at all while the issued

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/ITokenContextValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/ITokenContextValidator.cs
@@ -40,5 +40,21 @@ public interface ITokenContextValidator
     /// A <see cref="OidcError"/> containing error details if the validation fails;
     /// otherwise, returns null indicating that the validation was successful.
     /// </returns>
-    Task<OidcError?> ValidateAsync(TokenValidationContext context);
+    [Obsolete("Implement and call the overload taking a CancellationToken. This one is kept so an existing " +
+              "implementation keeps working, and will be removed in the next major version.")]
+    Task<OidcError?> ValidateAsync(TokenValidationContext context)
+        => ValidateAsync(context, CancellationToken.None);
+
+    /// <inheritdoc cref="ValidateAsync(TokenValidationContext)"/>
+    /// <param name="context">The context containing the token request and related information.</param>
+    /// <param name="cancellationToken">
+    /// Abandons validation when the caller stops waiting. It is a parameter rather than a member of the
+    /// context because the context carries per-call data, and a cancellation token is not data.
+    /// </param>
+    /// <remarks>
+    /// This is the member an implementation provides. The obsolete overload above defaults to forwarding here,
+    /// so a caller still holding the old signature keeps working, while an implementation that provided only
+    /// the old one fails to compile rather than silently never receiving the token.
+    /// </remarks>
+    Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/SyncTokenContextValidatorBase.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/SyncTokenContextValidatorBase.cs
@@ -42,7 +42,8 @@ public abstract class SyncTokenContextValidatorBase : ITokenContextValidator
     /// if the validation fails;
     /// otherwise, resolves to null indicating that the validation was successful.
     /// </returns>
-    public Task<OidcError?> ValidateAsync(TokenValidationContext context)
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken)
         => Task.FromResult(Validate(context));
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/TokenContextValidatorComposite.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/TokenContextValidatorComposite.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -44,6 +44,7 @@ public class TokenContextValidatorComposite(ITokenContextValidator[] validators)
     /// A <see cref="OidcError"/> containing error details if any validation step fails;
     /// otherwise, returns null indicating that all validation steps were successful.
     /// </returns>
-    public Task<OidcError?> ValidateAsync(TokenValidationContext context)
-        => validators.FirstOrDefaultAsync(v => v.ValidateAsync(context));
+    /// <param name="cancellationToken">Abandons the operation when the caller stops waiting.</param>
+    public Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken)
+        => validators.FirstOrDefaultAsync(v => v.ValidateAsync(context, cancellationToken));
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -20,9 +20,9 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
-using Microsoft.AspNetCore.Http;
 
 namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
@@ -34,13 +34,15 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// <param name="storage">The storage service for device authorization requests.</param>
 /// <param name="rateLimiter">The rate limiter for preventing brute force attacks.</param>
 /// <param name="normalizer">Canonicalizes user-entered codes before lookup (RFC 8628 Section 6.1).</param>
-/// <param name="httpContextAccessor">Accessor for the current HTTP context to retrieve client IP.</param>
+/// <param name="requestInfoProvider">Supplies the client IP the rate limiter buckets by. The core reads it
+/// through this abstraction rather than the HTTP context so it stays independent of the host, and so a test
+/// can drive the limiter without standing up a web host.</param>
 /// <param name="timeProvider">Provides the current time for deriving the request's remaining lifetime.</param>
 public class UserCodeVerificationService(
     IDeviceAuthorizationStorage storage,
     IUserCodeRateLimiter rateLimiter,
     IUserCodeNormalizer normalizer,
-    IHttpContextAccessor httpContextAccessor,
+    IRequestInfoProvider requestInfoProvider,
     TimeProvider timeProvider) : IUserCodeVerificationService
 {
     /// <inheritdoc />
@@ -51,7 +53,7 @@ public class UserCodeVerificationService(
         // dash variations cannot be used to multiply the per-code brute-force budget.
         userCode = normalizer.Normalize(userCode);
 
-        var clientIp = httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var clientIp = requestInfoProvider.RemoteIpAddress?.ToString() ?? "unknown";
 
         // Check rate limiting before attempting verification
         var rateLimitCheck = await rateLimiter.CheckAsync(userCode, clientIp);

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/src/Abblix.Utils/UriBuilder.cs
+++ b/src/Abblix.Utils/UriBuilder.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using Microsoft.AspNetCore.Http;
 
 namespace Abblix.Utils;
 
@@ -111,10 +110,16 @@ public class UriBuilder
     /// <summary>
     /// The path part of the URI.
     /// </summary>
-    public PathString Path
+    /// <remarks>
+    /// Typed as a plain string rather than the framework's PathString: this is a foundation library, and that
+    /// type would put an ASP.NET Core dependency on every package beneath the server, including hosts that
+    /// never serve HTTP. A caller holding a PathString still assigns and reads it, since that type converts
+    /// to and from string implicitly.
+    /// </remarks>
+    public string Path
     {
-        get => new(_builder.Path);
-        set => _builder.Path = value.Value;
+        get => _builder.Path;
+        set => _builder.Path = value;
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeGrantHandlerTests.cs
@@ -54,19 +54,19 @@ public class AuthorizationCodeGrantHandlerTests
 
 	/// <summary>
 	/// RFC 6749 §5.2: a token request without the required code parameter is the caller's protocol
-	/// error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+	/// error and yields invalid_request - previously it threw and surfaced as HTTP 500.
 	/// </summary>
 	[Fact]
 	public async Task AuthorizeAsync_MissingCode_ReturnsInvalidRequest()
 	{
-		var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo("client1"));
+		var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo("client1"), TestContext.Current.CancellationToken);
 
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
 	}
 
 	/// <summary>
-	/// RFC 6749 §5.2 lists a code issued to another client explicitly under invalid_grant —
+	/// RFC 6749 §5.2 lists a code issued to another client explicitly under invalid_grant -
 	/// previously this case was reported as unauthorized_client, which describes a client barred
 	/// from the grant type itself.
 	/// </summary>
@@ -83,7 +83,7 @@ public class AuthorizationCodeGrantHandlerTests
 					new AuthSession("123", "session1", authenticationTime, "ip"),
 					Context: new AuthorizationContext("original-client", [Scopes.OpenId], null)));
 
-		var result = await _handler.AuthorizeAsync(tokenRequest, new ClientInfo("another-client"));
+		var result = await _handler.AuthorizeAsync(tokenRequest, new ClientInfo("another-client"), TestContext.Current.CancellationToken);
 
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
@@ -117,7 +117,7 @@ public class AuthorizationCodeGrantHandlerTests
 	[InlineData(CodeChallengeMethods.Plain, "qwerty", "asdfgh")]
 	[InlineData(CodeChallengeMethods.Plain, "qwerty", null)]
 	// RFC 7636 §4.6: the plain verifier is compared byte-for-byte, so a case flip must fail. This case
-	// would have passed under the previous case-insensitive comparison — it locks the ordinal comparison in.
+	// would have passed under the previous case-insensitive comparison - it locks the ordinal comparison in.
 	[InlineData(CodeChallengeMethods.Plain, "qwerty", "QWERTY")]
 	public async Task PkceFailureChallengeTest(string codeChallengeMethod, string codeChallenge, string? codeVerifier)
 	{
@@ -146,7 +146,7 @@ public class AuthorizationCodeGrantHandlerTests
 					new AuthSession("123", "session1", DateTimeOffset.UtcNow, "ip"),
 					Context: new AuthorizationContext(clientInfo.ClientId, [Scopes.OpenId], null)));
 
-		var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		Assert.True(result.TryGetFailure(out var error));
 		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
@@ -154,7 +154,7 @@ public class AuthorizationCodeGrantHandlerTests
 
 	/// <summary>
 	/// A code issued without a code_challenge and redeemed without a code_verifier is the ordinary
-	/// non-PKCE flow and must still succeed — the downgrade guard only fires when a verifier is present.
+	/// non-PKCE flow and must still succeed - the downgrade guard only fires when a verifier is present.
 	/// </summary>
 	[Fact]
 	public async Task AuthorizeAsync_NoCodeChallengeAndNoVerifier_Succeeds()
@@ -169,7 +169,7 @@ public class AuthorizationCodeGrantHandlerTests
 					new AuthSession("123", "session1", DateTimeOffset.UtcNow, "ip"),
 					Context: new AuthorizationContext(clientInfo.ClientId, [Scopes.OpenId], null)));
 
-		var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		Assert.True(result.TryGetSuccess(out var grant));
 		Assert.NotNull(grant);
@@ -193,7 +193,7 @@ public class AuthorizationCodeGrantHandlerTests
 					}));
 
 		// act
-		var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 		return result;
 	}
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -119,12 +119,12 @@ public class BackChannelAuthenticationGrantHandlerTests
 
     /// <summary>
     /// RFC 6749 §5.2: a token request without the required auth_req_id parameter is the caller's
-    /// protocol error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+    /// protocol error and yields invalid_request - previously it threw and surfaced as HTTP 500.
     /// </summary>
     [Fact]
     public async Task AuthorizeAsync_MissingAuthenticationRequestId_ReturnsInvalidRequest()
     {
-        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId));
+        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -154,7 +154,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
         var clientInfo = new ClientInfo(ClientId) { BackChannelTokenDeliveryMode = deliveryMode };
 
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidClient, error.Error);
@@ -202,7 +202,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -228,7 +228,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync((BackChannelAuthenticationRequest?)null);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -261,7 +261,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, wrongClientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, wrongClientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -297,7 +297,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -332,7 +332,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -368,7 +368,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -398,7 +398,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -420,7 +420,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryGetAsync(null!)).ReturnsAsync((BackChannelAuthenticationRequest?)null);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert: the missing required auth_req_id is rejected by the parameter validator.
         Assert.True(result.TryGetFailure(out _));
@@ -453,7 +453,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
@@ -484,7 +484,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert - TryRemoveAsync should never be called
         _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
@@ -518,7 +518,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -557,7 +557,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -591,7 +591,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -627,7 +627,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -662,7 +662,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync(authRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -739,7 +739,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authenticatedRequest);
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -813,7 +813,7 @@ public class BackChannelAuthenticationGrantHandlerTests
             .ReturnsAsync(false);
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -848,7 +848,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -902,7 +902,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         storage.Setup(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -966,7 +966,7 @@ public class BackChannelAuthenticationGrantHandlerTests
             .ReturnsAsync(false);
 
         // Act
-        await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert - verify the custom timeout was used
         statusNotifier.Verify(
@@ -994,7 +994,7 @@ public class BackChannelAuthenticationGrantHandlerTests
         // pinning an ordering that made a refusable request pay for a storage round trip.
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/ClientCredentialsGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/ClientCredentialsGrantHandlerTests.cs
@@ -62,7 +62,7 @@ public class ClientCredentialsGrantHandlerTests
         };
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -89,7 +89,7 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest { Scope = null! };
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -115,7 +115,7 @@ public class ClientCredentialsGrantHandlerTests
         };
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -139,7 +139,7 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest();
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -161,8 +161,8 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest();
 
         // Act
-        var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo);
-        var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+        var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result1.TryGetSuccess(out var grant1));
@@ -188,7 +188,7 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest();
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -209,7 +209,7 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest();
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -230,7 +230,7 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest();
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -274,7 +274,7 @@ public class ClientCredentialsGrantHandlerTests
         };
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -296,8 +296,8 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest { Scope = ["api.read"] };
 
         // Act
-        var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo1);
-        var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo2);
+        var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo1, TestContext.Current.CancellationToken);
+        var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo2, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result1.TryGetSuccess(out var grant1));
@@ -331,7 +331,7 @@ public class ClientCredentialsGrantHandlerTests
         };
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -353,7 +353,7 @@ public class ClientCredentialsGrantHandlerTests
         var tokenRequest = new TokenRequest { Scope = ["api.read"] };
 
         // Act
-        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -82,12 +82,12 @@ public class DeviceCodeGrantHandlerTests
 
     /// <summary>
     /// RFC 6749 §5.2: a token request without the required device_code parameter is the caller's
-    /// protocol error and yields invalid_request — previously it threw and surfaced as HTTP 500.
+    /// protocol error and yields invalid_request - previously it threw and surfaced as HTTP 500.
     /// </summary>
     [Fact]
     public async Task AuthorizeAsync_MissingDeviceCode_ReturnsInvalidRequest()
     {
-        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId));
+        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -132,7 +132,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -170,7 +170,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(false); // Removal failed - another thread won
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -194,7 +194,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync((StoredDeviceAuthorizationRequest?)null);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -222,7 +222,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync(deviceRequest);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, wrongClientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, wrongClientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -254,7 +254,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(DeviceCode, deviceRequest, It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -288,7 +288,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(DeviceCode, deviceRequest, It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -321,7 +321,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.RemoveAsync(DeviceCode)).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -344,7 +344,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryGetByDeviceCodeAsync(null!)).ReturnsAsync((StoredDeviceAuthorizationRequest?)null);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert: the missing required device_code is rejected by the parameter validator.
         Assert.True(result.TryGetFailure(out _));
@@ -370,7 +370,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(DeviceCode, deviceRequest, It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         _storage.Verify(s => s.RemoveAsync(It.IsAny<string>()), Times.Never);
@@ -406,7 +406,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -442,7 +442,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(DeviceCode, deviceRequest, It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -473,7 +473,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.UpdateAsync(DeviceCode, deviceRequest, It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -482,7 +482,7 @@ public class DeviceCodeGrantHandlerTests
 
     /// <summary>
     /// RFC 8628 §3.2: once the device_code reaches its fixed lifetime the token endpoint returns
-    /// expired_token and the record is cleaned up — polling must not keep an expired code alive.
+    /// expired_token and the record is cleaned up - polling must not keep an expired code alive.
     /// </summary>
     [Fact]
     public async Task AuthorizeAsync_CodeExpired_ReturnsExpiredTokenAndRemoves()
@@ -502,7 +502,7 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.RemoveAsync(DeviceCode)).Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -552,9 +552,9 @@ public class DeviceCodeGrantHandlerTests
         _storage.Setup(s => s.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
-        // Assert: the approval survives — tokens are issued, and no Pending snapshot was written back.
+        // Assert: the approval survives - tokens are issued, and no Pending snapshot was written back.
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(UserId, grant.AuthSession.Subject);
         _storage.Verify(
@@ -564,7 +564,7 @@ public class DeviceCodeGrantHandlerTests
 
     /// <summary>
     /// RFC 8628 §3.2: each poll refreshes the cache TTL with the code's remaining lifetime, never the full
-    /// CodeLifetime — so a client that keeps polling cannot extend the device_code past its fixed expiry.
+    /// CodeLifetime - so a client that keeps polling cannot extend the device_code past its fixed expiry.
     /// </summary>
     [Fact]
     public async Task PendingPoll_CapsCacheTtlAtRemainingLifetime_NotFullCodeLifetime()
@@ -587,7 +587,7 @@ public class DeviceCodeGrantHandlerTests
             .Returns(Task.CompletedTask);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert: the refreshed TTL is the 3-minute remainder, not the 15-minute CodeLifetime.
         Assert.True(result.TryGetFailure(out var error));

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -74,7 +74,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -103,7 +103,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -127,7 +127,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -151,7 +151,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -177,7 +177,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -204,7 +204,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -231,7 +231,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -256,7 +256,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -282,7 +282,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -309,7 +309,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -338,7 +338,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -364,7 +364,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -390,8 +390,8 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo);
-		var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+		var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result1.TryGetSuccess(out var grant1));
@@ -420,7 +420,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -450,7 +450,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.NotNull(capturedParams);
@@ -502,8 +502,8 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo);
-		var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result1 = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+		var result2 = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result1.TryGetSuccess(out var grant1));
@@ -530,7 +530,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -558,7 +558,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -585,7 +585,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -610,7 +610,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -750,7 +750,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -779,7 +779,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -810,7 +810,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -839,7 +839,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -867,7 +867,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -892,7 +892,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -920,7 +920,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -947,7 +947,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -978,7 +978,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -1008,7 +1008,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -1039,7 +1039,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -1070,7 +1070,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetFailure(out var error));
@@ -1100,7 +1100,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));
@@ -1130,7 +1130,7 @@ public class JwtBearerGrantHandlerTests
 		};
 
 		// Act
-		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo);
+		var result = await handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.True(result.TryGetSuccess(out var grant));

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/PasswordGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/PasswordGrantHandlerTests.cs
@@ -60,7 +60,7 @@ public class PasswordGrantHandlerTests
 
     /// <summary>
     /// RFC 6749 §5.2: a token request without the required username or password parameter is the
-    /// caller's protocol error and yields invalid_request — previously it threw and surfaced as
+    /// caller's protocol error and yields invalid_request - previously it threw and surfaced as
     /// HTTP 500.
     /// </summary>
     [Theory]
@@ -71,7 +71,7 @@ public class PasswordGrantHandlerTests
     {
         var tokenRequest = new TokenRequest { UserName = userName, Password = password };
 
-        var result = await _handler.AuthorizeAsync(tokenRequest, new ClientInfo(ClientId));
+        var result = await _handler.AuthorizeAsync(tokenRequest, new ClientInfo(ClientId), TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -105,7 +105,7 @@ public class PasswordGrantHandlerTests
             .ReturnsAsync(expectedGrant);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -134,7 +134,7 @@ public class PasswordGrantHandlerTests
             .ReturnsAsync(authError);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -163,7 +163,7 @@ public class PasswordGrantHandlerTests
             .ReturnsAsync(authError);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -197,7 +197,7 @@ public class PasswordGrantHandlerTests
             .ReturnsAsync(expectedGrant);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -230,7 +230,7 @@ public class PasswordGrantHandlerTests
             .ReturnsAsync(expectedGrant);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -262,7 +262,7 @@ public class PasswordGrantHandlerTests
             .ReturnsAsync(expectedGrant);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -309,7 +309,7 @@ public class PasswordGrantHandlerTests
             .Callback<string, string, AuthorizationContext>((_, _, ctx) => capturedContext = ctx);
 
         // Act
-        await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(capturedContext);
@@ -349,7 +349,7 @@ public class PasswordGrantHandlerTests
             .Callback<string, string, AuthorizationContext>((_, _, ctx) => capturedContext = ctx);
 
         // Act
-        await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(capturedContext);

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/RefreshTokenGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/RefreshTokenGrantHandlerTests.cs
@@ -70,7 +70,7 @@ public class RefreshTokenGrantHandlerTests
     [Fact]
     public async Task AuthorizeAsync_MissingRefreshToken_ReturnsInvalidRequest()
     {
-        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId));
+        var result = await _handler.AuthorizeAsync(new TokenRequest(), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -101,7 +101,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(expectedGrant);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var grant));
@@ -135,7 +135,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(grantForDifferentClient);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -160,7 +160,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(accessToken);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -184,7 +184,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(idToken);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -207,7 +207,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(new JwtValidationError(JwtError.InvalidToken, "Token is malformed"));
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -230,7 +230,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(new JwtValidationError(JwtError.InvalidToken, "Token has expired"));
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));
@@ -260,7 +260,7 @@ public class RefreshTokenGrantHandlerTests
             .ReturnsAsync(serviceError);
 
         // Act
-        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo);
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var error));

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -62,7 +62,7 @@ public class TokenExchangeGrantHandlerTests
 
     /// <summary>
     /// RFC 8693 §2.1 / RFC 6749 §5.2: a request without subject_token or subject_token_type is the
-    /// caller's protocol error and yields invalid_request — previously it threw and surfaced as
+    /// caller's protocol error and yields invalid_request - previously it threw and surfaced as
     /// HTTP 500.
     /// </summary>
     [Theory]
@@ -79,7 +79,7 @@ public class TokenExchangeGrantHandlerTests
             SubjectTokenType = subjectTokenType,
         };
 
-        var result = await handler.AuthorizeAsync(request, ClientWithAllowlist(null));
+        var result = await handler.AuthorizeAsync(request, ClientWithAllowlist(null), TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -94,7 +94,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(TestSubject, grant.AuthSession.Subject);
@@ -112,7 +112,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.NotNull(grant.Context.AuthorizationDetails);
@@ -128,7 +128,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(null);
         var request = ExchangeRequest("urn:ietf:params:oauth:token-type:saml2");
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -143,7 +143,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist();  // empty -> deny-all
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -157,7 +157,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.IdToken);  // only id_token allowed
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -182,7 +182,7 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal("alice", grant.AuthSession.Subject);
@@ -211,7 +211,7 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal("svc-worker-7", grant.Context.Actor!["sub"]!.GetValue<string>());
@@ -230,7 +230,7 @@ public class TokenExchangeGrantHandlerTests
             ActorToken = "actor.jwt",  // type missing
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -247,7 +247,7 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,  // value missing
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -273,7 +273,7 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -295,7 +295,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -311,7 +311,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(null);  // tri-state: no constraint
         var request = ExchangeRequest(TokenExchangeTokenTypes.IdToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(TestSubject, grant.AuthSession.Subject);
@@ -328,7 +328,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = requestScope };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(requestScope, grant.Context.Scope);
@@ -337,7 +337,7 @@ public class TokenExchangeGrantHandlerTests
     /// <summary>
     /// 2b: when the request omits scope, the handler falls back to the subject_token's scope. The
     /// explicit request.Scope path is gated against the requesting client's AllowedScopes by
-    /// ScopeValidator in the token pipeline, but the fallback path is not — so an inherited scope the
+    /// ScopeValidator in the token pipeline, but the fallback path is not - so an inherited scope the
     /// broker client was never registered for must be filtered out rather than leaking into the token.
     /// </summary>
     [Fact]
@@ -353,7 +353,7 @@ public class TokenExchangeGrantHandlerTests
         };
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken); // no explicit scope -> fallback
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.DoesNotContain("admin", grant.Context.Scope);
@@ -379,7 +379,7 @@ public class TokenExchangeGrantHandlerTests
         };
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(["openid", "admin"], grant.Context.Scope);
@@ -399,7 +399,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = ["read", "admin"] };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.DoesNotContain("admin", grant.Context.Scope);
@@ -420,7 +420,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = ["api:read"] };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(["api:read"], grant.Context.Scope);
@@ -450,7 +450,7 @@ public class TokenExchangeGrantHandlerTests
         var requestingClient = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken); // ClientId = "test-client"
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, requestingClient);
+        var result = await handler.AuthorizeAsync(request, requestingClient, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -473,7 +473,7 @@ public class TokenExchangeGrantHandlerTests
         };
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, brokerClient);
+        var result = await handler.AuthorizeAsync(request, brokerClient, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal("alice", grant.AuthSession.Subject);
@@ -493,7 +493,7 @@ public class TokenExchangeGrantHandlerTests
         var requestingClient = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, requestingClient);
+        var result = await handler.AuthorizeAsync(request, requestingClient, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal("alice", grant.AuthSession.Subject);
@@ -520,7 +520,7 @@ public class TokenExchangeGrantHandlerTests
         };
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientWithDifferentAllowlist);
+        var result = await handler.AuthorizeAsync(request, clientWithDifferentAllowlist, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -544,7 +544,7 @@ public class TokenExchangeGrantHandlerTests
             Audiences = ["https://api1.example.com", "https://api2.example.com"],
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(request.Audiences, grant.Context.Audiences);
@@ -568,7 +568,7 @@ public class TokenExchangeGrantHandlerTests
             Audiences = ["https://victim.example.com"],
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
@@ -587,12 +587,12 @@ public class TokenExchangeGrantHandlerTests
         clientInfo.TokenExchangeAllowedAudiences = ["https://api1.example.com"];
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with
         {
-            // One allowlisted, two not — the whole request must be rejected and EVERY disallowed
+            // One allowlisted, two not - the whole request must be rejected and EVERY disallowed
             // audience reported, so the client can fix them all in one round-trip.
             Audiences = ["https://api1.example.com", "https://api2.example.com", "https://api3.example.com"],
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
@@ -620,7 +620,7 @@ public class TokenExchangeGrantHandlerTests
             Resources = [new Uri("https://api2.example.com")],
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidTarget, error.Error);
@@ -644,7 +644,7 @@ public class TokenExchangeGrantHandlerTests
             Resources = [new Uri("https://api2.example.com")],
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.Equal(request.Audiences, grant.Context.Audiences);
@@ -666,7 +666,7 @@ public class TokenExchangeGrantHandlerTests
             Resources = [new Uri("https://api.example.com")],
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetSuccess(out var grant));
         Assert.NotNull(grant.Context.Resources);
@@ -692,7 +692,7 @@ public class TokenExchangeGrantHandlerTests
             RequestedTokenType = TokenExchangeTokenTypes.IdToken,
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -714,7 +714,7 @@ public class TokenExchangeGrantHandlerTests
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
@@ -754,7 +754,7 @@ public class TokenExchangeGrantHandlerTests
             ActorTokenType = TokenExchangeTokenTypes.AccessToken,  // not in allowlist
         };
 
-        var result = await handler.AuthorizeAsync(request, clientInfo);
+        var result = await handler.AuthorizeAsync(request, clientInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenHandlerTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -105,7 +106,7 @@ public class TokenHandlerTests
         var tokenIssued = CreateTokenIssued();
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Success(validRequest));
 
         _processor
@@ -113,12 +114,12 @@ public class TokenHandlerTests
             .ReturnsAsync(Result<TokenIssued, OidcError>.Success(tokenIssued));
 
         // Act
-        var result = await _handler.HandleAsync(tokenRequest, clientRequest);
+        var result = await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var issued));
         Assert.Same(tokenIssued, issued);
-        _validator.Verify(v => v.ValidateAsync(tokenRequest, clientRequest), Times.Once);
+        _validator.Verify(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()), Times.Once);
         _processor.Verify(p => p.ProcessAsync(validRequest), Times.Once);
     }
 
@@ -137,16 +138,16 @@ public class TokenHandlerTests
             "Authorization code is invalid or expired");
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Failure(error));
 
         // Act
-        var result = await _handler.HandleAsync(tokenRequest, clientRequest);
+        var result = await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var failure));
         Assert.Equal(error, failure);
-        _validator.Verify(v => v.ValidateAsync(tokenRequest, clientRequest), Times.Once);
+        _validator.Verify(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()), Times.Once);
         _processor.VerifyNoOtherCalls();
     }
 
@@ -166,7 +167,7 @@ public class TokenHandlerTests
             "Failed to issue token");
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Success(validRequest));
 
         _processor
@@ -174,12 +175,12 @@ public class TokenHandlerTests
             .ReturnsAsync(Result<TokenIssued, OidcError>.Failure(error));
 
         // Act
-        var result = await _handler.HandleAsync(tokenRequest, clientRequest);
+        var result = await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var failure));
         Assert.Equal(error, failure);
-        _validator.Verify(v => v.ValidateAsync(tokenRequest, clientRequest), Times.Once);
+        _validator.Verify(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()), Times.Once);
         _processor.Verify(p => p.ProcessAsync(validRequest), Times.Once);
     }
 
@@ -198,7 +199,7 @@ public class TokenHandlerTests
         var tokenIssued = CreateTokenIssued();
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Success(validRequest));
 
         _processor
@@ -206,7 +207,7 @@ public class TokenHandlerTests
             .ReturnsAsync(Result<TokenIssued, OidcError>.Success(tokenIssued));
 
         // Act
-        await _handler.HandleAsync(tokenRequest, clientRequest);
+        await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         _processor.Verify(p => p.ProcessAsync(validRequest), Times.Once);
@@ -228,7 +229,7 @@ public class TokenHandlerTests
         var callOrder = new System.Collections.Generic.List<string>();
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
                 callOrder.Add("validate");
@@ -244,7 +245,7 @@ public class TokenHandlerTests
             });
 
         // Act
-        await _handler.HandleAsync(tokenRequest, clientRequest);
+        await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, callOrder.Count);
@@ -267,11 +268,11 @@ public class TokenHandlerTests
             "Client authentication failed");
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Failure(error));
 
         // Act
-        var result = await _handler.HandleAsync(tokenRequest, clientRequest);
+        var result = await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var failure));
@@ -293,17 +294,18 @@ public class TokenHandlerTests
         var error = new OidcError(ErrorCodes.InvalidRequest, "Invalid request");
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Failure(error));
 
         // Act
-        await _handler.HandleAsync(tokenRequest, clientRequest);
+        await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         _validator.Verify(
             v => v.ValidateAsync(
                 It.Is<TokenRequest>(r => r == tokenRequest),
-                It.Is<ClientRequest>(r => r == clientRequest)),
+                It.Is<ClientRequest>(r => r == clientRequest),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -321,11 +323,11 @@ public class TokenHandlerTests
         var error = new OidcError(ErrorCodes.InvalidGrant, "Invalid authorization code");
 
         _validator
-            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest))
+            .Setup(v => v.ValidateAsync(tokenRequest, clientRequest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ValidTokenRequest, OidcError>.Failure(error));
 
         // Act
-        await _handler.HandleAsync(tokenRequest, clientRequest);
+        await _handler.HandleAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         _processor.VerifyNoOtherCalls();

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestValidatorTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -85,8 +86,8 @@ public class TokenRequestValidatorTests
         var clientRequest = CreateClientRequest();
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
                 ctx.AuthorizedGrant = CreateAuthorizedGrant();
@@ -96,7 +97,7 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        var result = await _validator.ValidateAsync(tokenRequest, clientRequest);
+        var result = await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var validRequest));
@@ -119,11 +120,11 @@ public class TokenRequestValidatorTests
             "Authorization code is invalid or expired");
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(error);
 
         // Act
-        var result = await _validator.ValidateAsync(tokenRequest, clientRequest);
+        var result = await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var failure));
@@ -143,8 +144,8 @@ public class TokenRequestValidatorTests
         TokenValidationContext? capturedContext = null;
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 capturedContext = ctx;
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
@@ -155,7 +156,7 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        await _validator.ValidateAsync(tokenRequest, clientRequest);
+        await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(capturedContext);
@@ -175,8 +176,8 @@ public class TokenRequestValidatorTests
         var clientRequest = CreateClientRequest();
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
                 ctx.AuthorizedGrant = CreateAuthorizedGrant();
@@ -186,11 +187,11 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        await _validator.ValidateAsync(tokenRequest, clientRequest);
+        await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         _contextValidator.Verify(
-            v => v.ValidateAsync(It.IsAny<TokenValidationContext>()),
+            v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -208,8 +209,8 @@ public class TokenRequestValidatorTests
         TokenValidationContext? capturedContext = null;
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 capturedContext = ctx;
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
@@ -220,7 +221,7 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        var result = await _validator.ValidateAsync(tokenRequest, clientRequest);
+        var result = await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var validRequest));
@@ -242,8 +243,8 @@ public class TokenRequestValidatorTests
         var clientRequest = CreateClientRequest();
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
                 ctx.AuthorizedGrant = CreateAuthorizedGrant();
@@ -253,7 +254,7 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        var result = await _validator.ValidateAsync(tokenRequest, clientRequest);
+        var result = await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetSuccess(out var validRequest));
@@ -275,11 +276,11 @@ public class TokenRequestValidatorTests
             "Client authentication failed");
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(error);
 
         // Act
-        var result = await _validator.ValidateAsync(tokenRequest, clientRequest);
+        var result = await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.TryGetFailure(out var failure));
@@ -302,8 +303,8 @@ public class TokenRequestValidatorTests
         var capturedContexts = new System.Collections.Generic.List<TokenValidationContext>();
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 capturedContexts.Add(ctx);
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
@@ -314,8 +315,8 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        await _validator.ValidateAsync(tokenRequest1, clientRequest);
-        await _validator.ValidateAsync(tokenRequest2, clientRequest);
+        await _validator.ValidateAsync(tokenRequest1, clientRequest, TestContext.Current.CancellationToken);
+        await _validator.ValidateAsync(tokenRequest2, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, capturedContexts.Count);
@@ -346,8 +347,8 @@ public class TokenRequestValidatorTests
         var clientRequest = CreateClientRequest();
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
                 ctx.AuthorizedGrant = CreateAuthorizedGrant();
@@ -357,8 +358,8 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        var result1 = await _validator.ValidateAsync(authCodeRequest, clientRequest);
-        var result2 = await _validator.ValidateAsync(refreshTokenRequest, clientRequest);
+        var result1 = await _validator.ValidateAsync(authCodeRequest, clientRequest, TestContext.Current.CancellationToken);
+        var result2 = await _validator.ValidateAsync(refreshTokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result1.TryGetSuccess(out var validRequest1));
@@ -366,7 +367,7 @@ public class TokenRequestValidatorTests
         Assert.Equal(GrantTypes.AuthorizationCode, validRequest1.Model.GrantType);
         Assert.Equal(GrantTypes.RefreshToken, validRequest2.Model.GrantType);
         _contextValidator.Verify(
-            v => v.ValidateAsync(It.IsAny<TokenValidationContext>()),
+            v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
 
@@ -383,9 +384,11 @@ public class TokenRequestValidatorTests
         TokenValidationContext? capturedContext = null;
 
         _contextValidator
-            .Setup(v => v.ValidateAsync(It.Is<TokenValidationContext>(
-                ctx => ctx.Request == tokenRequest && ctx.ClientRequest == clientRequest)))
-            .Callback<TokenValidationContext>(ctx =>
+            .Setup(v => v.ValidateAsync(
+                It.Is<TokenValidationContext>(
+                    ctx => ctx.Request == tokenRequest && ctx.ClientRequest == clientRequest),
+                It.IsAny<CancellationToken>()))
+            .Callback<TokenValidationContext, CancellationToken>((ctx, _) =>
             {
                 capturedContext = ctx;
                 ctx.ClientInfo = new ClientInfo(TestConstants.DefaultClientId);
@@ -396,15 +399,17 @@ public class TokenRequestValidatorTests
             .ReturnsAsync((OidcError?)null);
 
         // Act
-        await _validator.ValidateAsync(tokenRequest, clientRequest);
+        await _validator.ValidateAsync(tokenRequest, clientRequest, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(capturedContext);
         Assert.Same(tokenRequest, capturedContext.Request);
         Assert.Same(clientRequest, capturedContext.ClientRequest);
         _contextValidator.Verify(
-            v => v.ValidateAsync(It.Is<TokenValidationContext>(
-                ctx => ctx.Request == tokenRequest && ctx.ClientRequest == clientRequest)),
+            v => v.ValidateAsync(
+                It.Is<TokenValidationContext>(
+                    ctx => ctx.Request == tokenRequest && ctx.ClientRequest == clientRequest),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/AuthorizationGrantValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/AuthorizationGrantValidatorTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -106,11 +107,11 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant(redirectUri);
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -130,7 +131,7 @@ public class AuthorizationGrantValidatorTests
             allowedGrantTypes: [GrantTypes.ClientCredentials]);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -151,11 +152,11 @@ public class AuthorizationGrantValidatorTests
         var grantError = new OidcError(ErrorCodes.InvalidGrant, "Invalid authorization code");
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Failure(grantError));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Same(grantError, error);
@@ -175,11 +176,11 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant(grantRedirectUri);
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -199,11 +200,11 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant(redirectUri: null);
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -222,14 +223,14 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant();
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(context.Request, context.ClientInfo))
+            .Setup(h => h.AuthorizeAsync(context.Request, context.ClientInfo, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
-        _grantHandler.Verify(h => h.AuthorizeAsync(context.Request, context.ClientInfo), Times.Once);
+        _grantHandler.Verify(h => h.AuthorizeAsync(context.Request, context.ClientInfo, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
@@ -245,7 +246,7 @@ public class AuthorizationGrantValidatorTests
             allowedGrantTypes: [GrantTypes.AuthorizationCode]);
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         _grantHandler.VerifyNoOtherCalls();
@@ -263,11 +264,11 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant();
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Same(authorizedGrant, context.AuthorizedGrant);
@@ -292,11 +293,11 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant();
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -316,11 +317,11 @@ public class AuthorizationGrantValidatorTests
         var authorizedGrant = CreateAuthorizedGrant(grantRedirectUri);
 
         _grantHandler
-            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>()))
+            .Setup(h => h.AuthorizeAsync(It.IsAny<TokenRequest>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<AuthorizedGrant, OidcError>.Success(authorizedGrant));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert - Path is case-sensitive
         Assert.NotNull(error);

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ClientValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ClientValidatorTests.cs
@@ -70,7 +70,7 @@ public class ClientValidatorTests
             .ReturnsAsync(clientInfo);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -93,7 +93,7 @@ public class ClientValidatorTests
             .ReturnsAsync((ClientInfo?)null);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -118,7 +118,7 @@ public class ClientValidatorTests
             .ReturnsAsync(clientInfo);
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         _clientAuthenticator.Verify(a => a.TryAuthenticateClientAsync(clientRequest), Times.Once);
@@ -140,7 +140,7 @@ public class ClientValidatorTests
             .ReturnsAsync(clientInfo);
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Same(clientInfo, context.ClientInfo);
@@ -164,7 +164,7 @@ public class ClientValidatorTests
             .ReturnsAsync(clientInfo);
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         _clientAuthenticator.Verify(
@@ -187,7 +187,7 @@ public class ClientValidatorTests
             .ReturnsAsync((ClientInfo?)null);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -218,8 +218,8 @@ public class ClientValidatorTests
             .ReturnsAsync(clientInfo2);
 
         // Act
-        var error1 = await _validator.ValidateAsync(context1);
-        var error2 = await _validator.ValidateAsync(context2);
+        var error1 = await _validator.ValidateAsync(context1, TestContext.Current.CancellationToken);
+        var error2 = await _validator.ValidateAsync(context2, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error1);
@@ -243,7 +243,7 @@ public class ClientValidatorTests
             .ReturnsAsync((ClientInfo?)null);
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert - Context.ClientInfo getter will throw if not set, which is expected behavior
         // We just verify the error was returned

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/DPoPTokenEndpointValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/DPoPTokenEndpointValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -56,7 +56,7 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token.Validation;
 /// Unit tests for <see cref="DPoPTokenEndpointValidator"/> covering the four-way branch
 /// (mandatory vs opportunistic × proof-present vs proof-missing), the proof-validation
 /// failure path, and the RFC 9449 §8 nonce challenge-response loop. The validator's own
-/// JWT structural / signature / claim-binding checks are out of scope here — those land
+/// JWT structural / signature / claim-binding checks are out of scope here - those land
 /// in <see cref="ProofValidatorTests"/>; this test mocks <see cref="IProofValidator"/>
 /// to focus on the wiring between proof, nonce, and confirmation-stash decisions.
 /// </summary>
@@ -90,7 +90,7 @@ public class DPoPTokenEndpointValidatorTests
     {
         var context = CreateContext(proofJwt: null, clientRequiresDPoP: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -100,7 +100,7 @@ public class DPoPTokenEndpointValidatorTests
     {
         var context = CreateContext(proofJwt: null, clientRequiresDPoP: false);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         Assert.Null(error);
         Assert.Null(context.ProofKeyThumbprint);
@@ -119,7 +119,7 @@ public class DPoPTokenEndpointValidatorTests
             clientRequiresDPoP: false,
             securityProfile: ClientSecurityProfile.Fapi2);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -140,7 +140,7 @@ public class DPoPTokenEndpointValidatorTests
             clientCertificate: certificate,
             tlsClientCertificateBoundAccessTokens: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         Assert.Null(error);
         Assert.Null(context.ProofKeyThumbprint);
@@ -160,7 +160,7 @@ public class DPoPTokenEndpointValidatorTests
             clientCertificate: certificate,
             tlsClientCertificateBoundAccessTokens: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -175,7 +175,7 @@ public class DPoPTokenEndpointValidatorTests
         _opts.DefaultSecurityProfile = ClientSecurityProfile.Fapi2;
         var context = CreateContext(proofJwt: null, clientRequiresDPoP: false, securityProfile: null);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -193,7 +193,7 @@ public class DPoPTokenEndpointValidatorTests
             clientRequiresDPoP: false,
             securityProfile: ClientSecurityProfile.None);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         Assert.Null(error);
         Assert.Null(context.ProofKeyThumbprint);
@@ -205,7 +205,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupProofValidatorSuccess(BuildProof());
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: false);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofStashed(error, context);
     }
@@ -216,7 +216,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupProofValidatorSuccess(BuildProof());
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofStashed(error, context);
     }
@@ -227,7 +227,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupProofValidatorFailure(new ProofError(ProofErrorReasons.SignatureInvalid));
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: false);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -240,7 +240,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupNonceIssue();
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertNonceChallenge(error, context);
     }
@@ -254,7 +254,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupNonceIssue();
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertNonceChallenge(error, context);
     }
@@ -267,7 +267,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupNonceValidate("good-nonce", failure: null);
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: true);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofStashed(error, context);
     }
@@ -281,7 +281,7 @@ public class DPoPTokenEndpointValidatorTests
             clientRequiresDPoP: false,
             committedThumbprint: ProofKeyThumbprint);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofStashed(error, context);
     }
@@ -295,7 +295,7 @@ public class DPoPTokenEndpointValidatorTests
             clientRequiresDPoP: false,
             committedThumbprint: "different-committed-thumbprint");
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -311,7 +311,7 @@ public class DPoPTokenEndpointValidatorTests
             clientRequiresDPoP: false,
             committedThumbprint: "committed-thumbprint-from-authorize");
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofRejected(error, context);
     }
@@ -325,7 +325,7 @@ public class DPoPTokenEndpointValidatorTests
         SetupProofValidatorSuccess(BuildProof(nonceClaim: "some-nonce"));
         var context = CreateContext(proofJwt: ProofJwt, clientRequiresDPoP: false);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         AssertProofStashed(error, context);
         _nonceService.VerifyNoOtherCalls();
@@ -333,7 +333,7 @@ public class DPoPTokenEndpointValidatorTests
 
     /// <summary>
     /// RFC 8705 §4: a certificate-bound grant redeemed by a non-mTLS client that presents no certificate
-    /// must be rejected with invalid_grant — otherwise a stolen certificate-bound refresh token is
+    /// must be rejected with invalid_grant - otherwise a stolen certificate-bound refresh token is
     /// redeemable with no certificate at all.
     /// </summary>
     [Fact]
@@ -345,7 +345,7 @@ public class DPoPTokenEndpointValidatorTests
             committedCertThumbprint: "committed-x5t-s256",
             tokenEndpointAuthMethod: ClientAuthenticationMethods.None);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         Assert.NotNull(error);
         Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
@@ -366,7 +366,7 @@ public class DPoPTokenEndpointValidatorTests
             committedCertThumbprint: CertThumbprint(certificate),
             tokenEndpointAuthMethod: ClientAuthenticationMethods.None);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         Assert.Null(error);
     }
@@ -385,7 +385,7 @@ public class DPoPTokenEndpointValidatorTests
             committedCertThumbprint: "committed-x5t-s256",
             tokenEndpointAuthMethod: ClientAuthenticationMethods.TlsClientAuth);
 
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         Assert.Null(error);
     }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ResourceValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ResourceValidatorTests.cs
@@ -80,7 +80,7 @@ public class ResourceValidatorTests
         var context = CreateContext(resources: null, scope: ["read"]);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -98,7 +98,7 @@ public class ResourceValidatorTests
         var context = CreateContext(resources: [], scope: ["read"]);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -127,7 +127,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -157,7 +157,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -186,7 +186,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -213,7 +213,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(new[] { resourceDefinition }, context.Resources);
@@ -249,7 +249,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -285,7 +285,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         _resourceManager.Verify(
@@ -316,7 +316,7 @@ public class ResourceValidatorTests
             }));
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ScopeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/ScopeValidatorTests.cs
@@ -101,7 +101,7 @@ public class ScopeValidatorTests
         SetupScopeManagerForScopes("read", "write");
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -126,7 +126,7 @@ public class ScopeValidatorTests
             .Returns(false);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -147,7 +147,7 @@ public class ScopeValidatorTests
         SetupScopeManagerForScopes(TestConstants.DefaultScope, "profile", "email");
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         _scopeManager.Verify(m => m.TryGet(TestConstants.DefaultScope, out It.Ref<ScopeDefinition?>.IsAny), Times.Once);
@@ -167,7 +167,7 @@ public class ScopeValidatorTests
         SetupScopeManagerForScopes(TestConstants.DefaultScope, "profile");
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, context.Scope.Length);
@@ -190,7 +190,7 @@ public class ScopeValidatorTests
             .Returns(false);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(error);
@@ -209,7 +209,7 @@ public class ScopeValidatorTests
         SetupScopeManagerForScopes("read");
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -230,7 +230,7 @@ public class ScopeValidatorTests
         SetupScopeManagerForScopes(scopes);
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -253,7 +253,7 @@ public class ScopeValidatorTests
         // No need to setup scope manager for empty scopes
 
         // Act
-        var error = await _validator.ValidateAsync(context);
+        var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -272,7 +272,7 @@ public class ScopeValidatorTests
         SetupScopeManagerForScopes("read");
 
         // Act
-        await _validator.ValidateAsync(context);
+        await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         _scopeManager.Verify(

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/TokenContextValidatorCompositeTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/TokenContextValidatorCompositeTests.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -57,7 +58,7 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        var error = await validator.ValidateAsync(context);
+        var error = await validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
@@ -75,9 +76,9 @@ public class TokenContextValidatorCompositeTests
         var validator2 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
         var validator3 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
 
-        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
-        validator2.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
-        validator3.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
+        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
+        validator2.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
+        validator3.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
 
         var composite = new TokenContextValidatorComposite([
             validator1.Object,
@@ -87,13 +88,13 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        var error = await composite.ValidateAsync(context);
+        var error = await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
-        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
-        validator2.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
-        validator3.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
+        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        validator2.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        validator3.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
@@ -108,7 +109,7 @@ public class TokenContextValidatorCompositeTests
         var validator1 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
         var validator2 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
 
-        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync(error1);
+        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(error1);
 
         var composite = new TokenContextValidatorComposite([
             validator1.Object,
@@ -117,11 +118,11 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        var error = await composite.ValidateAsync(context);
+        var error = await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Same(error1, error);
-        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
+        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
         validator2.VerifyNoOtherCalls();
     }
 
@@ -138,8 +139,8 @@ public class TokenContextValidatorCompositeTests
         var validator2 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
         var validator3 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
 
-        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
-        validator2.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync(error2);
+        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
+        validator2.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(error2);
 
         var composite = new TokenContextValidatorComposite([
             validator1.Object,
@@ -149,12 +150,12 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        var error = await composite.ValidateAsync(context);
+        var error = await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Same(error2, error);
-        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
-        validator2.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
+        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        validator2.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
         validator3.VerifyNoOtherCalls();
     }
 
@@ -171,9 +172,9 @@ public class TokenContextValidatorCompositeTests
         var validator2 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
         var validator3 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
 
-        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
-        validator2.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
-        validator3.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync(error3);
+        validator1.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
+        validator2.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
+        validator3.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(error3);
 
         var composite = new TokenContextValidatorComposite([
             validator1.Object,
@@ -183,13 +184,13 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        var error = await composite.ValidateAsync(context);
+        var error = await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Same(error3, error);
-        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
-        validator2.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
-        validator3.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
+        validator1.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        validator2.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        validator3.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
@@ -206,16 +207,16 @@ public class TokenContextValidatorCompositeTests
         var validator3 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
 
         validator1
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback(new Action<TokenValidationContext>(_ => callOrder.Add(1)))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback(new Action<TokenValidationContext, CancellationToken>((_, _) => callOrder.Add(1)))
             .ReturnsAsync((OidcError?)null);
         validator2
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback(new Action<TokenValidationContext>(_ => callOrder.Add(2)))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback(new Action<TokenValidationContext, CancellationToken>((_, _) => callOrder.Add(2)))
             .ReturnsAsync((OidcError?)null);
         validator3
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback(new Action<TokenValidationContext>(_ => callOrder.Add(3)))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback(new Action<TokenValidationContext, CancellationToken>((_, _) => callOrder.Add(3)))
             .ReturnsAsync((OidcError?)null);
 
         var composite = new TokenContextValidatorComposite([
@@ -226,7 +227,7 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        await composite.ValidateAsync(context);
+        await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(new[] { 1, 2, 3 }, callOrder);
@@ -245,12 +246,12 @@ public class TokenContextValidatorCompositeTests
         var validator2 = new Mock<ITokenContextValidator>(MockBehavior.Strict);
 
         validator1
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback(new Action<TokenValidationContext>(ctx => capturedContexts.Add(ctx)))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback(new Action<TokenValidationContext, CancellationToken>((ctx, _) => capturedContexts.Add(ctx)))
             .ReturnsAsync((OidcError?)null);
         validator2
-            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()))
-            .Callback(new Action<TokenValidationContext>(ctx => capturedContexts.Add(ctx)))
+            .Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()))
+            .Callback(new Action<TokenValidationContext, CancellationToken>((ctx, _) => capturedContexts.Add(ctx)))
             .ReturnsAsync((OidcError?)null);
 
         var composite = new TokenContextValidatorComposite([
@@ -260,7 +261,7 @@ public class TokenContextValidatorCompositeTests
         var context = CreateContext();
 
         // Act
-        await composite.ValidateAsync(context);
+        await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, capturedContexts.Count);
@@ -277,16 +278,16 @@ public class TokenContextValidatorCompositeTests
     {
         // Arrange
         var validator = new Mock<ITokenContextValidator>(MockBehavior.Strict);
-        validator.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>())).ReturnsAsync((OidcError?)null);
+        validator.Setup(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync((OidcError?)null);
 
         var composite = new TokenContextValidatorComposite([validator.Object]);
         var context = CreateContext();
 
         // Act
-        var error = await composite.ValidateAsync(context);
+        var error = await composite.ValidateAsync(context, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(error);
-        validator.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>()), Times.Once);
+        validator.Verify(v => v.ValidateAsync(It.IsAny<TokenValidationContext>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/AddAuthorizationGrantTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/AddAuthorizationGrantTests.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -53,7 +54,7 @@ public class AddAuthorizationGrantTests
     /// Mirrors <c>ServiceDescriptor.GetImplementationType()</c> (which is internal in
     /// .NET): for factory-based descriptors registered via
     /// <c>ServiceDescriptor.Singleton&lt;TService, TImpl&gt;(factory)</c>, the runtime type
-    /// of the factory is <c>Func&lt;IServiceProvider, TImpl&gt;</c> — its second generic
+    /// of the factory is <c>Func&lt;IServiceProvider, TImpl&gt;</c> - its second generic
     /// argument is the implementation type the dual-registration helper preserves for
     /// dedup purposes.
     /// </summary>
@@ -73,7 +74,7 @@ public class AddAuthorizationGrantTests
     {
         public IEnumerable<string> GrantTypesSupported { get; } = ["urn:test:stub"];
 
-        public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+        public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
             => Task.FromResult<Result<AuthorizedGrant, OidcError>>(
                 new OidcError(ErrorCodes.UnsupportedGrantType, "stub"));
     }
@@ -82,14 +83,14 @@ public class AddAuthorizationGrantTests
     {
         public IEnumerable<string> GrantTypesSupported { get; } = ["urn:test:other"];
 
-        public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo)
+        public Task<Result<AuthorizedGrant, OidcError>> AuthorizeAsync(TokenRequest request, ClientInfo clientInfo, CancellationToken cancellationToken)
             => Task.FromResult<Result<AuthorizedGrant, OidcError>>(
                 new OidcError(ErrorCodes.UnsupportedGrantType, "other"));
     }
 
     /// <summary>
     /// A single call places the grant handler under both <see cref="IAuthorizationGrantHandler"/>
-    /// and <see cref="IGrantTypeInformer"/> service types. This is the core of the invariant —
+    /// and <see cref="IGrantTypeInformer"/> service types. This is the core of the invariant -
     /// the rule the helper exists to enforce.
     /// </summary>
     [Fact]
@@ -114,7 +115,7 @@ public class AddAuthorizationGrantTests
 
     /// <summary>
     /// The dual-registration shares ONE concrete <typeparamref name="TImpl"/> singleton between
-    /// both interface aliases — resolving <see cref="IAuthorizationGrantHandler"/> and
+    /// both interface aliases - resolving <see cref="IAuthorizationGrantHandler"/> and
     /// <see cref="IGrantTypeInformer"/> returns the same instance, not two separate ones. This
     /// preserves the «handler is constructed once per host» invariant that the previous direct
     /// dual-registration would have broken.
@@ -140,7 +141,7 @@ public class AddAuthorizationGrantTests
 
     /// <summary>
     /// <c>TryAddEnumerable</c> dedupes on <c>(ServiceType, ImplementationType)</c>. Calling the
-    /// helper twice with the same impl must not accumulate duplicate entries — repeated
+    /// helper twice with the same impl must not accumulate duplicate entries - repeated
     /// invocations from extension methods that share a handler stay idempotent.
     /// </summary>
     [Fact]
@@ -249,7 +250,7 @@ public class AddAuthorizationGrantTests
     /// every built-in grant handler as <see cref="IGrantTypeInformer"/> via the helper, so the
     /// discovery endpoint and registration-time validators see the same set the token endpoint
     /// dispatches on. <c>Compose&lt;&gt;</c> removes leaves only from
-    /// <see cref="IAuthorizationGrantHandler"/> — leaves' <see cref="IGrantTypeInformer"/>
+    /// <see cref="IAuthorizationGrantHandler"/> - leaves' <see cref="IGrantTypeInformer"/>
     /// registrations survive composition.
     /// </summary>
     [Fact]
@@ -291,7 +292,7 @@ public class AddAuthorizationGrantTests
 
     /// <summary>
     /// When the host opts into ROPC via <c>EnablePasswordGrant()</c> BEFORE <c>AddOidcServices</c>,
-    /// <see cref="PasswordGrantHandler"/> appears in the <see cref="IGrantTypeInformer"/> descriptor list — proving
+    /// <see cref="PasswordGrantHandler"/> appears in the <see cref="IGrantTypeInformer"/> descriptor list - proving
     /// the opt-in surfaces in the same registry discovery and the registration validator read. The opt-in must
     /// precede <c>AddOidcCore</c> so the handler is included in the composite the token endpoint dispatches on;
     /// registering it after is rejected by the ordering guard (see below).
@@ -316,7 +317,7 @@ public class AddAuthorizationGrantTests
     /// A grant handler registered AFTER the grant handlers were composed by <c>AddOidcCore</c> would land beside the
     /// composite rather than inside it, so the token endpoint would silently not dispatch its grant type. The
     /// ordering guard turns that latent misconfiguration into a loud startup error naming the offending handler and
-    /// pointing at the fix — call the opt-in before <c>AddOidcCore</c>.
+    /// pointing at the fix - call the opt-in before <c>AddOidcCore</c>.
     /// </summary>
     [Fact]
     public void AddAuthorizationGrant_AfterOidcCore_ThrowsWithOrderingGuidance()
@@ -332,7 +333,7 @@ public class AddAuthorizationGrantTests
     }
 
     /// <summary>
-    /// The mirror of the guard: a grant handler registered BEFORE <c>AddOidcCore</c> — the correct order — is
+    /// The mirror of the guard: a grant handler registered BEFORE <c>AddOidcCore</c> - the correct order - is
     /// accepted, and the subsequent composition does not throw. This is the path every opt-in feature method takes.
     /// </summary>
     [Fact]
@@ -349,7 +350,7 @@ public class AddAuthorizationGrantTests
 
     /// <summary>
     /// The guard fires through a real opt-in feature method, not only the low-level helper: calling
-    /// <c>EnablePasswordGrant()</c> after <c>AddOidcServices</c> — the exact misuse a host might commit — is rejected
+    /// <c>EnablePasswordGrant()</c> after <c>AddOidcServices</c> - the exact misuse a host might commit - is rejected
     /// with the grant handler named and the fix pointed at. This is the consumer-facing shape of the ordering
     /// contract, and the regression that would return if the sentinel check were removed.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -23,10 +23,10 @@
 using System;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 using Abblix.Utils;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -36,8 +36,8 @@ namespace Abblix.Oidc.Server.UnitTests.Features.DeviceAuthorization;
 
 /// <summary>
 /// Verifies that <see cref="UserCodeVerificationService"/> canonicalizes the user-entered code
-/// before lookup (RFC 8628 Section 6.1), so the readability variants a user may type — a different
-/// case or copied-in dashes — resolve to the same stored device authorization request rather than
+/// before lookup (RFC 8628 Section 6.1), so the readability variants a user may type - a different
+/// case or copied-in dashes - resolve to the same stored device authorization request rather than
 /// being rejected as invalid.
 /// </summary>
 public class UserCodeVerificationServiceTests
@@ -80,7 +80,7 @@ public class UserCodeVerificationServiceTests
             storage.Object,
             rateLimiter.Object,
             normalizer,
-            Mock.Of<IHttpContextAccessor>(),
+            Mock.Of<IRequestInfoProvider>(),
             new FakeTimeProvider(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)));
     }
 

--- a/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -15,8 +15,15 @@
         <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
     </ItemGroup>
 
+    <!-- Only the tests reference ASP.NET Core, and from the shared framework rather than a package. UriBuilder
+         deliberately types its path as a plain string so the library stays host-neutral, and the tests hold it
+         to the promise that comes with that: a host passing a PathString keeps working through the implicit
+         conversions. Proving that needs the type, and the test project is the one place it costs nobody. -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/tests/Abblix.Utils.UnitTests/UriBuilderTests.cs
+++ b/tests/Abblix.Utils.UnitTests/UriBuilderTests.cs
@@ -277,6 +277,9 @@ public class UriBuilderTests
     public void Constructor_WithPathStringValue_CreatesRelativeUri()
     {
         var pathString = new PathString("/manage/linked_accounts");
+        // The framework annotates Value as nullable because an empty PathString carries none; this one was
+        // built from a literal, so assert it rather than suppress the warning.
+        Assert.NotNull(pathString.Value);
 
         var builder = new UriBuilder(pathString.Value);
 
@@ -293,6 +296,9 @@ public class UriBuilderTests
     public void Constructor_WithPathStringValue_WithQueryParameters()
     {
         var pathString = new PathString("/manage/linked_accounts");
+        // The framework annotates Value as nullable because an empty PathString carries none; this one was
+        // built from a literal, so assert it rather than suppress the warning.
+        Assert.NotNull(pathString.Value);
 
         var builder = new UriBuilder(pathString.Value)
         {
@@ -470,7 +476,7 @@ public class UriBuilderTests
 
         var path = builder.Path;
 
-        Assert.Equal("/api/users", path.Value);
+        Assert.Equal("/api/users", path);
     }
 
     /// <summary>
@@ -483,7 +489,7 @@ public class UriBuilderTests
 
         var path = builder.Path;
 
-        Assert.Equal(AuthCallbackPath, path.Value);
+        Assert.Equal(AuthCallbackPath, path);
     }
 
     /// <summary>


### PR DESCRIPTION
## The dependency, and how it got there

`Abblix.Oidc.Server` reached for `IHttpContextAccessor` in two places while declaring no ASP.NET dependency of its own. Neither was a need, and the type was available for a reason unrelated to either.

`Abblix.Utils` referenced `Microsoft.AspNetCore.Http.Abstractions` for a single property: `UriBuilder.Path` was typed as `PathString`. That one reference put ASP.NET Core into the graph of everything beneath the server, `Abblix.Jwt` and `Abblix.Oidc.Client` included, and it did so through the 2.x compatibility line rather than the shared framework. Both the compile and runtime assets resolved to `lib/netstandard2.0/Microsoft.AspNetCore.Http.Abstractions.dll` from version 2.3.10, a line that is out of support and that Microsoft advises against referencing from .NET Core 3.0 or later.

With the type in scope, two services used it. `UserCodeVerificationService` read the client IP for device-code rate limiting, and `BackChannelAuthenticationGrantHandler` read `RequestAborted` to bound its long-polling wait.

## The cancellation token

CIBA holds a token request open for the configured long-polling window, so a real cancellation token has to reach it. `ITokenHandler`, `ITokenRequestValidator`, `ITokenContextValidator` and `IAuthorizationGrantHandler` each gained an overload taking one, and that overload is now the member an implementation provides. The previous overloads remain as obsolete default implementations forwarding to it with `CancellationToken.None`, so a caller holding the old signature keeps working, while an implementation that provided only the old one fails to compile rather than silently never receiving the token.

The adapters pass the request's own token: `HttpContext.RequestAborted` in MVC, the platform-bound parameter in Minimal API. A client that disconnects now stops the work it started rather than leaving it to run out its own timeout.

## What the core reads instead

`IRequestInfoProvider` is the core's own abstraction for request data, implemented in the shared ASP.NET assembly and already used by eight services. The device-code service moves onto it, so nothing under `Abblix.Oidc.Server` names ASP.NET any more.

## The foundation library

`UriBuilder.Path` is a plain string. A caller holding a `PathString` still assigns and reads it, since that type converts to and from string implicitly, and the tests hold the library to that promise: they keep using `PathString`, taking it from the shared framework in the test project, where it costs no consumer anything.

The legacy package was also hiding nullability, being compiled without annotations. The same tests now see `PathString.Value` as the nullable it is and assert its presence rather than assume it.

Verified against `project.assets.json`: no `Microsoft.AspNetCore` package remains in the graph of `Abblix.Utils`, `Abblix.Jwt`, `Abblix.Oidc.Client`, or `Abblix.Oidc.Server` on any of its three target frameworks.

## Deliberately out of scope

Token issuance keeps no cancellation token. It begins by claiming the authorization code irreversibly, so cancelling past that point destroys a grant rather than saving work, and what cancellation should mean there needs an answer before the parameter is worth carrying. Tracked as #300 against the 3.0 milestone.