### PR TITLE
Stop counting generated adapter models in coverage, and deprecate the HTML result nothing derives from

### DIFF
--- a/src/Abblix.Oidc.Server.Mvc/ActionResults/GeneratedHtmlResult.cs
+++ b/src/Abblix.Oidc.Server.Mvc/ActionResults/GeneratedHtmlResult.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Oidc.Server.AspNetCore;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using System.Xml;
 using Microsoft.AspNetCore.Http;
@@ -36,6 +37,13 @@ namespace Abblix.Oidc.Server.Mvc.ActionResults;
 /// This abstract class is designed to be inherited by classes that need to dynamically generate HTML content as an action result.
 /// It sets various HTTP headers to ensure that the generated content is not cached and is served as HTML.
 /// </remarks>
+[Obsolete("Nothing derives from this type. The form_post response it was written for is produced by " +
+          "AuthorizationResponseFormatter instead, and no derived class exists in this library or its tests. " +
+          "It will be removed in the next major version; if you derive from it, say so on issue #303.")]
+[SuppressMessage("Major Code Smell", "S1133:Deprecated code should be removed",
+    Justification = "Removal is scheduled and tracked: the type is public and abstract, so a consumer outside " +
+                    "this repository could derive from it, which makes deletion a break rather than a cleanup " +
+                    "and puts it on the next major version (#303).")]
 public abstract class GeneratedHtmlResult : ActionResult, IStatusCodeActionResult
 {
 	/// <inheritdoc />

--- a/src/Abblix.Oidc.Server.SourceGenerators.MinimalApi/MinimalApiModelGenerator.cs
+++ b/src/Abblix.Oidc.Server.SourceGenerators.MinimalApi/MinimalApiModelGenerator.cs
@@ -84,6 +84,10 @@ public class MinimalApiModelGenerator : IIncrementalGenerator
     private static readonly string CompilerServicesNamespace =
         typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute).Namespace!;
 
+    // Taken from the type rather than written out, so it cannot rot into a dangling emitted reference.
+    private static readonly string ExcludeFromCoverageAttribute =
+        $"global::{typeof(System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute).FullName}";
+
     private static readonly SymbolDisplayFormat FullyQualifiedWithNullability =
         SymbolDisplayFormat.FullyQualifiedFormat.AddMiscellaneousOptions(
             SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
@@ -372,6 +376,12 @@ public class MinimalApiModelGenerator : IIncrementalGenerator
             // When any property carries a translated validation attribute, the model opts into validation by the
             // group-scoped endpoint filter through this marker.
             var marker = _properties.Any(property => property.Validations.Count > 0) ? $" : {known.ValidatableModel}" : string.Empty;
+            // Nobody writes this file, so counting its lines tells nobody anything: it drags the adapter's
+            // coverage denominator down with code that can only be changed by changing the generator, and
+            // hides the hand-written shortfall behind it. The attribute travels with the source rather than
+            // living in a coverage settings file, which is both tool-independent and the only route that
+            // works here - dotnet test refuses to run at all when handed --coverage-settings.
+            _writer.AppendLine($"[{ExcludeFromCoverageAttribute}]");
             _writer.AppendLine($"public partial record {stub.Name}{marker}");
             _writer.AppendLine("{");
 

--- a/src/Abblix.Oidc.Server.SourceGenerators.Mvc/MvcModelGenerator.cs
+++ b/src/Abblix.Oidc.Server.SourceGenerators.Mvc/MvcModelGenerator.cs
@@ -66,6 +66,10 @@ public class MvcModelGenerator : IIncrementalGenerator
 	private static readonly string CompilerServicesNamespace =
 		typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute).Namespace!;
 
+	// Taken from the type rather than written out, so it cannot rot into a dangling emitted reference.
+	private static readonly string ExcludeFromCoverageAttribute =
+		$"global::{typeof(System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute).FullName}";
+
 	private static readonly SymbolDisplayFormat FullyQualifiedWithNullability =
 		SymbolDisplayFormat.FullyQualifiedFormat.AddMiscellaneousOptions(
 			SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
@@ -240,6 +244,12 @@ public class MvcModelGenerator : IIncrementalGenerator
 			_writer.AppendLine();
 			_writer.AppendLine($"namespace {stub.Namespace};");
 			_writer.AppendLine();
+			// Nobody writes this file, so counting its lines tells nobody anything: it drags the adapter's
+			// coverage denominator down with code that can only be changed by changing the generator, and
+			// hides the hand-written shortfall behind it. The attribute travels with the source rather than
+			// living in a coverage settings file, which is both tool-independent and the only route that
+			// works here - dotnet test refuses to run at all when handed --coverage-settings.
+			_writer.AppendLine($"[{ExcludeFromCoverageAttribute}]");
 			_writer.AppendLine($"public partial record {stub.Name}");
 			_writer.AppendLine("{");
 

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BackChannelAuthenticationFormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BackChannelAuthenticationFormatterTests.cs
@@ -243,6 +243,12 @@ public sealed class BackChannelAuthenticationFormatterTests(TestFactory factory)
     /// Stands in for the integrator-supplied device interaction and refuses with the error the test needs, so
     /// the refusal arms of the formatter are reached the only way production reaches them.
     /// </summary>
+    /// <remarks>
+    /// A class rather than a mock, matching every other seam these suites fill. An end-to-end test asserts
+    /// composition, so what it registers has to be something the container constructs and the pipeline calls
+    /// like any other registration; a mock there is a proxy configured by the test, which is the thing the
+    /// suite exists to rule out. Neither E2E project references a mocking framework for that reason.
+    /// </remarks>
     private sealed class RefusingUserDeviceHandler(OidcError refusal) : IUserDeviceAuthenticationHandler
     {
         public Task<Result<AuthSession, OidcError>> InitiateAuthenticationAsync(

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BackChannelAuthenticationFormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BackChannelAuthenticationFormatterTests.cs
@@ -102,8 +102,12 @@ public sealed class BackChannelAuthenticationFormatterTests(TestFactory factory)
         var body = await ReadJsonAsync(response);
         Assert.True(response.IsSuccessStatusCode, $"registering a CIBA client failed: {(int)response.StatusCode} {body}");
 
-        return (body[ClientParameters.ClientId]!.GetValue<string>(),
-                body[ClientParameters.ClientSecret]!.GetValue<string>());
+        var clientId = body[ClientParameters.ClientId];
+        var secret = body[ClientParameters.ClientSecret];
+        Assert.NotNull(clientId);
+        Assert.NotNull(secret);
+
+        return (clientId.GetValue<string>(), secret.GetValue<string>());
     }
 
     private static Dictionary<string, string> RequestFor((string ClientId, string Secret) ciba) => new()
@@ -115,7 +119,13 @@ public sealed class BackChannelAuthenticationFormatterTests(TestFactory factory)
     };
 
     private static async Task<JsonObject> ReadJsonAsync(HttpResponseMessage response)
-        => JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+    {
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var node = JsonNode.Parse(raw);
+        Assert.NotNull(node);
+
+        return node.AsObject();
+    }
 
     [Fact]
     public async Task A_device_handler_refusing_the_client_answers_401_with_a_bearer_challenge()
@@ -138,7 +148,9 @@ public sealed class BackChannelAuthenticationFormatterTests(TestFactory factory)
         Assert.Contains(TestConstants.Issuer, challenge, StringComparison.Ordinal);
 
         var body = await ReadJsonAsync(response);
-        Assert.Equal(ErrorCodes.AccessDenied, body[ResponseParameters.Error]!.GetValue<string>());
+        var error = body[ResponseParameters.Error];
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.AccessDenied, error.GetValue<string>());
     }
 
     /// <summary>
@@ -197,7 +209,9 @@ public sealed class BackChannelAuthenticationFormatterTests(TestFactory factory)
         Assert.False(response.Headers.Contains(HeaderNames.WWWAuthenticate));
 
         var body = await ReadJsonAsync(response);
-        Assert.Equal(ErrorCodes.AccessDenied, body[ResponseParameters.Error]!.GetValue<string>());
+        var error = body[ResponseParameters.Error];
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.AccessDenied, error.GetValue<string>());
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BackChannelAuthenticationFormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BackChannelAuthenticationFormatterTests.cs
@@ -1,0 +1,238 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Interfaces;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
+using Abblix.Oidc.Server.Features.UserAuthentication;
+using Abblix.Oidc.Server.Model;
+using Abblix.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+using CibaParameters = Abblix.Oidc.Server.Model.BackChannelAuthenticationRequest.Parameters;
+using ClientParameters = Abblix.Oidc.Server.Model.ClientRequest.Parameters;
+using ResponseParameters = Abblix.Oidc.Server.Endpoints.Authorization.Interfaces.AuthorizationResponse.Parameters;
+
+namespace Abblix.Oidc.Server.MinimalApi.E2E.Tests;
+
+/// <summary>
+/// The CIBA result formatter, which had no coverage at all: the Minimal API host opts the endpoint in, and no
+/// request ever reached it, so every one of its arms was unexercised.
+/// </summary>
+/// <remarks>
+/// The three refusal arms differ in status and in what they carry, and only one of them is reachable without
+/// an integrator-supplied device handler. A client that fails authentication is refused earlier, by the
+/// validator, and gets the plain 400 - the 401 and 403 arms belong to a device handler that refuses a request
+/// whose client already authenticated, which is why the tests below replace that handler rather than sending
+/// bad credentials.
+///
+/// The 401 arm is the one worth driving carefully: RFC 9110 section 11.6.1 requires a challenge on a 401, and
+/// per RFC 6749 section 5.2 its scheme has to match what the client attempted, so a client that sent Basic
+/// credentials gets a Basic challenge and one that sent none gets Bearer. Getting that backwards sends a
+/// client round a retry loop it cannot win.
+/// </remarks>
+public sealed class BackChannelAuthenticationFormatterTests(TestFactory factory) : IClassFixture<TestFactory>
+{
+    private const string LoginHint = "someone@example.com";
+
+    private static HttpClient CreateClientFor(WebApplicationFactory<Program> host)
+        => host.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = TestFactory.BaseAddress,
+        });
+
+    private WebApplicationFactory<Program> HostRefusingWith(OidcError refusal)
+        => factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.Replace(ServiceDescriptor.Scoped<IUserDeviceAuthenticationHandler>(
+                    _ => new RefusingUserDeviceHandler(refusal)))));
+
+    /// <summary>
+    /// A CIBA client has to be registered as one: the grant and a token delivery mode, and no redirect URI,
+    /// because the flow never touches a browser. The default confidential client of the host declares none of
+    /// that, so a request in its name is refused by validation long before the device handler is consulted.
+    /// </summary>
+    private static async Task<(string ClientId, string Secret)> RegisterCibaClientAsync(
+        HttpClient client, JsonObject discovery, string authMethod = ClientAuthenticationMethods.ClientSecretPost)
+    {
+        var response = await client.PostAsync(
+            OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.RegistrationEndpoint),
+            JsonContent.Create(new JsonObject
+            {
+                [ClientRegistrationRequest.Parameters.ClientName] = $"ciba-{Guid.NewGuid():N}",
+                [ClientRegistrationRequest.Parameters.ResponseTypes] = new JsonArray(),
+                [ClientRegistrationRequest.Parameters.GrantTypes] = new JsonArray { GrantTypes.Ciba },
+                [ClientRegistrationRequest.Parameters.TokenEndpointAuthMethod] = authMethod,
+                [ClientRegistrationRequest.Parameters.BackChannelTokenDeliveryMode] =
+                    BackchannelTokenDeliveryModes.Poll,
+            }),
+            TestContext.Current.CancellationToken);
+
+        var body = await ReadJsonAsync(response);
+        Assert.True(response.IsSuccessStatusCode, $"registering a CIBA client failed: {(int)response.StatusCode} {body}");
+
+        return (body[ClientParameters.ClientId]!.GetValue<string>(),
+                body[ClientParameters.ClientSecret]!.GetValue<string>());
+    }
+
+    private static Dictionary<string, string> RequestFor((string ClientId, string Secret) ciba) => new()
+    {
+        [ClientParameters.ClientId] = ciba.ClientId,
+        [ClientParameters.ClientSecret] = ciba.Secret,
+        [CibaParameters.Scope] = Scopes.OpenId,
+        [CibaParameters.LoginHint] = LoginHint,
+    };
+
+    private static async Task<JsonObject> ReadJsonAsync(HttpResponseMessage response)
+        => JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+
+    [Fact]
+    public async Task A_device_handler_refusing_the_client_answers_401_with_a_bearer_challenge()
+    {
+        await using var host = HostRefusingWith(
+            new OidcError(ErrorCodes.UnauthorizedClient, "this client may not reach that user"));
+        var client = CreateClientFor(host);
+        var discovery = await client.FetchDiscoveryAsync();
+        var endpoint = OidcFlows.Endpoint(
+            discovery, ConfigurationResponse.Parameters.BackchannelAuthenticationEndpoint);
+        var ciba = await RegisterCibaClientAsync(client, discovery);
+
+        var response = await client.PostFormAsync(endpoint, RequestFor(ciba));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        // The credentials went in the body, not the Authorization header, so the challenge names Bearer.
+        var challenge = Assert.Single(response.Headers.GetValues(HeaderNames.WWWAuthenticate));
+        Assert.StartsWith(TokenTypes.Bearer, challenge, StringComparison.Ordinal);
+        Assert.Contains(TestConstants.Issuer, challenge, StringComparison.Ordinal);
+
+        var body = await ReadJsonAsync(response);
+        Assert.Equal(ErrorCodes.AccessDenied, body[ResponseParameters.Error]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// The same refusal to a client that authenticated through the Authorization header: the challenge has to
+    /// name the scheme that client used, or it is told to retry with one it never attempted.
+    /// </summary>
+    [Fact]
+    public async Task The_challenge_names_the_scheme_the_client_actually_used()
+    {
+        await using var host = HostRefusingWith(
+            new OidcError(ErrorCodes.UnauthorizedClient, "this client may not reach that user"));
+        var client = CreateClientFor(host);
+        var discovery = await client.FetchDiscoveryAsync();
+        var endpoint = OidcFlows.Endpoint(
+            discovery, ConfigurationResponse.Parameters.BackchannelAuthenticationEndpoint);
+        // Registered for the header-based method, because a client is only allowed to authenticate the way it
+        // registered: sending Basic credentials for a client_secret_post client is refused by the validator
+        // long before the device handler is reached, and the challenge branch under test never runs.
+        var ciba = await RegisterCibaClientAsync(
+            client, discovery, ClientAuthenticationMethods.ClientSecretBasic);
+
+        var credentials = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{ciba.ClientId}:{ciba.Secret}"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TokenTypes.Basic, credentials);
+
+        var response = await client.PostFormAsync(endpoint, new Dictionary<string, string>
+        {
+            [CibaParameters.Scope] = Scopes.OpenId,
+            [CibaParameters.LoginHint] = LoginHint,
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        var challenge = Assert.Single(response.Headers.GetValues(HeaderNames.WWWAuthenticate));
+        Assert.StartsWith(TokenTypes.Basic, challenge, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The user refusing is not the client being unauthorised: 403 says the request was understood and denied,
+    /// and it carries no challenge because retrying with different credentials would not help.
+    /// </summary>
+    [Fact]
+    public async Task A_device_handler_reporting_the_user_declined_answers_403_without_a_challenge()
+    {
+        await using var host = HostRefusingWith(
+            new OidcError(ErrorCodes.AccessDenied, "the user declined on their device"));
+        var client = CreateClientFor(host);
+        var discovery = await client.FetchDiscoveryAsync();
+        var endpoint = OidcFlows.Endpoint(
+            discovery, ConfigurationResponse.Parameters.BackchannelAuthenticationEndpoint);
+        var ciba = await RegisterCibaClientAsync(client, discovery);
+
+        var response = await client.PostFormAsync(endpoint, RequestFor(ciba));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.False(response.Headers.Contains(HeaderNames.WWWAuthenticate));
+
+        var body = await ReadJsonAsync(response);
+        Assert.Equal(ErrorCodes.AccessDenied, body[ResponseParameters.Error]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Everything else lands on the plain 400 arm, reached here without touching the device handler: a request
+    /// that names nobody to reach never gets that far.
+    /// </summary>
+    [Fact]
+    public async Task A_request_that_names_nobody_is_refused_with_400_and_no_challenge()
+    {
+        var client = CreateClientFor(factory);
+        var discovery = await client.FetchDiscoveryAsync();
+        var endpoint = OidcFlows.Endpoint(
+            discovery, ConfigurationResponse.Parameters.BackchannelAuthenticationEndpoint);
+        var ciba = await RegisterCibaClientAsync(client, discovery);
+
+        var form = RequestFor(ciba);
+        form.Remove(CibaParameters.LoginHint);
+
+        var response = await client.PostFormAsync(endpoint, form);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.False(response.Headers.Contains(HeaderNames.WWWAuthenticate));
+
+        var body = await ReadJsonAsync(response);
+        Assert.False(string.IsNullOrEmpty(body[ResponseParameters.Error]?.GetValue<string>()));
+    }
+
+    /// <summary>
+    /// Stands in for the integrator-supplied device interaction and refuses with the error the test needs, so
+    /// the refusal arms of the formatter are reached the only way production reaches them.
+    /// </summary>
+    private sealed class RefusingUserDeviceHandler(OidcError refusal) : IUserDeviceAuthenticationHandler
+    {
+        public Task<Result<AuthSession, OidcError>> InitiateAuthenticationAsync(
+            ValidBackChannelAuthenticationRequest request)
+            => Task.FromResult<Result<AuthSession, OidcError>>(refusal);
+    }
+}


### PR DESCRIPTION
## Generated models are no longer counted

Issue #274 asked for generated sources to stop dragging the adapters' coverage denominator down. Both model generators now emit `[ExcludeFromCodeCoverage]` on the type they produce.

The attribute rather than a settings file, for two reasons. It travels with the source, so it holds whichever coverage tool is pointed at the assembly. And it is the only route that works here: `dotnet test --coverage-settings` refuses to run at all in this repository - zero tests, exit 5, and no message naming the file - whatever schema the file uses, while the same command without the option runs the full suite.

Verified rather than assumed, in both directions. A control run over a test project that carries the assembly-level attribute shows none of its own sources in the report, which is what proves the engine honours it. After the change, no generated adapter model appears in the report at all, and the Mvc denominator drops from 1346 lines to 1336.

What is still generated-but-counted is other people's output: the `Grpc.Tools` protobuf classes under `Features/Storages/Proto` and Microsoft's `LoggerMessage.g.cs`. Neither can carry an attribute this library emits, so they are a separate question.

## GeneratedHtmlResult is deprecated

`ActionResults/GeneratedHtmlResult.cs` is a public abstract `ActionResult` with no derived class anywhere in this library or its tests, and the form_post response it was written for is produced by `AuthorizationResponseFormatter` returning an `OkObjectResult`. Its 0 of 19 lines are not a testing gap - the type cannot be reached without writing the subclass it never got.

It is public and abstract, so a consumer outside this repository could have derived from it. That makes deletion a break rather than a cleanup, so it is marked `[Obsolete]` here and removed in #303 on the 3.0 milestone. The `S1133` suppression at the declaration points at that issue, matching how the other deliberate deprecations in this repository answer the same rule.