### PR TITLE
Give every key-set consumer a cache of its own

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SoftwareStatementValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SoftwareStatementValidator.cs
@@ -24,6 +24,7 @@ using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -41,7 +42,8 @@ public partial class SoftwareStatementValidator(
     ILogger<SoftwareStatementValidator> logger,
     IJsonWebTokenValidator jwtValidator,
     IOptionsMonitor<OidcOptions> options,
-    ISecureHttpFetcher secureFetcher) : IClientRegistrationContextValidator
+    [FromKeyedServices(KeySetOwners.SoftwareStatementIssuer)] ISecureHttpFetcher secureFetcher)
+    : IClientRegistrationContextValidator
 {
     /// <inheritdoc />
     public async Task<OidcError?> ValidateAsync(ClientRegistrationValidationContext context)
@@ -66,7 +68,7 @@ public partial class SoftwareStatementValidator(
 
         var validationParameters = new ValidationParameters
         {
-            // Skip audience — software statements describe the software, not target a specific server
+            // Skip audience - software statements describe the software, not target a specific server
             Options = ValidationOptions.Default &
                       ~ValidationOptions.RequireAudience &
                       ~ValidationOptions.ValidateAudience,
@@ -140,7 +142,8 @@ public partial class SoftwareStatementValidator(
         if (trustedIssuer == null)
             yield break;
 
-        var keys = secureFetcher.FetchKeysAsync(trustedIssuer.JwksUri, logger, issuer, "software statement issuer");
+        var keys = secureFetcher.FetchKeysAsync(
+            trustedIssuer.JwksUri, logger, issuer, KeySetOwners.SoftwareStatementIssuer);
         await foreach (var key in keys.Where(k => k.Usage is null or PublicKeyUsages.Signature))
         {
             yield return key;

--- a/src/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/ServiceCollectionExtensions.cs
@@ -326,11 +326,6 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<JwtBearer.IJwtReplayCache, JwtBearer.DistributedJwtReplayCache>();
 #pragma warning restore CS0618
 
-        // Register keyed caching decorator for JWT Bearer JWKS fetching
-        // DecorateKeyed will find the non-keyed ISecureHttpFetcher and create a keyed decorated version
-        services.DecorateKeyed<ISecureHttpFetcher, CachingSecureHttpFetcherDecorator>(
-            JwtBearerIssuerProvider.SecureHttpFetcherKey);
-
         return services.AddAuthorizationGrant<JwtBearerGrantHandler>();
     }
 

--- a/src/Abblix.Oidc.Server/Features/JwtBearer/JwtBearerIssuerProvider.cs
+++ b/src/Abblix.Oidc.Server/Features/JwtBearer/JwtBearerIssuerProvider.cs
@@ -37,18 +37,13 @@ namespace Abblix.Oidc.Server.Features.JwtBearer;
 /// <param name="logger">Logger for recording JWKS fetch operations and errors.</param>
 /// <param name="oidcOptions">OIDC configuration options containing JWT Bearer trusted issuers.</param>
 /// <param name="replayCache">Cache for JWT replay protection per RFC 7523 Section 5.2.</param>
-/// <param name="secureFetcher">HTTP fetcher with SSRF protection and JWKS caching.</param>
+/// <param name="secureFetcher">HTTP fetcher with SSRF protection and caching.</param>
 public partial class JwtBearerIssuerProvider(
 	ILogger<JwtBearerIssuerProvider> logger,
 	IOptionsMonitor<OidcOptions> oidcOptions,
 	ReplayPrevention.IJwtReplayCache replayCache,
-	[FromKeyedServices(JwtBearerIssuerProvider.SecureHttpFetcherKey)] ISecureHttpFetcher secureFetcher) : IJwtBearerIssuerProvider
+	[FromKeyedServices(KeySetOwners.Issuer)] ISecureHttpFetcher secureFetcher) : IJwtBearerIssuerProvider
 {
-	/// <summary>
-	/// The keyed service key used to resolve the caching <see cref="ISecureHttpFetcher"/> for JWKS fetching.
-	/// </summary>
-	public const string SecureHttpFetcherKey = "JwtBearerJwks";
-
 	/// <inheritdoc />
 	public JwtBearerOptions Options => oidcOptions.CurrentValue.JwtBearer;
 
@@ -126,7 +121,7 @@ public partial class JwtBearerIssuerProvider(
 			yield break;
 		}
 
-		var keys = secureFetcher.FetchKeysAsync(trustedIssuer.JwksUri, logger, issuer, "issuer");
+		var keys = secureFetcher.FetchKeysAsync(trustedIssuer.JwksUri, logger, issuer, KeySetOwners.Issuer);
 		await foreach (var key in keys.Where(k => k.Usage is null or PublicKeyUsages.Signature))
 		{
 			yield return key;

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/CachingSecureHttpFetcherDecorator.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/CachingSecureHttpFetcherDecorator.cs
@@ -35,11 +35,14 @@ namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
 /// </summary>
 /// <param name="inner">The inner fetcher to decorate.</param>
 /// <param name="cache">The memory cache to store responses.</param>
-/// <param name="oidcOptions">OIDC options containing the cache duration configuration.</param>
+/// <param name="cacheDuration">How long a successfully fetched document is held. Supplied per consumer at
+/// registration rather than read from a shared setting, so each one states the staleness it can live with:
+/// a key set backing token issuance and one backing an occasional signature check do not want the same
+/// lifetime, and the transport contract stays free of the caller's policy.</param>
 public class CachingSecureHttpFetcherDecorator(
 	ISecureHttpFetcher inner,
 	IMemoryCache cache,
-	IOptionsMonitor<OidcOptions> oidcOptions) : ISecureHttpFetcher
+	TimeSpan cacheDuration) : ISecureHttpFetcher
 {
 	/// <inheritdoc />
 	public async Task<Result<T, OidcError>> FetchAsync<T>(Uri uri)
@@ -51,9 +54,14 @@ public class CachingSecureHttpFetcherDecorator(
 
 		var result = await inner.FetchAsync<T>(uri);
 
-		if (result.TryGetSuccess(out var value))
+		// A non-positive lifetime means caching off, and it has to be handled here: MemoryCache does not read
+		// TimeSpan.Zero as "do not store", so a host zeroing the setting to force fresh fetches would get a
+		// stored entry instead of the behaviour it asked for.
+		if (result.TryGetSuccess(out var value) && cacheDuration > TimeSpan.Zero)
 		{
-			cache.Set(cacheKey, value, oidcOptions.CurrentValue.JwtBearer.JwksCacheDuration);
+			// Keyed on the URI alone, because one address is one document. What differs between consumers is
+			// how long it may be held, and that is fixed per instance rather than per call.
+			cache.Set(cacheKey, value, cacheDuration);
 		}
 
 		return result;

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetchOptions.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetchOptions.cs
@@ -48,6 +48,35 @@ public class SecureHttpFetchOptions
     public long MaxResponseSizeBytes { get; set; } = 5 << 20;
 
     /// <summary>
+    /// How long a client's fetched key set is held before it is fetched again. Default: 1 hour.
+    /// </summary>
+    /// <remarks>
+    /// These keys verify request objects and client assertions, so this bounds how long a key the client has
+    /// already removed from its published set is still accepted here.
+    /// </remarks>
+    public TimeSpan ClientKeysCacheDuration { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// How long a protected resource's fetched key set is held before it is fetched again. Default: 1 hour.
+    /// </summary>
+    /// <remarks>
+    /// This one sits on the hottest path of the four: the key is read while issuing an access token for that
+    /// resource, so every issuance would otherwise be an HTTP request. Lowering it buys faster propagation of
+    /// a rotated resource key at the cost of a fetch per interval.
+    /// </remarks>
+    public TimeSpan ResourceKeysCacheDuration { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// How long a software-statement issuer's fetched key set is held before it is fetched again.
+    /// Default: 1 hour.
+    /// </summary>
+    /// <remarks>
+    /// Read only while a dynamic client registration presents a software statement, so the coldest of the
+    /// four.
+    /// </remarks>
+    public TimeSpan SoftwareStatementKeysCacheDuration { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// List of allowed URI schemes.
     /// Default: null (all schemes allowed).
     /// </summary>

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetcherExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetcherExtensions.cs
@@ -89,8 +89,9 @@ public static partial class SecureHttpFetcherExtensions
 	/// <param name="jwksUri">The URI the party publishes its key set at, if any.</param>
 	/// <param name="logger">Logger for recording fetch operations and errors.</param>
 	/// <param name="entityId">The identifier of the party, for logging.</param>
-	/// <param name="entityType">What kind of party it is, for logging. Use a value from
-	/// <see cref="KeySetOwners"/>.</param>
+	/// <param name="entityType">What kind of party it is. Must be a value from <see cref="KeySetOwners"/>:
+	/// besides labelling the log, it is the service key under which this consumer's cached fetcher is
+	/// registered, so the same value selects the cache lifetime that consumer was given.</param>
 	/// <returns>The inline keys followed by the fetched ones. Empty when the party declares neither.</returns>
 	/// <remarks>
 	/// The fetch itself is SSRF-protected and cached by the decorators around <see cref="ISecureHttpFetcher"/>,
@@ -114,7 +115,7 @@ public static partial class SecureHttpFetcherExtensions
 			yield break;
 
 		using var scope = serviceProvider.CreateScope();
-		var secureFetcher = scope.ServiceProvider.GetRequiredService<ISecureHttpFetcher>();
+		var secureFetcher = scope.ServiceProvider.GetRequiredKeyedService<ISecureHttpFetcher>(entityType);
 
 		await foreach (var key in secureFetcher.FetchKeysAsync(jwksUri, logger, entityId, entityType))
 		{

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -781,8 +781,51 @@ public static class ServiceCollectionExtensions
             client.Timeout = options.RequestTimeout;
         });
 
+        // One cached fetcher per consumer, each keyed by who asks and carrying its own lifetime. Caching used
+        // to hang off a single service key that only the JWT bearer grant read, so client, software-statement
+        // and resource key sets were fetched over the network on every use. Giving each consumer its own
+        // instance keeps the lifetime a property of the caller without putting it into the transport contract:
+        // how stale a document may be depends on what it is used for, and a resource key set backing every
+        // token issued is not the same case as a client key set read on the occasional request object.
+        services.AddCachedSecureHttpFetcher(
+            KeySetOwners.Client,
+            fetch => fetch.ClientKeysCacheDuration);
+
+        services.AddCachedSecureHttpFetcher(
+            KeySetOwners.Resource,
+            fetch => fetch.ResourceKeysCacheDuration);
+
+        services.AddCachedSecureHttpFetcher(
+            KeySetOwners.SoftwareStatementIssuer,
+            fetch => fetch.SoftwareStatementKeysCacheDuration);
+
+        // The JWT bearer grant keeps its own long-standing setting, which lives with the rest of that
+        // feature's options rather than here.
+        services.DecorateKeyed<ISecureHttpFetcher, CachingSecureHttpFetcherDecorator>(
+            KeySetOwners.Issuer,
+            Dependency.Override(serviceProvider => serviceProvider
+                .GetRequiredService<IOptionsMonitor<OidcOptions>>()
+                .CurrentValue.JwtBearer.JwksCacheDuration));
+
         return services;
     }
+
+    /// <summary>
+    /// Registers a caching <see cref="ISecureHttpFetcher"/> for one consumer, under its own service key and
+    /// with its own cache lifetime.
+    /// </summary>
+    /// <param name="services">The service collection to add the registration to.</param>
+    /// <param name="consumer">The consumer's key, from <see cref="KeySetOwners"/>.</param>
+    /// <param name="duration">Reads the consumer's lifetime out of the options. Resolved through a factory
+    /// rather than captured here, so a host configuring options after this call is still honoured.</param>
+    private static void AddCachedSecureHttpFetcher(
+        this IServiceCollection services,
+        string consumer,
+        Func<SecureHttpFetchOptions, TimeSpan> duration)
+        => services.DecorateKeyed<ISecureHttpFetcher, CachingSecureHttpFetcherDecorator>(
+            consumer,
+            Dependency.Override(serviceProvider => duration(
+                serviceProvider.GetRequiredService<IOptionsMonitor<SecureHttpFetchOptions>>().CurrentValue)));
 
     /// <summary>
     /// Registers the generic stateless-nonce service. The default

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/JwtBearer/AddSecureHttpFetchIntegrationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/JwtBearer/AddSecureHttpFetchIntegrationTests.cs
@@ -65,10 +65,39 @@ public class AddSecureHttpFetchIntegrationTests
 
         // Assert - Keyed service should be decorated with caching
         var keyedFetcher = serviceProvider.GetRequiredKeyedService<ISecureHttpFetcher>(
-            JwtBearerIssuerProvider.SecureHttpFetcherKey);
+            KeySetOwners.Issuer);
 
         Assert.NotNull(keyedFetcher);
         Assert.IsType<CachingSecureHttpFetcherDecorator>(keyedFetcher);
+    }
+
+    /// <summary>
+    /// Every consumer that fetches a key set gets a cached fetcher of its own, not just the JWT bearer grant.
+    /// Asserted per consumer because the defect this pins was precisely that they differed: caching hung off a
+    /// single service key, and the other three fetched over the network on every use.
+    /// </summary>
+    [Theory]
+    [InlineData(KeySetOwners.Client)]
+    [InlineData(KeySetOwners.Resource)]
+    [InlineData(KeySetOwners.SoftwareStatementIssuer)]
+    [InlineData(KeySetOwners.Issuer)]
+    public void EveryKeySetConsumer_ResolvesACachingFetcher(string consumer)
+    {
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddDistributedMemoryCache();
+        services.AddSingleton(System.TimeProvider.System);
+        services.AddOptions();
+        services.AddLogging();
+
+        services.AddSecureHttpFetch();
+        services.AddJwtBearerGrant();
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var fetcher = serviceProvider.GetRequiredKeyedService<ISecureHttpFetcher>(consumer);
+
+        Assert.IsType<CachingSecureHttpFetcherDecorator>(fetcher);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/CachingSecureHttpFetcherDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/CachingSecureHttpFetcherDecoratorTests.cs
@@ -1,0 +1,106 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Abblix.Utils;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.SecureHttpFetch;
+
+/// <summary>
+/// Verifies that the caching decorator actually spares the network, and that its lifetime is the one it was
+/// constructed with. Asserting the type of the registered decorator is not enough: an instance built with a
+/// zero lifetime is the same type and caches nothing.
+/// </summary>
+public class CachingSecureHttpFetcherDecoratorTests
+{
+    private static readonly Uri KeySetUri = new("https://issuer.example.com/.well-known/jwks.json");
+
+    private static (CachingSecureHttpFetcherDecorator Decorator, Mock<ISecureHttpFetcher> Inner) Create(
+        TimeSpan cacheDuration)
+    {
+        var inner = new Mock<ISecureHttpFetcher>(MockBehavior.Strict);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        return (new CachingSecureHttpFetcherDecorator(inner.Object, cache, cacheDuration), inner);
+    }
+
+    /// <summary>
+    /// A second fetch of the same document is served from the cache: the inner fetcher is called once. This is
+    /// the property the registration exists for, and the one a type assertion cannot see.
+    /// </summary>
+    [Fact]
+    public async Task SecondFetchOfTheSameUri_DoesNotReachTheInnerFetcher()
+    {
+        var (decorator, inner) = Create(TimeSpan.FromHours(1));
+        inner
+            .Setup(f => f.FetchAsync<string>(KeySetUri))
+            .ReturnsAsync(Result<string, OidcError>.Success("key-set"));
+
+        await decorator.FetchAsync<string>(KeySetUri);
+        await decorator.FetchAsync<string>(KeySetUri);
+
+        inner.Verify(f => f.FetchAsync<string>(KeySetUri), Times.Once);
+    }
+
+    /// <summary>
+    /// The lifetime comes from the instance, so a decorator built with a zero duration holds nothing and every
+    /// fetch reaches the network. This is what separates one consumer's cached fetcher from another's, and it
+    /// is why the duration is a constructor argument rather than a parameter of the transport contract.
+    /// </summary>
+    [Fact]
+    public async Task ZeroCacheDuration_ReachesTheInnerFetcherEveryTime()
+    {
+        var (decorator, inner) = Create(TimeSpan.Zero);
+        inner
+            .Setup(f => f.FetchAsync<string>(KeySetUri))
+            .ReturnsAsync(Result<string, OidcError>.Success("key-set"));
+
+        await decorator.FetchAsync<string>(KeySetUri);
+        await decorator.FetchAsync<string>(KeySetUri);
+
+        inner.Verify(f => f.FetchAsync<string>(KeySetUri), Times.Exactly(2));
+    }
+
+    /// <summary>
+    /// A failed fetch is not cached, so a transient failure does not lock the consumer out for the whole
+    /// lifetime: the next call tries again.
+    /// </summary>
+    [Fact]
+    public async Task FailedFetch_IsNotCached()
+    {
+        var (decorator, inner) = Create(TimeSpan.FromHours(1));
+        inner
+            .Setup(f => f.FetchAsync<string>(KeySetUri))
+            .ReturnsAsync(new OidcError(ErrorCodes.ServerError, "unreachable"));
+
+        await decorator.FetchAsync<string>(KeySetUri);
+        await decorator.FetchAsync<string>(KeySetUri);
+
+        inner.Verify(f => f.FetchAsync<string>(KeySetUri), Times.Exactly(2));
+    }
+}


### PR DESCRIPTION
Closes #315.

## The defect

Caching for fetched key sets hung off a single service key, and only the JWT bearer grant read it:

```csharp
services.DecorateKeyed<ISecureHttpFetcher, CachingSecureHttpFetcherDecorator>(
    JwtBearerIssuerProvider.SecureHttpFetcherKey);
```

Everyone else resolved the plain, undecorated fetcher:

| consumer | what it fetches | cached before |
|---|---|---|
| `JwtBearerIssuerProvider` | a trusted issuer's key set | yes |
| `ClientKeysProvider` | a client's key set, for request objects and client assertions | no |
| `SoftwareStatementValidator` | a software-statement issuer's key set | no |
| `ResourceKeysProvider` | a resource server's key set, read while issuing its access token | no |

The last one is the hottest path of the four: without a cache, every access token issued for a resource that publishes its keys at a URI is an HTTP request.

The setting compounded it from the other side. `JwtBearer.JwksCacheDuration` reads as though it governs every key-set fetch and governs one, so lengthening it for jwt-bearer changed nothing for anyone else, and zeroing it to force fresh fetches changed nothing either.

## The shape of the fix

Each consumer resolves its own cached fetcher, keyed by who is asking and carrying its own lifetime, supplied at registration:

```csharp
services.DecorateKeyed<ISecureHttpFetcher, CachingSecureHttpFetcherDecorator>(
    consumer,
    Dependency.Override(serviceProvider => duration(
        serviceProvider.GetRequiredService<IOptionsMonitor<SecureHttpFetchOptions>>().CurrentValue)));
```

`Dependency.Override` takes a factory rather than a captured value, so options a host configures after this call are still honoured.

**The transport contract is untouched.** `FetchAsync` still takes a URI and nothing else. How stale a document may be is a property of the caller, not of the transport, so it belongs on the instance the caller resolves rather than in the signature everyone implements.

The label a consumer already passes for the log is the service key it resolves by, so the two cannot drift apart; both sides say so in their documentation rather than leaving it to look like a coincidence.

Three durations join `SecureHttpFetchOptions` beside the existing timeout and size limits. Jwt-bearer keeps reading its long-standing setting from its own feature options, so nothing changes for a host that configured it.

## Found while writing the tests

`MemoryCache` does not read `TimeSpan.Zero` as "do not store". A host zeroing a duration to force fresh fetches would have got a stored entry instead of the behaviour it asked for. A non-positive lifetime now means caching off, explicitly.

## Verification

Unit 2537, end-to-end 138, plus the Minimal API, client, MVC and JWT suites, all green.

The tests assert behaviour rather than registration, because a type assertion cannot tell a working cache from an instance built with a zero lifetime: two fetches of one URI reach the inner fetcher once, a zero lifetime reaches it twice, and a failed fetch is not cached so a transient failure does not lock a consumer out for the whole lifetime. A compiling mutation making the caching branch unreachable kills the first of them.
