### PR TITLE
Keep a session's affected clients from being lost when requests race

### DIFF
--- a/src/Abblix.Oidc.Server.AspNetCore/AuthenticationSchemeAdapter.cs
+++ b/src/Abblix.Oidc.Server.AspNetCore/AuthenticationSchemeAdapter.cs
@@ -27,6 +27,7 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Utils;
+using Abblix.Utils.Collections;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
@@ -203,7 +204,7 @@ public class AuthenticationSchemeAdapter(
 
 		if (authenticationResult.Properties is { } properties &&
 		    properties.TryGetStringList(nameof(AuthSession.AffectedClientIds), out var affectedClientIds))
-			authSession = authSession with { AffectedClientIds = affectedClientIds };
+			authSession = authSession with { AffectedClientIds = new ConcurrentSet<string>(affectedClientIds) };
 
 		if (principal.TryGetStringList(JwtClaimTypes.AuthenticationMethodReferences, out var authenticationMethodReferences))
 			authSession = authSession with { AuthenticationMethodReferences = authenticationMethodReferences };

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/AuthSessionMapper.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/AuthSessionMapper.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Utils.Collections;
 using Abblix.Utils.Json;
 using Google.Protobuf.WellKnownTypes;
 
@@ -72,7 +73,7 @@ internal static class AuthSessionMapper
             source.IdentityProvider)
         {
             AuthContextClassRef = ProtoMapper.GetString(source.AuthContextClassRef, source.HasAuthContextClassRef),
-            AffectedClientIds = source.AffectedClientIds.ToList(),
+            AffectedClientIds = new ConcurrentSet<string>(source.AffectedClientIds),
             AuthenticationMethodReferences = source.AuthenticationMethodReferences.Count > 0
                 ? source.AuthenticationMethodReferences.ToList()
                 : null,

--- a/src/Abblix.Oidc.Server/Features/UserAuthentication/AuthSession.cs
+++ b/src/Abblix.Oidc.Server/Features/UserAuthentication/AuthSession.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Text.Json.Nodes;
+using Abblix.Utils.Collections;
 
 namespace Abblix.Oidc.Server.Features.UserAuthentication;
 
@@ -66,7 +67,19 @@ public record AuthSession(string Subject, string SessionId, DateTimeOffset Authe
     /// A collection of client identifiers that the user has interacted with during the session.
     /// This can be used to manage and track user consent and interaction with multiple clients within the same session.
     /// </summary>
-    public ICollection<string> AffectedClientIds { get; init; } = new List<string>();
+    /// <remarks>
+    /// The default is a concurrent set, because a host that caches the session serves one instance to several
+    /// requests at once, and this is the one member they all write to: the authorization endpoint adds a client
+    /// here, the end-session endpoint enumerates it to decide whom to notify. A plain list loses one of two
+    /// simultaneous additions and throws if an enumeration is open while one lands - a client that never learns
+    /// the user signed out, or a failed logout.
+    ///
+    /// This bounds the guarantee to a shared instance, which is worth stating because the usual host is not one:
+    /// the cookie-backed adapter rebuilds a session from claims per request, so concurrent requests there hold
+    /// separate instances and can still lose an addition when both write the cookie back. Closing that needs a
+    /// store that can add atomically, not a collection type.
+    /// </remarks>
+    public ICollection<string> AffectedClientIds { get; init; } = new ConcurrentSet<string>();
 
     /// <summary>
     /// A list of authentication methods used during the user's authentication process,

--- a/src/Abblix.Utils/Collections/ConcurrentSet.cs
+++ b/src/Abblix.Utils/Collections/ConcurrentSet.cs
@@ -1,0 +1,115 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections;
+using System.Collections.Concurrent;
+
+namespace Abblix.Utils.Collections;
+
+/// <summary>
+/// A set that several threads may add to and enumerate at the same time, losing neither what is already stored
+/// nor what is being added.
+/// </summary>
+/// <remarks>
+/// The .NET base class library ships no concurrent set, so the choice is between a <see cref="HashSet{T}"/>
+/// under a lock and the keys of a <see cref="ConcurrentDictionary{TKey,TValue}"/>, which are exactly a
+/// concurrent set with a value nobody reads. The dictionary wins on two counts.
+///
+/// Its <c>TryAdd</c> is an atomic test-and-add that also reports which caller performed the addition. That is
+/// the operation the defect needed: <c>if (!Contains) Add</c> is two operations with a window between them, and
+/// a lock closes the window only for as long as every caller remembers to take it, whereas here the guarantee
+/// belongs to the type.
+///
+/// And its <c>Keys</c> property is documented to return "a copy of all the keys", not "kept in sync" with the
+/// dictionary. That promise is what makes this usable from an <c>async</c> loop: a reader holding a lock cannot
+/// <c>await</c> inside the loop, so any lock-based set would force the caller to copy first - and a copy is
+/// what this returns to begin with. A reader iterating while a writer adds therefore neither throws
+/// <see cref="InvalidOperationException"/> nor loses an element that was already there.
+///
+/// The alternative considered was an <c>ImmutableHashSet</c> field updated by
+/// <see cref="System.Threading.Interlocked.CompareExchange{T}(ref T, T, T)"/>: correct, and lock-free, but it
+/// allocates a new version of the set per addition and spins a retry loop under contention, for no gain over
+/// this. The cost of what is here instead is a placeholder byte per element and a <see cref="Count"/> that
+/// takes every segment lock - both irrelevant at the sizes this holds.
+/// </remarks>
+/// <typeparam name="T">The element type. Uses the type's default equality comparer.</typeparam>
+public sealed class ConcurrentSet<T> : ICollection<T> where T : notnull
+{
+    /// <summary>Creates an empty set.</summary>
+    public ConcurrentSet()
+    {
+    }
+
+    /// <summary>Creates a set containing the distinct elements of <paramref name="items"/>.</summary>
+    public ConcurrentSet(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+            Add(item);
+    }
+
+    // The value is a placeholder: the dictionary's keys are the set, and nothing ever reads the value.
+    private readonly ConcurrentDictionary<T, byte> _items = new();
+
+    /// <summary>
+    /// Adds an item if it is not already present. Returns whether this call is the one that added it, which
+    /// lets a caller act on the transition (persist, notify) exactly once even under concurrency - something
+    /// <see cref="ICollection{T}.Add"/> cannot express, since it returns nothing.
+    /// </summary>
+    public bool TryAdd(T item) => _items.TryAdd(item, 0);
+
+    /// <inheritdoc />
+    public void Add(T item) => TryAdd(item);
+
+    /// <inheritdoc />
+    public bool Remove(T item) => _items.TryRemove(item, out _);
+
+    /// <inheritdoc />
+    public void Clear() => _items.Clear();
+
+    /// <inheritdoc />
+    public bool Contains(T item) => _items.ContainsKey(item);
+
+    /// <inheritdoc />
+    public int Count => _items.Count;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public void CopyTo(T[] array, int arrayIndex) => _items.Keys.CopyTo(array, arrayIndex);
+
+    /// <summary>
+    /// Enumerates a snapshot taken when enumeration begins, so what a reader sees does not depend on what a
+    /// writer does while it reads.
+    /// </summary>
+    /// <remarks>
+    /// Goes through <c>Keys</c> deliberately, and not through the dictionary's own enumerator: the latter is
+    /// documented as "safe to use concurrently with reads and writes ... however it does not represent a
+    /// moment-in-time snapshot", so it would show some later additions and not others depending on timing.
+    /// Neither form can throw, so this is not about safety - it is about a caller that enumerates across
+    /// <c>await</c> points getting a defined answer rather than a race-dependent one. Do not "simplify" this to
+    /// the dictionary's enumerator to save the copy.
+    /// </remarks>
+    public IEnumerator<T> GetEnumerator() => _items.Keys.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -155,7 +155,8 @@ public class AuthorizationRequestProcessorTests
             IdentityProvider: "local")
         {
             AuthContextClassRef = acr,
-            AffectedClientIds = new List<string>(),
+            // AffectedClientIds is left at its default on purpose: hard-coding a List here would test the
+            // fixture's collection rather than the one a session actually carries.
         };
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/UserAuthentication/AffectedClientIdsConcurrencyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/UserAuthentication/AffectedClientIdsConcurrencyTests.cs
@@ -1,0 +1,150 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Features.UserAuthentication;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.UserAuthentication;
+
+/// <summary>
+/// What <see cref="AuthSession.AffectedClientIds"/> must survive when a host hands the same session instance to
+/// several requests at once: additions from different threads, and an enumeration running while another thread
+/// adds.
+/// </summary>
+/// <remarks>
+/// A host that caches the session and serves one instance to concurrent requests is the case these guard. The
+/// list is written by the authorization endpoint, which records every client that took part in the session, and
+/// read by the end-session endpoint, which notifies exactly those clients that the user signed out. So a lost
+/// addition is a client that never learns the user left - its local session outlives the logout - and a torn
+/// enumeration is a 500 on the way out.
+///
+/// Note the boundary this does NOT cross: the cookie-backed <c>AuthenticationSchemeAdapter</c> rebuilds a fresh
+/// session from claims on every request, so concurrent requests there never share an instance and these
+/// guarantees do not reach them. Their lost updates are a property of read-modify-write against the browser's
+/// cookie and can only be closed by a store that adds atomically.
+/// </remarks>
+public class AffectedClientIdsConcurrencyTests
+{
+    private const int Writers = 16;
+    private const int PerWriter = 64;
+
+    private static AuthSession NewSession() => new(
+        Subject: "subject",
+        SessionId: "session",
+        AuthenticationTime: TimeProvider.System.GetUtcNow(),
+        IdentityProvider: "test");
+
+    /// <summary>
+    /// Every client added concurrently is present afterwards. A plain list loses additions here, and it loses
+    /// them silently: the writer sees no error, and the client simply never appears in the logout notice.
+    /// </summary>
+    [Fact]
+    public async Task Concurrent_additions_all_survive()
+    {
+        var session = NewSession();
+        var expected = Enumerable
+            .Range(0, Writers * PerWriter)
+            .Select(i => $"client-{i}")
+            .ToArray();
+
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, Writers),
+            TestContext.Current.CancellationToken,
+            (writer, _) =>
+            {
+                for (var i = 0; i < PerWriter; i++)
+                    session.AffectedClientIds.Add(expected[writer * PerWriter + i]);
+
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.Equal(expected.Length, session.AffectedClientIds.Count);
+        Assert.Empty(expected.Except(session.AffectedClientIds));
+    }
+
+    /// <summary>
+    /// The same client id arriving from several threads at once is stored once. A duplicate is not cosmetic:
+    /// the end-session endpoint notifies per entry, so a client would be asked to log out twice.
+    /// </summary>
+    [Fact]
+    public async Task The_same_client_added_concurrently_is_stored_once()
+    {
+        var session = NewSession();
+
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, Writers),
+            TestContext.Current.CancellationToken,
+            (_, _) =>
+            {
+                for (var i = 0; i < PerWriter; i++)
+                    session.AffectedClientIds.Add("the-same-client");
+
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.Equal(["the-same-client"], session.AffectedClientIds);
+    }
+
+    /// <summary>
+    /// Enumerating while another thread adds must neither throw nor tear. This is the shape the end-session
+    /// endpoint runs in - it iterates the ids and awaits a client lookup inside the loop, so the enumeration is
+    /// open across suspension points and any concurrent write lands in the middle of it.
+    /// </summary>
+    [Fact]
+    public async Task Enumerating_while_another_thread_adds_neither_throws_nor_tears()
+    {
+        var session = NewSession();
+        session.AffectedClientIds.Add("already-there");
+
+        using var stop = new CancellationTokenSource();
+
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; !stop.IsCancellationRequested && i < Writers * PerWriter; i++)
+                session.AffectedClientIds.Add($"late-{i}");
+        }, TestContext.Current.CancellationToken);
+
+        try
+        {
+            for (var round = 0; round < 200; round++)
+            {
+                var seen = new List<string>();
+                foreach (var clientId in session.AffectedClientIds)
+                    seen.Add(clientId);
+
+                // Whatever else the snapshot caught, what was there before the writer started must still be in
+                // it: a reader that can lose an existing entry is worse than one that misses a new one.
+                Assert.Contains("already-there", seen);
+            }
+        }
+        finally
+        {
+            await stop.CancelAsync();
+            await writer;
+        }
+    }
+}


### PR DESCRIPTION
A host that caches the session and serves one instance to several requests has two problems with
`AuthSession.AffectedClientIds`, and both are silent.

Two concurrent authorization requests each add their client to the same list, and one addition is dropped: a
list grows by a read-modify-write on an index. The dropped client never learns the user signed out, and its
local session outlives the logout. Meanwhile the end-session endpoint enumerates that same list to decide whom
to notify, and a write landing mid-enumeration throws - turning the user's logout into a 500. That one was
observed intermittently in the end-to-end suite, roughly one run in six.

The collection itself now carries the guarantee: the default is a concurrent set, whose addition is atomic and
idempotent and whose enumeration is a snapshot. The snapshot is the part that matters at the reading end -
that loop awaits a client lookup on every iteration, so it stays open across suspension points, and any
lock-based set would force the caller to copy first anyway.

Reproduced before fixing: two of the three new tests fail against the previous list, one on lost additions and
one on duplicates.

## Scope, which is narrower than it looks

This reaches a shared instance and nothing else. The cookie-backed adapter rebuilds a session from claims on
every request, so concurrent requests there hold separate instances and can still lose an addition when both
write the cookie back - no server-side collection can reach state that lives in the user agent. Closing that
needs the list to stop being state at all, derived instead from the grants already stored, which is #307 on the
3.0 milestone.

## Notes

`ConcurrentSet` lives in `Abblix.Utils` because the base class library ships none. It is the keys of a
`ConcurrentDictionary`, chosen over a locked `HashSet` for its atomic test-and-add and its documented
copy-on-read `Keys`; the reasoning, including the `ImmutableHashSet` alternative that was rejected, is on the
type.
