### PR TITLE
Let a host name the default resource an access token is minted for

### DIFF
--- a/src/Abblix.Oidc.Server/Common/AuthorizationContextExtensions.cs
+++ b/src/Abblix.Oidc.Server/Common/AuthorizationContextExtensions.cs
@@ -41,6 +41,35 @@ public static class AuthorizationContextExtensions
     };
 
     /// <summary>
+    /// Names the given resource as the audience when the context names none, so a token says which party is
+    /// meant to consume it rather than which one asked for it.
+    /// </summary>
+    /// <param name="context">The authorization context to complete.</param>
+    /// <param name="defaultResource">The resource to fall back on, or <c>null</c> to leave the context alone.</param>
+    /// <returns>The context, with the default resource applied where it was needed.</returns>
+    /// <remarks>
+    /// RFC 9068 Section 3: "If the request does not include a `resource` parameter, the authorization server
+    /// MUST use a default resource indicator in the `aud` claim." With no default supplied the context is
+    /// returned untouched and the audience falls back to the client identifier, which is what prior versions
+    /// did - the behaviour changes only where a host states the default, because that value is read by every
+    /// resource server in the deployment.
+    /// A context that already names a resource or an audience is returned unchanged: it says who the token is
+    /// for, and this only fills a gap.
+    /// </remarks>
+    public static AuthorizationContext WithDefaultResource(
+        this AuthorizationContext context,
+        Uri? defaultResource)
+    {
+        if (defaultResource is null)
+            return context;
+
+        if (context.Resources is { Length: > 0 } || context.Audiences is { Length: > 0 })
+            return context;
+
+        return context with { Resources = [defaultResource] };
+    }
+
+    /// <summary>
     /// Applies the information from an <see cref="AuthorizationContext"/> to a <see cref="JsonWebTokenPayload"/>,
     /// converting the context into JWT claims.
     /// </summary>

--- a/src/Abblix.Oidc.Server/Common/Configuration/DefaultResourceIndicatorValidator.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/DefaultResourceIndicatorValidator.cs
@@ -1,0 +1,69 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Refuses at startup a <see cref="OidcOptions.DefaultResourceIndicator"/> that would put an unusable value in
+/// every access token's <c>aud</c> claim.
+/// </summary>
+/// <remarks>
+/// Both refusals are contradictions the host cannot see at runtime, because the token still issues and only
+/// the resource server rejects it - somewhere else, later, and reported as an invalid token rather than as a
+/// misconfiguration here.
+/// </remarks>
+public sealed class DefaultResourceIndicatorValidator : IValidateOptions<OidcOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OidcOptions options)
+    {
+        if (options.DefaultResourceIndicator is not { } defaultResource)
+            return ValidateOptionsResult.Success;
+
+        // RFC 8707 Section 2 requires a resource indicator to be an absolute URI, and a relative one could
+        // never match a request either, so it would sit as a value nothing accepts.
+        if (!defaultResource.IsAbsoluteUri)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(OidcOptions.DefaultResourceIndicator)} '{defaultResource}' must be an absolute URI " +
+                $"(RFC 8707 Section 2).");
+        }
+
+        // A default naming a resource this server does not know produces tokens whose audience no resource
+        // server recognises, and the request that would have named it explicitly is refused as
+        // invalid_target - so the two paths would disagree about the same identifier.
+        var known = options.Resources is { Length: > 0 } resources &&
+                    Array.Exists(resources, resource => resource.Resource == defaultResource);
+
+        if (!known)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(OidcOptions.DefaultResourceIndicator)} '{defaultResource}' is not among the " +
+                $"configured {nameof(OidcOptions.Resources)}. Register it there, or clear the default to keep " +
+                $"the client identifier as the audience.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -103,13 +103,13 @@ public record OidcOptions
 	/// <summary>
 	/// Specifies which OIDC endpoints are enabled on the server. This property allows for fine-grained control over
 	/// the available functionality, enabling or disabling specific endpoints based on the server's role, security
-	/// considerations, or operational requirements. Defaults to <see cref="OidcEndpoints.Base"/> — the core
+	/// considerations, or operational requirements. Defaults to <see cref="OidcEndpoints.Base"/> - the core
 	/// interactive OIDC set plus PAR and RP-initiated logout. The six niche or security-sensitive endpoints
 	/// (CheckSession, Revocation, Introspection, dynamic client registration, CIBA and device authorization) are
 	/// off by default and each turned on by its dedicated <c>AddX()</c> opt-in, which registers the feature and
-	/// re-enables the corresponding flag. Leaving them off keeps a server that never opts in from advertising — or
-	/// validating — an endpoint it was never asked to serve. Setting this to <see cref="OidcEndpoints.All"/> only
-	/// re-advertises and routes every endpoint — the handler for each opt-in endpoint (CheckSession, Revocation,
+	/// re-enables the corresponding flag. Leaving them off keeps a server that never opts in from advertising - or
+	/// validating - an endpoint it was never asked to serve. Setting this to <see cref="OidcEndpoints.All"/> only
+	/// re-advertises and routes every endpoint - the handler for each opt-in endpoint (CheckSession, Revocation,
 	/// Introspection, dynamic client registration, CIBA, device authorization) is still registered solely by its
 	/// <c>AddX()</c> call, so <c>All</c> restores the previous every-endpoint-on behaviour only when combined with
 	/// all of those opt-in calls. Setting <c>All</c> without them advertises and routes endpoints whose handlers are
@@ -254,6 +254,25 @@ public record OidcOptions
 	public ResourceDefinition[]? Resources { get; set; }
 
 	/// <summary>
+	/// The resource an access token is minted for when the request names none. Left null, the token's
+	/// <c>aud</c> falls back to the client identifier, which is what prior versions did.
+	/// </summary>
+	/// <remarks>
+	/// RFC 9068 Section 3 requires an authorization server to "use a default resource indicator in the `aud`
+	/// claim" when a request carries no <c>resource</c> parameter, and Section 4 tells a resource server to
+	/// reject a token whose <c>aud</c> does not name it. A client identifier names the party that asked for the
+	/// token rather than the one meant to consume it, so a conforming resource server should refuse it; a
+	/// deployment with one API therefore says so here once, instead of teaching every client to send
+	/// <c>resource</c>.
+	/// This is opt-in because the value is read by every resource server in the deployment: changing it is a
+	/// change to their contract, not to this server's configuration alone. The fallback is unchanged until a
+	/// host states otherwise. Must be an absolute URI naming a registered <see cref="Resources"/> entry -
+	/// startup refuses anything else, since a token minted for a resource this server does not know is one
+	/// nobody can accept.
+	/// </remarks>
+	public Uri? DefaultResourceIndicator { get; set; }
+
+	/// <summary>
 	/// Configuration options for the backchannel authentication flow,
 	/// used in scenarios such as Client-Initiated Backchannel Authentication (CIBA).
 	/// </summary>
@@ -298,7 +317,7 @@ public record OidcOptions
 
 	/// <summary>
 	/// Governs how a request object resolves a parameter that appears both inside the object and in the
-	/// OAuth query syntax — a choice between two specifications. When <c>false</c> (the default), request-object
+	/// OAuth query syntax - a choice between two specifications. When <c>false</c> (the default), request-object
 	/// processing follows the OpenID Connect Core §6.1 merge semantics: the object's values supersede those
 	/// passed outside it, but a parameter passed only outside the object is still used. Set to <c>true</c> for
 	/// the strict RFC 9101 §6.3 rule, where the authorization request is exactly the content of the object and
@@ -307,8 +326,8 @@ public record OidcOptions
 	/// server defaults to the merge behaviour, since strict processing would drop parameters that existing
 	/// OpenID Connect clients commonly pass outside the object. A client held to the FAPI 2.0 security profile
 	/// is processed strictly regardless of this global default.
-	/// This switch affects only parameter exclusivity; the other RFC 9101 §6.3 requirement — that a
-	/// <c>client_id</c> or <c>response_type</c> present both inside and outside the object be identical — is
+	/// This switch affects only parameter exclusivity; the other RFC 9101 §6.3 requirement - that a
+	/// <c>client_id</c> or <c>response_type</c> present both inside and outside the object be identical - is
 	/// enforced in both modes and cannot be turned off.
 	/// </summary>
 	public bool IgnoreParametersOutsideRequestObject { get; set; } = false;
@@ -350,7 +369,7 @@ public record OidcOptions
 	/// <summary>
 	/// The server-wide default security profile, applied to every client whose own
 	/// <see cref="ClientInfo.SecurityProfile"/> is left unset (<c>null</c>). A single-profile
-	/// deployment sets this once — for example to <see cref="ClientSecurityProfile.Fapi2"/> — and
+	/// deployment sets this once - for example to <see cref="ClientSecurityProfile.Fapi2"/> - and
 	/// every client without an explicit profile inherits the FAPI 2.0 control bundle; an individual
 	/// client opts out by setting its own profile to <see cref="ClientSecurityProfile.None"/>. The
 	/// default <see cref="ClientSecurityProfile.None"/> leaves unprofiled clients governed by their
@@ -364,7 +383,7 @@ public record OidcOptions
 	/// (RFC 9700 Section 2.1.1 encourages the authorization server to make a reasonable effort to detect and
 	/// prevent it). When set, the server records each value at the moment it issues an authorization code and
 	/// rejects a later authorization request from the same client that repeats a value within this interval.
-	/// Recording at code issuance — not on every authorization request — means re-processing one request
+	/// Recording at code issuance - not on every authorization request - means re-processing one request
 	/// across a login or consent redirect is not flagged. Left <c>null</c> (the default) the check is off:
 	/// a conforming client generates a fresh value per request and is never affected, but a client that
 	/// incorrectly reuses a value across separate authorizations would then be rejected, so it is opt-in.

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -150,6 +150,11 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, ServiceTokensAlgorithmsValidator>());
 
+        // Refuse a default resource indicator that no resource server could accept, rather than minting every
+        // access token with an audience nothing recognises.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, DefaultResourceIndicatorValidator>());
+
         // TryAddAlias: a host that pre-registers its own client store must win over the
         // OidcOptions-backed default (issue #226) - same host-first contract as TryAdd* seams.
         return services

--- a/src/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/AccessTokenService.cs
@@ -113,64 +113,23 @@ internal class AccessTokenService(
 		};
 
 		authSession.ApplyTo(accessToken.Payload);
-		authContext.ApplyTo(accessToken.Payload);
+
+		// The audience is settled once, before anything reads it, so the payload below and the encryption
+		// policy further down agree on who this token is for instead of each deriving its own answer.
+		var audienceContext = authContext.WithDefaultResource(options.Value.DefaultResourceIndicator);
+		audienceContext.ApplyTo(accessToken.Payload);
 
 		// For a pairwise client, replace the real subject in 'sub' with the client's reversible per-sector
 		// pseudonym (the id_token carries the same value); a public client is left untouched. The pseudonym itself
 		// carries the real subject, which the server opens back at UserInfo, refresh and token exchange.
 		accessToken.Payload.Subject = subjectTypeConverter.Convert(authSession.Subject, clientInfo);
 
-		var encryption = await ApplyAudienceKeyAsync(
-			ServiceJwtEncryption.ForAccessToken(options.Value), authContext);
+		var encryption = await ServiceJwtEncryption.ForAccessToken(options.Value)
+			.WithAudienceKeyAsync(audienceContext, resourceManager, resourceKeysProvider);
 
 		var encoded = await serviceJwtFormatter.FormatAsync(accessToken, encryption);
 
 		return new EncodedJsonWebToken(accessToken, encoded);
-	}
-
-	/// <summary>
-	/// Points the encryption policy at the key published by the resource this token was minted for, so the
-	/// party named in <c>aud</c> can read it. A resource that publishes no key leaves the policy untouched,
-	/// which is how it says a signed JWS is what it expects.
-	/// </summary>
-	/// <remarks>
-	/// Several audiences each publishing a key have no correct answer: compact JWE serialization carries one
-	/// recipient, so encrypting to one of them would silently leave the token unreadable to the rest. Refuse
-	/// instead of choosing. Unknown resources never reach here, having been rejected as <c>invalid_target</c>
-	/// during request validation (RFC 8707 Section 2).
-	/// </remarks>
-	private async Task<ServiceJwtEncryption> ApplyAudienceKeyAsync(
-		ServiceJwtEncryption encryption,
-		AuthorizationContext authContext)
-	{
-		if (authContext.Resources is not { Length: > 0 } resources)
-			return encryption;
-
-		JsonWebKey? audienceKey = null;
-		Uri? keyOwner = null;
-
-		foreach (var resource in resources)
-		{
-			if (!resourceManager.TryGet(resource, out var definition))
-				continue;
-
-			var key = await resourceKeysProvider.GetEncryptionKeys(definition).FirstOrDefaultAsync();
-			if (key is null)
-				continue;
-
-			if (audienceKey is not null)
-			{
-				throw new InvalidOperationException(
-					$"The access token names several resources that each publish an encryption key " +
-					$"('{keyOwner}' and '{resource}'), and an encrypted JWT has a single recipient. " +
-					$"Request one such resource per token, or remove the key from all but one of them.");
-			}
-
-			audienceKey = key;
-			keyOwner = resource;
-		}
-
-		return audienceKey is null ? encryption : encryption with { Key = audienceKey };
 	}
 
 	/// <summary>

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryptionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ServiceJwtEncryptionExtensions.cs
@@ -1,0 +1,85 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Features.ResourceIndicators;
+
+namespace Abblix.Oidc.Server.Features.Tokens.Formatters;
+
+/// <summary>
+/// Completes a <see cref="ServiceJwtEncryption"/> policy from the request it is about to serve.
+/// </summary>
+public static class ServiceJwtEncryptionExtensions
+{
+    /// <summary>
+    /// Points the policy at the key published by the resource this token was minted for, so the party named in
+    /// <c>aud</c> can read it.
+    /// </summary>
+    /// <param name="encryption">The policy projected from the server's own settings.</param>
+    /// <param name="context">The authorization context naming the token's audience.</param>
+    /// <param name="resourceManager">Resolves a requested resource URI to its registered definition.</param>
+    /// <param name="resourceKeysProvider">Supplies that resource's published encryption keys.</param>
+    /// <returns>The policy, pointed at the audience's key where one is published.</returns>
+    /// <remarks>
+    /// A resource that publishes no key leaves the policy untouched, which is how it says a signed JWS is what
+    /// it expects. Several audiences each publishing a key have no correct answer: compact JWE serialization
+    /// carries one recipient, so encrypting to one of them would silently leave the token unreadable to the
+    /// rest - refuse instead of choosing. Unknown resources never reach here, having been rejected as
+    /// <c>invalid_target</c> during request validation (RFC 8707 Section 2).
+    /// </remarks>
+    public static async Task<ServiceJwtEncryption> WithAudienceKeyAsync(
+        this ServiceJwtEncryption encryption,
+        AuthorizationContext context,
+        IResourceManager resourceManager,
+        IResourceKeysProvider resourceKeysProvider)
+    {
+        if (context.Resources is not { Length: > 0 } resources)
+            return encryption;
+
+        JsonWebKey? audienceKey = null;
+        Uri? keyOwner = null;
+
+        foreach (var resource in resources)
+        {
+            if (!resourceManager.TryGet(resource, out var definition))
+                continue;
+
+            var key = await resourceKeysProvider.GetEncryptionKeys(definition).FirstOrDefaultAsync();
+            if (key is null)
+                continue;
+
+            if (audienceKey is not null)
+            {
+                throw new InvalidOperationException(
+                    $"The access token names several resources that each publish an encryption key " +
+                    $"('{keyOwner}' and '{resource}'), and an encrypted JWT has a single recipient. " +
+                    $"Request one such resource per token, or remove the key from all but one of them.");
+            }
+
+            audienceKey = key;
+            keyOwner = resource;
+        }
+
+        return audienceKey is null ? encryption : encryption with { Key = audienceKey };
+    }
+}

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
@@ -89,6 +89,68 @@ public class ResourceIndicatorTests(TestFactory factory) : TestBase(factory)
     }
 
     /// <summary>
+    /// With a default resource indicator configured, a request naming no resource still gets an access token
+    /// whose <c>aud</c> names the API rather than the client. RFC 9068 section 3 requires that default, and
+    /// section 4 tells a resource server to reject a token whose <c>aud</c> does not name it - so a client
+    /// identifier there is a value no conforming resource server should accept.
+    /// </summary>
+    [Fact]
+    public async Task ClientCredentials_without_resource_uses_the_configured_default_indicator()
+    {
+        await using var host = CreateHostWithDefaultResource();
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.ClientCredentials,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ClientCredentialsClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+        });
+
+        var payload = DecodeJwtPayload(tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+        var audiences = ExtractAudiences(payload);
+
+        Assert.Contains(TestConstants.ApiResource, audiences);
+        Assert.DoesNotContain(TestConstants.ClientCredentialsClientId, audiences);
+    }
+
+    /// <summary>
+    /// The default fills a gap rather than overriding a stated intent: a request naming a resource keeps it.
+    /// </summary>
+    [Fact]
+    public async Task ClientCredentials_with_resource_keeps_it_over_the_default()
+    {
+        await using var host = CreateHostWithDefaultResource();
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var tokens = await ExchangeCodeForTokensAsync(client, discovery, new Dictionary<string, string>
+        {
+            [TokenRequest.Parameters.GrantType] = GrantTypes.ClientCredentials,
+            [AuthorizationRequest.Parameters.ClientId] = TestConstants.ClientCredentialsClientId,
+            [ClientRequest.Parameters.ClientSecret] = TestConstants.ConfidentialClientSecret,
+            [TokenRequest.Parameters.Resource] = TestConstants.ApiResource,
+        });
+
+        var payload = DecodeJwtPayload(tokens[UserInfoRequest.Parameters.AccessToken]!.GetValue<string>());
+
+        Assert.Equal([TestConstants.ApiResource], ExtractAudiences(payload));
+    }
+
+    /// <summary>
+    /// Builds an isolated host stating a default resource indicator, leaving the shared suite on the
+    /// client-identifier fallback that every existing deployment still gets.
+    /// </summary>
+    private WebApplicationFactory<Program> CreateHostWithDefaultResource()
+        => Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IPostConfigureOptions<OidcOptions>>(_ =>
+                    new PostConfigureOptions<OidcOptions>(
+                        Options.DefaultName,
+                        options => options.DefaultResourceIndicator = new Uri(TestConstants.ApiResource)))));
+
+    /// <summary>
     /// A resource that publishes an encryption key gets its access token encrypted to that key, so the party
     /// named in <c>aud</c> can read the token minted for it. The proof is the recipient: the JWE header names
     /// the resource's own <c>kid</c>, not the server's, and a token encrypted to the server's key would be

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/AuthorizationContextExtensionsTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/AuthorizationContextExtensionsTests.cs
@@ -89,4 +89,74 @@ public class AuthorizationContextExtensionsTests
         var ac2 = payload.ToAuthorizationContext();
         Assert.Null(ac2.Resources);
     }
+
+    // WithDefaultResource: RFC 9068 section 3 wants a default resource indicator in aud when the request
+    // names none, instead of the client identifier, which names the party that asked rather than the one
+    // meant to consume the token.
+
+    private static readonly Uri DefaultApi = new("https://api.example.com");
+
+    /// <summary>
+    /// A context naming no audience takes the configured default, so the token says who it is for.
+    /// </summary>
+    [Fact]
+    public void WithDefaultResource_NoAudienceNamed_TakesTheDefault()
+    {
+        var context = new AuthorizationContext("clientId", ["scope1"], null);
+
+        var result = context.WithDefaultResource(DefaultApi);
+
+        Assert.NotNull(result.Resources);
+        Assert.Equal([DefaultApi], result.Resources);
+
+        var payload = new JsonWebTokenPayload(new JsonObject());
+        result.ApplyTo(payload);
+        Assert.Equal([DefaultApi.OriginalString], payload.Audiences.ToArray());
+    }
+
+    /// <summary>
+    /// Supplying no default leaves the context alone, which is what every host that has not opted in gets:
+    /// the audience still falls back to the client identifier exactly as before.
+    /// </summary>
+    [Fact]
+    public void WithDefaultResource_NoDefaultConfigured_LeavesContextUnchanged()
+    {
+        var context = new AuthorizationContext("clientId", ["scope1"], null);
+
+        var result = context.WithDefaultResource(null);
+
+        Assert.Same(context, result);
+        Assert.Null(result.Resources);
+    }
+
+    /// <summary>
+    /// A request that named a resource already says who the token is for, so the default does not override it.
+    /// </summary>
+    [Fact]
+    public void WithDefaultResource_ResourceAlreadyNamed_LeavesContextUnchanged()
+    {
+        var requested = new Uri("https://orders.example.com");
+        var context = new AuthorizationContext("clientId", ["scope1"], null) { Resources = [requested] };
+
+        var result = context.WithDefaultResource(DefaultApi);
+
+        Assert.Same(context, result);
+        Assert.NotNull(result.Resources);
+        Assert.Equal([requested], result.Resources);
+    }
+
+    /// <summary>
+    /// The same holds for an audience named through RFC 8693 token exchange, which is the other way a request
+    /// states its intended consumer.
+    /// </summary>
+    [Fact]
+    public void WithDefaultResource_AudienceAlreadyNamed_LeavesContextUnchanged()
+    {
+        var context = new AuthorizationContext("clientId", ["scope1"], null) { Audiences = ["urn:orders"] };
+
+        var result = context.WithDefaultResource(DefaultApi);
+
+        Assert.Same(context, result);
+        Assert.Null(result.Resources);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/DefaultResourceIndicatorValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/DefaultResourceIndicatorValidatorTests.cs
@@ -1,0 +1,122 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Linq;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Verifies that <see cref="DefaultResourceIndicatorValidator"/> refuses a default that would put an unusable
+/// value in every access token's <c>aud</c> claim, rather than letting it surface later as a resource server
+/// rejecting tokens it cannot recognise.
+/// </summary>
+public class DefaultResourceIndicatorValidatorTests
+{
+    private static readonly Uri Api = new("https://api.example.com");
+
+    private readonly DefaultResourceIndicatorValidator _validator = new();
+
+    /// <summary>
+    /// The shipped default states nothing, so a stock configuration validates and the audience keeps falling
+    /// back to the client identifier.
+    /// </summary>
+    [Fact]
+    public void Validate_NoDefaultStated_Succeeds()
+    {
+        var options = new OidcOptions();
+
+        Assert.Null(options.DefaultResourceIndicator);
+        Assert.True(_validator.Validate(null, options).Succeeded);
+    }
+
+    /// <summary>
+    /// A default naming a registered resource is exactly the configuration this setting exists for.
+    /// </summary>
+    [Fact]
+    public void Validate_DefaultNamesARegisteredResource_Succeeds()
+    {
+        var options = new OidcOptions
+        {
+            Resources = [new ResourceDefinition(Api)],
+            DefaultResourceIndicator = Api,
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// A relative URI can never match a request either, so it would sit as a value nothing accepts
+    /// (RFC 8707 section 2 requires an absolute URI).
+    /// </summary>
+    [Fact]
+    public void Validate_RelativeUri_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Resources = [new ResourceDefinition(Api)],
+            DefaultResourceIndicator = new Uri("/api", UriKind.Relative),
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("absolute URI"));
+    }
+
+    /// <summary>
+    /// A default naming a resource this server does not know produces tokens whose audience no resource server
+    /// recognises - and the request that named the same identifier explicitly would be refused as
+    /// <c>invalid_target</c>, so the two paths would disagree about one value.
+    /// </summary>
+    [Fact]
+    public void Validate_DefaultNotAmongRegisteredResources_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Resources = [new ResourceDefinition(new Uri("https://orders.example.com"))],
+            DefaultResourceIndicator = Api,
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(OidcOptions.Resources)));
+    }
+
+    /// <summary>
+    /// The same refusal applies when no resources are registered at all, which is the likeliest way to reach
+    /// this: setting the default and forgetting to declare the resource it names.
+    /// </summary>
+    [Fact]
+    public void Validate_DefaultWithNoResourcesRegistered_Fails()
+    {
+        var options = new OidcOptions { DefaultResourceIndicator = Api };
+
+        Assert.True(_validator.Validate(null, options).Failed);
+    }
+}


### PR DESCRIPTION
Delivers the required half of #316. The rest of that issue, and #321, stay on 3.0.

## The defect

RFC 9068 section 3:

> If the request does not include a `resource` parameter, the authorization server MUST use a default resource indicator in the `aud` claim.

This server put the client identifier there instead - the party that asked for the token rather than the one meant to consume it. Section 4 tells a resource server to reject a token whose `aud` does not name it, so that value is one no conforming resource server should accept. A deployment with a separate API therefore had to teach every client to send `resource` explicitly, and the server never said why.

## What changed

`OidcOptions.DefaultResourceIndicator` names the resource once. Left unset, the audience still falls back to the client identifier exactly as before.

**Opt-in on purpose.** The value is read by every resource server in the deployment, so changing it is a change to their contract, not to this server's configuration alone. Hosts get a full release cycle to set it and move their resource servers across; making it required is what remains of #316 for 3.0.

Startup refuses a default that is not an absolute URI (RFC 8707 section 2) or that names no registered resource. Both are contradictions a host cannot see at runtime: the token still issues, and only the resource server rejects it - elsewhere, later, and reported as an invalid token rather than as a misconfiguration here. The second refusal also keeps the two paths agreeing, since a request naming that same identifier explicitly is refused as `invalid_target`.

## One thing worth pointing at in review

The audience is settled once, into a local `audienceContext`, which both the payload and the encryption policy then read:

```csharp
var audienceContext = authContext.WithDefaultResource(options.Value.DefaultResourceIndicator);
audienceContext.ApplyTo(accessToken.Payload);
...
var encryption = await ServiceJwtEncryption.ForAccessToken(options.Value)
    .WithAudienceKeyAsync(audienceContext, resourceManager, resourceKeysProvider);
```

Deriving it twice would let the `aud` claim and the resource-key lookup from #313 disagree: the token would name the API while its encryption key was chosen as though no audience existed.

`WithDefaultResource` sits beside `ApplyTo` as an extension on `AuthorizationContext`, and the audience-key resolution moved out of `AccessTokenService` into `ServiceJwtEncryptionExtensions.WithAudienceKeyAsync`, next to the policy type it completes.

## No public contract changed

A property on `OidcOptions`, two extension methods and a validator - all additions. No signature was touched, and no mocked interface moved, so no test broke for structural reasons.

## Verification

Unit 2552, end-to-end 140, plus the Minimal API, client and JWT suites, all green.

A compiling mutation that never applies the default takes down both the unit test and the end-to-end one. The tests also pin what must NOT change: no default configured, a request naming a resource, and a request naming an RFC 8693 audience each leave the context untouched, asserted by reference identity rather than by value.
