### PR TITLE
Define the test suite once, and derive its projects from the projects

### DIFF
--- a/.github/workflows/discover-test-projects.yml
+++ b/.github/workflows/discover-test-projects.yml
@@ -1,0 +1,58 @@
+name: Discover test projects
+
+# The list of test projects is derived from the projects themselves, never kept by hand. A
+# hand-written list fails in one direction only: a new test project is simply absent from it, its
+# tests stay green locally, never execute in CI, and that is indistinguishable from being covered.
+#
+# Called by every workflow that shards tests, so the derivation exists once. Duplicating the job
+# would reintroduce the same drift one level up.
+on:
+  workflow_call:
+    outputs:
+      projects:
+        description: JSON array of test project names, suitable for a matrix via fromJSON.
+        value: ${{ jobs.discover.outputs.projects }}
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Discover test projects
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    outputs:
+      projects: ${{ steps.list.outputs.projects }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+        timeout-minutes: 3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+        timeout-minutes: 3
+      - name: List test projects
+        id: list
+        # IsTestProject is the honest marker: every test project sets it and neither E2E test host
+        # does, so hosts are excluded without naming them. Failing on an empty list keeps a broken
+        # query from producing a green run that tested nothing - the failure mode this job exists
+        # to prevent.
+        run: |
+          projects=$(grep -rl '<IsTestProject>true</IsTestProject>' tests --include='*.csproj' \
+            | xargs -r -n1 basename \
+            | sed 's/\.csproj$//' \
+            | sort \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          count=$(echo "$projects" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "No test projects found - the discovery query is wrong, or the checkout is empty." >&2
+            exit 1
+          fi
+          echo "Discovered $count test projects:"
+          echo "$projects" | jq -r '.[]'
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
+        timeout-minutes: 3

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -12,107 +12,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-shard:
-    # One shard per test project, run in parallel so the wall-clock is the slowest single project
-    # rather than the sum of all of them. The aggregate gate job below keeps a single required check.
-    name: Tests (${{ matrix.project }})
-    runs-on: ubuntu-latest
-    # 5 minutes per shard: the slowest shard runs ~3m14s, so this keeps ample headroom while
-    # catching a runaway sooner than the previous single-job wall did.
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    strategy:
-      # Report every shard's result; do not cancel siblings when one fails.
-      fail-fast: false
-      matrix:
-        project:
-          - Abblix.DependencyInjection.UnitTests
-          - Abblix.Jwt.UnitTests
-          - Abblix.Oidc.Server.AspNetCore.UnitTests
-          - Abblix.Oidc.Server.E2E.Tests
-          - Abblix.Oidc.Server.MinimalApi.E2E.Tests
-          - Abblix.Oidc.Server.MinimalApi.UnitTests
-          - Abblix.Jwt.Azure.UnitTests
-          - Abblix.Oidc.Server.Mvc.UnitTests
-          - Abblix.Oidc.Server.UnitTests
-          - Abblix.Jwt.Vault.UnitTests
-          - Abblix.Utils.UnitTests
-    env:
-      PROJECT: ${{ matrix.project }}
-    steps:
-      # harden-runner in audit mode: this workflow restores/builds/tests
-      # untrusted fork-PR code, so capture baseline egress for later review.
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-        timeout-minutes: 3
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          # MinVer (referenced in Directory.Build.props) reads the latest tag
-          # plus commit height from git to derive the version. fetch-depth: 0
-          # disables the shallow clone so all tags and commits are visible.
-          fetch-depth: 0
-          # No git push here, and the workflow runs untrusted fork-PR code, so
-          # strip the GITHUB_TOKEN from the runner git config after checkout.
-          persist-credentials: false
-
-        timeout-minutes: 3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
-        with:
-          dotnet-version: '10.x'
-
-        timeout-minutes: 3
-      - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.sln', '**/*.slnx', '**/Directory.Packages.props', '**/packages.lock.json', 'global.json') }}
-          restore-keys: ${{ runner.os }}-nuget-
-
-        timeout-minutes: 3
-      - name: Restore
-        run: dotnet restore "tests/$PROJECT/$PROJECT.csproj"
-
-        timeout-minutes: 3
-      - name: Test
-        # --no-restore reuses the cached restore; the project's dependency closure still builds here,
-        # so allow more room than the 3-minute step baseline for the largest shard.
-        run: |
-          dotnet test "tests/$PROJECT/$PROJECT.csproj" --configuration Release --no-restore \
-            --report-trx --report-trx-filename test-results.trx \
-            --coverage --coverage-output-format cobertura \
-            --results-directory ./tests/results
-
-      # The new dotnet test experience (Microsoft.Testing.Platform runner, opted in via global.json)
-      # takes MTP options directly, without the VSTest separator. --results-directory resolves from the
-      # working directory (repo root), so files land at ./tests/results/ - beside the projects that
-      # produced them rather than in a directory of their own at the root.
-        timeout-minutes: 5
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-${{ matrix.project }}
-          path: |
-            tests/results/*.trx
-            tests/results/**/*.cobertura.xml
-          retention-days: 7
-        timeout-minutes: 3
+  shards:
+    # The shards themselves live in a called workflow, shared with the dev-build publish, so the
+    # suite is defined once. The project list inside it is derived from the projects, not written
+    # by hand, so a new test project cannot be left out.
+    uses: ./.github/workflows/test-shards.yml
 
   test:
-    # Single required status check that aggregates the shards: it succeeds only when every shard did.
-    # Keeping the "Unit tests" name preserves the existing branch-protection required check.
+    # Single required status check aggregating the shards: it succeeds only when every shard did.
+    # It stays a job of THIS workflow on purpose - a job inside a called workflow is reported as
+    # "<caller job> / <job name>", which would rename the check that branch protection requires and
+    # leave every pull request waiting for a check that no longer appears.
     name: Unit tests
-    needs: test-shard
+    needs: shards
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # The gate only inspects shard results; it never touches the repo or the GITHUB_TOKEN.
+    # The gate only inspects the shards' result; it never touches the repo or the GITHUB_TOKEN.
     permissions: {}
     steps:
       - name: Fail if any shard failed
-        if: needs.test-shard.result != 'success'
+        if: needs.shards.result != 'success'
         run: exit 1

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -44,14 +44,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  shards:
+    # The same shards the pull request ran, defined once in a called workflow. They run here too
+    # because a squash merge produces a new commit on top of whatever develop had moved to, so what
+    # lands on the branch is a state no pull request tested.
+    uses: ./.github/workflows/test-shards.yml
+
   pack-and-publish:
+    needs: shards
     name: Pack and publish dev build
     runs-on: ubuntu-latest
-    # Raised from 5, which the job had outgrown: two consecutive runs died at 5m06s and 5m16s,
-    # once mid-pack and once mid-push, leaving the dev feed without that commit's packages. A
-    # job timeout surfaces as "cancelled" with the same wording as a manual stop, so the only
-    # thing that identifies it is the duration landing on the configured ceiling. This value is
-    # deliberately generous until a run completes and gives a real figure to size it from.
+    # The suite moved to the shards above, so this job is now restore, build, pack and push -
+    # measured at roughly 130s of the 269s the combined job used to take. Ten minutes is generous
+    # on purpose until a few runs give a figure to size it from; the previous ceiling of 5 was set
+    # from a measurement with no headroom and the job silently outgrew it, dying at 5m06s and
+    # 5m16s. Worth knowing when it happens again: a job timeout is reported as "cancelled" with
+    # the same wording as a manual stop, so the only thing that identifies it is the duration
+    # landing exactly on the configured ceiling.
     timeout-minutes: 10
     permissions:
       contents: read
@@ -84,10 +93,6 @@ jobs:
         timeout-minutes: 3
       - name: Build
         run: dotnet build --no-restore -c Release
-
-        timeout-minutes: 3
-      - name: Test
-        run: dotnet test --no-build -c Release --verbosity normal
 
         timeout-minutes: 3
       - name: Pack

--- a/.github/workflows/test-shards.yml
+++ b/.github/workflows/test-shards.yml
@@ -1,0 +1,95 @@
+name: Test shards
+
+# One shard per test project, run in parallel, so the wall-clock is the slowest single project
+# rather than the sum of all of them. Called by every workflow that needs the suite, so the shard
+# definition exists once: a second copy would drift, and a drifted CI copy fails silently - the
+# tests stay green locally and simply never run.
+#
+# Deliberately does NOT expose an aggregate gate. A job inside a called workflow appears as
+# "<caller job> / <job name>", so a required status check cannot live here without its name
+# changing. Callers keep their own aggregate job and depend on this one.
+on:
+  workflow_call:
+    outputs:
+      projects:
+        description: JSON array of the test projects that were run.
+        value: ${{ jobs.discover.outputs.projects }}
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    uses: ./.github/workflows/discover-test-projects.yml
+
+  shard:
+    needs: discover
+    name: Tests (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    # 5 minutes per shard: the slowest runs a little over three, so this leaves room while still
+    # catching a runaway sooner than a single whole-suite wall would.
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    strategy:
+      # Report every shard's result; do not cancel siblings when one fails.
+      fail-fast: false
+      matrix:
+        project: ${{ fromJSON(needs.discover.outputs.projects) }}
+    env:
+      PROJECT: ${{ matrix.project }}
+    steps:
+      # harden-runner in audit mode: this may restore, build and test untrusted fork-PR code, so
+      # capture baseline egress for later review.
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+        timeout-minutes: 3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # MinVer (referenced in Directory.Build.props) reads the latest tag plus commit height
+          # from git to derive the version, so the shallow clone has to be disabled.
+          fetch-depth: 0
+          # No git push here, and this may run untrusted fork-PR code, so strip the GITHUB_TOKEN
+          # from the runner git config after checkout.
+          persist-credentials: false
+        timeout-minutes: 3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '10.x'
+        timeout-minutes: 3
+      - name: Cache NuGet packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.sln', '**/*.slnx', '**/Directory.Packages.props', '**/packages.lock.json', 'global.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
+        timeout-minutes: 3
+      - name: Restore
+        run: dotnet restore "tests/$PROJECT/$PROJECT.csproj"
+        timeout-minutes: 3
+      - name: Test
+        # --no-restore reuses the restore above; the project's dependency closure still builds here,
+        # so allow more room than the 3-minute step baseline for the largest shard.
+        #
+        # The new dotnet test experience (Microsoft.Testing.Platform runner, opted in via global.json)
+        # takes MTP options directly, without the VSTest separator. --results-directory resolves from
+        # the working directory (repo root), so files land beside the projects that produced them.
+        run: |
+          dotnet test "tests/$PROJECT/$PROJECT.csproj" --configuration Release --no-restore \
+            --report-trx --report-trx-filename test-results.trx \
+            --coverage --coverage-output-format cobertura \
+            --results-directory ./tests/results
+        timeout-minutes: 5
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-${{ matrix.project }}
+          path: |
+            tests/results/*.trx
+            tests/results/**/*.cobertura.xml
+          retention-days: 7
+        timeout-minutes: 3


### PR DESCRIPTION
## The problem

Two workflows ran the test suite, and only one of them knew what the suite was:

- `pr-tests.yml` carried a hand-written list of eleven project names in its matrix.
- `publish-dev-builds.yml` ran the whole solution in one sequential job, inside the job that publishes.

Sharding the publish side would have created a third place to keep in step with the first.

**A hand-kept list fails in one direction only.** A new test project is simply absent from it, its tests stay green locally, they never execute in CI, and that is indistinguishable from being covered. `CLAUDE.md` already records this happening once, which is why the fix is derivation rather than a more careful list.

## What changed

**`discover-test-projects.yml`** derives the list from the projects. `IsTestProject` is the honest marker: every test project sets it and neither E2E test host does, so hosts are excluded without being named. Verified across the branch - 11 of 11 test projects carry it, both hosts do not, which is exactly the list the matrix held by hand.

The job fails when it finds nothing. An empty matrix would otherwise produce a green run that tested nothing, which is the same failure one level up.

**`test-shards.yml`** holds the shards, and both workflows call it, so the suite is defined once.

## This is not a speed improvement

Measured on this PR's own run, against the last successful publish run before it:

| | before | after |
|---|---|---|
| publish job, whole | 269s (Build 100s, Test 123s, Restore 14s, Pack 10s, Push 6s) | ~130s |
| tests | inside that job, 123s | separate shards, slowest 202s |
| sum of all shards | - | 853s |

So the publish path gets **slower** in wall-clock: roughly 202s of shards followed by ~130s of packing, against 269s before.

The reason the shards are not simply faster: each one restores and builds its own project's dependency closure, because there is no shared build ahead of them. The old `Test` step ran `--no-build` over a tree the same job had already built.

The gain here is that the suite and its project list are defined once, not that CI finishes sooner. The publish path is not on anyone's critical route, so paying about a minute there for a definition that cannot drift is the trade being made deliberately.

## Why the tests stay on the publish path

A squash merge builds a new commit on top of wherever `develop` had moved to, so what lands on the branch is a state no pull request tested. `pr-tests.yml` only triggers on `pull_request`, and `codeql.yml` is analysis, so this is the only workflow that tests `develop` itself. Removing the tests to make publishing faster would leave the integration branch unverified.

## Why the aggregate gate did not move

`Unit tests` is a required status check in the `main-protection` ruleset. A job inside a called workflow is reported as `<caller job> / <job name>` - visible in this run as `shards / Tests (...)` - so moving the gate would rename it, and every pull request would then wait on a check that no longer appears, including the pull request making the change.

It therefore stays a job of `pr-tests.yml`, depending on the called workflow. Branch protection is untouched, and this PR passed `Unit tests` under its original name.

## Verification

`actionlint` clean on all four workflows. This PR exercised the change on itself: discovery succeeded and expanded into all eleven shards, every one of them green, 16 checks passing in total, with the required check reporting under its unchanged name.
