### PR TITLE
Accept both spellings of the access-token typ header

### DIFF
--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -223,7 +223,7 @@ internal class JsonWebTokenValidator(
 
     /// <summary>
     /// Validates the JWS signature according to validation parameters. Returns the token
-    /// unchanged on success — the chain stage adds nothing to the token, only gates the
+    /// unchanged on success - the chain stage adds nothing to the token, only gates the
     /// rest of the pipeline behind a successful integrity proof.
     /// </summary>
     private async Task<Result<JsonWebToken, JwtValidationError>> ValidateSignatureAsync(
@@ -239,7 +239,7 @@ internal class JsonWebTokenValidator(
         // Reject anything outside the registered RFC 7518 §3 alg taxonomy with the matching
         // taxonomy-level error. Without this gate, an unknown alg (e.g. byte-variant 'None')
         // streams into the signature-verification path and surfaces as InvalidSignature,
-        // which is the wrong category — the cryptographic check never had a chance to run
+        // which is the wrong category - the cryptographic check never had a chance to run
         // because the algorithm itself is unrecognised.
         if (!SigningAlgorithms.Known.Contains(algorithm))
         {
@@ -269,7 +269,7 @@ internal class JsonWebTokenValidator(
             SigningAlgorithms.None when jwtParts[2].HasValue()
                 => new JwtValidationError(JwtError.MalformedToken, "Unsigned token must have empty signature"),
 
-            // Reached only by alg "none" when signatures are not required — accept the unsigned token.
+            // Reached only by alg "none" when signatures are not required - accept the unsigned token.
             SigningAlgorithms.None => token,
 
             // Two trust-model branches selected by the caller via UseEmbeddedVerificationKey:
@@ -285,11 +285,11 @@ internal class JsonWebTokenValidator(
 
     /// <summary>
     /// Verifies the JWS signature against the key embedded in the JOSE header's <c>jwk</c>
-    /// parameter. This is the trust model RFC 9449 §4.2 prescribes for DPoP proofs — the
+    /// parameter. This is the trust model RFC 9449 §4.2 prescribes for DPoP proofs - the
     /// proof carries its own public key and the validator's job is solely to confirm that
     /// the signature matches that key. The issuer-resolved-keys delegate is intentionally
     /// not consulted: in the embedded-key model there is no out-of-band key registry, so
-    /// resolving by <c>iss</c> would either no-op or — worse — reintroduce the auto-trust
+    /// resolving by <c>iss</c> would either no-op or - worse - reintroduce the auto-trust
     /// surface this branch exists to keep closed.
     /// </summary>
     /// <param name="token">The parsed token; its <see cref="JsonWebTokenHeader.VerificationKey"/>
@@ -361,7 +361,7 @@ internal class JsonWebTokenValidator(
         // Symmetric with the JWE path: the validator's other trust mode looks up signing
         // keys by issuer (via parameters.ResolveIssuerSigningKeys, typically the host's
         // JWKS lookup). A caller routed here without wiring that delegate is a category
-        // mismatch — surface a typed JwtValidationError so the request fails with a 401,
+        // mismatch - surface a typed JwtValidationError so the request fails with a 401,
         // not an unhandled NotNull throw that propagates as 500.
         var resolveIssuerSigningKeys = parameters.ResolveIssuerSigningKeys;
         if (resolveIssuerSigningKeys is null)
@@ -447,7 +447,7 @@ internal class JsonWebTokenValidator(
         string[] jwtParts,
         ValidationParameters parameters)
     {
-        // The token may be a perfectly well-formed JWE — the failure mode here is that
+        // The token may be a perfectly well-formed JWE - the failure mode here is that
         // this validation path was not wired with a decryption-key resolver. Most callsites
         // validate JWS only (DPoP proofs per RFC 9449 §4.2, client_assertion per RFC 7521,
         // etc.) and intentionally pass ResolveTokenDecryptionKeys = null. Throwing
@@ -506,12 +506,10 @@ internal class JsonWebTokenValidator(
         {
             return new JwtValidationError(
                 JwtError.InvalidTokenType,
-                $"JWT 'typ' header is missing — expected one of: {string.Join(", ", expected)}");
+                $"JWT 'typ' header is missing - expected one of: {string.Join(", ", expected)}");
         }
 
-        var normalized = StripApplicationPrefix(typ);
-        var matched = expected.Any(expectedTyp => string.Equals(
-            StripApplicationPrefix(expectedTyp), normalized, StringComparison.OrdinalIgnoreCase));
+        var matched = expected.Any(expectedTyp => JwtTypeName.Matches(typ, expectedTyp));
 
         if (!matched)
         {
@@ -523,23 +521,6 @@ internal class JsonWebTokenValidator(
         return token;
     }
 
-    /// <summary>
-    /// Implements RFC 7515 §4.1.9's prefix convention: "A recipient using the media type value
-    /// MUST treat it as if 'application/' were prepended to any 'typ' value not containing a
-    /// '/'." Stripping the literal prefix instead of prepending it reaches the same equivalence
-    /// from either form, and is applied to both sides of the comparison so a caller may write
-    /// whichever they prefer.
-    /// </summary>
-    /// <remarks>
-    /// The prefix match ignores case because it is the media type portion, which RFC 2045 §5.1
-    /// declares case-insensitive; matching it ordinally would leave <c>Application/at+jwt</c>
-    /// unstripped and therefore unmatchable.
-    /// </remarks>
-    private static string StripApplicationPrefix(string typ)
-    {
-        const string prefix = "application/";
-        return typ.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ? typ[prefix.Length..] : typ;
-    }
 
     /// <summary>
     /// Validates the issuer claim according to validation parameters.

--- a/src/Abblix.Jwt/JwtTypeName.cs
+++ b/src/Abblix.Jwt/JwtTypeName.cs
@@ -1,0 +1,71 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Jwt;
+
+/// <summary>
+/// Compares JWT <c>typ</c> header values, which name a media type and therefore have more than one spelling
+/// for the same value.
+/// </summary>
+/// <remarks>
+/// Two rules make the spellings equivalent. RFC 7515 Section 4.1.9: "A recipient using the media type value
+/// MUST treat it as if 'application/' were prepended to any 'typ' value not containing a '/'", so
+/// <c>at+jwt</c> and <c>application/at+jwt</c> are one name. RFC 2045 Section 5.1: "Matching of media type and
+/// subtype is ALWAYS case-insensitive", so casing carries no meaning either.
+/// Note that RFC 7515 Section 5.3, which defines this library's general string-comparison rules, does not
+/// apply: it ends by exempting exactly this parameter, "Only the 'typ' and 'cty' member values defined in this
+/// specification do not use these comparison rules".
+/// This lives here rather than beside each comparison so the rule has one implementation: a second copy would
+/// be a second, quietly different answer to "is this an access token".
+/// </remarks>
+public static class JwtTypeName
+{
+    private const string ApplicationPrefix = "application/";
+
+    /// <summary>
+    /// Determines whether two <c>typ</c> values name the same token class, in any spelling of either.
+    /// </summary>
+    /// <param name="actual">The value read from the token's header, or <c>null</c> when it carries none.</param>
+    /// <param name="expected">The value the caller expects, written in whichever spelling it prefers.</param>
+    /// <returns><c>true</c> when both name the same media type.</returns>
+    public static bool Matches(string? actual, string expected)
+        => actual is not null && string.Equals(
+            StripApplicationPrefix(actual),
+            StripApplicationPrefix(expected),
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Removes the <c>application/</c> prefix when present, reaching RFC 7515 Section 4.1.9's equivalence from
+    /// either form rather than only from the short one.
+    /// </summary>
+    /// <param name="typ">The <c>typ</c> value to normalise.</param>
+    /// <returns>The value without its media-type prefix.</returns>
+    /// <remarks>
+    /// The prefix match ignores case because it is the media type portion, which RFC 2045 Section 5.1 declares
+    /// case-insensitive; matching it ordinally would leave <c>Application/at+jwt</c> unstripped and therefore
+    /// unmatchable.
+    /// </remarks>
+    public static string StripApplicationPrefix(string typ)
+        => typ.StartsWith(ApplicationPrefix, StringComparison.OrdinalIgnoreCase)
+            ? typ[ApplicationPrefix.Length..]
+            : typ;
+}

--- a/src/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/UserInfo/UserInfoRequestValidator.cs
@@ -87,8 +87,12 @@ public class UserInfoRequestValidator(
 
 		var token = result.GetSuccess();
 
+		// RFC 9068 Section 4: "The resource server MUST verify that the 'typ' header value is 'at+jwt' or
+		// 'application/at+jwt' and reject tokens carrying any other value." The two spellings name one media
+		// type, per RFC 7515 Section 4.1.9, so the comparison folds the prefix and the case rather than
+		// testing for equality against one of them.
 		var tokenType = token.Header.Type;
-		if (tokenType != JwtTypes.AccessToken)
+		if (!JwtTypeName.Matches(tokenType, JwtTypes.AccessToken))
 		{
 			return new OidcError(
 				ErrorCodes.InvalidToken,

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/UserInfoRequestValidatorTests.cs
@@ -421,4 +421,71 @@ public class UserInfoRequestValidatorTests
         Assert.NotNull(capturedOptions);
         Assert.False((capturedOptions.Value & ValidationOptions.ValidateAudience) == ValidationOptions.ValidateAudience);
     }
+
+    /// <summary>
+    /// Both spellings of the access-token media type are accepted, per RFC 9068 Section 4: "The resource
+    /// server MUST verify that the 'typ' header value is 'at+jwt' or 'application/at+jwt' and reject tokens
+    /// carrying any other value." RFC 7515 Section 4.1.9 is why there are two of them: a recipient treats a
+    /// value with no '/' as though 'application/' were prepended, so the short and long forms name one type
+    /// rather than two.
+    /// </summary>
+    [Theory]
+    [InlineData(JwtTypes.AccessToken)]
+    [InlineData("application/" + JwtTypes.AccessToken)]
+    [InlineData("Application/AT+JWT")]
+    public async Task ValidateAsync_AcceptsEitherSpellingOfTheAccessTokenType(string tokenType)
+    {
+        var userInfoRequest = CreateUserInfoRequest();
+        var authHeader = new AuthenticationHeaderValue(TokenTypes.Bearer, "valid_token_123");
+        var clientRequest = CreateClientRequest(authHeader: authHeader);
+
+        var accessToken = CreateValidAccessToken();
+        accessToken.Header.Type = tokenType;
+        var clientInfo = new ClientInfo(TestConstants.DefaultClientId);
+
+        _jwtValidator
+            .Setup(v => v.ValidateAsync("valid_token_123", It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(accessToken);
+
+        _accessTokenService
+            .Setup(service => service.AuthenticateByAccessTokenAsync(accessToken, It.IsAny<ClientInfo>()))
+            .ReturnsAsync((Result<AuthorizedGrant, OidcError>)new AuthorizedGrant(
+                CreateAuthSession(), CreateAuthContext()));
+
+        _clientInfoProvider
+            .Setup(provider => provider.TryFindClientAsync(TestConstants.DefaultClientId))
+            .ReturnsAsync(clientInfo);
+
+        var result = await _validator.ValidateAsync(userInfoRequest, clientRequest);
+
+        Assert.True(result.TryGetSuccess(out _), $"'{tokenType}' names the access-token media type");
+    }
+
+    /// <summary>
+    /// Widening the accepted spelling must not widen the accepted set of token classes: a token of another
+    /// class is still refused, which is the RFC 8725 Section 3.11 token-class-confusion guard the check exists
+    /// for.
+    /// </summary>
+    [Theory]
+    [InlineData(JwtTypes.RefreshToken)]
+    [InlineData("application/jwt")]
+    [InlineData("at+jwt-but-not-really")]
+    public async Task ValidateAsync_ForeignTokenType_IsRejected(string tokenType)
+    {
+        var userInfoRequest = CreateUserInfoRequest();
+        var authHeader = new AuthenticationHeaderValue(TokenTypes.Bearer, "valid_token_123");
+        var clientRequest = CreateClientRequest(authHeader: authHeader);
+
+        var accessToken = CreateValidAccessToken();
+        accessToken.Header.Type = tokenType;
+
+        _jwtValidator
+            .Setup(v => v.ValidateAsync("valid_token_123", It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(accessToken);
+
+        var result = await _validator.ValidateAsync(userInfoRequest, clientRequest);
+
+        Assert.True(result.TryGetFailure(out var error), $"'{tokenType}' is not an access token");
+        Assert.Equal(ErrorCodes.InvalidToken, error.Error);
+    }
 }


### PR DESCRIPTION
Closes #317.

## The defect

RFC 9068 section 4:

> The resource server MUST verify that the `typ` header value is `at+jwt` or `application/at+jwt` and reject tokens carrying any other value.

The UserInfo endpoint compared the header for equality against the short form alone, so a conforming token minted elsewhere was refused as an invalid token type, with nothing in the error naming the spelling as the cause.

There are two spellings because RFC 7515 section 4.1.9 makes a recipient treat a value with no `/` as though `application/` were prepended, so the short and long forms name one media type rather than two. RFC 2045 section 5.1 adds that media type matching is always case-insensitive.

## The shape of the fix

The JWT validator already folded both, with the reasoning written out beside it - but that path runs only when a caller states its expected token types, and UserInfo does not. Rather than duplicate the rule at the comparison, it moves into `JwtTypeName` and both places call it. One implementation, because a second copy is a second and quietly different answer to "is this an access token".

## Deliberately not done

Adding an expected-token-types parameter to `IAuthServiceJwtValidator` so the check could move into the validator. That reads as the tidier design and is a change to a shipped public contract: on an interface even a trailing optional parameter is a break, since the "optional" helps callers and never implementors, each of whom must change their signature.

The immediate cost was visible too - it took 17 unit tests down at once, because a mocked `Setup` with two arguments no longer matches a three-argument call. Those failures were the contract change announcing itself, not test debt.

## Verification

Unit 2543, end-to-end 138, plus the Minimal API, client, MVC and JWT suites, all green.

Red-first: the two long-spelling cases failed before the fix and pass after, and a mutation back to strict equality takes exactly those two down again. The rejection cases (a refresh token, `application/jwt`, and a value that merely contains `at+jwt`) pin that widening the spelling did not widen the accepted set of token classes, which is the RFC 8725 section 3.11 token-class-confusion guard the check exists for.
