### PR TITLE
Make the access token's encryption stated, and encrypt it to the resource it was minted for

### DIFF
--- a/src/Abblix.Oidc.Server/Common/Configuration/ServiceTokenOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/ServiceTokenOptions.cs
@@ -36,13 +36,23 @@ public record ServiceTokenOptions
     public JwtSigningSettings Signing { get; set; } = new();
 
     /// <summary>
-    /// Whether to encrypt this token type to the server's own encryption key. <c>true</c> (the default)
-    /// encrypts it whenever a server encryption key is configured and otherwise signs it only, matching the
-    /// behavior of prior versions. Set to <c>false</c> to keep the token signed only even when an encryption
-    /// key exists — for example to keep the access token readable by external resource servers that validate
-    /// it against the published key set.
+    /// Whether to encrypt this token type to the server's own encryption key.
     /// </summary>
-    public bool Encrypt { get; set; } = true;
+    /// <remarks>
+    /// Three states, and the difference between two of them decides how a missing key is answered:
+    /// <list type="bullet">
+    /// <item><c>false</c> keeps the token a signed JWS even when an encryption key exists, for example to keep
+    /// the access token readable by external resource servers that validate it against the published key set.
+    /// The server's encryption keys are not resolved at all.</item>
+    /// <item><c>true</c> requires encryption. If no encryption key can be resolved the server refuses to issue
+    /// the token rather than falling back to a signed JWS, because a host that asked for confidentiality and
+    /// silently did not get it has no way to find out.</item>
+    /// <item><c>null</c>, the default, states nothing: the token is encrypted when a server encryption key is
+    /// available and signed only when none is, which is the behaviour of prior versions. A host that never
+    /// touched this setting therefore sees no change and no new failure.</item>
+    /// </list>
+    /// </remarks>
+    public bool? Encrypt { get; set; }
 
     /// <summary>
     /// How this token type is encrypted when <see cref="Encrypt"/> is on and a server encryption key is

--- a/src/Abblix.Oidc.Server/Common/Configuration/ServiceTokensAlgorithmsValidator.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/ServiceTokensAlgorithmsValidator.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Abblix.Jwt.ExternalKeys;
 using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Common.Configuration;
@@ -30,13 +31,19 @@ namespace Abblix.Oidc.Server.Common.Configuration;
 /// key-management algorithm that no registered signer or encryptor can produce, instead of letting the
 /// contradiction surface at token-issuance time as a per-request failure. The accepted sets are read from
 /// the live JWT registrations, the same union OpenID Connect discovery advertises, so a host that adds or
-/// replaces an algorithm is validated against exactly what it registered — no static allow-list to keep in sync.
+/// replaces an algorithm is validated against exactly what it registered - no static allow-list to keep in sync.
 /// </summary>
-/// <param name="jwtCreator">Source of the registered signing and JWE key-management algorithms. The creator is
-/// deliberately the only dependency: it is lightweight, so validating options does not drag the runtime token
-/// pipeline (and its storage) into startup.</param>
+/// <param name="jwtCreator">Source of the registered signing and JWE key-management algorithms. Kept
+/// lightweight on purpose, so validating options does not drag the runtime token pipeline (and its storage)
+/// into startup.</param>
+/// <param name="custodian">Present when the host holds its keys in an external custodian (a Vault or Key Vault
+/// backend), absent when they come from <see cref="OidcOptions.EncryptionKeys"/>. It is a registration marker
+/// only, and is never called here: it answers where the keys come from without reading them, and without
+/// reading the options that are still being created. Injecting the key provider instead would re-enter
+/// <see cref="IOptions{TOptions}.Value"/> from inside its own creation.</param>
 public sealed class ServiceTokensAlgorithmsValidator(
-    IJsonWebTokenCreator jwtCreator) : IValidateOptions<OidcOptions>
+    IJsonWebTokenCreator jwtCreator,
+    IKeyCustodian? custodian = null) : IValidateOptions<OidcOptions>
 {
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, OidcOptions options)
@@ -66,12 +73,28 @@ public sealed class ServiceTokensAlgorithmsValidator(
                     $"registered signing algorithms ({string.Join(", ", signingAlgorithms)}).");
             }
 
+            if (token.Encrypt == false)
+                return;
+
             var encryptionAlgorithm = token.Encryption.Algorithm;
-            if (token.Encrypt && encryptionAlgorithm is not null && !keyManagementAlgorithms.Contains(encryptionAlgorithm))
+            if (encryptionAlgorithm is not null && !keyManagementAlgorithms.Contains(encryptionAlgorithm))
             {
                 results.Add(
                     $"ServiceTokens.{tokenType}.Encryption.Algorithm '{encryptionAlgorithm}' is not among the " +
                     $"registered JWE key-management algorithms ({string.Join(", ", keyManagementAlgorithms)}).");
+            }
+
+            // Asked to encrypt with nothing to encrypt with. Only an explicit true is refused: the null default
+            // states nothing, and a host that never touched the setting must keep starting and issuing a signed
+            // JWS exactly as before. The key set is only knowable here when it comes from the options; with a
+            // custodian registered the keys live outside them, so the emptiness above says nothing.
+            if (token.Encrypt == true && custodian is null && options.EncryptionKeys.Count == 0)
+            {
+                results.Add(
+                    $"ServiceTokens.{tokenType}.Encrypt is true, but no encryption key is available: " +
+                    $"{nameof(OidcOptions.EncryptionKeys)} is empty and no external key custodian is registered. " +
+                    $"Configure an encryption key, or set ServiceTokens.{tokenType}.Encrypt to false to issue " +
+                    $"this token as a signed JWS.");
             }
         }
     }

--- a/src/Abblix.Oidc.Server/Common/Constants/ResourceDefinition.cs
+++ b/src/Abblix.Oidc.Server/Common/Constants/ResourceDefinition.cs
@@ -20,6 +20,8 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Jwt;
+
 namespace Abblix.Oidc.Server.Common.Constants;
 
 /// <summary>
@@ -30,4 +32,29 @@ namespace Abblix.Oidc.Server.Common.Constants;
 /// <param name="Resource">The identifier for the resource, often a unique name or URL representing the resource.</param>
 /// <param name="Scopes">A variable number of scope definitions associated with the resource. Each scope definition
 /// specifies a scope and its related claims, detailing the access levels and permissions granted.</param>
-public record ResourceDefinition(Uri Resource, params ScopeDefinition[] Scopes);
+public record ResourceDefinition(Uri Resource, params ScopeDefinition[] Scopes)
+{
+    /// <summary>
+    /// The set of JSON Web Keys published by this resource server, used to encrypt an access token issued for
+    /// it. Only public keys belong here: encryption uses the public half, and the resource keeps the private
+    /// one (RFC 9728 Section 2 describes the same key set served over <see cref="JwksUri"/>).
+    /// </summary>
+    /// <remarks>
+    /// Declaring a key is what asks for the access token to be encrypted to this resource rather than left a
+    /// signed JWS. The key-management algorithm is taken from the key's own <c>alg</c> (RFC 7517 Section 4.4),
+    /// so there is no separate algorithm declaration to keep in step: a key that declares none matches
+    /// whatever the server offers.
+    /// </remarks>
+    public JsonWebKeySet? Jwks { get; init; }
+
+    /// <summary>
+    /// The URL where this resource server publishes its JSON Web Key Set, per
+    /// <see href="https://datatracker.ietf.org/doc/html/rfc9728#section-2">RFC 9728 Section 2</see>. Fetched
+    /// with the same SSRF-protected, cached path as a client's key set.
+    /// </summary>
+    /// <remarks>
+    /// May be combined with <see cref="Jwks"/>, in which case the inline keys are considered first, exactly as
+    /// for a client that registers both.
+    /// </remarks>
+    public Uri? JwksUri { get; init; }
+}

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientKeysProvider.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientKeysProvider.cs
@@ -58,35 +58,12 @@ public class ClientKeysProvider(
     }
 
     /// <summary>
-    /// Internally fetches keys from the client's JWKS or JWKS URI with SSRF protection.
+    /// Fetches the keys the client publishes, inline in its registration and at its JWKS URI, through the
+    /// shared SSRF-protected and cached path.
     /// </summary>
     /// <param name="clientInfo">The client information specifying where to find the JWKS.</param>
     /// <returns>An asynchronous enumerable of <see cref="JsonWebKey"/>.</returns>
-    /// <remarks>
-    /// This method attempts to retrieve keys directly from the client's configured JWKS. If a JWKS URI is provided,
-    /// it fetches the JWKS from the remote URI using ISecureHttpFetcher for SSRF protection.
-    /// Logs warnings if the retrieval process fails.
-    /// </remarks>
-    private async IAsyncEnumerable<JsonWebKey> GetKeys(ClientInfo clientInfo)
-    {
-        // Directly yield keys from configured JWKS
-        if (clientInfo.Jwks != null)
-        {
-            foreach (var key in clientInfo.Jwks.Keys)
-                yield return key;
-        }
-
-        // Attempt to fetch keys from JWKS URI with SSRF protection
-        var jwksUri = clientInfo.JwksUri;
-        if (jwksUri == null)
-            yield break;
-
-        using var scope = serviceProvider.CreateScope();
-        var secureFetcher = scope.ServiceProvider.GetRequiredService<ISecureHttpFetcher>();
-
-        await foreach (var key in secureFetcher.FetchKeysAsync(jwksUri, logger, clientInfo.ClientId, "client"))
-        {
-            yield return key;
-        }
-    }
+    private IAsyncEnumerable<JsonWebKey> GetKeys(ClientInfo clientInfo)
+        => serviceProvider.ResolveKeysAsync(
+            clientInfo.Jwks, clientInfo.JwksUri, logger, clientInfo.ClientId, KeySetOwners.Client);
 }

--- a/src/Abblix.Oidc.Server/Features/ResourceIndicators/IResourceKeysProvider.cs
+++ b/src/Abblix.Oidc.Server/Features/ResourceIndicators/IResourceKeysProvider.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+
+namespace Abblix.Oidc.Server.Features.ResourceIndicators;
+
+/// <summary>
+/// Supplies the encryption keys a protected resource publishes, so an access token minted for it can be
+/// encrypted to the party that reads it rather than to this server.
+/// </summary>
+/// <remarks>
+/// The service-side counterpart of <see cref="ClientInformation.IClientKeysProvider"/>: same two forms
+/// (inline in the registration, or fetched from a JWKS URI), same SSRF-protected and cached path. Only the
+/// owner differs, and with it who can decrypt the result.
+/// </remarks>
+public interface IResourceKeysProvider
+{
+    /// <summary>
+    /// Retrieves the encryption keys published by the given resource.
+    /// </summary>
+    /// <param name="definition">The registered definition of the resource.</param>
+    /// <returns>The resource's encryption keys, empty when it publishes none, which is how a resource says it
+    /// accepts a signed JWS.</returns>
+    IAsyncEnumerable<JsonWebKey> GetEncryptionKeys(ResourceDefinition definition);
+}

--- a/src/Abblix.Oidc.Server/Features/ResourceIndicators/ResourceKeysProvider.cs
+++ b/src/Abblix.Oidc.Server/Features/ResourceIndicators/ResourceKeysProvider.cs
@@ -1,0 +1,51 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Features.ResourceIndicators;
+
+/// <summary>
+/// Resolves a protected resource's encryption keys from its registration, inline or at its JWKS URI.
+/// </summary>
+/// <param name="logger">Logger for capturing fetch operations and errors.</param>
+/// <param name="serviceProvider">Used to resolve the scoped <see cref="ISecureHttpFetcher"/> per fetch.</param>
+public class ResourceKeysProvider(
+    ILogger<ResourceKeysProvider> logger,
+    IServiceProvider serviceProvider) : IResourceKeysProvider
+{
+    /// <inheritdoc />
+    public IAsyncEnumerable<JsonWebKey> GetEncryptionKeys(ResourceDefinition definition)
+        => serviceProvider
+            .ResolveKeysAsync(
+                definition.Jwks,
+                definition.JwksUri,
+                logger,
+                definition.Resource.OriginalString,
+                KeySetOwners.Resource)
+            // A key set may serve both roles, and only the encryption half can be used here. A key that
+            // declares no use is usable for either, per RFC 7517 Section 4.2, so it is kept.
+            .Where(key => key.Usage is null or PublicKeyUsages.Encryption);
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/KeySetOwners.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/KeySetOwners.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+/// <summary>
+/// The kinds of party whose key set this server fetches, as they appear in log messages.
+/// </summary>
+/// <remarks>
+/// These are log labels rather than protocol values, so nothing on the wire depends on them. They are named
+/// here so that the four call sites agree on their spelling: an operator grepping the log for one kind should
+/// not have to guess whether it was written as "software statement issuer" or "software-statement issuer".
+/// </remarks>
+public static class KeySetOwners
+{
+    /// <summary>A registered client, whose keys verify its request objects and client assertions.</summary>
+    public const string Client = "client";
+
+    /// <summary>A trusted issuer of the assertions accepted by the JWT bearer grant (RFC 7523).</summary>
+    public const string Issuer = "issuer";
+
+    /// <summary>The issuer of a software statement presented at dynamic client registration (RFC 7591).</summary>
+    public const string SoftwareStatementIssuer = "software statement issuer";
+
+    /// <summary>A protected resource, whose key encrypts the access token issued for it (RFC 9728).</summary>
+    public const string Resource = "resource";
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetcherExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetcherExtensions.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
@@ -73,6 +74,49 @@ public static partial class SecureHttpFetcherExtensions
 			});
 
 		await foreach (var key in jwksKeys)
+		{
+			yield return key;
+		}
+	}
+
+	/// <summary>
+	/// Resolves the keys a party publishes, in the two forms a party may publish them: inline in its
+	/// registration, and at a JWKS URI. Both may be present, and the inline keys come first.
+	/// </summary>
+	/// <param name="serviceProvider">Used to resolve <see cref="ISecureHttpFetcher"/>, which is scoped while
+	/// the providers calling this are not, so a scope is created per call rather than held.</param>
+	/// <param name="jwks">The key set held in the party's own registration, if any.</param>
+	/// <param name="jwksUri">The URI the party publishes its key set at, if any.</param>
+	/// <param name="logger">Logger for recording fetch operations and errors.</param>
+	/// <param name="entityId">The identifier of the party, for logging.</param>
+	/// <param name="entityType">What kind of party it is, for logging. Use a value from
+	/// <see cref="KeySetOwners"/>.</param>
+	/// <returns>The inline keys followed by the fetched ones. Empty when the party declares neither.</returns>
+	/// <remarks>
+	/// The fetch itself is SSRF-protected and cached by the decorators around <see cref="ISecureHttpFetcher"/>,
+	/// so a caller gets both without arranging either.
+	/// </remarks>
+	public static async IAsyncEnumerable<JsonWebKey> ResolveKeysAsync(
+		this IServiceProvider serviceProvider,
+		JsonWebKeySet? jwks,
+		Uri? jwksUri,
+		ILogger logger,
+		string entityId,
+		string entityType)
+	{
+		if (jwks != null)
+		{
+			foreach (var key in jwks.Keys)
+				yield return key;
+		}
+
+		if (jwksUri == null)
+			yield break;
+
+		using var scope = serviceProvider.CreateScope();
+		var secureFetcher = scope.ServiceProvider.GetRequiredService<ISecureHttpFetcher>();
+
+		await foreach (var key in secureFetcher.FetchKeysAsync(jwksUri, logger, entityId, entityType))
 		{
 			yield return key;
 		}

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -478,6 +478,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IScopeClaimsProvider, ScopeClaimsProvider>();
         services.TryAddSingleton<IScopeManager, ScopeManager>();
         services.TryAddSingleton<IResourceManager, ResourceManager>();
+        services.TryAddSingleton<IResourceKeysProvider, ResourceKeysProvider>();
         return services;
     }
 

--- a/src/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
@@ -30,6 +30,7 @@ using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 using Abblix.Oidc.Server.Features.RandomGenerators;
+using Abblix.Oidc.Server.Features.ResourceIndicators;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Utils;
@@ -54,13 +55,18 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// or real) on issuance, and opens it back when authenticating the token.</param>
 /// <param name="options">OIDC configuration options, source of the access token's signing and encryption settings.
 /// </param>
+/// <param name="resourceManager">Resolves a requested resource URI to its registered definition, where a
+/// resource may publish the key its access tokens are encrypted to.</param>
+/// <param name="resourceKeysProvider">Supplies that key, inline or fetched from the resource's JWKS URI.</param>
 internal class AccessTokenService(
 	IIssuerProvider issuerProvider,
 	TimeProvider clock,
 	ITokenIdGenerator tokenIdGenerator,
 	IAuthServiceJwtFormatter serviceJwtFormatter,
 	ISubjectTypeConverter subjectTypeConverter,
-	IOptions<OidcOptions> options) : IAccessTokenService
+	IOptions<OidcOptions> options,
+	IResourceManager resourceManager,
+	IResourceKeysProvider resourceKeysProvider) : IAccessTokenService
 {
 	/// <summary>
 	/// Asynchronously generates a new access token incorporating the authentication session and authorization context
@@ -114,10 +120,57 @@ internal class AccessTokenService(
 		// carries the real subject, which the server opens back at UserInfo, refresh and token exchange.
 		accessToken.Payload.Subject = subjectTypeConverter.Convert(authSession.Subject, clientInfo);
 
-		var encoded = await serviceJwtFormatter.FormatAsync(
-			accessToken, ServiceJwtEncryption.ForAccessToken(options.Value));
+		var encryption = await ApplyAudienceKeyAsync(
+			ServiceJwtEncryption.ForAccessToken(options.Value), authContext);
+
+		var encoded = await serviceJwtFormatter.FormatAsync(accessToken, encryption);
 
 		return new EncodedJsonWebToken(accessToken, encoded);
+	}
+
+	/// <summary>
+	/// Points the encryption policy at the key published by the resource this token was minted for, so the
+	/// party named in <c>aud</c> can read it. A resource that publishes no key leaves the policy untouched,
+	/// which is how it says a signed JWS is what it expects.
+	/// </summary>
+	/// <remarks>
+	/// Several audiences each publishing a key have no correct answer: compact JWE serialization carries one
+	/// recipient, so encrypting to one of them would silently leave the token unreadable to the rest. Refuse
+	/// instead of choosing. Unknown resources never reach here, having been rejected as <c>invalid_target</c>
+	/// during request validation (RFC 8707 Section 2).
+	/// </remarks>
+	private async Task<ServiceJwtEncryption> ApplyAudienceKeyAsync(
+		ServiceJwtEncryption encryption,
+		AuthorizationContext authContext)
+	{
+		if (authContext.Resources is not { Length: > 0 } resources)
+			return encryption;
+
+		JsonWebKey? audienceKey = null;
+		Uri? keyOwner = null;
+
+		foreach (var resource in resources)
+		{
+			if (!resourceManager.TryGet(resource, out var definition))
+				continue;
+
+			var key = await resourceKeysProvider.GetEncryptionKeys(definition).FirstOrDefaultAsync();
+			if (key is null)
+				continue;
+
+			if (audienceKey is not null)
+			{
+				throw new InvalidOperationException(
+					$"The access token names several resources that each publish an encryption key " +
+					$"('{keyOwner}' and '{resource}'), and an encrypted JWT has a single recipient. " +
+					$"Request one such resource per token, or remove the key from all but one of them.");
+			}
+
+			audienceKey = key;
+			keyOwner = resource;
+		}
+
+		return audienceKey is null ? encryption : encryption with { Key = audienceKey };
 	}
 
 	/// <summary>

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
@@ -95,21 +95,36 @@ public class AuthServiceJwtFormatter(
 
 		// Opt-out: this token type is configured signed only, so the server's encryption keys are not even
 		// resolved, mirroring the client formatter's JARM signed-only branch.
-		if (!encryption.Encrypt)
+		if (encryption.Encrypt == false)
 			return await jwtCreator.IssueAsync(token, signingCredentials);
 
 		// Select the encryption key symmetrically with signing: by the policy's key-management algorithm (and
 		// any pinned key id), exactly as the signing key is selected by the token's 'alg'. An algorithm-agnostic
 		// key (no declared 'alg') matches any algorithm per RFC 7517 Section 4.4; when the policy pins no
-		// algorithm, selection falls back to the first available encryption key. No key available at all means
-		// encryption is not configured, so fall back to a signed-only JWS (the behavior of prior versions a host
-		// keeps by leaving Encrypt on); a pinned key id or a required algorithm that matches nothing fails
-		// loudly inside the selector.
+		// algorithm, selection falls back to the first available encryption key. A pinned key id or a required
+		// algorithm that matches nothing fails loudly inside the selector.
 		var encryptingCredentials = await serviceKeysProvider.GetEncryptionKeys()
 			.FirstByAlgorithmAsync(encryption.KeyManagementAlgorithm, encryption.KeyId);
 
 		if (encryptingCredentials is null)
+		{
+			// Encryption was required and there is nothing to encrypt with. Refuse rather than fall back to a
+			// signed JWS: a host that asked for confidentiality and silently did not get it has no way to learn
+			// that, and the token would travel readable while its configuration says otherwise. Startup
+			// validation catches this when the keys come from the options; it cannot when they come from an
+			// external custodian, which is the case that reaches here.
+			if (encryption.Encrypt == true)
+			{
+				throw new InvalidOperationException(
+					$"Encryption is required for this token type, but no encryption key is available. " +
+					$"Configure a server encryption key, or set the token type's " +
+					$"{nameof(ServiceTokenOptions.Encrypt)} to false to issue it as a signed JWS.");
+			}
+
+			// Nothing was stated, so an absent key means encryption is simply not configured: issue a signed
+			// JWS, which is what the server produced before this policy existed.
 			return await jwtCreator.IssueAsync(token, signingCredentials);
+		}
 
 		// Derive the key-management alg from the policy, else the key's declared alg (RFC 7517 §4.4), else the default.
 		var keyEncryptionAlgorithm = encryption.KeyManagementAlgorithm

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/AuthServiceJwtFormatter.cs
@@ -98,13 +98,16 @@ public class AuthServiceJwtFormatter(
 		if (encryption.Encrypt == false)
 			return await jwtCreator.IssueAsync(token, signingCredentials);
 
-		// Select the encryption key symmetrically with signing: by the policy's key-management algorithm (and
-		// any pinned key id), exactly as the signing key is selected by the token's 'alg'. An algorithm-agnostic
-		// key (no declared 'alg') matches any algorithm per RFC 7517 Section 4.4; when the policy pins no
-		// algorithm, selection falls back to the first available encryption key. A pinned key id or a required
-		// algorithm that matches nothing fails loudly inside the selector.
-		var encryptingCredentials = await serviceKeysProvider.GetEncryptionKeys()
-			.FirstByAlgorithmAsync(encryption.KeyManagementAlgorithm, encryption.KeyId);
+		// A policy may name the key itself, which is how a token minted for another party is encrypted to that
+		// party rather than to this server. Otherwise select among the server's own keys symmetrically with
+		// signing: by the policy's key-management algorithm (and any pinned key id), exactly as the signing key
+		// is selected by the token's 'alg'. An algorithm-agnostic key (no declared 'alg') matches any algorithm
+		// per RFC 7517 Section 4.4; when the policy pins no algorithm, selection falls back to the first
+		// available encryption key. A pinned key id or a required algorithm that matches nothing fails loudly
+		// inside the selector.
+		var encryptingCredentials = encryption.Key
+			?? await serviceKeysProvider.GetEncryptionKeys()
+				.FirstByAlgorithmAsync(encryption.KeyManagementAlgorithm, encryption.KeyId);
 
 		if (encryptingCredentials is null)
 		{

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
@@ -33,8 +33,8 @@ namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
 /// <see cref="OidcOptions.ServiceTokens"/>.
 /// </summary>
 /// <param name="Encrypt">Whether to encrypt the token. <c>false</c> yields a signed-only JWS and the
-/// server's encryption keys are not even resolved. <c>true</c> encrypts when a server encryption key is
-/// available and otherwise falls back to a signed-only JWS (the behavior of prior versions).</param>
+/// server's encryption keys are not even resolved. <c>true</c> requires encryption and fails when no key can
+/// be resolved. <c>null</c> states nothing: encrypt if a key is available, sign only if not.</param>
 /// <param name="KeyManagementAlgorithm">The JWE key-management <c>alg</c>, or <c>null</c> to derive it from
 /// the selected encryption key's declared <c>alg</c> (RFC 7517 Section 4.4), falling back to
 /// <c>RSA-OAEP-256</c>.</param>
@@ -43,7 +43,7 @@ namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
 /// <param name="ContentEncryptionAlgorithm">The JWE content-encryption <c>enc</c>, taken from
 /// <see cref="OidcOptions.DefaultContentEncryptionAlgorithm"/>.</param>
 public sealed record ServiceJwtEncryption(
-    bool Encrypt,
+    bool? Encrypt,
     string? KeyManagementAlgorithm,
     string? KeyId,
     string ContentEncryptionAlgorithm)

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryption.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
 
 namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
@@ -48,6 +49,18 @@ public sealed record ServiceJwtEncryption(
     string? KeyId,
     string ContentEncryptionAlgorithm)
 {
+    /// <summary>
+    /// The key to encrypt to, when it is not one of this server's own. Set for an access token whose named
+    /// audience publishes a key: the token is then readable by the party it was minted for, instead of only by
+    /// this server.
+    /// </summary>
+    /// <remarks>
+    /// Carried as data rather than resolved by the formatter, so the formatter stays unaware of resources and
+    /// the decision is made where the request context is. When null the server's own encryption keys are
+    /// selected as before.
+    /// </remarks>
+    public JsonWebKey? Key { get; init; }
+
     /// <summary>Policy for the access token, projected from <c>ServiceTokens.AccessToken</c>.</summary>
     public static ServiceJwtEncryption ForAccessToken(OidcOptions options)
         => FromSettings(options.ServiceTokens.AccessToken, options);

--- a/src/Abblix.Oidc.Server/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/ServiceCollectionExtensions.cs
@@ -69,7 +69,15 @@ public static class ServiceCollectionExtensions
 	{
 		return services
 			.AddOptions<OidcOptions>()
-			.Configure(configureOptions).Services
+			.Configure(configureOptions)
+			// Makes validation a stated contract rather than a side effect. Without it the registered
+			// IValidateOptions validators run on whoever first reads the options value, and today something in
+			// this composition already reads it while the host starts, so removing this line changes no
+			// observable behaviour (measured: the end-to-end startup-refusal test stays green without it).
+			// That is a property of the current wiring rather than a guarantee. The day the last startup-time
+			// reader becomes lazy, a contradictory configuration would boot, report healthy and fail on live
+			// traffic instead.
+			.ValidateOnStart().Services
 			.AddCommonServices()
             .AddSecureHttpFetch() // Must be before AddEndpoints() so DecorateKeyed can find it
             .AddEndpoints()
@@ -121,7 +129,7 @@ public static class ServiceCollectionExtensions
 	}
 
 	/// <summary>
-	/// Configures the service collection with the always-on OAuth 2.0 and OpenID Connect endpoints — the set
+	/// Configures the service collection with the always-on OAuth 2.0 and OpenID Connect endpoints - the set
 	/// mounted unconditionally regardless of <see cref="OidcOptions.EnabledEndpoints"/>: discovery, authorization,
 	/// PAR, token, UserInfo and end session.
 	/// </summary>
@@ -135,8 +143,8 @@ public static class ServiceCollectionExtensions
 	/// - User Info Endpoint for accessing authenticated user information.
 	/// - End Session Endpoint for managing user logout processes.
 	///
-	/// The niche or security-sensitive endpoints — Revocation, Introspection, CIBA, Check Session and Dynamic
-	/// Client Registration — are not wired here. Each is opt-in through its dedicated <c>AddX()</c> feature method
+	/// The niche or security-sensitive endpoints - Revocation, Introspection, CIBA, Check Session and Dynamic
+	/// Client Registration - are not wired here. Each is opt-in through its dedicated <c>AddX()</c> feature method
 	/// (<c>AddRevocation</c>, <c>AddIntrospection</c>, <c>AddBackChannelAuthentication</c>, <c>AddCheckSession</c>,
 	/// <c>AddDynamicClientRegistration</c>), which registers the endpoint services and re-enables its flag in
 	/// <see cref="OidcOptions.EnabledEndpoints"/> (defaulting to <see cref="OidcEndpoints.Base"/>).

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenTamperingTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RefreshTokenTamperingTests.cs
@@ -38,8 +38,8 @@ namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 /// validation gate (<c>RefreshTokenGrantHandler</c> → <c>AuthServiceJwtValidator</c> → the real
 /// signer) before it ever touches the token store: a tampered refresh token is rejected with
 /// <c>invalid_grant</c> however it was mutated. Covers the RFC 8725 attack matrix on the refresh-token
-/// path — alg-stripping (§3.1), payload tampering (§2.1), signature corruption, and segment-count
-/// confusion (RFC 7515 §7.1) — which the handler's unit tests cannot exercise because they mock the
+/// path - alg-stripping (§3.1), payload tampering (§2.1), signature corruption, and segment-count
+/// confusion (RFC 7515 §7.1) - which the handler's unit tests cannot exercise because they mock the
 /// validator. Each test obtains its own genuine refresh token and only ever submits a mutated copy, so
 /// the real token is never spent and no rotation/family state is disturbed.
 /// </summary>
@@ -143,15 +143,4 @@ public class RefreshTokenTamperingTests(TestFactory factory) : TestBase(factory)
 
     private static string Base64UrlEncode(string value) =>
         Convert.ToBase64String(Encoding.UTF8.GetBytes(value)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
-
-    private static byte[] Base64UrlDecode(string input)
-    {
-        var padded = input.Replace('-', '+').Replace('_', '/');
-        switch (padded.Length % 4)
-        {
-            case 2: padded += "=="; break;
-            case 3: padded += "="; break;
-        }
-        return Convert.FromBase64String(padded);
-    }
 }

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
@@ -3,9 +3,15 @@
 
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Common.Constants;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 using ResponseParameters = Abblix.Oidc.Server.Endpoints.Authorization.Interfaces.AuthorizationResponse.Parameters;
 
@@ -81,6 +87,76 @@ public class ResourceIndicatorTests(TestFactory factory) : TestBase(factory)
         var error = JsonNode.Parse(raw)?.AsObject();
         Assert.Equal(ErrorCodes.InvalidTarget, error?[ResponseParameters.Error]?.GetValue<string>());
     }
+
+    /// <summary>
+    /// A resource that publishes an encryption key gets its access token encrypted to that key, so the party
+    /// named in <c>aud</c> can read the token minted for it. The proof is the recipient: the JWE header names
+    /// the resource's own <c>kid</c>, not the server's, and a token encrypted to the server's key would be
+    /// unreadable by the resource, which holds only the published public half.
+    /// </summary>
+    [Fact]
+    public async Task ClientCredentials_with_resource_publishing_a_key_encrypts_the_token_to_it()
+    {
+        var resourceKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Encryption);
+        resourceKey = resourceKey with { KeyId = "orders-api-enc" };
+
+        await using var host = CreateHostWithResourceKey(resourceKey);
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.ClientCredentials,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ClientCredentialsClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.Resource] = TestConstants.ApiResource,
+        });
+
+        var accessToken = tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>();
+
+        var segments = accessToken.Split('.');
+        Assert.True(segments.Length == 5, $"Expected a JWE (5 segments), got {segments.Length}");
+
+        var header = JsonNode.Parse(Base64UrlDecode(segments[0]))?.AsObject();
+        Assert.NotNull(header);
+        Assert.Equal(resourceKey.KeyId, header![JwtClaimTypes.KeyId]?.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Builds an isolated host where the registered resource publishes the given encryption key, and the
+    /// server holds an encryption key of its own. Both being present is what makes the assertion meaningful:
+    /// the token could have been encrypted to either, and the header says which one was chosen.
+    /// </summary>
+    private WebApplicationFactory<Program> CreateHostWithResourceKey(JsonWebKey resourceKey)
+        => Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
+                    new PostConfigureOptions<OidcOptions>(
+                        Options.DefaultName,
+                        options =>
+                        {
+                            options.EncryptionKeys =
+                            [
+                                JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Encryption) with
+                                {
+                                    KeyId = "server-enc",
+                                },
+                            ];
+                            options.Resources =
+                            [
+                                new ResourceDefinition(new Uri(TestConstants.ApiResource))
+                                {
+                                    Jwks = new JsonWebKeySet([resourceKey]),
+                                },
+                            ];
+                        }))));
+
+    private static HttpClient CreateClientFor(WebApplicationFactory<Program> host)
+        => host.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = TestServerAddress.BaseAddress,
+        });
 
     // RFC 7519 §4.1.3: aud is serialized as a single string when there is one value, or an array
     // when there are several. Normalize both shapes to a flat list for assertion.

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ServiceTokenEncryptionTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ServiceTokenEncryptionTests.cs
@@ -38,8 +38,8 @@ namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 /// <summary>
 /// End-to-end proof of the service-token encryption model: when a server encryption key is configured, the
 /// tokens the server issues for itself are encrypted to it by default (as in prior versions), and encryption
-/// can be turned off per token type. The default is opaque-first — an encrypted access token is consumed by
-/// the server's own UserInfo endpoint — and a host keeps the access token readable by external resource
+/// can be turned off per token type. The default is opaque-first - an encrypted access token is consumed by
+/// the server's own UserInfo endpoint - and a host keeps the access token readable by external resource
 /// servers by disabling its encryption. These settings are enabled on an isolated host so the shared default
 /// suite is untouched.
 /// </summary>
@@ -48,7 +48,7 @@ public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory
     /// <summary>
     /// With an encryption key configured and default settings, the access token issued through the real flow
     /// is an encrypted JWE (five segments), reproducing the prior-version behavior, and the server's own
-    /// UserInfo endpoint reads it back — the access token is opaque to third parties but consumed first-party.
+    /// UserInfo endpoint reads it back - the access token is opaque to third parties but consumed first-party.
     /// </summary>
     [Fact]
     public async Task EncryptionKeyConfigured_AccessTokenEncryptedByDefault_AndConsumedByOwnUserInfo()
@@ -75,7 +75,7 @@ public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory
     /// <summary>
     /// Encryption is turned off per token type: disabling the access token's encryption leaves it a signed JWS
     /// (three segments) even though a key is configured, while the refresh token stays encrypted (five
-    /// segments). The encrypted refresh token still round-trips — the server decrypts and validates its own
+    /// segments). The encrypted refresh token still round-trips - the server decrypts and validates its own
     /// JWE on the refresh grant.
     /// </summary>
     [Fact]
@@ -131,4 +131,34 @@ public class ServiceTokenEncryptionTests(TestFactory factory) : TestBase(factory
         });
 
     private static int SegmentCount(string jwt) => jwt.Split('.').Length;
+
+    /// <summary>
+    /// A host that requires encryption while no key can serve it does not come up. This is the end-to-end half
+    /// of the refusal: the unit test proves the validator returns a failure, and only a real host proves the
+    /// failure is raised rather than collected and ignored.
+    /// </summary>
+    /// <remarks>
+    /// It does not prove that the refusal comes from <c>ValidateOnStart</c>. Measured by mutation: removing
+    /// that call leaves this test green, because something in the composition already reads
+    /// <c>IOptions&lt;OidcOptions&gt;.Value</c> while the host starts. The call is kept as a stated contract
+    /// rather than a behaviour this test can observe.
+    /// </remarks>
+    [Fact]
+    public void StartupIsRefusedWhenEncryptionIsRequiredWithoutAnyKey()
+    {
+        using var host = Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
+                    new PostConfigureOptions<OidcOptions>(
+                        Options.DefaultName,
+                        options =>
+                        {
+                            options.EncryptionKeys = [];
+                            options.ServiceTokens.AccessToken.Encrypt = true;
+                        }))));
+
+        var exception = Assert.Throws<OptionsValidationException>(() => CreateClientFor(host));
+
+        Assert.Contains(exception.Failures, f => f.Contains("AccessToken.Encrypt is true"));
+    }
 }

--- a/tests/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -293,7 +293,7 @@ public abstract class TestBase(TestFactory factory)
     private static string Base64UrlEncode(byte[] bytes) =>
         Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
-    private static byte[] Base64UrlDecode(string input)
+    protected static byte[] Base64UrlDecode(string input)
     {
         var padded = input.Replace('-', '+').Replace('_', '/');
         switch (padded.Length % 4)

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ServiceTokensAlgorithmsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ServiceTokensAlgorithmsValidatorTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using Abblix.Jwt;
+using Abblix.Jwt.ExternalKeys;
 using Abblix.Oidc.Server.Common.Configuration;
 using Moq;
 using Xunit;
@@ -44,11 +45,16 @@ public class ServiceTokensAlgorithmsValidatorTests
 
     public ServiceTokensAlgorithmsValidatorTests()
     {
+        _validator = CreateValidator();
+    }
+
+    private static ServiceTokensAlgorithmsValidator CreateValidator(IKeyCustodian? custodian = null)
+    {
         var jwtCreator = new Mock<IJsonWebTokenCreator>(MockBehavior.Strict);
         jwtCreator.SetupGet(c => c.SignedResponseAlgorithmsSupported).Returns(RegisteredSigningAlgorithms);
         jwtCreator.SetupGet(c => c.EncryptedResponseAlgorithmsSupported).Returns(RegisteredKeyManagementAlgorithms);
 
-        _validator = new ServiceTokensAlgorithmsValidator(jwtCreator.Object);
+        return new ServiceTokensAlgorithmsValidator(jwtCreator.Object, custodian);
     }
 
     /// <summary>
@@ -108,6 +114,72 @@ public class ServiceTokensAlgorithmsValidatorTests
             Algorithm = EncryptionAlgorithms.KeyManagement.RsaOaep256,
         };
         options.ServiceTokens.RefreshToken.Encryption = new JwtEncryptionSettings(); // derive-from-key, Algorithm null
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// A host that requires encryption while no key can serve it is refused at startup, naming both the
+    /// setting and the way out. Left to run, it would reach issuance and produce a token whose confidentiality
+    /// the configuration promises and the output does not carry.
+    /// </summary>
+    [Fact]
+    public void Validate_EncryptRequiredWithoutAnyKey_Fails()
+    {
+        var options = new OidcOptions();
+        options.ServiceTokens.AccessToken.Encrypt = true;
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("AccessToken.Encrypt is true"));
+    }
+
+    /// <summary>
+    /// The same requirement validates once a key is configured, which is the whole condition being checked.
+    /// </summary>
+    [Fact]
+    public void Validate_EncryptRequiredWithConfiguredKey_Succeeds()
+    {
+        var options = new OidcOptions();
+        options.ServiceTokens.AccessToken.Encrypt = true;
+        options.EncryptionKeys = [new RsaJsonWebKey { KeyId = "enc-key" }];
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// With an external custodian registered the keys live outside the options, so an empty
+    /// <see cref="OidcOptions.EncryptionKeys"/> says nothing about whether a key exists. Refusing here would
+    /// reject startup for exactly the deployments that keep their keys in a Vault or Key Vault backend.
+    /// </summary>
+    [Fact]
+    public void Validate_EncryptRequiredWithCustodian_Succeeds()
+    {
+        var validator = CreateValidator(new Mock<IKeyCustodian>(MockBehavior.Strict).Object);
+        var options = new OidcOptions();
+        options.ServiceTokens.AccessToken.Encrypt = true;
+
+        var result = validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// A host that never stated a decision keeps starting with no keys configured, which is what separates
+    /// "asked to encrypt" from "did not object" and why the setting is nullable. The shipped default is this
+    /// state, so refusing it would break every deployment that does not use encryption at all.
+    /// </summary>
+    [Fact]
+    public void Validate_EncryptUnstatedWithoutAnyKey_Succeeds()
+    {
+        var options = new OidcOptions();
+
+        Assert.Null(options.ServiceTokens.AccessToken.Encrypt);
 
         var result = _validator.Validate(null, options);
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/AccessTokenServiceTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Jwt;
@@ -32,6 +33,8 @@ using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Features.Tokens;
+using System.Collections.Generic;
+using Abblix.Oidc.Server.Features.ResourceIndicators;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Microsoft.Extensions.Options;
@@ -80,8 +83,18 @@ public class AccessTokenServiceTests
             tokenIdGenerator.Object,
             _jwtFormatter.Object,
             new SubjectTypeConverter(),
-            Options.Create(new OidcOptions()));
+            Options.Create(new OidcOptions()),
+            NoResources,
+            NoResourceKeys);
     }
+
+    /// <summary>
+    /// A registry with nothing registered: these tests request no resource, so the audience-key lookup never
+    /// reaches it. Strict mocks would be equivalent here and noisier.
+    /// </summary>
+    private static IResourceManager NoResources => Mock.Of<IResourceManager>();
+
+    private static IResourceKeysProvider NoResourceKeys => Mock.Of<IResourceKeysProvider>();
 
     /// <summary>
     /// Verifies that CreateAccessTokenAsync generates a JWT with correct header fields:
@@ -489,7 +502,9 @@ public class AccessTokenServiceTests
             Mock.Of<ITokenIdGenerator>(),
             Mock.Of<IAuthServiceJwtFormatter>(),
             converter,
-            Options.Create(new OidcOptions()));
+            Options.Create(new OidcOptions()),
+            NoResources,
+            NoResourceKeys);
 
         var presentingClient = new ClientInfo(ClientId)
         {
@@ -563,5 +578,117 @@ public class AccessTokenServiceTests
         if (accessTokenExpiresIn.HasValue)
             clientInfo.AccessTokenExpiresIn = accessTokenExpiresIn.Value;
         return clientInfo;
+    }
+
+    // Encrypting to the audience rather than to this server
+
+    private static readonly Uri OrdersApi = new("https://orders.example.com");
+    private static readonly Uri BillingApi = new("https://billing.example.com");
+
+    /// <summary>
+    /// Builds a service whose resource registry answers for the given resources, each with the encryption keys
+    /// listed for it. A resource mapped to an empty array is registered but publishes no key.
+    /// </summary>
+    private AccessTokenService CreateServiceWithResources(
+        Dictionary<Uri, JsonWebKey[]> resources)
+    {
+        var manager = new Mock<IResourceManager>(MockBehavior.Strict);
+        var keys = new Mock<IResourceKeysProvider>(MockBehavior.Strict);
+
+        foreach (var (uri, resourceKeys) in resources)
+        {
+            var definition = new ResourceDefinition(uri);
+            var captured = definition;
+            manager.Setup(m => m.TryGet(uri, out captured)).Returns(true);
+            keys.Setup(k => k.GetEncryptionKeys(definition)).Returns(resourceKeys.ToAsyncEnumerable());
+        }
+
+        var issuerProvider = new Mock<IIssuerProvider>(MockBehavior.Strict);
+        issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
+
+        var tokenIdGenerator = new Mock<ITokenIdGenerator>(MockBehavior.Strict);
+        tokenIdGenerator.Setup(g => g.GenerateTokenId()).Returns(TokenId);
+
+        return new AccessTokenService(
+            issuerProvider.Object,
+            new FakeTimeProvider(_currentTime),
+            tokenIdGenerator.Object,
+            _jwtFormatter.Object,
+            new SubjectTypeConverter(),
+            Options.Create(new OidcOptions()),
+            manager.Object,
+            keys.Object);
+    }
+
+    private static AuthorizationContext ContextFor(params Uri[] resources) =>
+        new(ClientId, [Scopes.OpenId], null) { Resources = resources };
+
+    /// <summary>
+    /// A resource that publishes an encryption key gets the access token encrypted to it, so the party named
+    /// in <c>aud</c> can read the token minted for it. Without this the token is encrypted to this server's
+    /// own key, which the audience cannot decrypt: it holds only the published public half.
+    /// </summary>
+    [Fact]
+    public async Task CreateAccessToken_ResourcePublishesKey_EncryptsToThatKey()
+    {
+        var resourceKey = new RsaJsonWebKey { KeyId = "orders-enc" };
+        var service = CreateServiceWithResources(new() { [OrdersApi] = [resourceKey] });
+
+        ServiceJwtEncryption? capturedPolicy = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((_, policy) => capturedPolicy = policy)
+            .ReturnsAsync(EncodedToken);
+
+        await service.CreateAccessTokenAsync(
+            CreateAuthSession(), ContextFor(OrdersApi), CreateClientInfo());
+
+        Assert.NotNull(capturedPolicy);
+        Assert.Same(resourceKey, capturedPolicy!.Key);
+    }
+
+    /// <summary>
+    /// A resource that publishes no key leaves the policy alone, so the token follows the server's own
+    /// settings exactly as it did before resources could carry keys. Publishing nothing is how a resource says
+    /// a signed JWS is what it expects.
+    /// </summary>
+    [Fact]
+    public async Task CreateAccessToken_ResourcePublishesNoKey_LeavesPolicyUntouched()
+    {
+        var service = CreateServiceWithResources(new() { [OrdersApi] = [] });
+
+        ServiceJwtEncryption? capturedPolicy = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .Callback<JsonWebToken, ServiceJwtEncryption>((_, policy) => capturedPolicy = policy)
+            .ReturnsAsync(EncodedToken);
+
+        await service.CreateAccessTokenAsync(
+            CreateAuthSession(), ContextFor(OrdersApi), CreateClientInfo());
+
+        Assert.NotNull(capturedPolicy);
+        Assert.Null(capturedPolicy!.Key);
+    }
+
+    /// <summary>
+    /// Two audiences that each publish a key have no correct answer, because compact JWE serialization carries
+    /// a single recipient. Encrypting to one would leave the token unreadable to the other while looking
+    /// successful, so the request is refused instead.
+    /// </summary>
+    [Fact]
+    public async Task CreateAccessToken_SeveralResourcesPublishKeys_Throws()
+    {
+        var service = CreateServiceWithResources(new()
+        {
+            [OrdersApi] = [new RsaJsonWebKey { KeyId = "orders-enc" }],
+            [BillingApi] = [new RsaJsonWebKey { KeyId = "billing-enc" }],
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await service.CreateAccessTokenAsync(
+                CreateAuthSession(), ContextFor(OrdersApi, BillingApi), CreateClientInfo()));
+
+        Assert.Contains(OrdersApi.OriginalString, exception.Message);
+        Assert.Contains(BillingApi.OriginalString, exception.Message);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
@@ -384,6 +384,33 @@ public class AuthServiceJwtFormatterTests
     }
 
     /// <summary>
+    /// Verifies that a policy naming its own key encrypts to that key and does not consult the server's key
+    /// set at all. This is how an access token minted for a resource is encrypted to the party that reads it:
+    /// the strict mock has no <c>GetEncryptionKeys</c> setup, so any attempt to fall back to the server's own
+    /// keys would fail the test.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_PolicyCarriesKey_EncryptsToItWithoutResolvingServerKeys()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+
+        var audienceKey = new RsaJsonWebKey { KeyId = "audience-enc" };
+        var policy = Encrypt() with { Key = audienceKey };
+
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, audienceKey, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
+
+        var result = await _formatter.FormatAsync(token, policy);
+
+        Assert.Equal(EncodedJwt, result);
+        Assert.Same(audienceKey, capturedEncryptionKey);
+    }
+
+    /// <summary>
     /// Verifies that a policy requiring encryption refuses to issue the token when no encryption key is
     /// available, rather than downgrading to a signed JWS. A host that asked for confidentiality and silently
     /// did not get it has no way to learn that, and the token would travel readable while the configuration

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/AuthServiceJwtFormatterTests.cs
@@ -37,9 +37,9 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Formatters;
 /// <summary>
 /// Unit tests for <see cref="AuthServiceJwtFormatter"/> verifying JWT formatting, signing and encryption
 /// for tokens the authorization server issues for itself, per RFC 7519 (JWT), RFC 7515 (JWS) and RFC 7516
-/// (JWE). The tests exercise the explicit <see cref="ServiceJwtEncryption"/> policy overload — signed only,
+/// (JWE). The tests exercise the explicit <see cref="ServiceJwtEncryption"/> policy overload - signed only,
 /// encrypt with a key-derived or explicit key-management algorithm, signing- and encryption-key pinning by
-/// <c>kid</c>, and the missing-key error — plus the retained implicit legacy path.
+/// <c>kid</c>, and the missing-key error - plus the retained implicit legacy path.
 /// </summary>
 public class AuthServiceJwtFormatterTests
 {
@@ -78,6 +78,13 @@ public class AuthServiceJwtFormatterTests
 
     private static ServiceJwtEncryption Encrypt(string? keyManagementAlgorithm = null, string? keyId = null) => new(
         Encrypt: true, keyManagementAlgorithm, keyId, ContentEnc);
+
+    /// <summary>
+    /// The policy of a host that never stated whether this token type should be encrypted: encrypt when a key
+    /// is available, sign only when none is.
+    /// </summary>
+    private static ServiceJwtEncryption Unstated => new(
+        Encrypt: null, KeyManagementAlgorithm: null, KeyId: null, ContentEnc);
 
     private void SetupSigningKeys(params JsonWebKey[] keys) =>
         _keysProvider.Setup(p => p.GetSigningKeys(true)).Returns(keys.ToAsyncEnumerable());
@@ -138,8 +145,8 @@ public class AuthServiceJwtFormatterTests
     // Signed only
 
     /// <summary>
-    /// Verifies that a signed-only policy issues a JWS with no encryption key, and — mirroring the client
-    /// formatter's JARM signed-only branch — does not even resolve the server's encryption keys. The strict
+    /// Verifies that a signed-only policy issues a JWS with no encryption key, and - mirroring the client
+    /// formatter's JARM signed-only branch - does not even resolve the server's encryption keys. The strict
     /// mock has no <c>GetEncryptionKeys</c> setup, so any attempt to resolve them would fail the test.
     /// </summary>
     [Fact]
@@ -377,12 +384,29 @@ public class AuthServiceJwtFormatterTests
     }
 
     /// <summary>
-    /// Verifies that a policy asking for encryption while no encryption key is configured falls back to a
-    /// signed-only JWS rather than failing, matching the behavior of prior versions a host keeps by leaving
-    /// encryption on without configuring a key.
+    /// Verifies that a policy requiring encryption refuses to issue the token when no encryption key is
+    /// available, rather than downgrading to a signed JWS. A host that asked for confidentiality and silently
+    /// did not get it has no way to learn that, and the token would travel readable while the configuration
+    /// says otherwise.
     /// </summary>
     [Fact]
-    public async Task FormatAsync_Encrypt_WithNoEncryptionKey_SignsOnly()
+    public async Task FormatAsync_EncryptRequired_WithNoEncryptionKey_Throws()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _formatter.FormatAsync(token, Encrypt()));
+    }
+
+    /// <summary>
+    /// Verifies that a host which never stated an encryption decision keeps the behavior of prior versions:
+    /// with no encryption key available the token is issued as a signed JWS, without failing. This is what
+    /// separates "asked to encrypt" from "did not object", and it is why the decision is nullable.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_EncryptUnstated_WithNoEncryptionKey_SignsOnly()
     {
         var token = TokenWith();
         SetupSigningKeys(_signingKeyRS256);
@@ -394,10 +418,33 @@ public class AuthServiceJwtFormatterTests
             .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
             .ReturnsAsync(EncodedJwt);
 
-        var result = await _formatter.FormatAsync(token, Encrypt());
+        var result = await _formatter.FormatAsync(token, Unstated);
 
         Assert.Equal(EncodedJwt, result);
         Assert.Null(capturedEncryptionKey);
+    }
+
+    /// <summary>
+    /// Verifies that an unstated decision still encrypts when a key is available, which is the other half of
+    /// the prior-version behavior and the reason a host that configured a key sees no change.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsync_EncryptUnstated_WithEncryptionKey_Encrypts()
+    {
+        var token = TokenWith();
+        SetupSigningKeys(_signingKeyRS256);
+        SetupEncryptionKeys(_encryptionKey);
+
+        JsonWebKey? capturedEncryptionKey = null;
+        _jwtCreator
+            .Setup(c => c.IssueAsync(token, _signingKeyRS256, _encryptionKey, It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<JsonWebToken, JsonWebKey, JsonWebKey?, string, string>((_, _, enc, _, _) => capturedEncryptionKey = enc)
+            .ReturnsAsync(EncodedJwt);
+
+        var result = await _formatter.FormatAsync(token, Unstated);
+
+        Assert.Equal(EncodedJwt, result);
+        Assert.Same(_encryptionKey, capturedEncryptionKey);
     }
 
     /// <summary>


### PR DESCRIPTION
Two commits on the access token's encryption. Closes #314 and #313.

## Refuse to issue a token that was required to be encrypted (#314)

`ServiceTokens.<Type>.Encrypt` defaulted to `true` and, with no encryption key available, quietly produced a signed JWS instead. A host that asked for confidentiality and did not get it had no way to find out: no error, no log line, and the token travelled readable while the configuration said otherwise.

Note the direction of the old failure. The more precisely a host described what it wanted, the louder it failed (a pinned `kid` matching nothing throws on every issuance); the vaguer it was, the quieter.

The flag becomes `bool?`, which is what makes the refusal possible at all: `true` and the default were the same value, so refusing would have broken every host that never touched the setting.

| `Encrypt` | key available | outcome |
|---|---|---|
| `false` | - | signed JWS, keys not resolved |
| `true` | yes | encrypted |
| `true` | no | refused |
| unset | yes | encrypted, as before |
| unset | no | signed JWS, as before |

The check runs in two places because neither covers the other. `ServiceTokensAlgorithmsValidator` catches it at startup when the keys come from the options, and takes `IKeyCustodian?` as a registration marker to tell that case apart: with an external custodian the keys live outside the options, so an empty `EncryptionKeys` says nothing, and refusing there would reject startup for exactly the deployments that keep their keys in Vault or Key Vault. Injecting the key provider instead would re-enter `IOptions<OidcOptions>.Value` from inside its own creation. The formatter carries the other half, for the custodian case startup cannot see.

`AddOidcCore` now registers the options with `ValidateOnStart`. Measured by mutation, removing that call leaves the end-to-end test green, because something in the composition already reads the options while the host starts. It is kept as a stated contract, and both the code comment and the test say that is what it is rather than claiming an effect they cannot observe.

## Encrypt an access token to the resource it was minted for (#313)

Confidentiality and audience were mutually exclusive. Encrypting an access token meant encrypting it to this server's own key, which the party named in `aud` cannot open: it holds the published public half, and decryption needs the private one. A deployment with a separate resource server therefore had to switch encryption off entirely, and the `Encrypt` flag's own documentation said so.

A resource now declares its key the way a client does, inline or at a JWKS URI, and an access token minted for it is encrypted to that key. Declaring nothing changes nothing: the token follows the server's own settings exactly as before, which is how a resource says a signed JWS is what it expects.

Two things are deliberately not invented here:

- The key-management algorithm comes from the key's own `alg` (RFC 7517 section 4.4). RFC 9728 has `resource_signing_alg_values_supported` and nothing on the encryption side, so any declaration we added there would be ours to explain to every integrator.
- An unknown resource is already refused as `invalid_target` during request validation, so a mistyped resource identifier never reaches issuance.

Several audiences each declaring a key are refused rather than resolved: compact JWE serialisation carries one recipient, so encrypting to one of them would leave the token unreadable to the rest while looking like success.

Nothing new was built for the fetch. `ISecureHttpFetcher.FetchKeysAsync` already takes the owner as parameters that only reach the log, and already serves clients, trusted issuers and software-statement issuers behind SSRF protection; a resource is the fourth caller. The inline-or-URI pattern moved out of `ClientKeysProvider` into the shared extension, together with the `CreateScope()` that pattern needs, so both providers are one-liners over it rather than two copies. The four owner labels became constants.

The formatter takes the key as data on the policy rather than resolving it, so it stays unaware of resources, and the decision is made where the request context already is.

## Known follow-up

Resource key sets are fetched without caching, so a resource that publishes its keys at a JWKS URI is fetched on each issuance. That is not specific to resources: the caching decorator is registered as a keyed decorator for the JWT bearer grant alone, and clients and software-statement issuers are uncached today for the same reason. [#315](https://github.com/Abblix/Oidc.Server/issues/315) moves the cache lifetime to the call so every consumer names its own, and lands next.

## Verification

Unit 2530, end-to-end 138, plus the Minimal API, client and JWT suites, all green.

Every decision point was killed by a compiling mutation, each taking its own test down: never applying the resolved audience key (unit and end-to-end), making the several-audience refusal unreachable, the formatter's required-encryption branch, and the validator's explicit-true condition.
