### PR TITLE
Stop typing the ID token, and refuse hints by class instead

### DIFF
--- a/src/Abblix.Oidc.Server/Common/Constants/JwtTypes.cs
+++ b/src/Abblix.Oidc.Server/Common/Constants/JwtTypes.cs
@@ -72,30 +72,13 @@ public static class JwtTypes
 	/// </remarks>
 	public const string AccessToken = "at+jwt";
 
-	/// <summary>
-	/// OpenID Connect ID Token.
-	/// Indicates this token is an OpenID Connect ID Token.
-	/// Used in the 'typ' header of ID tokens for explicit typing.
-	/// </summary>
-	/// <remarks>
-	/// Ours entirely: OpenID Connect Core 1.0 never mentions the <c>typ</c> header parameter, let alone a value
-	/// for the ID token, so there is no standard name here to match or to squat on. The value is emitted for
-	/// this server's own benefit, following the RFC 8725 Section 3.11 guidance on explicit typing - the
-	/// <c>id_token_hint</c> validators pin it so an access or refresh token cannot be replayed as a hint, which
-	/// the signature and audience checks alone would not catch.
-	/// <para>
-	/// A relying party will not check it, precisely because the specification does not ask for one. That cuts
-	/// both ways and is worth remembering when consuming somebody else's ID token: theirs will carry a
-	/// different value or none at all, so this constant is a rule about what we issue, never a test to apply to
-	/// a foreign token.
-	/// </para>
-	/// </remarks>
-	// S6418 reads a short literal assigned to a name ending in "Token" as a possible hard-coded secret. This
-	// one is a media type that every ID token carries in the clear, and it is short because the registry's own
-	// names for this suffix are (at+jwt, kb+jwt, vc+jwt). The rule does not fire on the longer spelling, which
-	// is the only thing that changed.
-	[SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
-    public const string IdToken = VendorPrefix + "id+jwt";
+	// There is deliberately no value here for the ID token. OpenID Connect Core 1.0 never mentions the typ
+	// header parameter at all, so nothing standard exists to use, and a vendor value would be one no relying
+	// party reads: neither Duende IdentityServer nor OpenIddict types an ID token either, both leaving the
+	// generic JWT that the JWT library writes. What a vendor value does instead is break at a version
+	// boundary - an ID token issued before a rename is refused after it, which is how RP-initiated logout
+	// stopped working across two servers of different builds. The classes this system does define are listed
+	// in TokenClasses below, and an ID token is recognised by not being one of them.
 
 	/// <summary>
 	/// The "LogoutToken" JWT type is used in the context of OpenID Connect for single logout functionality.
@@ -111,19 +94,22 @@ public static class JwtTypes
 	/// The "RefreshToken" JWT type is used to represent refresh tokens, which allow obtaining new access tokens
 	/// without reauthentication.
 	/// </summary>
-	public const string RefreshToken = VendorPrefix + "refresh+jwt";
+    [SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
+	public const string RefreshToken = VendorPrefix + "rt+jwt";
 
 	/// <summary>
 	/// The "RegistrationAccessToken" JWT type is used in OAuth 2.0 Dynamic Client Registration for securely
 	/// registering clients.
 	/// </summary>
-	public const string RegistrationAccessToken = VendorPrefix + "registration+jwt";
+    [SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
+	public const string RegistrationAccessToken = VendorPrefix + "dcr+jwt";
 
 	/// <summary>
 	/// The "InitialAccessToken" JWT type is used to authorize calls to the client registration endpoint
 	/// per RFC 7591 Section 3.
 	/// </summary>
-	public const string InitialAccessToken = VendorPrefix + "initial-access+jwt";
+    [SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
+	public const string InitialAccessToken = VendorPrefix + "iat+jwt";
 
 	/// <summary>
 	/// The "DPoP proof" JWT type per RFC 9449 §4.2. The <c>typ</c> header MUST equal this
@@ -194,7 +180,6 @@ public static class JwtTypes
 	private static readonly string[] TokenClasses =
 	[
 		AccessToken,
-		IdToken,
 		LogoutToken,
 		RefreshToken,
 		RegistrationAccessToken,

--- a/src/Abblix.Oidc.Server/Common/Constants/JwtTypes.cs
+++ b/src/Abblix.Oidc.Server/Common/Constants/JwtTypes.cs
@@ -94,6 +94,14 @@ public static class JwtTypes
 	/// The "RefreshToken" JWT type is used to represent refresh tokens, which allow obtaining new access tokens
 	/// without reauthentication.
 	/// </summary>
+	/// <remarks>
+	/// Not replaceable by <see cref="AccessToken"/>, and the reason is a protection rather than a preference.
+	/// A refresh token carries the resources of its grant in the audience claim, exactly as the access token of
+	/// that grant does, so with a shared type nothing would separate the two and a resource server presented
+	/// with a refresh token would have no ground to refuse it. There is also nowhere standard to move to: the
+	/// IANA media types registry holds no entry for a refresh token, which follows from RFC 6749 Section 1.5
+	/// making it a value "intended for use only with authorization servers".
+	/// </remarks>
     [SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
 	public const string RefreshToken = VendorPrefix + "rt+jwt";
 
@@ -101,6 +109,13 @@ public static class JwtTypes
 	/// The "RegistrationAccessToken" JWT type is used in OAuth 2.0 Dynamic Client Registration for securely
 	/// registering clients.
 	/// </summary>
+	/// <remarks>
+	/// Not replaceable by <see cref="AccessToken"/>. Its validator does ask for more - the subject must name the
+	/// client being managed, and the identifier must match the one that client records - but the second of those
+	/// is enforced only where a record exists, which leaves a statically configured client defended by the
+	/// subject alone. An access token issued for the client itself carries that same subject, so the type is
+	/// what keeps the two apart. See also <see cref="InitialAccessToken"/>, which has nothing else at all.
+	/// </remarks>
     [SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
 	public const string RegistrationAccessToken = VendorPrefix + "dcr+jwt";
 
@@ -108,6 +123,11 @@ public static class JwtTypes
 	/// The "InitialAccessToken" JWT type is used to authorize calls to the client registration endpoint
 	/// per RFC 7591 Section 3.
 	/// </summary>
+	/// <remarks>
+	/// Not replaceable by <see cref="AccessToken"/>, and here the type is load-bearing on its own. Beyond it,
+	/// the validator asks only for a non-empty subject that has not been revoked, so sharing a type with the
+	/// access token would let any access token this server issued register clients.
+	/// </remarks>
     [SuppressMessage("Blocker Vulnerability", "S6418:Secrets should not be hard-coded")]
 	public const string InitialAccessToken = VendorPrefix + "iat+jwt";
 

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidator.cs
@@ -153,10 +153,11 @@ public class UserIdentityValidator(
 
         var token = result.GetSuccess();
 
-        // RFC 8725 §3.12: pin the token class. The id_token_hint MUST be an ID Token; without this
-        // check another own-issued token whose audience matches (an access or refresh token) would
-        // be accepted here, since the audience/signature checks alone do not distinguish the class.
-        if (token.Header.Type != JwtTypes.IdToken)
+        // RFC 8725 §3.12: keep the validation rules for different kinds of JWT mutually exclusive, so another
+        // own-issued token whose audience happens to match - an access or refresh token - cannot be replayed
+        // here, which the signature and audience checks alone would not catch. Stated as a refusal because an
+        // ID token carries no type of its own; see JwtTypes.IsTokenClass.
+        if (JwtTypes.IsTokenClass(token.Header.Type))
         {
             return new OidcError(
                 ErrorCodes.InvalidRequest, "The id token hint is not an ID Token");

--- a/src/Abblix.Oidc.Server/Endpoints/EndSession/Validation/IdTokenHintValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/EndSession/Validation/IdTokenHintValidator.cs
@@ -60,10 +60,16 @@ public class IdTokenHintValidator(
 
             var idToken = result.GetSuccess();
 
-            // RFC 8725 §3.12: pin the token class. The id_token_hint MUST be an ID Token; without this
-            // check another own-issued token whose audience matches (an access or refresh token) would
-            // be accepted here, since the audience/signature checks alone do not distinguish the class.
-            if (idToken.Header.Type != JwtTypes.IdToken)
+            // RFC 8725 §3.12: keep the validation rules for different kinds of JWT mutually exclusive, so
+            // another own-issued token whose audience happens to match - an access or refresh token - cannot
+            // be replayed here, which the signature and audience checks alone would not catch.
+            //
+            // Stated as a refusal rather than a requirement, because the accepting side cannot be enumerated:
+            // an ID token carries no type of its own, and RFC 8725 §3.11 warns that explicit typing "may not
+            // achieve disambiguation from existing kinds of JWTs, as the validation rules for existing kinds
+            // of JWTs often do not use the typ Header Parameter value". What can be enumerated exactly is what
+            // this system issues under a class of its own, and that is what is refused.
+            if (JwtTypes.IsTokenClass(idToken.Header.Type))
                 return new OidcError(
                     ErrorCodes.InvalidRequest, "The id token hint is not an ID Token");
 

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -404,14 +404,13 @@ public class TokenExchangeGrantHandler(
 
         // typ header expected per URI (JWT-based subject types only):
         //   access_token  -> at+jwt
-        //   id_token      -> id+jwt
-        //   refresh_token -> rt+jwt
+        //   refresh_token -> the refresh class this server issues
+        //   id_token      -> nothing to expect: an ID token carries no type of its own
         //   jwt           -> any typ acceptable (generic JWT URI)
         // Resolvers for non-JWT formats leave JwtTokenType null; this check is a no-op for them.
         var expectedTyp = requestedTypeUri switch
         {
             TokenExchangeTokenTypes.AccessToken => JwtTypes.AccessToken,
-            TokenExchangeTokenTypes.IdToken => JwtTypes.IdToken,
             TokenExchangeTokenTypes.RefreshToken => JwtTypes.RefreshToken,
             _ => null,
         };

--- a/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtFormatter.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Formatters/ClientJwtFormatter.cs
@@ -55,11 +55,15 @@ public class ClientJwtFormatter(
               "This overload infers the policy from token.Header.Type and is kept for backward compatibility.")]
     public Task<string> FormatAsync(JsonWebToken token, ClientInfo clientInfo)
     {
-        // The legacy contract picks the client's registered encryption metadata by JWT class: id_token and
-        // logout_token use id_token_encrypted_response_*, everything else (UserInfo) uses userinfo_encrypted_response_*.
+        // The legacy contract picks the client's registered encryption metadata by JWT class: a logout token
+        // uses id_token_encrypted_response_*, everything else (UserInfo) uses userinfo_encrypted_response_*.
+        //
+        // An ID token no longer lands in the first arm, because it no longer carries a type of its own - which
+        // is precisely why this overload is obsolete. Inferring an encryption policy from a header that the
+        // specifications do not define was never sound; callers pass the policy explicitly instead.
         var encryption = token.Header.Type switch
         {
-            JwtTypes.IdToken or JwtTypes.LogoutToken => ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value),
+            JwtTypes.LogoutToken => ClientJwtEncryption.ForIdentityToken(clientInfo, options.Value),
             _ => ClientJwtEncryption.ForUserInfo(clientInfo, options.Value),
         };
 

--- a/src/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -111,7 +111,9 @@ internal class IdentityTokenService(
 		{
 			Header =
 			{
-				Type = JwtTypes.IdToken,
+				// No explicit type. OpenID Connect Core defines none for an ID token, no relying party checks
+				// one, and a vendor value only breaks when two servers of different builds share a deployment.
+				// The JWT library writes the generic JWT that RFC 7519 Section 5.1 recommends.
 				Algorithm = clientInfo.IdentityTokenSignedResponseAlgorithm,
 			},
 			Payload = new JsonWebTokenPayload(userInfo)

--- a/src/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -106,20 +106,27 @@ public class RefreshTokenService(
 		// grant id ties every refresh token of one authorization grant into a family a detected replay revokes whole.
 		var grantId = refreshToken?.Payload.GrantId ?? grantIdGenerator.GenerateGrantId();
 
-		// The same four claims as on an access token, answering the same four questions - but the audience
-		// lands differently, and that difference is the point:
+		// The same four claims as on an access token, answering the same four questions - except that one of
+		// them answers a different question here than its name suggests:
 		//
 		//   iss       - who issued it        (RFC 7519 Section 4.1.1)
-		//   aud       - who reads it         (RFC 7519 Section 4.1.3). Here it is always this server. A
-		//                                     refresh token grants access to nothing: the client presents it
-		//                                     to the token endpoint and never opens it, so "who reads it"
-		//                                     and "where it grants access" - which coincide on an access
-		//                                     token - come apart. Naming the client instead would say who
-		//                                     asked rather than who reads, and leave the audience uncheckable
-		//                                     on the way back in.
+		//   aud       - not who reads it     (RFC 7519 Section 4.1.3). Set by ApplyTo below, from the same
+		//                                     authorization context the access token uses, so it holds the
+		//                                     resources the grant was issued for - or the issuer where it
+		//                                     named none. AuthorizeByRefreshTokenAsync reads them straight
+		//                                     back out of it to rebuild the grant, which makes the claim a
+		//                                     store of grant state rather than a statement about the reader,
+		//                                     and gives a refresh token the same audience as every access
+		//                                     token of the same grant.
 		//   client_id - who asked for it     (RFC 8693 Section 4.3) - set by ApplyTo below.
 		//   sub       - who it is about      (RFC 9068 Section 2.2), sealed per sector for a pairwise client
 		//                                     further down.
+		//
+		// The type below therefore carries a protection rather than a label. With the audiences identical, it
+		// is the only thing separating a refresh token from an access token, and a resource server presented
+		// with one has nothing else to reject it by - the mutually exclusive validation rules RFC 8725
+		// Section 3.12 asks for. Encryption does not stand in for it: it applies only where the host
+		// configured a server encryption key, and without one every service token ships as a readable JWS.
 		var signing = options.Value.ServiceTokens.RefreshToken.Signing;
 
 		var newToken = new JsonWebToken
@@ -142,8 +149,8 @@ public class RefreshTokenService(
 		};
 		authSession.ApplyTo(newToken.Payload);
 
-		// This also sets the audience - the resources the grant was issued for, or the issuer when it named
-		// none - so setting it above would only be overwritten.
+		// This is what sets the audience described above, so setting it in the initializer would only be
+		// overwritten here.
 		authContext.ApplyTo(newToken.Payload);
 
 		// For a pairwise client, replace the real subject in 'sub' with the client's reversible per-sector

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/UserIdentityValidatorTests.cs
@@ -249,7 +249,6 @@ public class UserIdentityValidatorTests
         // Arrange
         var token = new JsonWebToken
         {
-            Header = { Type = JwtTypes.IdToken },
             Payload = { Audiences = ["test-client"] },
         };
 
@@ -280,7 +279,6 @@ public class UserIdentityValidatorTests
         // Arrange
         var token = new JsonWebToken
         {
-            Header = { Type = JwtTypes.IdToken },
             Payload = { Audiences = ["test-client"] },
         };
 
@@ -301,10 +299,14 @@ public class UserIdentityValidatorTests
     }
 
     /// <summary>
-    /// RFC 8725 §3.12: the id_token_hint must be an ID Token, not another own-issued class.
-    /// A token whose 'typ' is not <see cref="JwtTypes.IdToken"/> (e.g. a stolen access token replayed as a
-    /// hint) must be rejected even when its audience matches the requesting client.
+    /// RFC 8725 §3.12: the id_token_hint must be an ID Token, not another own-issued class. A token typed as
+    /// one of this server's own classes - a stolen access token replayed as a hint - must be rejected even
+    /// when its audience matches the requesting client.
     /// </summary>
+    /// <remarks>
+    /// The rejection reason is asserted, not just the error code: every refusal here answers
+    /// <c>invalid_request</c>, so a test checking only the code passes whichever check happened to fire.
+    /// </remarks>
     [Fact]
     public async Task ValidateAsync_IdTokenHintWrongType_ShouldReturnInvalidRequest()
     {
@@ -327,6 +329,7 @@ public class UserIdentityValidatorTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Equal("The id token hint is not an ID Token", result.ErrorDescription);
     }
 
     /// <summary>
@@ -339,7 +342,6 @@ public class UserIdentityValidatorTests
         // Arrange
         var token = new JsonWebToken
         {
-            Header = { Type = JwtTypes.IdToken },
             Payload = { Audiences = ["different-client"] },
         };
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/Validation/IdTokenHintValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/Validation/IdTokenHintValidatorTests.cs
@@ -71,8 +71,8 @@ public class IdTokenHintValidatorTests
 
     private static JsonWebToken CreateValidIdToken(params string[] audiences)
     {
+        // No type is set: an ID token carries none of its own, so this is what a real one looks like.
         var token = new JsonWebToken();
-        token.Header.Type = JwtTypes.IdToken;
         token.Payload.Audiences = audiences;
         return token;
     }
@@ -181,10 +181,16 @@ public class IdTokenHintValidatorTests
     }
 
     /// <summary>
-    /// RFC 8725 §3.12: the id_token_hint must be an ID Token, not another own-issued class.
-    /// A token whose 'typ' is not <see cref="JwtTypes.IdToken"/> (e.g. a stolen access token replayed as a
-    /// hint) must be rejected even when its audience matches the requesting client.
+    /// RFC 8725 §3.12: the id_token_hint must be an ID Token, not another own-issued class. A token typed as
+    /// one of this server's own classes - a stolen access token replayed as a hint - must be rejected even
+    /// when its audience matches the requesting client.
     /// </summary>
+    /// <remarks>
+    /// The rejection reason is asserted, not just the error code. Every refusal in this validator answers
+    /// <c>invalid_request</c>, so a test that checks only the code passes whichever check fired - and this one
+    /// did: removing the class check entirely left it green, because the request then failed further down for
+    /// an unrelated reason.
+    /// </remarks>
     [Fact]
     public async Task ValidateAsync_WithNonIdTokenType_ShouldReturnError()
     {
@@ -205,6 +211,7 @@ public class IdTokenHintValidatorTests
         // Assert
         Assert.NotNull(error);
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+        Assert.Equal("The id token hint is not an ID Token", error.ErrorDescription);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -1052,7 +1052,7 @@ public class JwtBearerGrantHandlerTests
 	/// </summary>
 	[Theory]
 	[InlineData(JwtTypes.AccessToken)]
-	[InlineData(JwtTypes.IdToken)]
+	[InlineData(JwtTypes.RefreshToken)]
 	[InlineData(null)]
 	public async Task TokenTypeValidation_WithDisallowedType_ShouldReject(string? tokenType)
 	{

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -702,13 +702,13 @@ public class TokenExchangeGrantHandlerTests
     [Fact]
     public async Task S3_IdTokenTyp_rejected_when_subject_token_type_is_access_token()
     {
-        // A JWT minted as id_token (typ=id+jwt) presented under subject_token_type=access_token
-        // is a cross-type confusion: id_tokens carry identity assertions, not authorisation,
-        // and may have different audience expectations. Reject even though signature validates.
+        // A JWT minted as a refresh token presented under subject_token_type=access_token is a cross-type
+        // confusion: the two carry different authority and are redeemed at different places. Reject even
+        // though the signature validates.
         var subject = new SubjectTokenContext("alice", null, ["openid"], null)
         {
             OriginalClientId = ClientId,
-            JwtTokenType = JwtTypes.IdToken,  // typ mismatch
+            JwtTokenType = JwtTypes.RefreshToken,  // typ mismatch
         };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
@@ -95,7 +95,7 @@ public class PrivateKeyJwtAuthenticatorTests
     /// </summary>
     [Theory]
     [InlineData(JwtTypes.AccessToken)]
-    [InlineData(JwtTypes.IdToken)]
+    [InlineData(JwtTypes.LogoutToken)]
     [InlineData(JwtTypes.RefreshToken)]
     public async Task ATokenClassPresentedAsAssertion_ShouldReturnNull(string tokenType)
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/ClientJwtFormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Formatters/ClientJwtFormatterTests.cs
@@ -126,7 +126,7 @@ public class ClientJwtFormatterTests
         // Arrange
         var token = new JsonWebToken
         {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.IdToken },
+            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.LogoutToken },
             Payload = { Subject = "user123", Audiences = [ClientId] }
         };
 
@@ -162,7 +162,7 @@ public class ClientJwtFormatterTests
         // Arrange
         var token = new JsonWebToken
         {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.IdToken },
+            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.LogoutToken },
             Payload = { Subject = "user123", Audiences = [ClientId] }
         };
 
@@ -232,7 +232,7 @@ public class ClientJwtFormatterTests
         // Arrange
         var token = new JsonWebToken
         {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.IdToken },
+            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.LogoutToken },
             Payload =
             {
                 JwtId = Guid.NewGuid().ToString("N"),
@@ -348,7 +348,7 @@ public class ClientJwtFormatterTests
         // Act & Assert — id_token uses the id_token encryption metadata (both alg and enc).
         var idToken = new JsonWebToken
         {
-            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.IdToken },
+            Header = { Algorithm = SigningAlgorithms.RS256, Type = JwtTypes.LogoutToken },
             Payload = { Audiences = [ClientId] },
         };
         await _formatter.FormatAsync(idToken, clientInfo);


### PR DESCRIPTION
An ID token no longer carries a `typ` of its own. OpenID Connect Core never mentions the header, so there was no standard value to use, and the private one this server minted was read by nobody: two widely deployed .NET providers leave an ID token as a generic JWT for the same reason.

What a private value did instead was break across a version boundary. Observed live: a token issued by one build was refused by another after the value was renamed, and the endpoint it broke was logout, so the user could not even leave. RFC 8725 Section 3.11 describes exactly this, that explicit typing "may not achieve disambiguation from existing kinds of JWTs, as the validation rules for existing kinds of JWTs often do not use the `typ` Header Parameter value".

The protection that value carried stays, restated as a refusal. The `id_token_hint` validators no longer require one value; they refuse any `typ` naming a class this server issues in its own right, which keeps the mutually exclusive validation rules Section 3.12 requires without asserting something no specification defines.

## The other service types stay, and now say why

A second commit corrects a contradiction found while weighing whether to retire them. Two comments in the refresh token service disagreed about its audience: one called it "always this server", the other noted that applying the authorization context overwrites it with the resources of the grant. The second is what the code does, and the renewal path reads those resources straight back out of the claim to rebuild the grant, so the claim is a store of grant state rather than a statement about who reads the token.

That has a consequence worth recording where it can be acted on. Because the audience comes from the same authorization context the access token uses, a refresh token carries the same audience as every access token of its grant, and the type is the only thing separating them. Encryption does not stand in for it, applying only where the host configured a server encryption key.

Each of the three remaining private types now records why it cannot move to `at+jwt`: the refresh token for the shared audience above, and because the IANA media types registry holds no entry for one; the registration access token because a statically configured client is defended by its subject alone, which an access token issued for that client also carries; the initial access token because its validator asks for nothing beyond a non-empty subject that has not been revoked.
