### PR TITLE
Rewrite the public policy documents: make the security policy answerable and enforceable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,5 +41,5 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant logs or token (redact all secrets)
+      label: Relevant logs, or a decoded JWT header and payload (drop the signature, remove every secret)
       render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Question / how-to (OIDC, OAuth 2.0, .NET integration)
     url: https://github.com/Abblix/Oidc.Server/discussions/categories/q-a
-    about: Ask usage and integration questions in Discussions — maintainers and the community answer there.
+    about: Ask usage and integration questions in Discussions - maintainers and the community answer there.
   - name: Ideas & feedback
     url: https://github.com/Abblix/Oidc.Server/discussions/categories/ideas
     about: Share an idea or vote on what to build next.
@@ -10,5 +10,5 @@ contact_links:
     url: mailto:info@abblix.com
     about: Pricing, licensing, redistribution, and commercial support.
   - name: Security vulnerability (do not open a public issue)
-    url: mailto:info@abblix.com
-    about: Report security issues privately by email.
+    url: https://github.com/Abblix/Oidc.Server/security/advisories/new
+    about: Report privately on GitHub, or email support@abblix.com. Never in a public issue.

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -60,12 +60,14 @@ Usage:
 🔒 Security
 -----------
 
+<!-- Describe the new behaviour or the requirement, never the hole it closes: a release body that names a
+     vulnerability advertises it in every version published before this one. Never mention an issue that is
+     still open. A fix a host need not act on ships silently - see SECURITY.md. -->
 <!-- Include security-related changes -->
 <!-- Examples:
 - Enhanced SSRF protection with multi-layered security approach
   - Added DNS resolution validation before HTTP requests
   - Implemented IP-based blocking for private network ranges
-  - Note: TOCTOU vulnerability exists between DNS validation and HTTP request
 - Hardened GitHub Actions workflow against supply chain attacks
   - Pinned all GitHub Actions to commit SHA instead of mutable version tags
 - Fixed Denial of Service vulnerability in cryptography libraries
@@ -91,7 +93,7 @@ Detailed description
 
 **Fixed routing-template resolution**
 
-- The original token parser used a regex that stopped capturing fallback values at the first closing bracket, and its resolution loop could exit before all placeholders were replaced—resulting in literal `[route:…]` fragments, malformed templates, and startup-time 404s. We broadened the regex to capture any character in the fallback and improved the loop to run until no further substitutions occur.
+- The original token parser used a regex that stopped capturing fallback values at the first closing bracket, and its resolution loop could exit before all placeholders were replaced, resulting in literal `[route:…]` fragments, malformed templates, and startup-time 404s. We broadened the regex to capture any character in the fallback and improved the loop to run until no further substitutions occur.
 -->
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,39 @@
 # Contributing to Abblix OIDC Server
 
-Thank you for your interest in Abblix OIDC Server. Feedback from the people who build on this library is what keeps it correct, secure, and aligned with the specifications — and we genuinely rely on it.
+Thank you for your interest in Abblix OIDC Server. Bug reports, specification gaps and real integration scenarios from the people who build on this library go straight into what we fix and what we build next.
 
-Here is a note on how this project is developed, so your effort goes where it has the most impact.
+This note explains how the project is developed, so your effort goes where it counts.
 
 ## How the codebase is maintained
 
-Abblix OIDC Server is a source-available commercial product, developed in-house by the Abblix team. We do not accept external pull requests, and outside code is not merged into the codebase. This lets us keep full ownership of the architecture, hold one consistent standard for security and specification conformance, and keep the provenance of every line clear under our [license](LICENSE.md).
+Abblix OIDC Server is a source-available commercial product, developed in-house by the Abblix team. We do not accept external pull requests, and outside code is not merged into the codebase. This lets us keep full ownership of the architecture, apply one consistent standard for security and specification conformance, and keep the provenance of every line clear under our [license](LICENSE.md).
 
-This is not a judgement on the quality of outside work — it is how we keep a security-critical identity library coherent and accountable.
+That is not a judgement on the quality of outside work. It is how we keep a security-critical identity library coherent and accountable.
 
 ## How you can help
 
-These are the contributions we value most, and act on:
+These are the contributions we value most:
 
-- **Report a bug.** Open a [GitHub issue](https://github.com/Abblix/Oidc.Server/issues) with the version, your configuration, the request sequence, and what you expected versus what happened. A clear reproduction is the fastest path to a fix.
-- **Suggest a feature or improvement.** Open an [issue](https://github.com/Abblix/Oidc.Server/issues) or start a thread in [Discussions](https://github.com/orgs/Abblix/discussions) describing the use case. Real-world scenarios directly shape our roadmap.
-- **Point out a specification gap.** If something diverges from an RFC or an OpenID Connect specification, tell us which clause and where — conformance is a priority for us.
-- **Ask a question.** [Discussions](https://github.com/orgs/Abblix/discussions) is the place for integration questions and design conversations.
+- **Report a bug.** Open a [GitHub issue](https://github.com/Abblix/Oidc.Server/issues) with the library version, your .NET version, your configuration, the request sequence, and what you expected versus what happened. A clear reproduction is the fastest path to a fix.
+- **Suggest a feature or improvement.** Open an [issue](https://github.com/Abblix/Oidc.Server/issues), or post in [Ideas](https://github.com/Abblix/Oidc.Server/discussions/categories/ideas) describing the use case. That is where we ask what to build next, and we read it when planning. We cannot build everything, and we say so when we decide against something.
+- **Point out a specification gap.** If something diverges from an RFC or an OpenID Connect specification, tell us which clause, and where our behaviour departs from it. Abblix OIDC Server is certified by the OpenID Foundation, and the standards it implements are listed in the [documentation](https://docs.abblix.com/docs/implemented-standards): a divergence from a clause is a defect, and we treat it as one.
+- **Ask a question.** [Q&A](https://github.com/Abblix/Oidc.Server/discussions/categories/q-a) is the place for integration questions and design conversations.
 
 ## Security issues
 
-Please do not report security vulnerabilities through public issues or discussions. Follow the process in [SECURITY.md](SECURITY.md) and email [support@abblix.com](mailto:support@abblix.com) directly.
+Anything that lets someone obtain a token, a session or a claim they should not have, or that weakens a check this library is meant to perform, goes to [support@abblix.com](mailto:support@abblix.com) or through [private reporting on GitHub](https://github.com/Abblix/Oidc.Server/security/advisories/new). Never to a public issue or discussion. The process is in [SECURITY.md](SECURITY.md).
+
+If you are unsure which kind you are holding, treat it as a security issue. We would far rather receive an ordinary bug privately than read a live vulnerability in a public thread, and we will tell you when it is fine to move it into the open.
+
+## Ideas you post here
+
+Anything you post in issues or discussions we may implement freely and without obligation, and we claim nothing over what you keep to yourself. Please do not post code you want to retain rights in, or anything confidential to your employer: we will not merge it, and these are public forums.
 
 ## Contact
 
 - Bugs and feature ideas: [GitHub Issues](https://github.com/Abblix/Oidc.Server/issues)
-- Questions and discussion: [GitHub Discussions](https://github.com/orgs/Abblix/discussions)
-- Everything else: [support@abblix.com](mailto:support@abblix.com)
+- Questions and discussion: [GitHub Discussions](https://github.com/Abblix/Oidc.Server/discussions)
+- Security vulnerabilities: [support@abblix.com](mailto:support@abblix.com), see [SECURITY.md](SECURITY.md)
+- Everything else: [info@abblix.com](mailto:info@abblix.com)
 
-We read every issue and discussion, and we appreciate the time you take to help us make Abblix OIDC Server better.
+We triage new issues weekly and reply to every bug report. Thank you for the time you take to help us make Abblix OIDC Server better.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -54,6 +54,8 @@ This License Agreement ("Agreement") is a legal agreement between you (as a pers
    
    (d) Remove, obscure, or circumvent copyright, proprietary notices, or access controls.
 
+2.2.1. **Security Research Exception.** Subsections 2.2(a) and 2.2(b) do not apply to good-faith security research conducted in accordance with the Security Policy published in the Software's official repository (SECURITY.md), which is incorporated into this Agreement by reference under Section 11.4(c). For that purpose You may modify, instrument, decompile and analyse the Software on installations You control, and the Copyright Holder will not treat such work as a breach of this Agreement. This exception does not permit distribution of the Software or of any derivative work, and Section 2.2(c) and 2.2(d) continue to apply in full.
+
 2.3. You may not use the Software in commercial projects, except as provided in Section 2.5. If you wish to use the Software for non-commercial purposes, you may download and access the Software free of charge, subject to all license terms and technical limits specified in Section 2.3.1. Examples of non-commercial projects include:
 
    (a) Free educational projects;

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![License](https://img.shields.io/badge/license-Source_Available-blue)](LICENSE.md)
 [![Free](https://img.shields.io/badge/free_for_non_commercial_use-brightgreen)](#-license)
 
-⭐ Star us on GitHub — your support motivates us a lot! 🙏😊
+⭐ Star us on GitHub: your support motivates us a lot! 🙏😊
 
 [![Share](https://img.shields.io/badge/share-000000?logo=x&logoColor=white)](https://x.com/intent/tweet?text=Check%20out%20this%20project%20on%20GitHub:%20https://github.com/Abblix/Oidc.Server%20%23OpenIDConnect%20%23Security%20%23Authentication)
 [![Share](https://img.shields.io/badge/share-1877F2?logo=facebook&logoColor=white)](https://www.facebook.com/sharer/sharer.php?u=https://github.com/Abblix/Oidc.Server)
@@ -25,7 +25,7 @@
 [![Share](https://img.shields.io/badge/share-FF4500?logo=reddit&logoColor=white)](https://www.reddit.com/submit?title=Check%20out%20this%20project%20on%20GitHub:%20https://github.com/Abblix/Oidc.Server)
 [![Share](https://img.shields.io/badge/share-0088CC?logo=telegram&logoColor=white)](https://t.me/share/url?url=https://github.com/Abblix/Oidc.Server&text=Check%20out%20this%20project%20on%20GitHub)
 
-**Add a certified OpenID Connect provider to your own ASP.NET Core app — one you embed and own end to end, not a separate server to run and operate.**
+**Add a certified OpenID Connect provider to your own ASP.NET Core app, one you embed and own end to end rather than a separate server to run and operate.**
 
 📑 For the full picture, see the [technical overview](https://resources.abblix.com/pdf/abblix-oidc-server-presentation-eng.pdf).
 
@@ -37,6 +37,7 @@
 - [How to Install](#-how-to-install)
 - [How to Build](#-how-to-build)
 - [Documentation](#-documentation)
+- [Abblix Account](#-abblix-account)
 - [Feedback and Contributions](#-feedback-and-contributions)
 - [License](#-license)
 - [Contacts](#%EF%B8%8F-contacts)
@@ -45,13 +46,13 @@
 
 **Abblix OIDC Server** turns your ASP.NET Core application into a fully certified OpenID Connect provider. Rather than deploying and operating a separate identity server, you embed the protocol directly into your app, so your users, your data, and your UI stay inside your product.
 
-- **Certified to the letter** — every OpenID profile, 634 conformance tests passed, zero skipped and zero warnings.
-- **A library you own, not a server you run** — the OpenID Connect endpoints live inside your app, so users, data, and UI never leave it.
-- **Current with the modern security stack** — DPoP, PAR, JARM, RAR, token exchange, and certificate-bound tokens, alongside the OAuth 2.0 and OpenID Connect core.
-- **Engineering you can audit** — 2000+ passing tests, top SonarCloud security, reliability, and maintainability ratings, and CodeQL scanning on every change.
-- **Modern .NET, minimal friction** — targets .NET 8, 9, and 10, with drop-in adapters for both MVC and Minimal API.
+- **Certified to the letter:** every OpenID profile, 634 conformance tests passed, zero skipped and zero warnings.
+- **A library you own, not a server you run:** the OpenID Connect endpoints live inside your app, so users, data, and UI never leave it.
+- **Current with the modern security stack:** DPoP, PAR, JARM, RAR, token exchange, and certificate-bound tokens, alongside the OAuth 2.0 and OpenID Connect core.
+- **Engineering you can audit:** 2000+ passing tests, top SonarCloud security, reliability, and maintainability ratings, and CodeQL scanning on every change.
+- **Modern .NET, minimal friction:** targets .NET 8, 9, and 10, with drop-in adapters for both MVC and Minimal API.
 
-Under the hood, the library leans on modular and hexagonal architecture and the standard .NET DI container, which keeps it testable and easy to extend. It ships two ASP.NET Core integration adapters that expose the same OpenID Connect endpoints — one for MVC controllers and routing, one for Minimal API endpoint routing — so you adopt whichever hosting model your application already uses, without taking a dependency on the other.
+Under the hood, the library leans on modular and hexagonal architecture and the standard .NET DI container, which keeps it testable and easy to extend. It ships two ASP.NET Core integration adapters that expose the same OpenID Connect endpoints (one for MVC controllers and routing, one for Minimal API endpoint routing), so you adopt whichever hosting model your application already uses, without taking a dependency on the other.
 
 ## ⚡ Quickstart
 
@@ -77,7 +78,7 @@ builder.Services.AddOidcServices(options =>
 });
 ```
 
-That registers the full set of certified OpenID Connect endpoints. Point `LoginUri` at your login page and plug in your user store — the [Getting Started Guide](https://docs.abblix.com/docs/getting-started-guide) walks through a complete, runnable solution.
+That registers the full set of certified OpenID Connect endpoints. Point `LoginUri` at your login page and plug in your user store. The [Getting Started Guide](https://docs.abblix.com/docs/getting-started-guide) walks through a complete, runnable solution.
 
 ## ✨ What's New
 
@@ -113,7 +114,7 @@ That registers the full set of certified OpenID Connect endpoints. Point `LoginU
 
 Most deployments need only the first two; the rest apply if you use the named feature.
 
-- **Authorization response formatting unified.** `IAuthorizationErrorFormatter` is removed — success and error responses now flow through a single `IAuthorizationResponseFormatter`, and `AuthorizationError` is a subtype of the response model. Re-point any decorator or implementation to `IAuthorizationResponseFormatter` and branch on `response is AuthorizationError` (the `{ RedirectUri: null }` variant is the one to render on your own error page).
+- **Authorization response formatting unified.** `IAuthorizationErrorFormatter` is removed, and success and error responses now flow through a single `IAuthorizationResponseFormatter`, and `AuthorizationError` is a subtype of the response model. Re-point any decorator or implementation to `IAuthorizationResponseFormatter` and branch on `response is AuthorizationError` (the `{ RedirectUri: null }` variant is the one to render on your own error page).
 - **Implicit Flow is opt-in.** Implicit and hybrid response types are rejected at client registration unless you call `EnableImplicitFlow()` on the OIDC builder. Authorization Code Flow is the default; no action otherwise.
 - **Initial Access Token required for Dynamic Client Registration.** Anonymous registration is rejected by default (RFC 7591 §3). Issue and require Initial Access Tokens, or set `OidcOptions.RequireInitialAccessToken = false` to keep open registration.
 - **Back-channel logout endpoint validated at registration.** A `backchannel_logout_uri` with a non-`https` scheme, internal hostname, or private/loopback address is rejected with `invalid_client_metadata` under the secure default. Register public `https` endpoints, or relax `SecureHttpFetchOptions` (`AllowedSchemes`, `BlockPrivateNetworks`) for trusted internal deployments.
@@ -164,7 +165,7 @@ dotnet add package Abblix.OIDC.Server.MVC
 dotnet add package Abblix.OIDC.Server.MinimalApi
 ```
 
-Both adapters expose the same OpenID Connect endpoints and pull in the core `Abblix.OIDC.Server` package as a dependency — pick the one that matches how your application maps requests. For hosts that wire the protocol layer directly, install `Abblix.OIDC.Server` instead.
+Both adapters expose the same OpenID Connect endpoints and pull in the core `Abblix.OIDC.Server` package as a dependency, so pick the one that matches how your application maps requests. For hosts that wire the protocol layer directly, install `Abblix.OIDC.Server` instead.
 
 ## 📝 How to Build
 
@@ -203,9 +204,9 @@ To better understand the Abblix OIDC Server product, we recommend visiting our [
 
 ## 💎 Abblix Account
 
-Prefer not to run the provider yourself? [Abblix Account](https://account.abblix.com) is a ready-to-use service hosted in the cloud, built on this library. You get passkeys, MFA, social login, and security event notifications — everything your users need, integrated into your website in minutes.
+Prefer not to run the provider yourself? [Abblix Account](https://account.abblix.com) is a ready-to-use service hosted in the cloud, built on this library. You get passkeys, MFA, social login, and security event notifications: everything your users need, integrated into your website in minutes.
 
-👉 **See it live:** [Quorvel Coffee](https://quorvel.abblix.com) is a demo application using Abblix Account for user authentication. It shows how sign-in flows, session management, and user self-service — all delivered by Abblix Account — fit into a client website.
+👉 **See it live:** [Quorvel Coffee](https://quorvel.abblix.com) is a demo application using Abblix Account for user authentication. It shows how sign-in flows, session management, and user self-service, all delivered by Abblix Account, fit into a client website.
 
 ## 🤝 Feedback and Contributions
 
@@ -214,9 +215,9 @@ We've made every effort to implement all the main aspects of the OpenID protocol
 > [!IMPORTANT]
 > Whether you have feedback on features, have encountered any bugs, or have suggestions for enhancements, we're eager to hear from you. Your insights help us make the Abblix OIDC Server library more robust and user-friendly.
 
-Please feel free to contribute by [submitting an issue](https://github.com/Abblix/Oidc.Server/issues) or [joining the discussions](https://github.com/orgs/Abblix/discussions). Each contribution helps us grow and improve.
+Please feel free to contribute by [submitting an issue](https://github.com/Abblix/Oidc.Server/issues) or [joining the discussions](https://github.com/Abblix/Oidc.Server/discussions). Each contribution helps us grow and improve.
 
-For how we handle contributions — and why the library is developed in-house — see our [Contributing Guidelines](CONTRIBUTING.md).
+For how we handle contributions, and why the library is developed in-house, see our [Contributing Guidelines](CONTRIBUTING.md).
 
 We appreciate your support and look forward to making our product even better with your help!
 
@@ -230,7 +231,8 @@ For non-commercial use, this product is available for free.
 
 For more details about our products, services, or any general information regarding the Abblix OIDC Server, feel free to reach out to us. We are here to provide support and answer any questions you may have. Below are the best ways to contact our team:
 
-- **Email**: Send us your inquiries or support requests at [support@abblix.com](mailto:support@abblix.com).
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com), see the [Security Policy](SECURITY.md)
 - **Website**: Visit the official Abblix OIDC Server page for more information: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 Subscribe to our LinkedIn and Twitter:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,47 +1,125 @@
 # Security Policy
 
+## Supported Versions
+
+| Version     | Supported                                                                      |
+|-------------|--------------------------------------------------------------------------------|
+| Latest 2.x  | Yes: every security fix lands here                                             |
+| Earlier 2.x | No fix in place. Upgrade to the latest 2.x, or ask us about a back-ported patch |
+| 1.x         | No longer supported. Upgrade to 2.x                                            |
+
+Full platform and end-of-support dates are on the
+[version support lifecycle](https://docs.abblix.com/docs/version-support-lifecycle) page.
+
+A fix is made in the latest release and reaches you by upgrading the package. The fixed package is published
+on NuGet and available to everyone, including users of the free non-commercial licence: a security fix is
+never gated behind a purchase.
+
+Know what upgrading can cost, though. Minor releases in this library do carry breaking changes. In 2.4, for
+instance, several endpoints become opt-in, and clients configured for pairwise subject identifiers see their
+`sub` values change. Each release lists its breaking changes, and when we tell you which release carries your
+fix, we will tell you what stands between your version and it.
+
+Where upgrading is genuinely not an option, we can build a patch release for the specific 2.x version you run.
+That is commercial work under your purchase agreement, not part of the standard licence, so write to
+[info@abblix.com](mailto:info@abblix.com) and we will scope it. A version that has passed end of support
+cannot be brought back into support by request.
+
+## Scope
+
+In scope: everything published from this repository. The `Abblix.OIDC.Server` package and its MVC and Minimal
+API adapters, the `Abblix.JWT` packages including the Vault and Azure key providers, `Abblix.Oidc.Client`, and
+the sample hosts.
+
+We treat as a vulnerability a specification violation with a security consequence, an insecure default, a
+control a host cannot configure correctly through the documented API, and any bypass of a check the library
+claims to perform. A deployment that a host made insecure through its own configuration is not one, with an
+important exception: if a dangerous configuration is reachable without a warning, or our documentation
+recommends it, that is our defect and we will fix it.
+
+Out of scope here: the services Abblix operates, and findings from a scanner with no demonstrated exploit
+path. For the former, see Safe Harbor below.
+
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in Abblix OIDC Server, please report it responsibly.
+If you discover a security vulnerability in Abblix OIDC Server, please report it privately.
 
 **Do NOT:**
 - Open a public GitHub issue
 - Discuss the vulnerability in GitHub Discussions or any public forum
-- Publish details before the issue is resolved
+- Publish details while we are working on a fix
 
-**Instead, email us directly at [support@abblix.com](mailto:support@abblix.com)** with:
-- Description of the vulnerability and its potential impact
-- Steps to reproduce (environment, configuration, request sequence)
+**Preferred:
+[report it privately on GitHub](https://github.com/Abblix/Oidc.Server/security/advisories/new).** That opens a
+private thread with the maintainers, carries attachments, and does not travel as plain email.
+
+**By email:** [support@abblix.com](mailto:support@abblix.com), with `SECURITY` in the subject so the report is
+not queued behind support requests. If you have proof-of-concept code and would rather not send it by plain
+email, say so and we will arrange a private channel.
+
+Whichever route you take, tell us:
+- The version you are on, and whether you can upgrade
+- A description of the vulnerability and its potential impact
+- Steps to reproduce: environment, configuration, request sequence
 - Any proof-of-concept code, if available
 
 ## Our Response
 
-- **Acknowledgement** — within 24 hours of your report
-- **Investigation** — our security team will assess severity and begin working on a fix
-- **Progress updates** — we will keep you informed as we work toward resolution
-- **Coordinated disclosure** — once resolved, we will coordinate with you on public disclosure to ensure all users are informed and protected
+- **Acknowledgement:** a maintainer replies within two business days, Astana time (UTC+5). A person, not an
+  autoresponder. If five business days pass in silence, assume the message was lost rather than ignored, and
+  write to [info@abblix.com](mailto:info@abblix.com).
+- **Triage:** within five business days we tell you whether we reproduced it, how we rate it with CVSS v3.1,
+  and whether we consider it a defect in this library or a deployment issue.
+- **If we disagree:** tell us, and you will get a technical answer in the same thread from the person who made
+  the call. Disagreement does not affect anything promised under Safe Harbor below, and it does not affect
+  your right to publish on the timeline below.
+- **Fix:** we aim to ship within 90 days and name a target date at triage. If it slips, you hear that from us
+  before the date, while it still helps you.
+- **Disclosure:** we agree a date with you and credit you by name unless you ask us not to. If 90 days pass
+  from your report without a fix, or we cannot agree a date, you are free to publish, and doing so costs you
+  nothing under this policy.
 
-## Breach Notification
+These timings cover the handling of vulnerability reports, from anyone, licence or no licence: a defect in
+this library is our problem before it is yours. They are not technical support. Support and maintenance are
+governed by your licence and purchase agreement, and Section 3.7 of the [licence](LICENSE.md) is explicit that
+free non-commercial use carries no commitment to either.
 
-In the event of a confirmed data breach affecting Abblix Account (our hosted identity provider):
-- Users and the relevant authority of the Republic of Kazakhstan will be notified within 72 hours of discovery, as required by law
-- Notification will include the nature of the incident, measures taken, and recommended user actions
+We do not run a paid bug bounty.
 
 ## Safe Harbor
 
-We will not take legal action against researchers who report vulnerabilities in good faith and follow this policy. We ask that you:
-- Allow reasonable time for us to investigate and address the issue before any disclosure
-- Make a good-faith effort to avoid accessing or modifying other users' data
-- Do not degrade the availability of our services during testing
+This section is incorporated by reference into the Abblix License Agreement under its Section 11.4(c), and it
+binds Abblix LLP. Within its scope we will not bring or support legal action against you, and we will not
+treat your research as a breach of the licence.
+
+For good-faith security research under this policy, and notwithstanding Sections 2.2(a) and 2.2(b) of the
+[licence](LICENSE.md), you may modify, instrument, decompile and fuzz the Software on an installation you
+control. Nothing else in those sections is waived. What we ask in return:
+
+- **Test against an installation you control.** Providers built on this library are deployed and operated by
+  their owners, and their end users' accounts, tokens and data are not yours to reach. Probing a live provider
+  you do not run is that operator's security incident rather than research on this library, and this policy
+  does not cover it. That includes the services Abblix operates, among them Abblix Account and the public
+  demo: to test one of ours, write to us first and we will tell you what is in scope.
+- **Take no more data than proving the issue requires.** A working reproduction is what we need; anything
+  gathered past that point is not part of it.
+- **Give us time before you publish**, on the terms under Our Response above.
 
 ## Security Updates
 
-Security updates, patches, and advisories are published on:
-- [GitHub Releases](https://github.com/Abblix/Oidc.Server/releases)
-- [abblix.com](https://www.abblix.com)
-- [docs.abblix.com](https://docs.abblix.com)
+Releases carrying security fixes are published on
+[GitHub Releases](https://github.com/Abblix/Oidc.Server/releases) and on NuGet.
+
+Where a fix needs nothing from you beyond upgrading, it ships inside an ordinary release. Where it requires
+you to change configuration or code, we publish a
+[GitHub Security Advisory](https://github.com/Abblix/Oidc.Server/security/advisories) naming the affected and
+fixed versions, so that it reaches the GitHub Advisory Database and your build sees it through NuGet Audit and
+`dotnet list package --vulnerable`. Either way, we tell the reporter which release carries the fix.
+
+To follow along, watch this repository with Custom notifications and select Security alerts.
 
 ## Contact
 
-- **Security reports:** [support@abblix.com](mailto:support@abblix.com)
+- **Security reports:** [support@abblix.com](mailto:support@abblix.com), or
+  [privately on GitHub](https://github.com/Abblix/Oidc.Server/security/advisories/new)
 - **General inquiries:** [info@abblix.com](mailto:info@abblix.com)

--- a/src/Abblix.DependencyInjection/README.md
+++ b/src/Abblix.DependencyInjection/README.md
@@ -46,5 +46,6 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Jwt.Azure/README.md
+++ b/src/Abblix.Jwt.Azure/README.md
@@ -148,5 +148,6 @@ See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Jwt.Vault/README.md
+++ b/src/Abblix.Jwt.Vault/README.md
@@ -161,5 +161,6 @@ See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Jwt/README.md
+++ b/src/Abblix.Jwt/README.md
@@ -51,5 +51,6 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Oidc.Server.MinimalApi/README.md
+++ b/src/Abblix.Oidc.Server.MinimalApi/README.md
@@ -85,5 +85,6 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Oidc.Server.Mvc/README.md
+++ b/src/Abblix.Oidc.Server.Mvc/README.md
@@ -73,5 +73,6 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Oidc.Server/README.md
+++ b/src/Abblix.Oidc.Server/README.md
@@ -81,5 +81,6 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.Utils/README.md
+++ b/src/Abblix.Utils/README.md
@@ -36,5 +36,6 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## Contacts
 
-- **Email**: [support@abblix.com](mailto:support@abblix.com)
+- **General inquiries**: [info@abblix.com](mailto:info@abblix.com)
+- **Support and security reports**: [support@abblix.com](mailto:support@abblix.com)
 - **Website**: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)


### PR DESCRIPTION
Two commits over the public policy documents. No production code changes.

## Security policy

`SECURITY.md` is rewritten to answer what a reporter needs before writing to us, instead of describing our internal process:

- **Supported Versions** table. Fixes land in the latest 2.x and reach you by upgrading; the fixed package is on NuGet for everyone, free non-commercial licence included, so a security fix is never gated behind a purchase. Where upgrading is genuinely impossible we can back-port under a purchase agreement, and the policy says so plainly rather than leaving it to a support thread.
- **What upgrading costs** is named, because a policy that says "just upgrade" while minor releases carry breaking changes is not usable. 2.4 makes several endpoints opt-in and changes `sub` for clients configured for pairwise subject identifiers.
- **Scope.** A specification violation with a security consequence, an insecure default, and a control a host cannot configure correctly through the documented API are vulnerabilities. A host's own misconfiguration is not, unless a dangerous configuration is reachable without a warning or our documentation recommends it, which makes it ours.
- **Response terms.** Acknowledgement within two business days (Astana, UTC+5) from a person, triage in five with a CVSS v3.1 rating, a stated path when you disagree with our assessment, and a 90-day window after which you may publish regardless.
- These timings cover vulnerability handling from anyone, licence or no licence. They are not technical support, and the policy points at licence section 3.7, which is explicit that free non-commercial use carries no commitment to support or maintenance.

## Safe Harbor, and why the licence changed

The old Safe Harbor promised legal protection to researchers but bound nobody: licence section 11.4(c) says external content "does not modify the terms of this Agreement unless explicitly incorporated by reference", and nothing incorporated it. A researcher relying on it had no agreement to point to.

It is now incorporated by reference under that same clause, and a new licence clause **2.2.1 Security Research Exception** waives 2.2(a) and 2.2(b) for good-faith research on an installation the researcher controls. Distribution stays prohibited, and 2.2(c) and 2.2(d) continue to apply in full.

## Two templates that taught the opposite of the policy

- `RELEASE_TEMPLATE.md` carried an example release note naming an unfixed TOCTOU window. A release body that names an open vulnerability advertises it in every version published before that release. Removed, with the rule stated in the template so the next author does not re-derive it.
- `bug_report.yml` asked for a token in a public issue. It now asks for a decoded JWT header and payload with the signature dropped.
- `ISSUE_TEMPLATE/config.yml` pointed security reports at a mailto link. It now points at GitHub private advisory reporting, which is enabled on this repository.

## Contributing and contacts

`CONTRIBUTING.md` promised that we act on what people send and that ideas shape the roadmap directly. Neither is a promise we can keep, and an unkept promise is worse than none. It now states what is true: we read every issue, we cannot build everything, and we say so when we decide against something. Discussions links point at this repository's own board rather than the organisation's, and the licensing position on posted ideas is stated where people post them.

Contacts were a single `support@` address on every page. General enquiries now go to `info@`, `support@` keeps support and security reports, and all eight package READMEs carry the same split so the address is right whichever NuGet page a reader lands on.

## Related changes outside this repository

- `Abblix/.github`: the org-wide contributing guide had the same routing defect and named no security channel at all. Fixed.
- `Abblix/AuthenticationService`: the Breach Notification section belongs to a service holding real user data, not to a package of code. It moved to that repository's own `SECURITY.md`, and this policy now covers the code alone.
- `docs.abblix.com`: the version lifecycle page promised 1.x support until November 2026 while this policy states 1.x is no longer supported. The page now reads July 2026.
