### PR TITLE
Add Abblix.SecurityEvents.CAEP and Abblix.SecurityEvents.RISC event dictionaries

### DIFF
--- a/Abblix.Oidc.slnx
+++ b/Abblix.Oidc.slnx
@@ -28,6 +28,7 @@
     <Project Path="src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj" />
     <Project Path="src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj" />
     <Project Path="src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj" />
+    <Project Path="src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj" />
     <Project Path="src/Abblix.SharedSignals/Abblix.SharedSignals.csproj" />
     <Project Path="src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj" />
   </Folder>
@@ -46,6 +47,7 @@
     <Project Path="tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj" />
     <Project Path="tests/Abblix.Jwt.Azure.UnitTests/Abblix.Jwt.Azure.UnitTests.csproj" />
     <Project Path="tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj" />
+    <Project Path="tests/Abblix.SecurityEvents.CAEP.UnitTests/Abblix.SecurityEvents.CAEP.UnitTests.csproj" />
     <Project Path="tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj" />
     <Project Path="tests/Abblix.SharedSignals.E2E.Tests/Abblix.SharedSignals.E2E.Tests.csproj" />
   </Folder>

--- a/Abblix.Oidc.slnx
+++ b/Abblix.Oidc.slnx
@@ -29,6 +29,7 @@
     <Project Path="src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj" />
     <Project Path="src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj" />
     <Project Path="src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj" />
+    <Project Path="src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj" />
     <Project Path="src/Abblix.SharedSignals/Abblix.SharedSignals.csproj" />
     <Project Path="src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj" />
   </Folder>
@@ -48,6 +49,7 @@
     <Project Path="tests/Abblix.Jwt.Azure.UnitTests/Abblix.Jwt.Azure.UnitTests.csproj" />
     <Project Path="tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj" />
     <Project Path="tests/Abblix.SecurityEvents.CAEP.UnitTests/Abblix.SecurityEvents.CAEP.UnitTests.csproj" />
+    <Project Path="tests/Abblix.SecurityEvents.RISC.UnitTests/Abblix.SecurityEvents.RISC.UnitTests.csproj" />
     <Project Path="tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj" />
     <Project Path="tests/Abblix.SharedSignals.E2E.Tests/Abblix.SharedSignals.E2E.Tests.csproj" />
   </Folder>

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Abblix.SecurityEvents.CAEP</PackageId>
+    <Title>Abblix Security Events CAEP</Title>
+    <Description>The OpenID Continuous Access Evaluation Profile 1.0 event dictionary for Abblix Security Events: typed payload models and event type identifiers for session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, session-established, session-presented and risk-level-change, registered over the Security Events core in one call.</Description>
+    <Authors>Abblix LLP</Authors>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>Abblix CAEP SecurityEvent SET SharedSignals SSF ContinuousAccessEvaluation SessionRevoked Security Identity</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
+    <PackageIcon>Abblix.png</PackageIcon>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    <!-- Deterministic builds for reproducible binaries -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+
+    <!-- SourceLink for symbol packages -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Abblix.SecurityEvents\Abblix.SecurityEvents.csproj" />
+    <ProjectReference Include="..\Abblix.Utils\Abblix.Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abblix.SecurityEvents.CAEP/AssuranceLevelChangePayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/AssuranceLevelChangePayload.cs
@@ -1,0 +1,104 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Assurance Level Change (CAEP 1.0 Section 3.4): the subject's authentication strength changed
+/// since the initial login, in either direction - a user stepping up with a second factor at
+/// one provider is a signal every other provider holding the session may act on. When
+/// <see cref="CaepEventPayload.EventTimestamp"/> is included it is the moment of the change.
+/// </summary>
+public sealed record AssuranceLevelChangePayload : CaepEventPayload
+{
+    /// <summary>
+    /// The level namespaces Section 3.4.1 names. The set is open: any other value is an alias
+    /// for a custom namespace the two parties agreed on, which is why
+    /// <see cref="Namespace"/> is a string rather than a closed enumeration.
+    /// </summary>
+    public static class Namespaces
+    {
+        /// <summary>Values from RFC 8176, Authentication Method Reference Values.</summary>
+        public const string Rfc8176 = "RFC8176";
+
+        /// <summary>Values from RFC 6711, the IANA Level of Assurance profiles registry.
+        /// </summary>
+        public const string Rfc6711 = "RFC6711";
+
+        /// <summary>Values from ISO/IEC 29115.</summary>
+        public const string IsoIec29115 = "ISO-IEC-29115";
+
+        /// <summary>NIST Identity Assurance Levels.</summary>
+        public const string NistIal = "NIST-IAL";
+
+        /// <summary>NIST Authenticator Assurance Levels.</summary>
+        public const string NistAal = "NIST-AAL";
+
+        /// <summary>NIST Federation Assurance Levels.</summary>
+        public const string NistFal = "NIST-FAL";
+    }
+
+    /// <summary>
+    /// The values the "change_direction" member may carry (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    public static class ChangeDirections
+    {
+        /// <summary>The assurance level increased.</summary>
+        public const string Increase = "increase";
+
+        /// <summary>The assurance level decreased.</summary>
+        public const string Decrease = "decrease";
+    }
+
+    /// <summary>
+    /// REQUIRED. The namespace the level values come from, one of <see cref="Namespaces"/> or
+    /// an agreed custom alias (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.Namespace)]
+    public required string Namespace { get; init; }
+
+    /// <summary>
+    /// REQUIRED. The current assurance level, as the namespace defines it
+    /// (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.CurrentLevel)]
+    public required string CurrentLevel { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The previous assurance level; absent means the transmitter does not know it
+    /// (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.PreviousLevel)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PreviousLevel { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. Which way the level moved, one of <see cref="ChangeDirections"/>; a
+    /// transmitter that stated the previous level should state this too
+    /// (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.ChangeDirection)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ChangeDirection { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/CaepClaimNames.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepClaimNames.cs
@@ -1,0 +1,113 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// The wire names of the CAEP event claims (CAEP 1.0 Sections 2, 3): one registry, because the
+/// common claims cross every event type and per-model copies of one name drift apart.
+/// </summary>
+public static class CaepClaimNames
+{
+    /// <summary>When the event described by the SET occurred, as unix seconds
+    /// (CAEP 1.0 Section 2).</summary>
+    public const string EventTimestamp = "event_timestamp";
+
+    /// <summary>The entity that invoked the event (CAEP 1.0 Section 2).</summary>
+    public const string InitiatingEntity = "initiating_entity";
+
+    /// <summary>The localizable administrative message for logging and auditing
+    /// (CAEP 1.0 Section 2).</summary>
+    public const string ReasonAdmin = "reason_admin";
+
+    /// <summary>The localizable message for display to an end user (CAEP 1.0 Section 2).
+    /// </summary>
+    public const string ReasonUser = "reason_user";
+
+    /// <summary>The changed claims with their new values (CAEP 1.0 Section 3.2.1).</summary>
+    public const string Claims = "claims";
+
+    /// <summary>The kind of credential the change concerns (CAEP 1.0 Section 3.3.1).</summary>
+    public const string CredentialType = "credential_type";
+
+    /// <summary>What happened to the credential (CAEP 1.0 Section 3.3.1).</summary>
+    public const string ChangeType = "change_type";
+
+    /// <summary>The credential's friendly name (CAEP 1.0 Section 3.3.1).</summary>
+    public const string FriendlyName = "friendly_name";
+
+    /// <summary>The issuer of the X.509 certificate (CAEP 1.0 Section 3.3.1).</summary>
+    public const string X509Issuer = "x509_issuer";
+
+    /// <summary>The serial number of the X.509 certificate (CAEP 1.0 Section 3.3.1).</summary>
+    public const string X509Serial = "x509_serial";
+
+    /// <summary>The FIDO2 Authenticator Attestation GUID (CAEP 1.0 Section 3.3.1).</summary>
+    public const string Fido2Aaguid = "fido2_aaguid";
+
+    /// <summary>The namespace the assurance level values come from (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    public const string Namespace = "namespace";
+
+    /// <summary>The current level - of assurance (CAEP 1.0 Section 3.4.1) or of risk
+    /// (Section 3.8.1).</summary>
+    public const string CurrentLevel = "current_level";
+
+    /// <summary>The previous level - of assurance (CAEP 1.0 Section 3.4.1) or of risk
+    /// (Section 3.8.1).</summary>
+    public const string PreviousLevel = "previous_level";
+
+    /// <summary>Whether the assurance level increased or decreased (CAEP 1.0 Section 3.4.1).
+    /// </summary>
+    public const string ChangeDirection = "change_direction";
+
+    /// <summary>The compliance status before the change (CAEP 1.0 Section 3.5.1).</summary>
+    public const string PreviousStatus = "previous_status";
+
+    /// <summary>The compliance status that triggered the event (CAEP 1.0 Section 3.5.1).
+    /// </summary>
+    public const string CurrentStatus = "current_status";
+
+    /// <summary>The user agent fingerprint computed by the transmitter
+    /// (CAEP 1.0 Sections 3.6.1, 3.7.1).</summary>
+    public const string FpUa = "fp_ua";
+
+    /// <summary>The session's authentication context class reference
+    /// (CAEP 1.0 Section 3.6.1).</summary>
+    public const string Acr = "acr";
+
+    /// <summary>The session's authentication methods references (CAEP 1.0 Section 3.6.1).
+    /// </summary>
+    public const string Amr = "amr";
+
+    /// <summary>The external session identifier correlating this session with a broader one
+    /// (CAEP 1.0 Sections 3.6.1, 3.7.1).</summary>
+    public const string ExtId = "ext_id";
+
+    /// <summary>The principal entity the observed risk concerns (CAEP 1.0 Section 3.8.1).
+    /// </summary>
+    public const string Principal = "principal";
+
+    /// <summary>The reason contributing to the risk level change (CAEP 1.0 Section 3.8.1).
+    /// </summary>
+    public const string RiskReason = "risk_reason";
+}

--- a/src/Abblix.SecurityEvents.CAEP/CaepEventPayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepEventPayload.cs
@@ -1,0 +1,87 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+using Abblix.SecurityEvents.Events;
+using Abblix.Utils.Json;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// The claims every CAEP event may carry (CAEP 1.0 Section 2): when it happened, who set it in
+/// motion, and why - the latter twice, because the administrator's log line and the sentence an
+/// end user should read are different texts in different languages.
+/// </summary>
+public abstract record CaepEventPayload : IEventPayload
+{
+    /// <summary>
+    /// The values the "initiating_entity" claim may carry (CAEP 1.0 Section 2).
+    /// </summary>
+    public static class InitiatingEntities
+    {
+        /// <summary>An administrative action triggered the event.</summary>
+        public const string Admin = "admin";
+
+        /// <summary>An end-user action triggered the event.</summary>
+        public const string User = "user";
+
+        /// <summary>A policy evaluation triggered the event.</summary>
+        public const string Policy = "policy";
+
+        /// <summary>A system or platform assertion triggered the event.</summary>
+        public const string System = "system";
+    }
+
+    /// <summary>
+    /// OPTIONAL. When the event described by the SET occurred - each event type binds this to
+    /// its own moment, such as when the session was revoked or the credential changed
+    /// (CAEP 1.0 Sections 2, 3). Travels as unix seconds.
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.EventTimestamp)]
+    [JsonConverter(typeof(DateTimeOffsetUnixTimeSecondsConverter))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? EventTimestamp { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The entity that invoked the event, one of
+    /// <see cref="InitiatingEntities"/> (CAEP 1.0 Section 2).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.InitiatingEntity)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? InitiatingEntity { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The administrative message for logging and auditing, keyed by BCP 47 language
+    /// tag (CAEP 1.0 Section 2).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.ReasonAdmin)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? ReasonAdmin { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The message for display to an end user, keyed by BCP 47 language tag
+    /// (CAEP 1.0 Section 2).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.ReasonUser)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? ReasonUser { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/CaepEventTypes.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepEventTypes.cs
@@ -1,0 +1,90 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// The event type URIs CAEP 1.0 defines (its Section 3), and the one registration call that
+/// teaches a receiver's event registry the whole dictionary.
+/// </summary>
+public static class CaepEventTypes
+{
+#pragma warning disable S1075 // URIs should not be hardcoded - these are the specification-fixed event type identifiers, not configuration
+    /// <summary>
+    /// The base URI of the CAEP event types (CAEP 1.0 Section 3).
+    /// </summary>
+    private const string BaseUri = "https://schemas.openid.net/secevent/caep/event-type/";
+#pragma warning restore S1075
+
+    /// <summary>The session identified by the subject has been revoked
+    /// (CAEP 1.0 Section 3.1).</summary>
+    public const string SessionRevoked = BaseUri + "session-revoked";
+
+    /// <summary>A claim in the token identified by the subject has changed
+    /// (CAEP 1.0 Section 3.2).</summary>
+    public const string TokenClaimsChange = BaseUri + "token-claims-change";
+
+    /// <summary>A credential was created, changed, revoked or deleted
+    /// (CAEP 1.0 Section 3.3).</summary>
+    public const string CredentialChange = BaseUri + "credential-change";
+
+    /// <summary>The authentication assurance level changed since the initial login
+    /// (CAEP 1.0 Section 3.4).</summary>
+    public const string AssuranceLevelChange = BaseUri + "assurance-level-change";
+
+    /// <summary>A device's compliance status changed (CAEP 1.0 Section 3.5).</summary>
+    public const string DeviceComplianceChange = BaseUri + "device-compliance-change";
+
+    /// <summary>The transmitter established a new session for the subject
+    /// (CAEP 1.0 Section 3.6).</summary>
+    public const string SessionEstablished = BaseUri + "session-established";
+
+    /// <summary>The transmitter observed the subject's session to be present
+    /// (CAEP 1.0 Section 3.7).</summary>
+    public const string SessionPresented = BaseUri + "session-presented";
+
+    /// <summary>The subject's assessed risk level changed (CAEP 1.0 Section 3.8).</summary>
+    public const string RiskLevelChange = BaseUri + "risk-level-change";
+
+    /// <summary>
+    /// Registers every CAEP event type with its payload model - the whole dictionary in one
+    /// call, so a receiver cannot end up understanding half a profile.
+    /// </summary>
+    /// <param name="registry">The registry events deserialize through.</param>
+    public static EventTypeRegistry RegisterCaepEvents(this EventTypeRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        registry.Register<SessionRevokedPayload>(SessionRevoked);
+        registry.Register<TokenClaimsChangePayload>(TokenClaimsChange);
+        registry.Register<CredentialChangePayload>(CredentialChange);
+        registry.Register<AssuranceLevelChangePayload>(AssuranceLevelChange);
+        registry.Register<DeviceComplianceChangePayload>(DeviceComplianceChange);
+        registry.Register<SessionEstablishedPayload>(SessionEstablished);
+        registry.Register<SessionPresentedPayload>(SessionPresented);
+        registry.Register<RiskLevelChangePayload>(RiskLevelChange);
+
+        return registry;
+    }
+}

--- a/src/Abblix.SecurityEvents.CAEP/CredentialChangePayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CredentialChangePayload.cs
@@ -1,0 +1,134 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Credential Change (CAEP 1.0 Section 3.3): a credential was created, changed, revoked or
+/// deleted - a password reset, a certificate enrollment or revocation, a second-factor or
+/// passwordless credential enrolled or removed. When
+/// <see cref="CaepEventPayload.EventTimestamp"/> is included it is the moment of the change.
+/// </summary>
+public sealed record CredentialChangePayload : CaepEventPayload
+{
+    /// <summary>
+    /// The credential kinds Section 3.3.1 names. The set is open by the specification's own
+    /// words: any other credential type mutually supported by the transmitter and the receiver
+    /// is equally legal, which is why <see cref="CredentialType"/> is a string rather than a
+    /// closed enumeration.
+    /// </summary>
+    public static class CredentialTypes
+    {
+        /// <summary>A password.</summary>
+        public const string Password = "password";
+
+        /// <summary>A PIN.</summary>
+        public const string Pin = "pin";
+
+        /// <summary>An X.509 certificate.</summary>
+        public const string X509 = "x509";
+
+        /// <summary>A FIDO2 platform authenticator.</summary>
+        public const string Fido2Platform = "fido2-platform";
+
+        /// <summary>A FIDO2 roaming authenticator.</summary>
+        public const string Fido2Roaming = "fido2-roaming";
+
+        /// <summary>A FIDO U2F authenticator.</summary>
+        public const string FidoU2f = "fido-u2f";
+
+        /// <summary>A verifiable credential.</summary>
+        public const string VerifiableCredential = "verifiable-credential";
+
+        /// <summary>A voice-call phone factor.</summary>
+        public const string PhoneVoice = "phone-voice";
+
+        /// <summary>An SMS phone factor.</summary>
+        public const string PhoneSms = "phone-sms";
+
+        /// <summary>An app-based factor.</summary>
+        public const string App = "app";
+    }
+
+    /// <summary>
+    /// The values the "change_type" member may carry (CAEP 1.0 Section 3.3.1) - this set is
+    /// closed, unlike the credential types.
+    /// </summary>
+    public static class ChangeTypes
+    {
+        /// <summary>The credential was created.</summary>
+        public const string Create = "create";
+
+        /// <summary>The credential was revoked.</summary>
+        public const string Revoke = "revoke";
+
+        /// <summary>The credential was updated.</summary>
+        public const string Update = "update";
+
+        /// <summary>The credential was deleted.</summary>
+        public const string Delete = "delete";
+    }
+
+    /// <summary>
+    /// REQUIRED. The kind of credential, one of <see cref="CredentialTypes"/> or any other
+    /// type the two parties mutually support (CAEP 1.0 Section 3.3.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.CredentialType)]
+    public required string CredentialType { get; init; }
+
+    /// <summary>
+    /// REQUIRED. What happened to the credential, one of <see cref="ChangeTypes"/>
+    /// (CAEP 1.0 Section 3.3.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.ChangeType)]
+    public required string ChangeType { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The credential's friendly name (CAEP 1.0 Section 3.3.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.FriendlyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FriendlyName { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The issuer of the X.509 certificate (CAEP 1.0 Section 3.3.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.X509Issuer)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? X509Issuer { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The serial number of the X.509 certificate (CAEP 1.0 Section 3.3.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.X509Serial)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? X509Serial { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The FIDO2 Authenticator Attestation GUID (CAEP 1.0 Section 3.3.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.Fido2Aaguid)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Fido2Aaguid { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/DeviceComplianceChangePayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/DeviceComplianceChangePayload.cs
@@ -1,0 +1,59 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Device Compliance Change (CAEP 1.0 Section 3.5): the compliance status of the device
+/// identified by the subject changed. When <see cref="CaepEventPayload.EventTimestamp"/> is
+/// included it is the moment of the change.
+/// </summary>
+public sealed record DeviceComplianceChangePayload : CaepEventPayload
+{
+    /// <summary>
+    /// The values both status members carry (CAEP 1.0 Section 3.5.1).
+    /// </summary>
+    public static class ComplianceStatuses
+    {
+        /// <summary>The device complies with policy.</summary>
+        public const string Compliant = "compliant";
+
+        /// <summary>The device does not comply with policy.</summary>
+        public const string NotCompliant = "not-compliant";
+    }
+
+    /// <summary>
+    /// REQUIRED. The status before the change, one of <see cref="ComplianceStatuses"/>
+    /// (CAEP 1.0 Section 3.5.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.PreviousStatus)]
+    public required string PreviousStatus { get; init; }
+
+    /// <summary>
+    /// REQUIRED. The status that triggered the event, one of <see cref="ComplianceStatuses"/>
+    /// (CAEP 1.0 Section 3.5.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.CurrentStatus)]
+    public required string CurrentStatus { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -1,0 +1,54 @@
+# Abblix.SecurityEvents.CAEP
+
+The OpenID Continuous Access Evaluation Profile 1.0 event dictionary for [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents): typed payload models and event type identifiers for the eight CAEP events, registered over the Security Events core in one call.
+
+## Events
+
+| Event | Payload |
+|---|---|
+| `session-revoked` | `SessionRevokedPayload` |
+| `token-claims-change` | `TokenClaimsChangePayload` |
+| `credential-change` | `CredentialChangePayload` |
+| `assurance-level-change` | `AssuranceLevelChangePayload` |
+| `device-compliance-change` | `DeviceComplianceChangePayload` |
+| `session-established` | `SessionEstablishedPayload` |
+| `session-presented` | `SessionPresentedPayload` |
+| `risk-level-change` | `RiskLevelChangePayload` |
+
+Every payload carries the common CAEP claims - the event timestamp, the initiating entity, and the localizable administrative and end-user reasons - on the shared `CaepEventPayload` base.
+
+## Receiving
+
+```csharp
+services.AddSecurityEvents(options => options.Events.RegisterCaepEvents());
+```
+
+One call teaches the registry the whole dictionary; a validated SET's payloads then arrive as the typed models, and the sink pattern-matches:
+
+```csharp
+if (token.EventPayloads[CaepEventTypes.SessionRevoked] is SessionRevokedPayload revoked)
+{
+    // terminate the local session; revoked.ReasonUser carries the sentence to show
+}
+```
+
+## Transmitting
+
+```csharp
+await dispatcher.DispatchAsync(new SecurityEventDescriptor
+{
+    EventType = CaepEventTypes.SessionRevoked,
+    Subject = new ComplexSubject { Session = new OpaqueSubject(sessionId), User = userSubject },
+    Payload = new SessionRevokedPayload
+    {
+        InitiatingEntity = CaepEventPayload.InitiatingEntities.Policy,
+        ReasonAdmin = new Dictionary<string, string> { ["en"] = "Landspeed Policy Violation" },
+        EventTimestamp = revokedAt,
+    },
+});
+```
+
+## License
+
+Abblix.SecurityEvents.CAEP is licensed under the Abblix license agreement. See
+[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).

--- a/src/Abblix.SecurityEvents.CAEP/RiskLevelChangePayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/RiskLevelChangePayload.cs
@@ -1,0 +1,105 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Risk Level Change (CAEP 1.0 Section 3.8): the transmitter's assessed risk level for the
+/// subject changed at the moment <see cref="CaepEventPayload.EventTimestamp"/> names - a
+/// password found in a breach, unapproved software on a device, or any other signal the
+/// transmitter abstracts into a level.
+/// </summary>
+public sealed record RiskLevelChangePayload : CaepEventPayload
+{
+    /// <summary>
+    /// The values both level members carry (CAEP 1.0 Section 3.8.1) - a closed set.
+    /// </summary>
+    public static class RiskLevels
+    {
+        /// <summary>Low risk.</summary>
+        public const string Low = "LOW";
+
+        /// <summary>Medium risk.</summary>
+        public const string Medium = "MEDIUM";
+
+        /// <summary>High risk.</summary>
+        public const string High = "HIGH";
+    }
+
+    /// <summary>
+    /// The principal kinds Section 3.8.1 names, matching the complex-subject member names of
+    /// the Shared Signals Framework. The set is open to any other entity the framework's
+    /// subject model can express.
+    /// </summary>
+    public static class Principals
+    {
+        /// <summary>The risk concerns a user.</summary>
+        public const string User = "USER";
+
+        /// <summary>The risk concerns a device.</summary>
+        public const string Device = "DEVICE";
+
+        /// <summary>The risk concerns a session.</summary>
+        public const string Session = "SESSION";
+
+        /// <summary>The risk concerns a tenant.</summary>
+        public const string Tenant = "TENANT";
+
+        /// <summary>The risk concerns an organizational unit.</summary>
+        public const string OrgUnit = "ORG_UNIT";
+
+        /// <summary>The risk concerns a group.</summary>
+        public const string Group = "GROUP";
+    }
+
+    /// <summary>
+    /// REQUIRED. The principal entity the observed risk concerns, one of
+    /// <see cref="Principals"/> or another entity of the framework's subject model
+    /// (CAEP 1.0 Section 3.8.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.Principal)]
+    public required string Principal { get; init; }
+
+    /// <summary>
+    /// REQUIRED. The current risk level, one of <see cref="RiskLevels"/>
+    /// (CAEP 1.0 Section 3.8.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.CurrentLevel)]
+    public required string CurrentLevel { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The previously known risk level, one of <see cref="RiskLevels"/>; absent
+    /// means the transmitter does not know it (CAEP 1.0 Section 3.8.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.PreviousLevel)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PreviousLevel { get; init; }
+
+    /// <summary>
+    /// RECOMMENDED. The reason contributing to the change (CAEP 1.0 Section 3.8.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.RiskReason)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RiskReason { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/SessionEstablishedPayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/SessionEstablishedPayload.cs
@@ -1,0 +1,66 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Session Established (CAEP 1.0 Section 3.6): the transmitter established a new session for
+/// the subject - how a service closes the loop with the identity provider after federation, how
+/// an identity provider detects unintended logins, how a receiver inventories sessions. The
+/// <see cref="CaepEventPayload.EventTimestamp"/> is the moment the session was established.
+/// </summary>
+public sealed record SessionEstablishedPayload : CaepEventPayload
+{
+    /// <summary>
+    /// OPTIONAL. The user agent fingerprint the transmitter computed - qualities of the
+    /// session, not its identity (CAEP 1.0 Section 3.6.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.FpUa)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FingerprintUserAgent { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The session's authentication context class reference, read as the same field
+    /// of an OpenID Connect ID token (CAEP 1.0 Section 3.6.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.Acr)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AuthenticationContextClassReference { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The session's authentication methods references, each read as the same field
+    /// of an OpenID Connect ID token (CAEP 1.0 Section 3.6.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.Amr)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? AuthenticationMethodsReferences { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The external session identifier correlating this session with a broader one,
+    /// such as a federated SAML session (CAEP 1.0 Section 3.6.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.ExtId)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExternalId { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/SessionPresentedPayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/SessionPresentedPayload.cs
@@ -1,0 +1,49 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Session Presented (CAEP 1.0 Section 3.7): the transmitter observed the subject's session to
+/// be present at the moment <see cref="CaepEventPayload.EventTimestamp"/> names - the signal
+/// receivers build activity anomaly detection and live-session inventories on.
+/// </summary>
+public sealed record SessionPresentedPayload : CaepEventPayload
+{
+    /// <summary>
+    /// OPTIONAL. The user agent fingerprint the transmitter computed - qualities of the
+    /// session, not its identity (CAEP 1.0 Section 3.7.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.FpUa)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FingerprintUserAgent { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The external session identifier correlating this session with a broader one
+    /// (CAEP 1.0 Section 3.7.1).
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.ExtId)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExternalId { get; init; }
+}

--- a/src/Abblix.SecurityEvents.CAEP/SessionRevokedPayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/SessionRevokedPayload.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Session Revoked (CAEP 1.0 Section 3.1): the session identified by the subject has been
+/// revoked. The event carries no claims of its own - the subject names the session, directly
+/// or through the properties of a complex subject, in which case the revocation applies to any
+/// session matching the combined claims; when <see cref="CaepEventPayload.EventTimestamp"/> is
+/// included it is the moment of revocation.
+/// </summary>
+public sealed record SessionRevokedPayload : CaepEventPayload;

--- a/src/Abblix.SecurityEvents.CAEP/TokenClaimsChangePayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/TokenClaimsChangePayload.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Abblix.SecurityEvents.Caep;
+
+/// <summary>
+/// Token Claims Change (CAEP 1.0 Section 3.2): a claim in the token identified by the subject -
+/// a JWT through the jwt_id subject format, a SAML assertion through saml_assertion_id - has
+/// changed. When <see cref="CaepEventPayload.EventTimestamp"/> is included it is the moment the
+/// claim values changed.
+/// </summary>
+public sealed record TokenClaimsChangePayload : CaepEventPayload
+{
+    /// <summary>
+    /// REQUIRED. The changed claims with their new values (CAEP 1.0 Section 3.2.1). Raw JSON,
+    /// because the claims are whatever the token carries - OIDC names or SAML claim URIs alike.
+    /// </summary>
+    [JsonPropertyName(CaepClaimNames.Claims)]
+    public required JsonObject Claims { get; init; }
+}

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -1,0 +1,57 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Abblix.SecurityEvents.RISC</PackageId>
+    <Title>Abblix Security Events RISC</Title>
+    <Description>The OpenID RISC Profile 1.0 event dictionary for Abblix Security Events: typed payload models and event type identifiers for account lifecycle, identifier, credential compromise, opt-out and recovery events, registered over the Security Events core in one call.</Description>
+    <Authors>Abblix LLP</Authors>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>Abblix RISC SecurityEvent SET SharedSignals SSF RiskIncident AccountDisabled CredentialCompromise Security Identity</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
+    <PackageIcon>Abblix.png</PackageIcon>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    <!-- Deterministic builds for reproducible binaries -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+
+    <!-- SourceLink for symbol packages -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Update="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Abblix.SecurityEvents\Abblix.SecurityEvents.csproj" />
+    <!-- RISC 1.0 Section 2.7 defines credential_type by reference to the CAEP Credential Change
+         event's value set, so the dependency on the CAEP dictionary is the specification's own. -->
+    <ProjectReference Include="..\Abblix.SecurityEvents.CAEP\Abblix.SecurityEvents.CAEP.csproj" />
+    <ProjectReference Include="..\Abblix.Utils\Abblix.Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abblix.SecurityEvents.RISC/AccountCredentialChangeRequiredPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/AccountCredentialChangeRequiredPayload.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Account Credential Change Required (RISC 1.0 Section 2.1): the account identified by the
+/// subject was required to change a credential - a forced password change, for instance. The
+/// event carries no attributes.
+/// </summary>
+public sealed record AccountCredentialChangeRequiredPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/AccountDisabledPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/AccountDisabledPayload.cs
@@ -1,0 +1,55 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Account Disabled (RISC 1.0 Section 2.3): the account identified by the subject has been
+/// disabled and may be enabled again in the future - the reversible counterpart of
+/// <see cref="AccountPurgedPayload"/>.
+/// </summary>
+public sealed record AccountDisabledPayload : IEventPayload
+{
+    /// <summary>
+    /// The reasons Section 2.3 names. The claim is a free string, so the set is open to values
+    /// the two parties agree on beyond these.
+    /// </summary>
+    public static class Reasons
+    {
+        /// <summary>The account was disabled because it was hijacked.</summary>
+        public const string Hijacking = "hijacking";
+
+        /// <summary>The account was disabled as part of bulk-created abusive accounts.</summary>
+        public const string BulkAccount = "bulk-account";
+    }
+
+    /// <summary>
+    /// OPTIONAL. Why the account was disabled, one of <see cref="Reasons"/>
+    /// (RISC 1.0 Section 2.3).
+    /// </summary>
+    [JsonPropertyName(RiscClaimNames.Reason)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Reason { get; init; }
+}

--- a/src/Abblix.SecurityEvents.RISC/AccountEnabledPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/AccountEnabledPayload.cs
@@ -1,0 +1,31 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Account Enabled (RISC 1.0 Section 2.4): the account identified by the subject has been
+/// enabled after a disable. The event carries no attributes.
+/// </summary>
+public sealed record AccountEnabledPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/AccountPurgedPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/AccountPurgedPayload.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Account Purged (RISC 1.0 Section 2.2): the account identified by the subject has been
+/// permanently deleted - unlike a disable, there is no future enable to wait for. The event
+/// carries no attributes.
+/// </summary>
+public sealed record AccountPurgedPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/CredentialCompromisePayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/CredentialCompromisePayload.cs
@@ -1,0 +1,70 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+using Abblix.SecurityEvents.Caep;
+using Abblix.SecurityEvents.Events;
+using Abblix.Utils.Json;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Credential Compromise (RISC 1.0 Section 2.7): a credential of the subject was found to be
+/// compromised - in a data breach, for instance - and the receiver should treat it as burnt.
+/// </summary>
+public sealed record CredentialCompromisePayload : IEventPayload
+{
+    /// <summary>
+    /// REQUIRED. The type of the compromised credential. RISC 1.0 Section 2.7 defines the value
+    /// set by reference to the CAEP Credential Change event, so the values live in
+    /// <see cref="CredentialChangePayload.CredentialTypes"/> - one registry for both profiles.
+    /// </summary>
+    [JsonPropertyName(RiscClaimNames.CredentialType)]
+    public required string CredentialType { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. When the transmitter DISCOVERED the compromise - not when it happened, which
+    /// the transmitter rarely knows (RISC 1.0 Section 2.7). Travels as unix seconds.
+    /// </summary>
+    [JsonPropertyName(RiscClaimNames.EventTimestamp)]
+    [JsonConverter(typeof(DateTimeOffsetUnixTimeSecondsConverter))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? EventTimestamp { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The reason the event was generated, intended for administrators
+    /// (RISC 1.0 Section 2.7). The specification leaves the shape unstated; this model reads it
+    /// as CAEP 1.0 Section 2 shapes the identically named claim - a map of BCP 47 language tag
+    /// to text - since RISC leans on CAEP for its other shared vocabulary.
+    /// </summary>
+    [JsonPropertyName(RiscClaimNames.ReasonAdmin)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? ReasonAdmin { get; init; }
+
+    /// <summary>
+    /// OPTIONAL. The reason the event was generated, intended for end users
+    /// (RISC 1.0 Section 2.7), shaped as <see cref="ReasonAdmin"/> is.
+    /// </summary>
+    [JsonPropertyName(RiscClaimNames.ReasonUser)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? ReasonUser { get; init; }
+}

--- a/src/Abblix.SecurityEvents.RISC/IdentifierChangedPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/IdentifierChangedPayload.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Serialization;
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Identifier Changed (RISC 1.0 Section 2.5): the identifier in the subject has changed. The
+/// subject MUST be an email or phone_number subject carrying the OLD value, and only the
+/// provider authoritative over the identifier should issue the event - a username change at a
+/// non-authoritative provider is Recovery Information Changed (Section 2.10) instead.
+/// </summary>
+public sealed record IdentifierChangedPayload : IEventPayload
+{
+    /// <summary>
+    /// OPTIONAL. The new value of the identifier (RISC 1.0 Section 2.5).
+    /// </summary>
+    [JsonPropertyName(RiscClaimNames.NewValue)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? NewValue { get; init; }
+}

--- a/src/Abblix.SecurityEvents.RISC/IdentifierRecycledPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/IdentifierRecycledPayload.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Identifier Recycled (RISC 1.0 Section 2.6): the identifier in the subject was recycled and
+/// now belongs to a DIFFERENT user - the receiver must stop treating it as the old account's.
+/// The subject MUST be an email or phone_number subject. The event carries no attributes.
+/// </summary>
+public sealed record IdentifierRecycledPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/OptInPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/OptInPayload.cs
@@ -1,0 +1,31 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Opt In (RISC 1.0 Section 2.8.1): the account identified by the subject opted into RISC event
+/// exchanges and is now in the opt-in state. The event carries no attributes.
+/// </summary>
+public sealed record OptInPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/OptOutCancelledPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/OptOutCancelledPayload.cs
@@ -1,0 +1,31 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Opt Out Cancelled (RISC 1.0 Section 2.8.3): the account identified by the subject cancelled
+/// a pending opt-out and is back in the opt-in state. The event carries no attributes.
+/// </summary>
+public sealed record OptOutCancelledPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/OptOutEffectivePayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/OptOutEffectivePayload.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Opt Out Effective (RISC 1.0 Section 2.8.4): the opt-out took effect and the account
+/// identified by the subject no longer participates in RISC event exchanges - the last event
+/// the receiver will see for it. The event carries no attributes.
+/// </summary>
+public sealed record OptOutEffectivePayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/OptOutInitiatedPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/OptOutInitiatedPayload.cs
@@ -1,0 +1,33 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Opt Out Initiated (RISC 1.0 Section 2.8.2): the account identified by the subject asked to
+/// leave RISC event exchanges, but events still flow for a period - the delay exists so a
+/// hijacker cannot silence the alarm by opting the victim out immediately. The event carries no
+/// attributes.
+/// </summary>
+public sealed record OptOutInitiatedPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/README.md
+++ b/src/Abblix.SecurityEvents.RISC/README.md
@@ -1,0 +1,64 @@
+# Abblix.SecurityEvents.RISC
+
+The OpenID RISC Profile 1.0 event dictionary for [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents): typed payload models and event type identifiers for the fourteen RISC events, registered over the Security Events core in one call.
+
+## Events
+
+| Event | Payload |
+|---|---|
+| `account-credential-change-required` | `AccountCredentialChangeRequiredPayload` |
+| `account-purged` | `AccountPurgedPayload` |
+| `account-disabled` | `AccountDisabledPayload` |
+| `account-enabled` | `AccountEnabledPayload` |
+| `identifier-changed` | `IdentifierChangedPayload` |
+| `identifier-recycled` | `IdentifierRecycledPayload` |
+| `credential-compromise` | `CredentialCompromisePayload` |
+| `opt-in` | `OptInPayload` |
+| `opt-out-initiated` | `OptOutInitiatedPayload` |
+| `opt-out-cancelled` | `OptOutCancelledPayload` |
+| `opt-out-effective` | `OptOutEffectivePayload` |
+| `recovery-activated` | `RecoveryActivatedPayload` |
+| `recovery-information-changed` | `RecoveryInformationChangedPayload` |
+| `sessions-revoked` | `SessionsRevokedPayload` (deprecated by the specification; kept for receiving from older transmitters) |
+
+The compromised credential's `credential_type` takes its values from the CAEP Credential Change event, per the RISC specification's own cross-reference - the constants live in [Abblix.SecurityEvents.CAEP](https://www.nuget.org/packages/Abblix.SecurityEvents.CAEP), which this package depends on.
+
+## Receiving
+
+```csharp
+services.AddSecurityEvents(options => options.Events.RegisterRiscEvents());
+```
+
+One call teaches the registry the whole dictionary; a validated SET's payloads then arrive as the typed models, and the sink pattern-matches:
+
+```csharp
+if (token.EventPayloads[RiscEventTypes.CredentialCompromise] is CredentialCompromisePayload compromise)
+{
+    // force a credential reset; compromise.CredentialType names what was burnt
+}
+```
+
+Both dictionaries compose on one registry:
+
+```csharp
+services.AddSecurityEvents(options => options.Events.RegisterCaepEvents().RegisterRiscEvents());
+```
+
+## Transmitting
+
+```csharp
+await dispatcher.DispatchAsync(new SecurityEventDescriptor
+{
+    EventType = RiscEventTypes.CredentialCompromise,
+    Subject = new IssSubSubject(issuer, subject),
+    Payload = new CredentialCompromisePayload
+    {
+        CredentialType = CredentialChangePayload.CredentialTypes.Password,
+    },
+});
+```
+
+## License
+
+Abblix.SecurityEvents.RISC is licensed under the Abblix license agreement. See
+[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).

--- a/src/Abblix.SecurityEvents.RISC/RecoveryActivatedPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/RecoveryActivatedPayload.cs
@@ -1,0 +1,32 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Recovery Activated (RISC 1.0 Section 2.9): the account identified by the subject activated a
+/// recovery flow - a moment attackers favour, which is why it is worth signalling. The event
+/// carries no attributes.
+/// </summary>
+public sealed record RecoveryActivatedPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/RecoveryInformationChangedPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/RecoveryInformationChangedPayload.cs
@@ -1,0 +1,33 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Recovery Information Changed (RISC 1.0 Section 2.10): the account identified by the subject
+/// changed some of its recovery information - a recovery email added or removed, or an
+/// identifier change at a provider NOT authoritative over the identifier, which Section 2.5
+/// routes here instead of Identifier Changed. The event carries no attributes.
+/// </summary>
+public sealed record RecoveryInformationChangedPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents.RISC/RiscClaimNames.cs
+++ b/src/Abblix.SecurityEvents.RISC/RiscClaimNames.cs
@@ -1,0 +1,51 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// The wire names of the event-specific claims RISC 1.0 defines, spelled exactly as the
+/// specification spells them - including the one hyphenated outlier.
+/// </summary>
+public static class RiscClaimNames
+{
+    /// <summary>Why the account was disabled (RISC 1.0 Section 2.3).</summary>
+    public const string Reason = "reason";
+
+    /// <summary>
+    /// The new value of a changed identifier (RISC 1.0 Section 2.5). The specification spells
+    /// this one with a hyphen, unlike every underscore-separated claim around it.
+    /// </summary>
+    public const string NewValue = "new-value";
+
+    /// <summary>The type of the compromised credential (RISC 1.0 Section 2.7).</summary>
+    public const string CredentialType = "credential_type";
+
+    /// <summary>When the transmitter discovered the compromise (RISC 1.0 Section 2.7).</summary>
+    public const string EventTimestamp = "event_timestamp";
+
+    /// <summary>The reason intended for administrators (RISC 1.0 Section 2.7).</summary>
+    public const string ReasonAdmin = "reason_admin";
+
+    /// <summary>The reason intended for end users (RISC 1.0 Section 2.7).</summary>
+    public const string ReasonUser = "reason_user";
+}

--- a/src/Abblix.SecurityEvents.RISC/RiscEventTypes.cs
+++ b/src/Abblix.SecurityEvents.RISC/RiscEventTypes.cs
@@ -1,0 +1,115 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// The event type URIs RISC 1.0 defines (its Section 2), and the one registration call that
+/// teaches a receiver's event registry the whole dictionary.
+/// </summary>
+public static class RiscEventTypes
+{
+#pragma warning disable S1075 // URIs should not be hardcoded - these are the specification-fixed event type identifiers, not configuration
+    /// <summary>
+    /// The base URI of the RISC event types (RISC 1.0 Section 2).
+    /// </summary>
+    private const string BaseUri = "https://schemas.openid.net/secevent/risc/event-type/";
+#pragma warning restore S1075
+
+    /// <summary>The account was required to change a credential
+    /// (RISC 1.0 Section 2.1).</summary>
+    public const string AccountCredentialChangeRequired = BaseUri + "account-credential-change-required";
+
+    /// <summary>The account has been permanently deleted (RISC 1.0 Section 2.2).</summary>
+    public const string AccountPurged = BaseUri + "account-purged";
+
+    /// <summary>The account has been disabled (RISC 1.0 Section 2.3).</summary>
+    public const string AccountDisabled = BaseUri + "account-disabled";
+
+    /// <summary>The account has been enabled (RISC 1.0 Section 2.4).</summary>
+    public const string AccountEnabled = BaseUri + "account-enabled";
+
+    /// <summary>The identifier in the subject has changed (RISC 1.0 Section 2.5).</summary>
+    public const string IdentifierChanged = BaseUri + "identifier-changed";
+
+    /// <summary>The identifier in the subject now belongs to a new user
+    /// (RISC 1.0 Section 2.6).</summary>
+    public const string IdentifierRecycled = BaseUri + "identifier-recycled";
+
+    /// <summary>A credential of the subject was found compromised
+    /// (RISC 1.0 Section 2.7).</summary>
+    public const string CredentialCompromise = BaseUri + "credential-compromise";
+
+    /// <summary>The account opted into RISC event exchanges (RISC 1.0 Section 2.8.1).</summary>
+    public const string OptIn = BaseUri + "opt-in";
+
+    /// <summary>The account initiated an opt-out from RISC event exchanges
+    /// (RISC 1.0 Section 2.8.2).</summary>
+    public const string OptOutInitiated = BaseUri + "opt-out-initiated";
+
+    /// <summary>The account cancelled a pending opt-out (RISC 1.0 Section 2.8.3).</summary>
+    public const string OptOutCancelled = BaseUri + "opt-out-cancelled";
+
+    /// <summary>The opt-out took effect (RISC 1.0 Section 2.8.4).</summary>
+    public const string OptOutEffective = BaseUri + "opt-out-effective";
+
+    /// <summary>The account activated a recovery flow (RISC 1.0 Section 2.9).</summary>
+    public const string RecoveryActivated = BaseUri + "recovery-activated";
+
+    /// <summary>The account changed some of its recovery information
+    /// (RISC 1.0 Section 2.10).</summary>
+    public const string RecoveryInformationChanged = BaseUri + "recovery-information-changed";
+
+    /// <summary>All sessions of the account have been revoked (RISC 1.0 Section 2.11).
+    /// Deprecated by the specification in favour of the CAEP session-revoked event; kept so a
+    /// receiver still understands transmitters that predate the deprecation.</summary>
+    public const string SessionsRevoked = BaseUri + "sessions-revoked";
+
+    /// <summary>
+    /// Registers every RISC event type with its payload model - the whole dictionary in one
+    /// call, so a receiver cannot end up understanding half a profile.
+    /// </summary>
+    /// <param name="registry">The registry events deserialize through.</param>
+    public static EventTypeRegistry RegisterRiscEvents(this EventTypeRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        registry.Register<AccountCredentialChangeRequiredPayload>(AccountCredentialChangeRequired);
+        registry.Register<AccountPurgedPayload>(AccountPurged);
+        registry.Register<AccountDisabledPayload>(AccountDisabled);
+        registry.Register<AccountEnabledPayload>(AccountEnabled);
+        registry.Register<IdentifierChangedPayload>(IdentifierChanged);
+        registry.Register<IdentifierRecycledPayload>(IdentifierRecycled);
+        registry.Register<CredentialCompromisePayload>(CredentialCompromise);
+        registry.Register<OptInPayload>(OptIn);
+        registry.Register<OptOutInitiatedPayload>(OptOutInitiated);
+        registry.Register<OptOutCancelledPayload>(OptOutCancelled);
+        registry.Register<OptOutEffectivePayload>(OptOutEffective);
+        registry.Register<RecoveryActivatedPayload>(RecoveryActivated);
+        registry.Register<RecoveryInformationChangedPayload>(RecoveryInformationChanged);
+        registry.Register<SessionsRevokedPayload>(SessionsRevoked);
+
+        return registry;
+    }
+}

--- a/src/Abblix.SecurityEvents.RISC/SessionsRevokedPayload.cs
+++ b/src/Abblix.SecurityEvents.RISC/SessionsRevokedPayload.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.Risc;
+
+/// <summary>
+/// Sessions Revoked (RISC 1.0 Section 2.11): all sessions of the account identified by the
+/// subject have been revoked. The event carries no attributes.
+/// </summary>
+/// <remarks>
+/// The specification deprecates this event type: new implementations MUST transmit the CAEP
+/// session-revoked event instead. The type exists here so a RECEIVER still understands
+/// transmitters that predate the deprecation - it is deliberately not marked obsolete, because
+/// registering it for reception is exactly the supported use.
+/// </remarks>
+public sealed record SessionsRevokedPayload : IEventPayload;

--- a/src/Abblix.SecurityEvents/Infrastructure/DistributedJtiReplayCache.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/DistributedJtiReplayCache.cs
@@ -68,12 +68,9 @@ public sealed class DistributedJtiReplayCache(
     private const string CacheKeyPrefix =
         $"{nameof(Abblix)}.{nameof(SecurityEvents)}:{nameof(DistributedJtiReplayCache)}:";
 
-    private readonly TimeSpan _retention = retention > TimeSpan.Zero
-        ? retention
-        : throw new ArgumentOutOfRangeException(
-            nameof(retention),
-            retention,
-            "A replay cache remembering nothing detects nothing.");
+    private readonly TimeSpan _retention = retention <= TimeSpan.Zero
+        ? throw new ArgumentOutOfRangeException(nameof(retention), retention, "A replay cache remembering nothing detects nothing.")
+        : retention;
 
     /// <inheritdoc />
     public async ValueTask<bool> TryRegisterAsync(

--- a/src/Abblix.SecurityEvents/Subjects/SubjectIdentifier.cs
+++ b/src/Abblix.SecurityEvents/Subjects/SubjectIdentifier.cs
@@ -102,9 +102,7 @@ public abstract class SubjectIdentifier(string format)
         string? value,
         string memberName,
         [CallerArgumentExpression(nameof(value))] string? parameterName = null)
-        => !string.IsNullOrEmpty(value)
-            ? value
-            : throw new ArgumentException(
-                $"The '{memberName}' member is required and must not be null or empty.",
-                parameterName);
+        => string.IsNullOrEmpty(value)
+            ? throw new ArgumentException($"The '{memberName}' member is required and must not be null or empty.", parameterName)
+            : value;
 }

--- a/tests/Abblix.SecurityEvents.CAEP.UnitTests/Abblix.SecurityEvents.CAEP.UnitTests.csproj
+++ b/tests/Abblix.SecurityEvents.CAEP.UnitTests/Abblix.SecurityEvents.CAEP.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="xunit.v3.mtp-v2" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Abblix.SecurityEvents.CAEP\Abblix.SecurityEvents.CAEP.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Abblix.SecurityEvents.CAEP.UnitTests/CaepEventContractTests.cs
+++ b/tests/Abblix.SecurityEvents.CAEP.UnitTests/CaepEventContractTests.cs
@@ -1,0 +1,126 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Abblix.SecurityEvents.Events;
+using Xunit;
+
+namespace Abblix.SecurityEvents.Caep.UnitTests;
+
+/// <summary>
+/// Pins the dictionary's contract rather than any one figure: the registration teaches the
+/// registry all eight event types at once, a payload missing a REQUIRED member fails loudly, and
+/// absent OPTIONAL members stay off the wire instead of travelling as nulls.
+/// </summary>
+public class CaepEventContractTests
+{
+    [Fact]
+    public void RegisterCaepEvents_TeachesAllEightEventTypes()
+    {
+        var registry = new EventTypeRegistry().RegisterCaepEvents();
+
+        var expected = new Dictionary<string, Type>
+        {
+            [CaepEventTypes.SessionRevoked] = typeof(SessionRevokedPayload),
+            [CaepEventTypes.TokenClaimsChange] = typeof(TokenClaimsChangePayload),
+            [CaepEventTypes.CredentialChange] = typeof(CredentialChangePayload),
+            [CaepEventTypes.AssuranceLevelChange] = typeof(AssuranceLevelChangePayload),
+            [CaepEventTypes.DeviceComplianceChange] = typeof(DeviceComplianceChangePayload),
+            [CaepEventTypes.SessionEstablished] = typeof(SessionEstablishedPayload),
+            [CaepEventTypes.SessionPresented] = typeof(SessionPresentedPayload),
+            [CaepEventTypes.RiskLevelChange] = typeof(RiskLevelChangePayload),
+        };
+
+        Assert.All(expected, pair =>
+        {
+            Assert.True(registry.TryGetPayloadType(pair.Key, out var payloadType));
+            Assert.Equal(pair.Value, payloadType);
+        });
+    }
+
+    [Fact]
+    public void RegisterCaepEvents_Twice_IsRejected()
+    {
+        // The registry refuses duplicates; registering the dictionary twice is a configuration
+        // bug that must surface at startup, not a silent second write.
+        var registry = new EventTypeRegistry().RegisterCaepEvents();
+
+        Assert.Throws<ArgumentException>(() => registry.RegisterCaepEvents());
+    }
+
+    [Fact]
+    public void SessionRevoked_EmptyPayload_IsValid()
+    {
+        // CAEP 1.0 Section 3.1.1: session-revoked has no event-specific claims and every common
+        // claim is OPTIONAL, so the empty object of Figure 3 must deserialize cleanly.
+        var payload = new EventTypeRegistry()
+            .RegisterCaepEvents()
+            .Deserialize(CaepEventTypes.SessionRevoked, new JsonObject());
+
+        var revoked = Assert.IsType<SessionRevokedPayload>(payload);
+        Assert.Null(revoked.EventTimestamp);
+        Assert.Null(revoked.InitiatingEntity);
+        Assert.Null(revoked.ReasonAdmin);
+        Assert.Null(revoked.ReasonUser);
+    }
+
+    [Theory]
+    [InlineData("""{"change_type": "create"}""")]
+    [InlineData("""{"credential_type": "password"}""")]
+    public void CredentialChange_MissingRequiredMember_FailsLoudly(string payloadJson)
+    {
+        // CAEP 1.0 Section 3.3.1 makes both credential_type and change_type REQUIRED; a payload
+        // without either is a shape disagreement, not a value to default.
+        var registry = new EventTypeRegistry().RegisterCaepEvents();
+
+        Assert.ThrowsAny<JsonException>(() => registry.Deserialize(
+            CaepEventTypes.CredentialChange,
+            JsonNode.Parse(payloadJson)!.AsObject()));
+    }
+
+    [Fact]
+    public void RiskLevelChange_MissingPrincipal_FailsLoudly()
+    {
+        // CAEP 1.0 Section 3.8.1 makes principal REQUIRED.
+        var registry = new EventTypeRegistry().RegisterCaepEvents();
+
+        Assert.ThrowsAny<JsonException>(() => registry.Deserialize(
+            CaepEventTypes.RiskLevelChange,
+            JsonNode.Parse("""{"current_level": "LOW"}""")!.AsObject()));
+    }
+
+    [Fact]
+    public void AbsentOptionalClaims_StayOffTheWire()
+    {
+        // An absent OPTIONAL claim and a null-valued one are different texts on the wire, and
+        // the specification's examples never write nulls - neither may we.
+        var written = JsonSerializer.SerializeToNode(new SessionEstablishedPayload
+        {
+            AuthenticationContextClassReference = "AAL2",
+        });
+
+        var wire = Assert.IsType<JsonObject>(written);
+        var property = Assert.Single(wire);
+        Assert.Equal(CaepClaimNames.Acr, property.Key);
+    }
+}

--- a/tests/Abblix.SecurityEvents.CAEP.UnitTests/CaepEventFixtureTests.cs
+++ b/tests/Abblix.SecurityEvents.CAEP.UnitTests/CaepEventFixtureTests.cs
@@ -1,0 +1,326 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Abblix.SecurityEvents.Events;
+using Xunit;
+
+namespace Abblix.SecurityEvents.Caep.UnitTests;
+
+/// <summary>
+/// Pins the payload models to the specification's own examples: every fixture here is the event
+/// payload of a figure from CAEP 1.0, verbatim, so a drifted wire name or a mistyped member fails
+/// against the text both sides of the wire read.
+/// </summary>
+public class CaepEventFixtureTests
+{
+    /// <summary>The moment every example in CAEP 1.0 stamps into event_timestamp.</summary>
+    private static readonly DateTimeOffset FixtureTimestamp = DateTimeOffset.FromUnixTimeSeconds(1615304991);
+
+    private static IEventPayload Deserialize(string eventType, string payloadJson) =>
+        new EventTypeRegistry()
+            .RegisterCaepEvents()
+            .Deserialize(eventType, JsonNode.Parse(payloadJson)!.AsObject());
+
+    [Fact]
+    public void SessionRevoked_Figure4_CarriesTheCommonOptionalClaims()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.SessionRevoked,
+            """
+            {
+                "initiating_entity": "policy",
+                "reason_admin": {
+                    "en": "Landspeed Policy Violation: C076E82F"
+                },
+                "reason_user": {
+                    "en": "Access attempt from multiple regions.",
+                    "es-410": "Intento de acceso desde varias regiones."
+                },
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var revoked = Assert.IsType<SessionRevokedPayload>(payload);
+        Assert.Equal(CaepEventPayload.InitiatingEntities.Policy, revoked.InitiatingEntity);
+        Assert.Equal(FixtureTimestamp, revoked.EventTimestamp);
+        Assert.NotNull(revoked.ReasonAdmin);
+        Assert.Equal("Landspeed Policy Violation: C076E82F", revoked.ReasonAdmin["en"]);
+        Assert.NotNull(revoked.ReasonUser);
+        Assert.Equal("Access attempt from multiple regions.", revoked.ReasonUser["en"]);
+        Assert.Equal("Intento de acceso desde varias regiones.", revoked.ReasonUser["es-410"]);
+    }
+
+    [Fact]
+    public void TokenClaimsChange_Figure6_ReadsTheChangedClaims()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.TokenClaimsChange,
+            """
+            {
+                "event_timestamp": 1615304991,
+                "claims": {
+                    "role": "ro-admin"
+                }
+            }
+            """);
+
+        var change = Assert.IsType<TokenClaimsChangePayload>(payload);
+        Assert.Equal(FixtureTimestamp, change.EventTimestamp);
+        Assert.Equal("ro-admin", (string?)change.Claims["role"]);
+    }
+
+    [Fact]
+    public void TokenClaimsChange_Figure8_KeepsSamlClaimUrisAsKeys()
+    {
+        // A SAML attribute name is a full URI; the claims object must carry it untouched.
+        var payload = Deserialize(
+            CaepEventTypes.TokenClaimsChange,
+            """
+            {
+                "event_timestamp": 1615304991,
+                "claims": {
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": "ro-admin"
+                }
+            }
+            """);
+
+        var change = Assert.IsType<TokenClaimsChangePayload>(payload);
+        Assert.Equal(
+            "ro-admin",
+            (string?)change.Claims["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"]);
+    }
+
+    [Fact]
+    public void CredentialChange_Figure9_ReadsTheFido2Enrollment()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.CredentialChange,
+            """
+            {
+                "credential_type": "fido2-roaming",
+                "change_type": "create",
+                "fido2_aaguid": "accced6a-63f5-490a-9eea-e59bc1896cfc",
+                "friendly_name": "Jane's USB authenticator",
+                "initiating_entity": "user",
+                "reason_admin": {
+                    "en": "User self-enrollment"
+                },
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var change = Assert.IsType<CredentialChangePayload>(payload);
+        Assert.Equal(CredentialChangePayload.CredentialTypes.Fido2Roaming, change.CredentialType);
+        Assert.Equal(CredentialChangePayload.ChangeTypes.Create, change.ChangeType);
+        Assert.Equal("accced6a-63f5-490a-9eea-e59bc1896cfc", change.Fido2Aaguid);
+        Assert.Equal("Jane's USB authenticator", change.FriendlyName);
+        Assert.Equal(CaepEventPayload.InitiatingEntities.User, change.InitiatingEntity);
+        Assert.Equal(FixtureTimestamp, change.EventTimestamp);
+    }
+
+    [Fact]
+    public void AssuranceLevelChange_Figure10_ReadsTheNistIncrease()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.AssuranceLevelChange,
+            """
+            {
+                "namespace": "NIST-AAL",
+                "current_level": "nist-aal2",
+                "previous_level": "nist-aal1",
+                "change_direction": "increase",
+                "initiating_entity": "user",
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var change = Assert.IsType<AssuranceLevelChangePayload>(payload);
+        Assert.Equal(AssuranceLevelChangePayload.Namespaces.NistAal, change.Namespace);
+        Assert.Equal("nist-aal2", change.CurrentLevel);
+        Assert.Equal("nist-aal1", change.PreviousLevel);
+        Assert.Equal(AssuranceLevelChangePayload.ChangeDirections.Increase, change.ChangeDirection);
+    }
+
+    [Fact]
+    public void AssuranceLevelChange_Figure11_CustomNamespaceWithoutPreviousLevel()
+    {
+        // Section 3.4.1: an omitted previous_level means the transmitter does not know it, and
+        // the namespace set is open - "Retinal Scan" is a custom alias, not an error.
+        var payload = Deserialize(
+            CaepEventTypes.AssuranceLevelChange,
+            """
+            {
+                "namespace": "Retinal Scan",
+                "current_level": "hi-res-scan",
+                "initiating_entity": "user",
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var change = Assert.IsType<AssuranceLevelChangePayload>(payload);
+        Assert.Equal("Retinal Scan", change.Namespace);
+        Assert.Equal("hi-res-scan", change.CurrentLevel);
+        Assert.Null(change.PreviousLevel);
+        Assert.Null(change.ChangeDirection);
+    }
+
+    [Fact]
+    public void DeviceComplianceChange_Figure12_ReadsBothStatuses()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.DeviceComplianceChange,
+            """
+            {
+                "current_status": "not-compliant",
+                "previous_status": "compliant",
+                "initiating_entity": "policy",
+                "reason_admin": {
+                    "en": "Location Policy Violation: C076E8A3"
+                },
+                "reason_user": {
+                    "en": "Device is no longer in a trusted location."
+                },
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var change = Assert.IsType<DeviceComplianceChangePayload>(payload);
+        Assert.Equal(DeviceComplianceChangePayload.ComplianceStatuses.Compliant, change.PreviousStatus);
+        Assert.Equal(DeviceComplianceChangePayload.ComplianceStatuses.NotCompliant, change.CurrentStatus);
+    }
+
+    [Fact]
+    public void SessionEstablished_Section362_ReadsTheSessionQualities()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.SessionEstablished,
+            """
+            {
+                "fp_ua": "abb0b6e7da81a42233f8f2b1a8ddb1b9a4c81611",
+                "acr": "AAL2",
+                "amr": ["otp"],
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var established = Assert.IsType<SessionEstablishedPayload>(payload);
+        Assert.Equal("abb0b6e7da81a42233f8f2b1a8ddb1b9a4c81611", established.FingerprintUserAgent);
+        Assert.Equal("AAL2", established.AuthenticationContextClassReference);
+        Assert.NotNull(established.AuthenticationMethodsReferences);
+        Assert.Equal("otp", Assert.Single(established.AuthenticationMethodsReferences));
+        Assert.Null(established.ExternalId);
+    }
+
+    [Fact]
+    public void SessionPresented_Section372_ReadsTheCorrelationId()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.SessionPresented,
+            """
+            {
+                "fp_ua": "abb0b6e7da81a42233f8f2b1a8ddb1b9a4c81611",
+                "ext_id": "12345",
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        var presented = Assert.IsType<SessionPresentedPayload>(payload);
+        Assert.Equal("abb0b6e7da81a42233f8f2b1a8ddb1b9a4c81611", presented.FingerprintUserAgent);
+        Assert.Equal("12345", presented.ExternalId);
+    }
+
+    [Fact]
+    public void RiskLevelChange_Section382_ReadsTheBreachSignal()
+    {
+        var payload = Deserialize(
+            CaepEventTypes.RiskLevelChange,
+            """
+            {
+                "current_level": "LOW",
+                "previous_level": "HIGH",
+                "event_timestamp": 1615304991,
+                "principal": "USER",
+                "risk_reason": "PASSWORD_FOUND_IN_DATA_BREACH"
+            }
+            """);
+
+        var change = Assert.IsType<RiskLevelChangePayload>(payload);
+        Assert.Equal(RiskLevelChangePayload.Principals.User, change.Principal);
+        Assert.Equal(RiskLevelChangePayload.RiskLevels.Low, change.CurrentLevel);
+        Assert.Equal(RiskLevelChangePayload.RiskLevels.High, change.PreviousLevel);
+        Assert.Equal("PASSWORD_FOUND_IN_DATA_BREACH", change.RiskReason);
+    }
+
+    [Fact]
+    public void TypedWrite_ReproducesTheFigure6Payload()
+    {
+        // The transmitter direction against the same fixture: what a receiver reads back from the
+        // model must be the specification's own JSON, byte-for-byte in content.
+        var written = JsonSerializer.SerializeToNode(new TokenClaimsChangePayload
+        {
+            EventTimestamp = FixtureTimestamp,
+            Claims = new JsonObject { ["role"] = "ro-admin" },
+        });
+
+        var expected = JsonNode.Parse(
+            """
+            {
+                "event_timestamp": 1615304991,
+                "claims": {
+                    "role": "ro-admin"
+                }
+            }
+            """);
+
+        Assert.True(JsonNode.DeepEquals(expected, written));
+    }
+
+    [Fact]
+    public void TypedWrite_ReproducesTheFigure10Payload()
+    {
+        var written = JsonSerializer.SerializeToNode(new AssuranceLevelChangePayload
+        {
+            Namespace = AssuranceLevelChangePayload.Namespaces.NistAal,
+            CurrentLevel = "nist-aal2",
+            PreviousLevel = "nist-aal1",
+            ChangeDirection = AssuranceLevelChangePayload.ChangeDirections.Increase,
+            InitiatingEntity = CaepEventPayload.InitiatingEntities.User,
+            EventTimestamp = FixtureTimestamp,
+        });
+
+        var expected = JsonNode.Parse(
+            """
+            {
+                "namespace": "NIST-AAL",
+                "current_level": "nist-aal2",
+                "previous_level": "nist-aal1",
+                "change_direction": "increase",
+                "initiating_entity": "user",
+                "event_timestamp": 1615304991
+            }
+            """);
+
+        Assert.True(JsonNode.DeepEquals(expected, written));
+    }
+}

--- a/tests/Abblix.SecurityEvents.RISC.UnitTests/Abblix.SecurityEvents.RISC.UnitTests.csproj
+++ b/tests/Abblix.SecurityEvents.RISC.UnitTests/Abblix.SecurityEvents.RISC.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="xunit.v3.mtp-v2" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+        <PackageReference Update="SonarAnalyzer.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Abblix.SecurityEvents.RISC\Abblix.SecurityEvents.RISC.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Abblix.SecurityEvents.RISC.UnitTests/RiscEventContractTests.cs
+++ b/tests/Abblix.SecurityEvents.RISC.UnitTests/RiscEventContractTests.cs
@@ -1,0 +1,111 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Abblix.SecurityEvents.Caep;
+using Abblix.SecurityEvents.Events;
+using Xunit;
+
+namespace Abblix.SecurityEvents.Risc.UnitTests;
+
+/// <summary>
+/// Pins the dictionary's contract rather than any one figure: the registration teaches the
+/// registry all fourteen event types at once - the deprecated one included, since receivers
+/// still meet it on the wire - and both dictionaries compose on one registry.
+/// </summary>
+public class RiscEventContractTests
+{
+    [Fact]
+    public void RegisterRiscEvents_TeachesAllFourteenEventTypes()
+    {
+        var registry = new EventTypeRegistry().RegisterRiscEvents();
+
+        var expected = new Dictionary<string, Type>
+        {
+            [RiscEventTypes.AccountCredentialChangeRequired] = typeof(AccountCredentialChangeRequiredPayload),
+            [RiscEventTypes.AccountPurged] = typeof(AccountPurgedPayload),
+            [RiscEventTypes.AccountDisabled] = typeof(AccountDisabledPayload),
+            [RiscEventTypes.AccountEnabled] = typeof(AccountEnabledPayload),
+            [RiscEventTypes.IdentifierChanged] = typeof(IdentifierChangedPayload),
+            [RiscEventTypes.IdentifierRecycled] = typeof(IdentifierRecycledPayload),
+            [RiscEventTypes.CredentialCompromise] = typeof(CredentialCompromisePayload),
+            [RiscEventTypes.OptIn] = typeof(OptInPayload),
+            [RiscEventTypes.OptOutInitiated] = typeof(OptOutInitiatedPayload),
+            [RiscEventTypes.OptOutCancelled] = typeof(OptOutCancelledPayload),
+            [RiscEventTypes.OptOutEffective] = typeof(OptOutEffectivePayload),
+            [RiscEventTypes.RecoveryActivated] = typeof(RecoveryActivatedPayload),
+            [RiscEventTypes.RecoveryInformationChanged] = typeof(RecoveryInformationChangedPayload),
+            [RiscEventTypes.SessionsRevoked] = typeof(SessionsRevokedPayload),
+        };
+
+        Assert.All(expected, pair =>
+        {
+            Assert.True(registry.TryGetPayloadType(pair.Key, out var payloadType));
+            Assert.Equal(pair.Value, payloadType);
+        });
+    }
+
+    [Fact]
+    public void RegisterRiscEvents_Twice_IsRejected()
+    {
+        var registry = new EventTypeRegistry().RegisterRiscEvents();
+
+        Assert.Throws<ArgumentException>(() => registry.RegisterRiscEvents());
+    }
+
+    [Fact]
+    public void CaepAndRiscDictionaries_ComposeOnOneRegistry()
+    {
+        // A receiver of both profiles registers both dictionaries over the same registry; the
+        // URI spaces are disjoint, so nothing collides.
+        var registry = new EventTypeRegistry()
+            .RegisterCaepEvents()
+            .RegisterRiscEvents();
+
+        Assert.True(registry.TryGetPayloadType(CaepEventTypes.SessionRevoked, out _));
+        Assert.True(registry.TryGetPayloadType(RiscEventTypes.SessionsRevoked, out _));
+    }
+
+    [Fact]
+    public void CredentialCompromise_MissingRequiredCredentialType_FailsLoudly()
+    {
+        // RISC 1.0 Section 2.7 makes credential_type REQUIRED; a payload without it is a shape
+        // disagreement, not a value to default.
+        var registry = new EventTypeRegistry().RegisterRiscEvents();
+
+        Assert.ThrowsAny<JsonException>(() => registry.Deserialize(
+            RiscEventTypes.CredentialCompromise,
+            new JsonObject()));
+    }
+
+    [Fact]
+    public void AbsentOptionalClaims_StayOffTheWire()
+    {
+        // An absent OPTIONAL claim and a null-valued one are different texts on the wire, and
+        // the specification's examples never write nulls - neither may we.
+        var written = JsonSerializer.SerializeToNode(new AccountDisabledPayload());
+
+        var wire = Assert.IsType<JsonObject>(written);
+        Assert.Empty(wire);
+    }
+}

--- a/tests/Abblix.SecurityEvents.RISC.UnitTests/RiscEventFixtureTests.cs
+++ b/tests/Abblix.SecurityEvents.RISC.UnitTests/RiscEventFixtureTests.cs
@@ -1,0 +1,170 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Abblix.SecurityEvents.Caep;
+using Abblix.SecurityEvents.Events;
+using Xunit;
+
+namespace Abblix.SecurityEvents.Risc.UnitTests;
+
+/// <summary>
+/// Pins the payload models to the specification's own examples: every fixture here is the event
+/// payload of a figure from RISC 1.0, verbatim, so a drifted wire name - the hyphenated
+/// new-value above all - fails against the text both sides of the wire read.
+/// </summary>
+public class RiscEventFixtureTests
+{
+    private static IEventPayload Deserialize(string eventType, string payloadJson) =>
+        new EventTypeRegistry()
+            .RegisterRiscEvents()
+            .Deserialize(eventType, JsonNode.Parse(payloadJson)!.AsObject());
+
+    [Fact]
+    public void AccountCredentialChangeRequired_Figure1_EmptyPayloadIsValid()
+    {
+        // RISC 1.0 Section 2.1: the event has no attributes, so Figure 1 carries {}.
+        var payload = Deserialize(RiscEventTypes.AccountCredentialChangeRequired, "{}");
+
+        Assert.IsType<AccountCredentialChangeRequiredPayload>(payload);
+    }
+
+    [Fact]
+    public void AccountDisabled_Figure2_ReadsTheHijackingReason()
+    {
+        var payload = Deserialize(
+            RiscEventTypes.AccountDisabled,
+            """
+            {
+                "reason": "hijacking"
+            }
+            """);
+
+        var disabled = Assert.IsType<AccountDisabledPayload>(payload);
+        Assert.Equal(AccountDisabledPayload.Reasons.Hijacking, disabled.Reason);
+    }
+
+    [Fact]
+    public void IdentifierChanged_Figure3_ReadsTheHyphenatedNewValue()
+    {
+        // Section 2.5 spells the claim "new-value" with a hyphen - the one outlier among the
+        // underscore-separated claims, and exactly the kind of name a habit would misspell.
+        var payload = Deserialize(
+            RiscEventTypes.IdentifierChanged,
+            """
+            {
+                "new-value": "john.roe@example.com"
+            }
+            """);
+
+        var changed = Assert.IsType<IdentifierChangedPayload>(payload);
+        Assert.Equal("john.roe@example.com", changed.NewValue);
+    }
+
+    [Fact]
+    public void IdentifierRecycled_Figure4_EmptyPayloadIsValid()
+    {
+        var payload = Deserialize(RiscEventTypes.IdentifierRecycled, "{}");
+
+        Assert.IsType<IdentifierRecycledPayload>(payload);
+    }
+
+    [Fact]
+    public void CredentialCompromise_Figure5_ReadsTheCaepCredentialType()
+    {
+        // The expected value comes from the CAEP dictionary's constants on purpose: RISC 1.0
+        // Section 2.7 defines credential_type by reference to the CAEP Credential Change event,
+        // so the two packages must agree on the strings.
+        var payload = Deserialize(
+            RiscEventTypes.CredentialCompromise,
+            """
+            {
+                "credential_type": "password"
+            }
+            """);
+
+        var compromise = Assert.IsType<CredentialCompromisePayload>(payload);
+        Assert.Equal(CredentialChangePayload.CredentialTypes.Password, compromise.CredentialType);
+        Assert.Null(compromise.EventTimestamp);
+        Assert.Null(compromise.ReasonAdmin);
+        Assert.Null(compromise.ReasonUser);
+    }
+
+    [Fact]
+    public void TypedWrite_ReproducesTheFigure3Payload()
+    {
+        var written = JsonSerializer.SerializeToNode(new IdentifierChangedPayload
+        {
+            NewValue = "john.roe@example.com",
+        });
+
+        var expected = JsonNode.Parse(
+            """
+            {
+                "new-value": "john.roe@example.com"
+            }
+            """);
+
+        Assert.True(JsonNode.DeepEquals(expected, written));
+    }
+
+    [Fact]
+    public void TypedWrite_ReproducesTheFigure5Payload()
+    {
+        var written = JsonSerializer.SerializeToNode(new CredentialCompromisePayload
+        {
+            CredentialType = CredentialChangePayload.CredentialTypes.Password,
+        });
+
+        var expected = JsonNode.Parse(
+            """
+            {
+                "credential_type": "password"
+            }
+            """);
+
+        Assert.True(JsonNode.DeepEquals(expected, written));
+    }
+
+    [Fact]
+    public void CredentialCompromise_WithDiscoveryTime_TravelsAsUnixSeconds()
+    {
+        // Section 2.7: event_timestamp is a JSON number of seconds since the epoch - the moment
+        // the transmitter DISCOVERED the compromise.
+        var discoveredAt = DateTimeOffset.FromUnixTimeSeconds(1508184845);
+
+        var written = JsonSerializer.SerializeToNode(new CredentialCompromisePayload
+        {
+            CredentialType = CredentialChangePayload.CredentialTypes.Pin,
+            EventTimestamp = discoveredAt,
+        });
+
+        var wire = Assert.IsType<JsonObject>(written);
+        Assert.Equal(1508184845, (long?)wire[RiscClaimNames.EventTimestamp]);
+
+        var readBack = Assert.IsType<CredentialCompromisePayload>(Deserialize(
+            RiscEventTypes.CredentialCompromise,
+            wire.ToJsonString()));
+        Assert.Equal(discoveredAt, readBack.EventTimestamp);
+    }
+}


### PR DESCRIPTION
Two event dictionary packages over the Security Events core, completing the receiver and transmitter vocabulary for the Shared Signals profiles.

## Abblix.SecurityEvents.CAEP

Typed payload models and event type URIs for all eight CAEP 1.0 events: session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, session-established, session-presented and risk-level-change. The common Section 2 claims (event_timestamp as unix seconds, initiating_entity, localized reason_admin and reason_user) live on a shared base record; `RegisterCaepEvents` teaches an `EventTypeRegistry` the whole dictionary in one call.

## Abblix.SecurityEvents.RISC

Typed payload models and event type URIs for all fourteen RISC 1.0 events, including the deprecated sessions-revoked - kept so a receiver still understands transmitters that predate the deprecation, while new transmitters use the CAEP session-revoked event as the specification requires. The compromised credential's `credential_type` takes its values from the CAEP Credential Change event per the RISC specification's own normative cross-reference, so the package depends on Abblix.SecurityEvents.CAEP and reuses its constants instead of copying the strings.

## Tests

Both test suites pin the models to the specifications' own figure examples, verbatim, in both directions: the figures deserialize into the typed models, typed writes reproduce the figures, REQUIRED members missing on the wire fail loudly, absent OPTIONAL members stay off the wire, and both dictionaries compose on one registry. The RISC suite additionally pins the hyphenated `new-value` wire name and the unix-second discovery timestamp round trip.
