### PR TITLE
Remove the binder guards that cannot run, and state the invariant where it holds

### DIFF
--- a/src/Abblix.Oidc.Server.Mvc/Binders/CultureInfoBinder.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Binders/CultureInfoBinder.cs
@@ -25,6 +25,7 @@ using Abblix.Oidc.Server.DeclarativeBinding;
 using Abblix.Oidc.Server.Mvc.Attributes;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Primitives;
+using Abblix.Utils;
 
 namespace Abblix.Oidc.Server.Mvc.Binders;
 
@@ -63,12 +64,9 @@ public class CultureInfoBinder : ModelBinderBase, IModelBinderProvider
     /// <returns>True if parsing is successful, otherwise false.</returns>
     protected override bool TryParse(Type type, StringValues values, out object? result)
     {
-        string? stringValue = values;
-        if (stringValue == null)
-        {
-            result = null;
-            return false;
-        }
+        // The base binder returns before this is reached when the value provider held nothing, so a set with no
+        // values cannot arrive here - and a set with values converts to a string. See ModelBinderBase.TryParse.
+        var stringValue = ((string?)values).NotNull(nameof(values));
 
         if (type == typeof(CultureInfo))
         {

--- a/src/Abblix.Oidc.Server.Mvc/Binders/JsonSerializerModelBinder.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Binders/JsonSerializerModelBinder.cs
@@ -24,6 +24,7 @@ using System.Text.Json;
 using Abblix.Oidc.Server.DeclarativeBinding;
 using Abblix.Oidc.Server.Mvc.Attributes;
 using Microsoft.Extensions.Primitives;
+using Abblix.Utils;
 
 namespace Abblix.Oidc.Server.Mvc.Binders;
 
@@ -49,12 +50,9 @@ public class JsonSerializerModelBinder : ModelBinderBase
     /// <returns>Returns true if deserialization is successful; otherwise, false.</returns>
     protected override bool TryParse(Type type, StringValues values, out object? result)
     {
-        string? stringValue = values;
-        if (stringValue == null)
-        {
-            result = null;
-            return false;
-        }
+        // The base binder returns before this is reached when the value provider held nothing, so a set with no
+        // values cannot arrive here - and a set with values converts to a string. See ModelBinderBase.TryParse.
+        var stringValue = ((string?)values).NotNull(nameof(values));
 
         result = JsonSerializer.Deserialize(stringValue, type);
         return true;

--- a/src/Abblix.Oidc.Server.Mvc/Binders/ModelBinderBase.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Binders/ModelBinderBase.cs
@@ -75,8 +75,31 @@ public abstract class ModelBinderBase : IModelBinder
 	/// When implemented in a derived class, attempts to parse the incoming data into the specified type.
 	/// </summary>
 	/// <param name="type">The type to which the data should be bound.</param>
-	/// <param name="values">The data to be bound, represented as a collection of string values.</param>
+	/// <param name="values">The data to be bound, represented as a collection of string values. Never empty -
+	/// see the remarks.</param>
 	/// <param name="result">The result of the parsing, if successful.</param>
 	/// <returns>True if the parsing is successful; otherwise, false.</returns>
+	/// <remarks>
+	/// <para><b>An implementation never sees an absent value.</b> <see cref="BindModelAsync"/> returns as soon
+	/// as the value provider reports <see cref="ValueProviderResult.None"/>, and a result carrying no values
+	/// equals <c>None</c> whatever its culture (measured). So <paramref name="values"/> always holds at least
+	/// one entry, and converting it to a string - which yields <c>null</c> only for an empty set - always
+	/// produces one.</para>
+	///
+	/// <para>This is written down because three implementations once opened with a guard against the absent
+	/// case, and it could not run: the coverage stayed at zero through the whole suite while the tests passed,
+	/// which is the shape a defensive branch takes when it guards something already guaranteed. Worse than
+	/// unused, it would have answered a broken invariant with a silent "did not bind" while the two
+	/// implementations without such a guard threw - one contract, two behaviours, in the case nobody tests.</para>
+	///
+	/// <para>An implementation that wants the guarantee stated in code asserts it (<c>NotNull</c>) rather than
+	/// branching on it: an assertion fails loudly if the invariant ever breaks, and reads as a claim about this
+	/// contract instead of as a case the caller is expected to produce.</para>
+	///
+	/// <para>Note also what the single value can be: a parameter sent more than once arrives here as one
+	/// comma-joined string, not as several values and not as none. Refusing that is the implementation's job -
+	/// OpenID Connect Core 1.0 section 3.1.2.1 forbids the repetition, and every implementation here refuses it
+	/// by failing to parse the joined value.</para>
+	/// </remarks>
 	protected abstract bool TryParse(Type type, StringValues values, out object? result);
 }

--- a/src/Abblix.Oidc.Server.Mvc/Binders/SecondsToTimeSpanModelBinder.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Binders/SecondsToTimeSpanModelBinder.cs
@@ -23,6 +23,7 @@
 using Abblix.Oidc.Server.DeclarativeBinding;
 using Abblix.Oidc.Server.Mvc.Attributes;
 using Microsoft.Extensions.Primitives;
+using Abblix.Utils;
 
 namespace Abblix.Oidc.Server.Mvc.Binders;
 
@@ -51,12 +52,9 @@ public class SecondsToTimeSpanModelBinder : ModelBinderBase
     /// </remarks>
     protected override bool TryParse(Type type, StringValues values, out object? result)
     {
-        string? stringValue = values;
-        if (stringValue == null)
-        {
-            result = null;
-            return false;
-        }
+        // The base binder returns before this is reached when the value provider held nothing, so a set with no
+        // values cannot arrive here - and a set with values converts to a string. See ModelBinderBase.TryParse.
+        var stringValue = ((string?)values).NotNull(nameof(values));
 
         result = TimeSpan.FromSeconds(long.Parse(stringValue));
         return true;


### PR DESCRIPTION
Three model binders (`CultureInfoBinder`, `JsonSerializerModelBinder`, `SecondsToTimeSpanModelBinder`) opened
their parse with a guard against a value that was not there. None of the three could ever run.

`ModelBinderBase.BindModelAsync` returns as soon as the value provider reports `ValueProviderResult.None`, and
a result carrying no values equals `None` whatever its culture - measured, since the equality is by values and
the culture was the part I expected to matter. Converting the values to a string yields `null` only for an
empty set, so the case those guards test for cannot reach them. Coverage agreed independently: the lines stayed
at zero through the whole suite, including a test written specifically to hit them.

## Why remove rather than leave

The two binders in the same hierarchy that carry no such guard throw when the invariant breaks, and the
pipeline turns that into a model error. These three would have answered the same break with a silent "did not
bind" - one contract, two behaviours, in exactly the case nobody exercises. That is what the repository's rule
against defensive programming is about: a guard over something already guaranteed hides the day the guarantee
stops holding.

They also capped the measurement. Coverage of those files could not exceed two thirds, so the metric could no
longer tell a real gap from an unreachable one - which cost a full pass earlier, spent trying to reach them
first from an end-to-end request and then from a unit test, before the code said it was impossible. Both
binders that lost a guard are now at 100%.

## What replaces them

Where an implementation wants the guarantee visible it asserts it (`NotNull`) instead of branching on it: an
assertion fails loudly if the invariant ever breaks, and reads as a claim about the contract rather than as a
case the caller might produce.

The invariant is documented on `ModelBinderBase.TryParse`, which is what enforces it, together with the second
thing an implementer needs: a parameter sent more than once arrives as one comma-joined string, not as several
values and not as none, so refusing it (OpenID Connect Core 1.0 section 3.1.2.1) is the implementation's job.

No behaviour changes - the removed lines never executed.
