### PR TITLE
Let a deployment name a destination instead of standing SSRF protection down

### DIFF
--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetchOptions.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetchOptions.cs
@@ -100,4 +100,26 @@ public class SecureHttpFetchOptions
     /// Set to false only in development environments where fetching from internal networks is required.
     /// </remarks>
     public bool BlockPrivateNetworks { get; set; } = true;
+
+    /// <summary>
+    /// Destinations this server may reach whatever the rules above say. Default: null, meaning none.
+    /// </summary>
+    /// <remarks>
+    /// This is how a deployment reaches one known service inside its own network without standing the
+    /// protection down. The rules above are a blanket refusal that cannot be narrowed, only switched off, so
+    /// an authorization server that must call a sibling in its own cluster would otherwise set
+    /// <see cref="BlockPrivateNetworks"/> to <c>false</c> and widen <see cref="AllowedSchemes"/> - and both
+    /// relaxations apply equally to every address a *client* supplies: a key set, a sector identifier, a
+    /// back-channel logout endpoint. Naming the one destination leaves the refusal total everywhere else.
+    /// <para>
+    /// An entry is matched on scheme, host and port, and additionally on path when it carries one. So
+    /// <c>http://localhost:5002</c> permits every path on that origin, while
+    /// <c>http://localhost:5002/manage/api/signout-backchannel-oidc</c> permits that one and leaves the rest
+    /// of the host refused. Prefer the second: this permission is read at client registration as well as on
+    /// the way out, and registration is where a client chooses the address.
+    /// </para>
+    /// An entry carrying a query, a fragment or user information is refused at startup rather than ignored,
+    /// because an entry permitting more than it appears to say is the failure this option exists to avoid.
+    /// </remarks>
+    public Uri[]? AllowedDestinations { get; set; }
 }

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetchOptionsValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureHttpFetchOptionsValidator.cs
@@ -1,0 +1,78 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+/// <summary>
+/// Refuses a <see cref="SecureHttpFetchOptions.AllowedDestinations"/> entry that would permit more than it
+/// reads as permitting.
+/// </summary>
+/// <remarks>
+/// Matching considers a destination's scheme, host, port and path, and nothing else. An entry carrying a
+/// query, a fragment or user information therefore permits every request to that path whatever those parts
+/// say, so accepting one would grant a permission wider than the text of the entry - the single failure this
+/// option exists to prevent. A relative entry names no host at all and can never match.
+/// </remarks>
+public class SecureHttpFetchOptionsValidator : IValidateOptions<SecureHttpFetchOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, SecureHttpFetchOptions options)
+    {
+        if (options.AllowedDestinations is not { Length: > 0 } destinations)
+            return ValidateOptionsResult.Success;
+
+        var failures = new List<string>();
+        foreach (var destination in destinations)
+        {
+            var member = $"{nameof(SecureHttpFetchOptions)}.{nameof(SecureHttpFetchOptions.AllowedDestinations)}";
+
+            if (!destination.IsAbsoluteUri)
+            {
+                failures.Add(
+                    $"The entry '{destination}' in {member} must be an absolute URI naming a scheme and a host.");
+
+                // Every question below reads a component only an absolute URI has.
+                continue;
+            }
+
+            if (destination.Query.Length > 0 || destination.Fragment.Length > 0)
+            {
+                failures.Add(
+                    $"The entry '{destination}' in {member} must carry no query and no fragment: " +
+                    "neither takes part in matching, so the entry would permit more than it states.");
+            }
+
+            if (destination.UserInfo.Length > 0)
+            {
+                failures.Add(
+                    $"The entry '{destination}' in {member} must carry no user information: " +
+                    "it takes no part in matching and is never sent.");
+            }
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
@@ -61,9 +61,43 @@ public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISec
         ".lan"
     ];
 
+    /// <summary>
+    /// Reports whether a URI is one of the destinations named in
+    /// <see cref="SecureHttpFetchOptions.AllowedDestinations"/>.
+    /// </summary>
+    /// <param name="uri">The URI about to be reached.</param>
+    /// <param name="allowedDestinations">The configured permissions, which may be absent.</param>
+    /// <returns><c>true</c> when the URI matches one of them.</returns>
+    /// <remarks>
+    /// Static because two separate refusals have to honour the same permission: the synchronous policy
+    /// below, and the DNS re-resolution in <see cref="SsrfValidatingHttpMessageHandler"/>. A permission
+    /// honoured by only one of them passes validation and then dies at the request - which reads as a
+    /// working allow-list in every test of this class, and fails only against a live service.
+    /// <para>
+    /// An entry with no path of its own (<c>/</c>) matches the whole origin; an entry carrying a path
+    /// matches that path exactly. Comparison of scheme and host ignores case as RFC 3986 Section 6.2.2.1
+    /// requires, while the path is compared as written, because the same section leaves it case-sensitive.
+    /// </para>
+    /// </remarks>
+    public static bool IsAllowedDestination(Uri uri, Uri[]? allowedDestinations)
+        => allowedDestinations is { Length: > 0 } destinations &&
+           Array.Exists(destinations, allowed =>
+               allowed.IsAbsoluteUri &&
+               string.Equals(uri.Scheme, allowed.Scheme, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(uri.Host, allowed.Host, StringComparison.OrdinalIgnoreCase) &&
+               uri.Port == allowed.Port &&
+               (allowed.AbsolutePath == "/" ||
+                string.Equals(uri.AbsolutePath, allowed.AbsolutePath, StringComparison.Ordinal)));
+
     /// <inheritdoc />
     public string? Validate(Uri uri)
     {
+        // A named destination is the one way past everything below, and it is checked first so that it also
+        // lifts the scheme restriction: reaching a service inside the network means plain HTTP, and a
+        // permission unable to say so would permit nothing.
+        if (IsAllowedDestination(uri, options.Value.AllowedDestinations))
+            return null;
+
         if (options.Value.AllowedSchemes is { Length: > 0 } allowedSchemes &&
             !allowedSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase))
         {
@@ -120,7 +154,7 @@ public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISec
     public static bool IsPrivateOrReservedAddress(IPAddress address)
     {
         // Collapse an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1 / ::ffff:169.254.169.254) to its IPv4 form
-        // FIRST — RFC 4291 §2.5.5 — so every rule below, including the loopback check, inspects the embedded IPv4
+        // FIRST - RFC 4291 §2.5.5 - so every rule below, including the loopback check, inspects the embedded IPv4
         // address. Without this an attacker reaches loopback, cloud metadata or private ranges through the IPv6 arm,
         // which never inspects the embedded IPv4 address.
         if (address.IsIPv4MappedToIPv6)

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandler.cs
@@ -89,7 +89,15 @@ public class SsrfValidatingHttpMessageHandler(
 
         // DNS rebinding (TOCTOU) defence: for a resolvable hostname (not an IP literal, already checked
         // above), re-resolve immediately before the request and reject if any address is private.
-        if (options.Value.BlockPrivateNetworks && !IPAddress.TryParse(uri.Host, out _))
+        //
+        // A destination the host named is exempt here as well as above, and it has to be: such a service is
+        // reached at a private address by definition, so honouring the permission only in the validator
+        // would let the URI pass and then refuse it here, one line before the request. There is no rebinding
+        // to defend against either - the permission names the host, and an attacker who could change what it
+        // resolves to already owns the name.
+        if (options.Value.BlockPrivateNetworks &&
+            !SecureUriValidator.IsAllowedDestination(uri, options.Value.AllowedDestinations) &&
+            !IPAddress.TryParse(uri.Host, out _))
         {
             IPHostEntry hostEntry;
             try

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -777,6 +777,11 @@ public static class ServiceCollectionExtensions
             optionsBuilder.Configure(configure);
         }
 
+        // The framework resolves every registered validator, so this joins the set rather than replacing
+        // whatever a host registered for the same options.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<SecureHttpFetchOptions>, SecureHttpFetchOptionsValidator>());
+
         services.TryAddSingleton<ISecureUriValidator, SecureUriValidator>();
         services.TryAddTransient<SsrfValidatingHttpMessageHandler>();
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SecureHttpFetchOptionsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SecureHttpFetchOptionsValidatorTests.cs
@@ -1,0 +1,85 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.SecureHttpFetch;
+
+/// <summary>
+/// Unit tests for <see cref="SecureHttpFetchOptionsValidator"/>, which refuses a named destination that
+/// would permit more than its text says.
+/// </summary>
+public class SecureHttpFetchOptionsValidatorTests
+{
+    private static SecureHttpFetchOptionsValidator Validator => new();
+
+    private static bool Succeeds(params Uri[] destinations)
+        => Validator.Validate(null, new SecureHttpFetchOptions { AllowedDestinations = destinations }).Succeeded;
+
+    [Theory]
+    [InlineData("http://localhost:5002")]
+    [InlineData("http://localhost:5002/manage/api/signout-backchannel-oidc")]
+    [InlineData("https://backend-staging:5001/connect/token")]
+    public void Validate_DestinationOfSchemeHostPortAndPath_Succeeds(string destination)
+    {
+        Assert.True(Succeeds(new Uri(destination)));
+    }
+
+    // Matching reads scheme, host, port and path and nothing else, so any component beyond those would sit
+    // in the entry unread - the entry would permit every query at that path while appearing to permit one.
+    [Theory]
+    [InlineData("http://localhost:5002/api?tenant=abblix")]
+    [InlineData("http://localhost:5002/api#section")]
+    [InlineData("http://user:secret@localhost:5002/api")]
+    public void Validate_DestinationCarryingAnUnreadComponent_Fails(string destination)
+    {
+        Assert.False(Succeeds(new Uri(destination)));
+    }
+
+    // A relative entry names no host, so it can never match anything and is a configuration mistake rather
+    // than a permission.
+    [Fact]
+    public void Validate_RelativeDestination_Fails()
+    {
+        Assert.False(Succeeds(new Uri("/manage/api/signout-backchannel-oidc", UriKind.Relative)));
+    }
+
+    // One bad entry is refused even in the company of good ones - otherwise the mistake would be reported
+    // only when it happened to sit first.
+    [Fact]
+    public void Validate_OneBadDestinationAmongGoodOnes_Fails()
+    {
+        Assert.False(Succeeds(
+            new Uri("http://localhost:5002/api"),
+            new Uri("http://localhost:5003/api?tenant=abblix"),
+            new Uri("https://backend-staging:5001/connect/token")));
+    }
+
+    [Fact]
+    public void Validate_WithNoDestinations_Succeeds()
+    {
+        Assert.True(Validator.Validate(null, new SecureHttpFetchOptions()).Succeeded);
+        Assert.True(Succeeds());
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SecureUriValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SecureUriValidatorTests.cs
@@ -115,10 +115,68 @@ public class SecureUriValidatorTests
     [Theory]
     [InlineData("203.0.113.10")]   // public documentation range, treated as routable
     [InlineData("8.8.8.8")]        // public
-    [InlineData("100.63.255.255")] // one below the CGNAT range — must stay routable
-    [InlineData("100.128.0.0")]    // one above the CGNAT range — must stay routable
+    [InlineData("100.63.255.255")] // one below the CGNAT range - must stay routable
+    [InlineData("100.128.0.0")]    // one above the CGNAT range - must stay routable
     public void IsPrivateOrReservedAddress_PublicAddress_ReturnsFalse(string ip)
     {
         Assert.False(SecureUriValidator.IsPrivateOrReservedAddress(IPAddress.Parse(ip)));
+    }
+
+    // A named destination lifts both refusals at once - the scheme allow-list and the private-network block -
+    // because a service inside the network is reached over plain HTTP at a private address, and a permission
+    // that could only lift one of the two would permit nothing.
+    [Theory]
+    [InlineData("http://localhost:5002/manage/api/signout-backchannel-oidc")]
+    [InlineData("http://localhost:5002/anything/else")]
+    public void Validate_NamedOrigin_PermitsEveryPathOnIt(string uri)
+    {
+        var options = new SecureHttpFetchOptions
+        {
+            AllowedDestinations = [new Uri("http://localhost:5002")],
+        };
+        Assert.Null(CreateValidator(options).Validate(new Uri(uri)));
+    }
+
+    // The permission is exactly as wide as it is written: a neighbouring port, another scheme or another host
+    // is a different destination and stays refused, so naming one service does not open the machine.
+    [Theory]
+    [InlineData("http://localhost:5003/api")]     // another port on the same host
+    [InlineData("https://localhost:5002/api")]    // another scheme
+    [InlineData("http://127.0.0.1:5002/api")]     // the same service by address rather than by the name given
+    [InlineData("http://otherhost:5002/api")]     // another host
+    public void Validate_BesideTheNamedOrigin_StaysRefused(string uri)
+    {
+        var options = new SecureHttpFetchOptions
+        {
+            AllowedDestinations = [new Uri("http://localhost:5002")],
+        };
+        Assert.NotNull(CreateValidator(options).Validate(new Uri(uri)));
+    }
+
+    // Naming a path narrows the permission to it, which is what makes the option safe to leave on: the same
+    // list is read at client registration, where the client chooses the address.
+    [Fact]
+    public void Validate_NamedPath_PermitsThatPathAndRefusesItsNeighbours()
+    {
+        var options = new SecureHttpFetchOptions
+        {
+            AllowedDestinations = [new Uri("http://localhost:5002/manage/api/signout-backchannel-oidc")],
+        };
+        var validator = CreateValidator(options);
+
+        Assert.Null(validator.Validate(new Uri("http://localhost:5002/manage/api/signout-backchannel-oidc")));
+        Assert.NotNull(validator.Validate(new Uri("http://localhost:5002/manage/api/anything-else")));
+        Assert.NotNull(validator.Validate(new Uri("http://localhost:5002/")));
+    }
+
+    // Absent or empty, the option changes nothing - a deployment that never names a destination keeps exactly
+    // the refusals it had.
+    [Fact]
+    public void Validate_WithNoNamedDestinations_LeavesTheRefusalsUntouched()
+    {
+        Assert.NotNull(CreateValidator(SecureDefaults).Validate(new Uri("http://localhost:5002/api")));
+
+        var empty = new SecureHttpFetchOptions { AllowedDestinations = [] };
+        Assert.NotNull(CreateValidator(empty).Validate(new Uri("http://localhost:5002/api")));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandlerTests.cs
@@ -440,4 +440,56 @@ public class SsrfValidatingHttpMessageHandlerTests
     }
 
     #endregion
+
+    /// <summary>
+    /// A named destination has to be honoured by the DNS re-resolution here, not only by the synchronous
+    /// policy the validator applies.
+    /// </summary>
+    /// <remarks>
+    /// The name resolves to a loopback address, so a permission that reached only the validator would pass
+    /// validation and then be refused one line before the request goes out. Every test of
+    /// <see cref="SecureUriValidator"/> stays green in that state, which is what makes this the test worth
+    /// having: the two refusals are separate, and a permission has to clear both.
+    /// </remarks>
+    [Fact]
+    public async Task SendAsync_ToNamedDestination_IsNotRefusedByTheDnsRecheck()
+    {
+        var client = CreateClient(new SecureHttpFetchOptions
+        {
+            BlockPrivateNetworks = true,
+            AllowedDestinations = [new Uri("http://localhost:5002")],
+        });
+
+        try
+        {
+            await client.GetAsync("http://localhost:5002/health", TestContext.Current.CancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.Message.Contains("SSRF protection"))
+        {
+            Assert.Fail($"A named destination must reach the request: {ex.Message}");
+        }
+        catch
+        {
+            // Nothing listens on that port during a unit-test run, so a transport failure is the expected
+            // outcome here and is not what this asserts.
+        }
+    }
+
+    /// <summary>
+    /// Naming one destination must not stand the protection down for its neighbours.
+    /// </summary>
+    [Fact]
+    public async Task SendAsync_BesideANamedDestination_IsStillRefused()
+    {
+        var client = CreateClient(new SecureHttpFetchOptions
+        {
+            BlockPrivateNetworks = true,
+            AllowedDestinations = [new Uri("http://localhost:5002")],
+        });
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync("http://169.254.169.254/latest/meta-data", TestContext.Current.CancellationToken));
+
+        Assert.Contains("SSRF protection", exception.Message);
+    }
 }


### PR DESCRIPTION
The outbound SSRF protections were all-or-nothing. A deployment whose authorization server must reach a sibling inside its own network - the ordinary shape when the server and its relying party run in one cluster - had two switches available, both of them blanket: allow every scheme, and stop blocking private networks.

Both apply equally to every address a *client* supplies. Buying one trusted destination therefore meant trusting a registered client's key set address, its sector identifier and its back-channel logout endpoint to name anything reachable from the server, cloud metadata included. That is loosening by disabling the guard, which is the shape this change replaces.

## What it adds

A deployment can name destinations the protections let through. It is a positive statement about one address rather than the absence of a rule, so the refusal stays total everywhere a destination was not named.

An entry matches on scheme, host and port, and on path as well when it carries one. The path matters more than it looks: the same list is read at client registration, where the client chooses the address, so naming a path leaves the rest of that host refused.

An entry carrying a query, a fragment or user information is refused at startup. None of them take part in matching, so accepting one would grant a permission wider than its own text - the single failure this option exists to prevent.

## The seam worth reviewing

A URI can be refused in two places: the synchronous policy, and the DNS re-resolution immediately before the request goes out. They are separate, and a permission honoured by only the first passes validation and then dies one line before the request - while every test of the validator stays green. Both now honour it through one shared decision, and there is a test on the second.

Two mutations were run against the suite: removing the permission from the DNS re-resolution, and removing the port from the comparison. Each turns exactly one test red, and each is the test written for it.

## Follow-up worth filing separately

The DNS re-resolution has no other coverage. Every refusal the existing suite asserts is caught by the synchronous rules instead, so that branch was untested before this change. Testing it properly needs a resolver seam that does not exist today, which is why it is not in this PR.
