### PR TITLE
Move the JSON-to-Protobuf converters out of the foundational package

### DIFF
--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -68,7 +68,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Protobuf Include="Features\Storages\Proto\*.proto" GrpcServices="None" />
+      <!-- Access="Internal" keeps the generated message types out of the public API. They are the on-disk
+           shape of what the storages persist, not a contract any host programs against, and every mapper that
+           touches them is already internal. Left public they would be the only place Google.Protobuf reaches
+           this package's public surface, which makes replacing the serialisation format a breaking change for
+           consumers who never used it. -->
+      <Protobuf Include="Features\Storages\Proto\*.proto" GrpcServices="None" Access="Internal" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/AuthSessionMapper.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/AuthSessionMapper.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using Abblix.Utils.Json;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Abblix.Oidc.Server.Features.Storages.Proto.Mappers;

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/JsonNodeExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/JsonNodeExtensions.cs
@@ -24,14 +24,19 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Google.Protobuf.WellKnownTypes;
 
-namespace Abblix.Utils.Json;
+namespace Abblix.Oidc.Server.Features.Storages.Proto.Mappers;
 
 /// <summary>
-/// Bidirectional conversion between System.Text.Json types (JsonObject, JsonNode) and Protocol Buffers well-known types (Struct, Value).
-/// Performs direct object-to-object mapping without intermediate JSON string serialization, providing efficient
-/// conversion for storing JSON data in protobuf messages.
+/// Bidirectional conversion between System.Text.Json types (JsonObject, JsonNode) and Protocol Buffers well-known
+/// types (Struct, Value). Performs direct object-to-object mapping without intermediate JSON string serialization,
+/// providing efficient conversion for storing JSON data in protobuf messages.
 /// </summary>
-public static class JsonNodeExtensions
+/// <remarks>
+/// Internal, and living beside the mappers that are its only callers, because its signatures name Protocol
+/// Buffers types. Exposing those on a public surface would make the storage serialisation format part of this
+/// package's contract, so replacing it would break consumers that never touched it.
+/// </remarks>
+internal static class JsonNodeExtensions
 {
     /// <summary>
     /// Converts JsonObject to protobuf Struct.

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/RequestedClaimsMapper.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/RequestedClaimsMapper.cs
@@ -20,7 +20,6 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
-using Abblix.Utils.Json;
 
 namespace Abblix.Oidc.Server.Features.Storages.Proto.Mappers;
 

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -34,7 +34,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/JsonNodeExtensionsTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/JsonNodeExtensionsTests.cs
@@ -20,11 +20,14 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
-using Abblix.Utils.Json;
+using Abblix.Oidc.Server.Features.Storages.Proto.Mappers;
 using Google.Protobuf.WellKnownTypes;
+using Xunit;
 
-namespace Abblix.Utils.UnitTests.Json;
+namespace Abblix.Oidc.Server.UnitTests.Features.Storages;
 
 /// <summary>
 /// Tests for JsonNodeExtensions protobuf conversion methods.
@@ -504,9 +507,11 @@ public class JsonNodeExtensionsTests
     /// The dictionary pair of the bridge: <c>ToStruct(IDictionary)</c> and <c>ToDictionary(Struct)</c>.
     /// </summary>
     /// <remarks>
-    /// Retained public API with no call site: the one production consumer of this bridge,
-    /// <c>AuthSessionMapper</c>, carries its additional claims as a <c>JsonObject</c> and uses the JsonObject
-    /// overloads in both directions. These are exercised so the first caller does not have to find out.
+    /// Retained without a call site: the one production consumer of this bridge, <c>AuthSessionMapper</c>,
+    /// carries its additional claims as a <c>JsonObject</c> and uses the JsonObject overloads in both
+    /// directions. Since the type became internal these are reachable only from inside this library, so the
+    /// question of whether to keep them is now ours alone - they are exercised so that whoever answers it, or
+    /// becomes their first caller, does not have to find out how they behave.
     /// The round trip is asserted rather than either direction alone, because the number handling is where a
     /// pair like this loses information: protobuf carries every number as a double, so a whole one has to be
     /// recognised on the way back or an integer claim returns as a fraction.


### PR DESCRIPTION
`Abblix.Utils` is what every other package here builds on, and its own description offers it as usable on its
own - yet it exposed a converter whose signatures name Protocol Buffers types. Anyone referencing it for the
string, URI or caching helpers restored `Google.Protobuf` and took the storage serialisation format into their
contract, so replacing that format would have broken consumers who never touched it.

The converters move beside the mappers that are their only callers and become internal there, free to change
with the format they serve. `Google.Protobuf` leaves `Abblix.Utils` altogether, which is the larger half: the
dependency was reaching every consumer of the foundational package, storage or no storage.

## Breaking, deliberately

This removes a public type from a package with fifteen published versions. The risk was weighed rather than
assumed: the type is a plain conversion between two libraries' JSON shapes, with no dependency on anything
here, so a caller copies it.

The generated message types have the same problem and are not touched - 25 of them are public in the published
2.3.0 assembly, measured by reflecting over it, and that is a scale where a quiet removal is the wrong default.
They are #308, milestone 3.0.

The test moves with the code, into the assembly that can now see it, and its remark about "retained public API"
is corrected: what those overloads are is now an internal question, not a compatibility obligation.
