### PR TITLE
Closed-deployment SSF stores: streams as configuration, outbox on the distributed cache

### DIFF
--- a/Abblix.Oidc.slnx
+++ b/Abblix.Oidc.slnx
@@ -30,6 +30,7 @@
     <Project Path="src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj" />
     <Project Path="src/Abblix.SharedSignals/Abblix.SharedSignals.csproj" />
     <Project Path="src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj" />
+    <Project Path="src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj" />
@@ -48,5 +49,6 @@
     <Project Path="tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj" />
     <Project Path="tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj" />
     <Project Path="tests/Abblix.SharedSignals.E2E.Tests/Abblix.SharedSignals.E2E.Tests.csproj" />
+    <Project Path="tests/Abblix.SharedSignals.Redis.UnitTests/Abblix.SharedSignals.Redis.UnitTests.csproj" />
   </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Garnet" Version="2.1.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.1.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Abblix.SharedSignals.Redis</PackageId>
+    <Title>Abblix Shared Signals Redis</Title>
+    <Description>Redis-native event outbox for Abblix Shared Signals: the transmitter's per-stream queues on Redis list and hash structures with atomic server-side operations, correct across transmitter replicas where a plain distributed-cache queue is not.</Description>
+    <Authors>Abblix LLP</Authors>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>Abblix SharedSignals SSF SecurityEvent SET Redis Outbox Stream Transmitter Security Identity</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
+    <PackageIcon>Abblix.png</PackageIcon>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    <!-- Deterministic builds for reproducible binaries -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+
+    <!-- SourceLink for symbol packages -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Abblix.SharedSignals\Abblix.SharedSignals.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -1,0 +1,26 @@
+# Abblix.SharedSignals.Redis
+
+The Redis-native event outbox for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals): each stream's queue on Redis list and hash structures, every mutation a server-side atomic operation.
+
+## Why native structures
+
+The in-package distributed-cache outbox stores each queue as one value, so its mutations are read-modify-write - correct for a single transmitter instance serializing them in-process, and silently lossy the day the transmitter scales to replicas. This outbox appends, removes by value and deletes fields on the server itself, so concurrent replicas compose instead of overwriting each other.
+
+## Usage
+
+```csharp
+builder.Services.AddSingleton<IConnectionMultiplexer>(
+    ConnectionMultiplexer.Connect(builder.Configuration.GetConnectionString("Redis")!));
+
+builder.Services
+    .AddSecurityEvents(...)
+    .AddSsfTransmitter(...)
+    .AddSsfRedisOutbox();
+```
+
+The queue and item keys of one stream share a cluster hash tag, so the outbox works unchanged under Redis Cluster. Losing Redis loses pending events - the tier is deliberate: the delivery protocols budget for dropped held events (SSF 1.0 Section 8.1.2.1), so the queue belongs beside caches, not beside data that earns backups.
+
+## License
+
+Abblix.SharedSignals.Redis is licensed under the Abblix license agreement. See
+[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).

--- a/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
@@ -1,0 +1,148 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using Abblix.SharedSignals.Transmitter;
+using StackExchange.Redis;
+
+namespace Abblix.SharedSignals.Redis;
+
+/// <summary>
+/// The outbox on Redis's own structures: a list carries each stream's order, a hash carries the
+/// items, and every mutation is a server-side atomic operation - append, remove-by-value,
+/// field delete - so concurrent transmitter REPLICAS compose instead of overwriting each other,
+/// which is the hole a whole-queue-as-one-value implementation cannot close.
+/// </summary>
+/// <remarks>
+/// The queue and item keys of one stream share a cluster hash tag, so they land on one slot and
+/// the multi-key transactions here stay valid under Redis Cluster. Losing Redis loses pending
+/// events - the tier is deliberate: the delivery protocols budget for dropped held events
+/// (SSF 1.0 Section 8.1.2.1), so the queue belongs beside caches, not beside data that earns
+/// backups.
+/// </remarks>
+/// <param name="connection">The Redis connection; opening and configuring it is the host's.</param>
+public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEventOutbox
+{
+    private const string KeyPrefix = $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(RedisEventOutbox)}:";
+
+    private readonly IDatabase _database = connection.GetDatabase();
+
+    /// <inheritdoc />
+    public async ValueTask EnqueueAsync(
+        string streamId,
+        OutboxItem item,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(streamId);
+        ArgumentNullException.ThrowIfNull(item);
+
+        // Order and payload land together or not at all: a jti listed without its item would
+        // read as an acked ghost, an item without its listing would never be served.
+        var transaction = _database.CreateTransaction();
+        _ = transaction.ListRightPushAsync(QueueKeyOf(streamId), item.JwtId);
+        _ = transaction.HashSetAsync(
+            ItemsKeyOf(streamId), item.JwtId, JsonSerializer.SerializeToUtf8Bytes(item));
+
+        await ExecuteAsync(transaction, streamId);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+        string streamId,
+        int? maxCount = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxCount is <= 0)
+        {
+            return [];
+        }
+
+        var listed = await _database.ListRangeAsync(
+            QueueKeyOf(streamId), 0, maxCount is { } limit ? limit - 1 : -1);
+        if (listed.Length == 0)
+        {
+            return [];
+        }
+
+        var stored = await _database.HashGetAsync(ItemsKeyOf(streamId), listed);
+
+        var pending = new List<OutboxItem>(listed.Length);
+        foreach (var value in stored)
+        {
+            // A listed jti whose item is gone was acknowledged between the two reads - the
+            // remove-by-value has or will drop its listing too, so it is simply not pending.
+            if (!value.IsNull)
+            {
+                pending.Add(JsonSerializer.Deserialize<OutboxItem>((byte[])value!)
+                    ?? throw new InvalidOperationException(
+                        $"An outbox item of stream '{streamId}' deserialized to null."));
+            }
+        }
+
+        return pending;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask AcknowledgeAsync(
+        string streamId,
+        IReadOnlyCollection<string> jwtIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jwtIds);
+
+        if (jwtIds.Count == 0)
+        {
+            return;
+        }
+
+        var transaction = _database.CreateTransaction();
+        foreach (var jwtId in jwtIds)
+        {
+            _ = transaction.ListRemoveAsync(QueueKeyOf(streamId), jwtId);
+            _ = transaction.HashDeleteAsync(ItemsKeyOf(streamId), jwtId);
+        }
+
+        await ExecuteAsync(transaction, streamId);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default)
+        => await _database.KeyDeleteAsync([QueueKeyOf(streamId), ItemsKeyOf(streamId)]);
+
+    /// <summary>
+    /// The stream identifier travels inside a cluster hash tag, which is what keeps both of a
+    /// stream's keys on one slot - the ground the multi-key transactions stand on.
+    /// </summary>
+    private static RedisKey QueueKeyOf(string streamId) => $"{KeyPrefix}{{{streamId}}}:queue";
+
+    private static RedisKey ItemsKeyOf(string streamId) => $"{KeyPrefix}{{{streamId}}}:items";
+
+    private static async Task ExecuteAsync(ITransaction transaction, string streamId)
+    {
+        if (!await transaction.ExecuteAsync())
+        {
+            throw new InvalidOperationException(
+                $"The outbox transaction of stream '{streamId}' did not execute; with no watched "
+                + "keys that points at the connection, not at contention.");
+        }
+    }
+}

--- a/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Abblix.SharedSignals.Redis;
+
+/// <summary>
+/// Wires the Redis-native outbox into a host's service collection.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Puts the transmitter's outbox on Redis's own structures - the choice for a transmitter
+    /// that scales beyond one replica, where a whole-queue-as-one-value outbox loses concurrent
+    /// mutations. The host registers its <c>IConnectionMultiplexer</c>; this call, like its
+    /// distributed-cache sibling, uses Replace so the explicit choice wins in any order
+    /// relative to the role registration.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddSsfRedisOutbox(this IServiceCollection services)
+    {
+        services.Replace(ServiceDescriptor.Singleton<IEventOutbox, RedisEventOutbox>());
+        return services;
+    }
+}

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -33,6 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -124,6 +124,43 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Declares the transmitter's stream set as configuration: the store of a closed
+    /// deployment whose receivers are the operator's own products - nothing to back up,
+    /// lifecycle in the operator's file, API mutations ephemeral until restart.
+    /// </summary>
+    /// <remarks>
+    /// Replace rather than TryAdd, deliberately: this call IS the host's explicit choice of
+    /// store, so it wins whether it runs before or after
+    /// <see cref="AddSsfTransmitter"/>'s in-memory default.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="streams">The declared streams.</param>
+    public static IServiceCollection AddSsfConfiguredStreams(
+        this IServiceCollection services,
+        IReadOnlyList<ConfiguredStream> streams)
+    {
+        ArgumentNullException.ThrowIfNull(streams);
+
+        services.Replace(ServiceDescriptor.Singleton<IStreamStore>(provider =>
+            provider.CreateService<ConfigurationStreamStore>(Dependency.Override(streams))));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Puts the transmitter's outbox on the host's <c>IDistributedCache</c>, so pending events
+    /// survive a process restart when the store behind the cache does. Replace rather than
+    /// TryAdd for the same reason as <see cref="AddSsfConfiguredStreams"/>: an explicit choice
+    /// wins in any order.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddSsfDistributedOutbox(this IServiceCollection services)
+    {
+        services.Replace(ServiceDescriptor.Singleton<IEventOutbox, DistributedCacheEventOutbox>());
+        return services;
+    }
+
+    /// <summary>
     /// Both roles build on the Security Events core, and the marker of that call is the one
     /// registration it refuses to duplicate: the event type registry.
     /// </summary>

--- a/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
@@ -1,0 +1,152 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// The stream store of a closed deployment: the stream set is configuration, seeded once at
+/// construction, and the store holds NOTHING worth backing up. Right where the receivers are
+/// the operator's own products - the lifecycle lives in configuration, not in the management
+/// API.
+/// </summary>
+/// <remarks>
+/// Mutations through the API are accepted but ephemeral: a status change or a verification
+/// timestamp lives until the process restarts, then the configuration is truth again. That is
+/// the deliberate trade of this store - the one field that must move at runtime, the
+/// verification throttle, tolerates loss by construction (one extra verification is allowed),
+/// and everything durable is the operator's file. A deployment that needs receiver-driven
+/// lifecycle registers a durable <see cref="IStreamStore"/> instead.
+/// </remarks>
+public sealed class ConfigurationStreamStore : IStreamStore
+{
+    private readonly InMemoryStreamStore _streams = new();
+
+    /// <summary>
+    /// Materializes the configured streams: the transmitter's half - issuer, supported and
+    /// delivered sets, the poll endpoint - comes from <paramref name="options"/>, exactly as
+    /// the dynamic create would supply it.
+    /// </summary>
+    /// <param name="options">The deployment's one-time decisions.</param>
+    /// <param name="streams">The declared streams.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Two declarations share a receiver and stream identifier, or a poll stream is declared on
+    /// a transmitter with no poll endpoint factory - configuration bugs, refused loudly at
+    /// startup rather than surfacing as a broken stream later.</exception>
+    public ConfigurationStreamStore(SsfTransmitterOptions options, IReadOnlyList<ConfiguredStream> streams)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(streams);
+
+        foreach (var declared in streams)
+        {
+            // The in-memory seed answers synchronously; AsTask keeps the wait an ordinary,
+            // rule-clean one for the constructor's single pass.
+            var created = _streams.TryCreateAsync(Materialize(options, declared)).AsTask();
+            if (!created.GetAwaiter().GetResult())
+            {
+                throw new InvalidOperationException(
+                    $"The stream '{declared.StreamId}' of receiver '{declared.ReceiverId}' is declared "
+                    + "more than once.");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
+        => _streams.TryCreateAsync(stream, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<StreamState?> FindAsync(
+        string receiverId,
+        string streamId,
+        CancellationToken cancellationToken = default)
+        => _streams.FindAsync(receiverId, streamId, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<StreamState>> ListAsync(
+        string receiverId,
+        CancellationToken cancellationToken = default)
+        => _streams.ListAsync(receiverId, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
+        => _streams.ListAllAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
+        => _streams.UpdateAsync(stream, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<bool> DeleteAsync(
+        string receiverId,
+        string streamId,
+        CancellationToken cancellationToken = default)
+        => _streams.DeleteAsync(receiverId, streamId, cancellationToken);
+
+    private static StreamState Materialize(SsfTransmitterOptions options, ConfiguredStream declared)
+    {
+        StreamDeliveryMethod delivery;
+        if (declared.PushEndpointUrl is { } pushEndpoint)
+        {
+            delivery = new PushDeliveryMethod(pushEndpoint)
+            {
+                AuthorizationHeader = declared.PushAuthorizationHeader,
+            };
+        }
+        else if (options.PollEndpointFactory is { } pollEndpointOf)
+        {
+            delivery = new PollDeliveryMethod(pollEndpointOf(declared.StreamId));
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"The stream '{declared.StreamId}' declares no push endpoint and the transmitter "
+                + $"offers no poll delivery: set {nameof(ConfiguredStream.PushEndpointUrl)} or "
+                + $"{nameof(SsfTransmitterOptions)}.{nameof(SsfTransmitterOptions.PollEndpointFactory)}.");
+        }
+
+        return new StreamState
+        {
+            ReceiverId = declared.ReceiverId,
+            SubjectsMode = declared.SubjectsMode,
+            Configuration = new StreamConfiguration
+            {
+                StreamId = declared.StreamId,
+                Issuer = options.Issuer,
+                Audiences = declared.Audiences.Length > 0 ? declared.Audiences : [declared.ReceiverId],
+                EventsSupported = options.EventsSupported is { Count: > 0 } supported ? supported : null,
+                EventsRequested = declared.EventsRequested.Length > 0 ? declared.EventsRequested : null,
+                EventsDelivered =
+                [
+                    .. declared.EventsRequested.Where(eventType =>
+                        options.EventsSupported.Contains(eventType, StringComparer.Ordinal)),
+                ],
+                Delivery = delivery,
+                MinVerificationInterval = options.MinVerificationInterval,
+                Description = declared.Description,
+            },
+        };
+    }
+}

--- a/src/Abblix.SharedSignals/Transmitter/ConfiguredStream.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ConfiguredStream.cs
@@ -1,0 +1,84 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// One stream as a closed deployment declares it: the shape a first-party transmitter binds
+/// from configuration when its receivers are its own products, known at deploy time and
+/// provisioned by the same operator on both sides. The members are deliberately
+/// binder-friendly - strings, arrays, a URL - so the whole stream set can live in the host's
+/// configuration.
+/// </summary>
+public sealed record ConfiguredStream
+{
+    /// <summary>
+    /// The receiver identity the stream belongs to, matching what the host's authentication
+    /// yields for that receiver's management and poll calls.
+    /// </summary>
+    public required string ReceiverId { get; init; }
+
+    /// <summary>
+    /// The stream's identifier. Fixed by configuration rather than generated, so both sides of
+    /// a first-party pair can name it in their own settings.
+    /// </summary>
+    public required string StreamId { get; init; }
+
+    /// <summary>
+    /// The "aud" of the stream's SETs; empty uses the receiver identity itself, the default the
+    /// dynamic path also takes (SSF 1.0 Section 4.1.8).
+    /// </summary>
+    public string[] Audiences { get; init; } = [];
+
+    /// <summary>
+    /// The event types the receiver wants; what the stream carries is the intersection with the
+    /// transmitter's supported set (SSF 1.0 Section 8.1.1).
+    /// </summary>
+    public string[] EventsRequested { get; init; } = [];
+
+    /// <summary>
+    /// The receiver's push endpoint; set makes the stream push-delivered, absent makes it poll
+    /// over the transmitter's own endpoint (SSF 1.0 Section 6.1).
+    /// </summary>
+    public Uri? PushEndpointUrl { get; init; }
+
+    /// <summary>
+    /// The whole Authorization header line the transmitter sends with every push
+    /// (SSF 1.0 Section 6.1.1). A secret: in a deployment it arrives through the host's secret
+    /// mechanism - an environment variable mounted from a secret store - never as plaintext in
+    /// a settings file.
+    /// </summary>
+    public string? PushAuthorizationHeader { get; init; }
+
+    /// <summary>
+    /// Which subjects the stream covers. The default here is <see cref="StreamSubjectsMode.All"/>,
+    /// the opposite of the dynamic path's conservative NONE - a first-party receiver is
+    /// provisioned to hear everything, and per-subject bookkeeping is exactly what a static
+    /// deployment does without.
+    /// </summary>
+    public StreamSubjectsMode SubjectsMode { get; init; } = StreamSubjectsMode.All;
+
+    /// <summary>
+    /// A human-readable description of the stream (SSF 1.0 Section 8.1.1).
+    /// </summary>
+    public string? Description { get; init; }
+}

--- a/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
@@ -1,0 +1,165 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// The outbox over the host's <see cref="IDistributedCache"/>: one entry per stream holding the
+/// queue, so pending events survive a process restart when the store behind the cache does. The
+/// tier is deliberate - the queue is short-lived, and the delivery protocols budget for losing
+/// it (a transmitter MAY drop held events, SSF 1.0 Section 8.1.2.1), so it belongs in the
+/// cache tier, not beside data that earns backups.
+/// </summary>
+/// <remarks>
+/// <see cref="IDistributedCache"/> reads and writes whole values with no compare-and-set, so
+/// queue mutations are serialized through an in-process gate per stream. That makes this
+/// implementation correct for a SINGLE transmitter instance; replicas mutating one stream's
+/// queue would overwrite each other's writes. A scaled-out transmitter needs a backend-aware
+/// outbox - native list operations - behind the same interface.
+/// </remarks>
+/// <param name="cache">The distributed cache the queues live in; the store is the host's
+/// choice.</param>
+public sealed class DistributedCacheEventOutbox(IDistributedCache cache) : IEventOutbox, IDisposable
+{
+    /// <summary>
+    /// Keeps the queues out of the way of whatever else shares the host's cache. Derived from
+    /// the type's own name; entries orphaned by a rename are re-created empty, costing at most
+    /// a redelivery the protocols already tolerate.
+    /// </summary>
+    private const string CacheKeyPrefix =
+        $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(DistributedCacheEventOutbox)}:";
+
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new();
+
+    /// <inheritdoc />
+    public async ValueTask EnqueueAsync(
+        string streamId,
+        OutboxItem item,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(streamId);
+        ArgumentNullException.ThrowIfNull(item);
+
+        var gate = GateOf(streamId);
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var queue = await ReadQueueAsync(streamId, cancellationToken);
+            queue.Add(item);
+            await WriteQueueAsync(streamId, queue, cancellationToken);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+        string streamId,
+        int? maxCount = null,
+        CancellationToken cancellationToken = default)
+    {
+        var queue = await ReadQueueAsync(streamId, cancellationToken);
+
+        return maxCount is { } limit && queue.Count > limit
+            ? queue.GetRange(0, limit)
+            : queue;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask AcknowledgeAsync(
+        string streamId,
+        IReadOnlyCollection<string> jwtIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jwtIds);
+
+        if (jwtIds.Count == 0)
+        {
+            return;
+        }
+
+        var acknowledged = new HashSet<string>(jwtIds, StringComparer.Ordinal);
+        var gate = GateOf(streamId);
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var queue = await ReadQueueAsync(streamId, cancellationToken);
+            if (queue.RemoveAll(item => acknowledged.Contains(item.JwtId)) > 0)
+            {
+                await WriteQueueAsync(streamId, queue, cancellationToken);
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default)
+        => await cache.RemoveAsync(CacheKeyPrefix + streamId, cancellationToken);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        foreach (var gate in _gates.Values)
+        {
+            gate.Dispose();
+        }
+    }
+
+    private SemaphoreSlim GateOf(string streamId)
+        => _gates.GetOrAdd(streamId, _ => new SemaphoreSlim(1, 1));
+
+    private async Task<List<OutboxItem>> ReadQueueAsync(string streamId, CancellationToken cancellationToken)
+    {
+        var stored = await cache.GetAsync(CacheKeyPrefix + streamId, cancellationToken);
+        return stored is null
+            ? []
+            : JsonSerializer.Deserialize<List<OutboxItem>>(stored)
+              ?? throw new InvalidOperationException(
+                  $"The outbox entry of stream '{streamId}' deserialized to null.");
+    }
+
+    private async Task WriteQueueAsync(
+        string streamId,
+        List<OutboxItem> queue,
+        CancellationToken cancellationToken)
+    {
+        var key = CacheKeyPrefix + streamId;
+        if (queue.Count == 0)
+        {
+            // An empty queue is the same fact as no entry, and no entry keeps an abandoned
+            // stream from parking bytes in the cache forever.
+            await cache.RemoveAsync(key, cancellationToken);
+            return;
+        }
+
+        await cache.SetAsync(key, JsonSerializer.SerializeToUtf8Bytes(queue), cancellationToken);
+    }
+}

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/Abblix.SharedSignals.Redis.UnitTests.csproj
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/Abblix.SharedSignals.Redis.UnitTests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Garnet" />
+        <!-- Garnet's own floor for its Azure tiering exceeds the centrally pinned versions the
+             product uses; the override lifts them for THIS test host alone, so the embedded
+             server restores without moving the product's Azure dependencies. -->
+        <PackageReference Include="Azure.Identity" VersionOverride="1.17.0" />
+        <PackageReference Include="Azure.Storage.Blobs" VersionOverride="12.27.0" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Abblix.SharedSignals.Redis\Abblix.SharedSignals.Redis.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/GarnetFixture.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/GarnetFixture.cs
@@ -1,0 +1,72 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Sockets;
+using Garnet;
+using Garnet.server;
+using StackExchange.Redis;
+
+namespace Abblix.SharedSignals.Redis.UnitTests;
+
+/// <summary>
+/// A real Redis-protocol server inside the test process: embedded Garnet on a loopback port
+/// picked at startup. No container, no external service - and still an actual server, which is
+/// what lets these tests witness the server-side atomicity the outbox exists for.
+/// </summary>
+public sealed class GarnetFixture : IDisposable
+{
+    private readonly GarnetServer _server;
+
+    public GarnetFixture()
+    {
+        var endPoint = new IPEndPoint(IPAddress.Loopback, FreeTcpPort());
+        _server = new GarnetServer(new GarnetServerOptions
+        {
+            EndPoints = [endPoint],
+        });
+        _server.Start();
+
+        Connection = ConnectionMultiplexer.Connect(
+            new ConfigurationOptions { EndPoints = { endPoint } });
+    }
+
+    public ConnectionMultiplexer Connection { get; }
+
+    public void Dispose()
+    {
+        Connection.Dispose();
+        _server.Dispose();
+    }
+
+    /// <summary>
+    /// Lets the operating system pick a free port and releases it for Garnet to take: the gap
+    /// is a race in principle, and in practice the port stays ours for the microseconds the
+    /// handover takes.
+    /// </summary>
+    private static int FreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+}

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
@@ -1,0 +1,120 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SharedSignals.Redis;
+using Abblix.SharedSignals.Transmitter;
+using Xunit;
+
+namespace Abblix.SharedSignals.Redis.UnitTests;
+
+/// <summary>
+/// Pins the Redis-native outbox against a REAL Redis-protocol server - the embedded Garnet the
+/// fixture starts - because the whole point of this implementation is server-side atomicity,
+/// which a mock of the client API cannot witness. The concurrency test is the reason the
+/// package exists: mutations from independent instances must compose, where the
+/// one-value-per-queue design loses them.
+/// </summary>
+public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<GarnetFixture>
+{
+    /// <summary>
+    /// Streams are namespaced per test: the class fixture is one shared server, and a
+    /// collision between tests would be a test defect wearing a product one's clothes.
+    /// </summary>
+    private static string NewStreamId() => $"s-{Guid.NewGuid():N}";
+
+    [Fact]
+    public async Task Enqueue_KeepsOrder_AndPendingHonorsTheLimit()
+    {
+        var outbox = new RedisEventOutbox(garnet.Connection);
+        var streamId = NewStreamId();
+
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-2", "b.b.b"), TestContext.Current.CancellationToken);
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-3", "c.c.c"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ["jti-1", "jti-2"],
+            (await outbox.PendingAsync(streamId, 2, TestContext.Current.CancellationToken))
+            .Select(item => item.JwtId));
+        Assert.Equal(3, (await outbox.PendingAsync(streamId, null, TestContext.Current.CancellationToken)).Count);
+        Assert.Empty(await outbox.PendingAsync(streamId, 0, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Acknowledge_RemovesByName_AndClearDropsTheStream()
+    {
+        var outbox = new RedisEventOutbox(garnet.Connection);
+        var streamId = NewStreamId();
+
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
+        await outbox.EnqueueAsync(
+            streamId,
+            new OutboxItem("jti-2", "b.b.b", IsStatusAnnouncement: true),
+            TestContext.Current.CancellationToken);
+
+        await outbox.AcknowledgeAsync(streamId, ["jti-1"], TestContext.Current.CancellationToken);
+
+        var remaining = Assert.Single(
+            await outbox.PendingAsync(streamId, null, TestContext.Current.CancellationToken));
+        Assert.Equal("jti-2", remaining.JwtId);
+        // The announcement flag is part of the item, and delivery filtering depends on it
+        // surviving the round trip.
+        Assert.True(remaining.IsStatusAnnouncement);
+
+        await outbox.ClearAsync(streamId, TestContext.Current.CancellationToken);
+        Assert.Empty(await outbox.PendingAsync(streamId, null, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ConcurrentInstances_ComposeInsteadOfOverwriting()
+    {
+        // The hole this package closes: two outbox instances - two transmitter replicas - hammer
+        // one stream concurrently, and every mutation must survive. A whole-queue-as-one-value
+        // implementation loses writes here by last-write-wins; server-side appends cannot.
+        var first = new RedisEventOutbox(garnet.Connection);
+        var second = new RedisEventOutbox(garnet.Connection);
+        var streamId = NewStreamId();
+
+        async Task EnqueueAsync(RedisEventOutbox outbox, string jwtId, string compactToken)
+            => await outbox.EnqueueAsync(
+                streamId, new OutboxItem(jwtId, compactToken), TestContext.Current.CancellationToken);
+
+        async Task AcknowledgeAsync(RedisEventOutbox outbox, string ownPrefix)
+            => await outbox.AcknowledgeAsync(
+                streamId,
+                [.. Enumerable.Range(0, 50).Select(i => $"{ownPrefix}-{i}")],
+                TestContext.Current.CancellationToken);
+
+        await Task.WhenAll(
+            Enumerable.Range(0, 50).Select(i => EnqueueAsync(first, $"a-{i}", "a.a.a"))
+            .Concat(Enumerable.Range(0, 50).Select(i => EnqueueAsync(second, $"b-{i}", "b.b.b"))));
+
+        var pending = await first.PendingAsync(streamId, null, TestContext.Current.CancellationToken);
+        Assert.Equal(100, pending.Count);
+        Assert.Equal(100, pending.Select(item => item.JwtId).Distinct().Count());
+
+        // Concurrent acknowledgements from both instances: each removes exactly its own half.
+        await Task.WhenAll(AcknowledgeAsync(first, "a"), AcknowledgeAsync(second, "b"));
+
+        Assert.Empty(await first.PendingAsync(streamId, null, TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
+++ b/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />

--- a/tests/Abblix.SharedSignals.UnitTests/ConfigurationHostStoresTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ConfigurationHostStoresTests.cs
@@ -1,0 +1,180 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Abstractions;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// Pins the two host-store choices of a closed deployment: the stream set as configuration -
+/// materialized like the dynamic create would, refusing configuration bugs loudly at startup -
+/// and the outbox on the distributed cache, whose queues survive a process restart when the
+/// store behind the cache does.
+/// </summary>
+public class ConfigurationHostStoresTests
+{
+    private const string TypeA = "https://example.com/events/type-a";
+
+    private static SsfTransmitterOptions TransmitterOptions => new()
+    {
+        Issuer = "https://tr.example.com",
+        EventsSupported = [TypeA],
+        PollEndpointFactory = streamId => new Uri($"https://tr.example.com/ssf/poll/{streamId}"),
+    };
+
+    [Fact]
+    public async Task ConfiguredStreams_MaterializeAsTheDynamicCreateWould()
+    {
+        var store = new ConfigurationStreamStore(TransmitterOptions,
+        [
+            new ConfiguredStream
+            {
+                ReceiverId = "kezio",
+                StreamId = "kezio-main",
+                EventsRequested = [TypeA, "https://example.com/events/unsupported"],
+                PushEndpointUrl = new Uri("https://kezio.example.com/events"),
+                PushAuthorizationHeader = "Bearer from-secret",
+            },
+            new ConfiguredStream { ReceiverId = "admin", StreamId = "admin-main" },
+        ]);
+
+        var kezio = await store.FindAsync("kezio", "kezio-main", TestContext.Current.CancellationToken);
+        Assert.NotNull(kezio);
+        Assert.Equal(StreamSubjectsMode.All, kezio.SubjectsMode);
+        Assert.Equal(["kezio"], kezio.Configuration.Audiences);
+        Assert.Equal([TypeA], kezio.Configuration.EventsDelivered);
+        var push = Assert.IsType<PushDeliveryMethod>(kezio.Configuration.Delivery);
+        Assert.Equal("Bearer from-secret", push.AuthorizationHeader);
+
+        // No push endpoint declared means poll over the transmitter's own URL.
+        var admin = await store.FindAsync("admin", "admin-main", TestContext.Current.CancellationToken);
+        var poll = Assert.IsType<PollDeliveryMethod>(admin!.Configuration.Delivery);
+        Assert.Equal(new Uri("https://tr.example.com/ssf/poll/admin-main"), poll.EndpointUrl);
+
+        Assert.Equal(2, (await store.ListAllAsync(TestContext.Current.CancellationToken)).Count);
+    }
+
+    [Fact]
+    public async Task ConfiguredStreams_AcceptEphemeralMutation_TheVerificationThrottleNeedsIt()
+    {
+        var store = new ConfigurationStreamStore(TransmitterOptions,
+            [new ConfiguredStream { ReceiverId = "kezio", StreamId = "kezio-main" }]);
+
+        var stream = await store.FindAsync("kezio", "kezio-main", TestContext.Current.CancellationToken);
+        Assert.True(await store.UpdateAsync(
+            stream! with { Status = StreamStatuses.Paused },
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            StreamStatuses.Paused,
+            (await store.FindAsync("kezio", "kezio-main", TestContext.Current.CancellationToken))!.Status);
+    }
+
+    [Fact]
+    public void ConfigurationBugs_RefuseLoudlyAtStartup()
+    {
+        // A duplicate declaration and an undeliverable stream are operator mistakes; surfacing
+        // them at construction beats a stream that silently cannot flow.
+        var duplicate = Assert.Throws<InvalidOperationException>(() => new ConfigurationStreamStore(
+            TransmitterOptions,
+            [
+                new ConfiguredStream { ReceiverId = "kezio", StreamId = "s-1" },
+                new ConfiguredStream { ReceiverId = "kezio", StreamId = "s-1" },
+            ]));
+        Assert.Contains("more than once", duplicate.Message);
+
+        var undeliverable = Assert.Throws<InvalidOperationException>(() => new ConfigurationStreamStore(
+            new SsfTransmitterOptions { Issuer = "https://tr.example.com" },
+            [new ConfiguredStream { ReceiverId = "kezio", StreamId = "s-1" }]));
+        Assert.Contains(nameof(ConfiguredStream.PushEndpointUrl), undeliverable.Message);
+    }
+
+    [Fact]
+    public async Task DistributedOutbox_KeepsTheQueueInTheCache_AcrossAProcessRestart()
+    {
+        // Two outbox instances over ONE cache stand in for the process before and after a
+        // restart: what the first enqueued, the second still serves - the queue's home is the
+        // cache, not the object.
+        var sharedCache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+        using (var before = new DistributedCacheEventOutbox(sharedCache))
+        {
+            await before.EnqueueAsync(
+                "s-1", new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
+            await before.EnqueueAsync(
+                "s-1", new OutboxItem("jti-2", "b.b.b"), TestContext.Current.CancellationToken);
+        }
+
+        using var after = new DistributedCacheEventOutbox(sharedCache);
+        Assert.Equal(
+            ["jti-1", "jti-2"],
+            (await after.PendingAsync("s-1", null, TestContext.Current.CancellationToken))
+            .Select(item => item.JwtId));
+
+        await after.AcknowledgeAsync("s-1", ["jti-1"], TestContext.Current.CancellationToken);
+        var remaining = Assert.Single(
+            await after.PendingAsync("s-1", null, TestContext.Current.CancellationToken));
+        Assert.Equal("jti-2", remaining.JwtId);
+
+        await after.ClearAsync("s-1", TestContext.Current.CancellationToken);
+        Assert.Empty(await after.PendingAsync("s-1", null, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void ExplicitStoreChoices_Win_WhicheverSideOfTheRoleRegistrationTheyLand()
+    {
+        // The conveniences are the host's explicit choice, so unlike the TryAdd defaults they
+        // must win even AFTER AddSsfTransmitter has registered the in-memory pair.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ISecurityEventTokenSigner, FakeSigner>();
+        services.AddSecurityEvents();
+        services.AddDistributedMemoryCache();
+
+        services
+            .AddSsfTransmitter(TransmitterOptions)
+            .AddSsfConfiguredStreams([new ConfiguredStream { ReceiverId = "kezio", StreamId = "s-1" }])
+            .AddSsfDistributedOutbox();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<ConfigurationStreamStore>(provider.GetRequiredService<IStreamStore>());
+        Assert.IsType<DistributedCacheEventOutbox>(provider.GetRequiredService<IEventOutbox>());
+    }
+
+    private sealed class FakeSigner : ISecurityEventTokenSigner
+    {
+        public Task<string> SignAsync(
+            Abblix.SecurityEvents.SecurityEventToken token,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult($"signed.{token.JwtId}");
+    }
+}


### PR DESCRIPTION
Implements the host-store decision for the first-party transmitter: the stream set is static configuration (nothing to back up; API mutations ephemeral until restart; the push authorization header arrives through the secret mechanism), and the outbox rides the host's IDistributedCache - the cache tier on purpose, since the delivery protocols budget for losing held events. The distributed outbox serializes queue mutations through in-process gates, correct for a single transmitter instance and documented as such; scaling out calls for native list operations behind the same interface. Registration conveniences use Replace semantics so the host's explicit choice wins in any order, pinned by a test.