### PR TITLE
Require the SET jti claim and fail closed on untrackable envelopes

### DIFF
--- a/src/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Abblix.DependencyInjection/ServiceCollectionExtensions.cs
@@ -429,9 +429,10 @@ public static class ServiceCollectionExtensions
     /// composite resolves in registration order; being keyed also hides them from plain resolution, so the
     /// singular resolve yields only the composite. The family thus remains descriptor data in the collection
     /// rather than a snapshot captured in a closure: <see cref="Decompose{TInterface}"/> returns a live cursor
-    /// over that data, and edits through it reach the composite at resolve — without the host ever naming the
-    /// composite type. The whole family shares one lifetime; a set of members with mixed lifetimes is a
-    /// composition error and throws, since a composite may not capture a shorter-lived member.
+    /// over that data, and edits through it reach the composite at resolve - without the host ever naming the
+    /// composite type. Members keep their own lifetimes and the composite adopts the shortest among them, so a
+    /// longer-lived member is simply shared; only a member shorter-lived than the composite is rejected, since
+    /// a composite may not capture something that dies before it.
     /// </remarks>
     public static IServiceCollection Compose<TInterface, TComposite>(
         this IServiceCollection services,

--- a/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
@@ -48,6 +48,7 @@ public static class ServiceCollectionExtensions
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, TypHeaderStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, ExpAbsenceStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, EventsPresenceStep>(),
+        ServiceDescriptor.Singleton<ISecurityEventTokenValidator, JwtIdPresenceStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, IssuerAllowlistStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, SignatureStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, AudienceStep>(),
@@ -72,7 +73,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The pipeline is an ordinary composed family: the nine default steps register as
+    /// The pipeline is an ordinary composed family: the ten default steps register as
     /// <see cref="ISecurityEventTokenValidator"/> implementations in execution order and
     /// collapse behind the singular contract. A consumer profile edits them in place afterwards -
     /// <c>services.Decompose&lt;ISecurityEventTokenValidator&gt;()</c> returns the live

--- a/src/Abblix.SecurityEvents/Validation/Steps/JwtIdPresenceStep.cs
+++ b/src/Abblix.SecurityEvents/Validation/Steps/JwtIdPresenceStep.cs
@@ -1,0 +1,57 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+
+namespace Abblix.SecurityEvents.Validation.Steps;
+
+/// <summary>
+/// Requires the "jti" claim to be a non-empty string: "This claim is REQUIRED"
+/// (RFC 8417 Section 2.2). The identifier is what every receiver-side replay accounting keys
+/// on, so a SET without a usable one is rejected here rather than reaching a consumer that
+/// cannot track it.
+/// </summary>
+public sealed class JwtIdPresenceStep : ISecurityCriticalValidator
+{
+    /// <inheritdoc />
+    public ValueTask<SecurityEventTokenValidationError?> ValidateAsync(
+        SecurityEventTokenValidationContext context,
+        CancellationToken cancellationToken)
+    {
+        context.Require(SecurityEventTokenValidationStates.Parsed);
+
+        var description = context.UnverifiedPayload!.Json[IanaClaimTypes.Jti] switch
+        {
+            null => $"The claims carry no '{IanaClaimTypes.Jti}' member (RFC 8417 Section 2.2).",
+            JsonValue value when value.TryGetValue<string>(out var jwtId) && jwtId.Length > 0 => null,
+            _ => $"The '{IanaClaimTypes.Jti}' claim is not a non-empty string "
+                + "(RFC 8417 Section 2.2).",
+        };
+
+        var error = description is null
+            ? null
+            : new SecurityEventTokenValidationError(SecurityEventTokenErrorCode.MalformedToken, description);
+
+        return ValueTask.FromResult(error);
+    }
+}

--- a/src/Abblix.SharedSignals/Receiver/PushDeliveryHandler.cs
+++ b/src/Abblix.SharedSignals/Receiver/PushDeliveryHandler.cs
@@ -97,15 +97,24 @@ public sealed class PushDeliveryHandler(
 
         verdict.TryGetSuccess(out var validated);
 
-        // The envelope claims are REQUIRED and the profile has verified them by now, so a miss
-        // here is a mis-composed pipeline, not a token defect - and with no replay cache the
-        // question does not arise.
-        if (replayCache is not null
-            && validated!.Token is { Issuer: { } issuer, JwtId: { } jwtId, IssuedAt: { } issuedAt }
-            && !await replayCache.TryRegisterAsync(issuer, jwtId, issuedAt, cancellationToken))
+        if (replayCache is not null)
         {
-            // A redelivery of something already processed: acknowledged, never re-consumed.
-            return PushDeliveryResult.Accepted;
+            // The default profile requires each of these envelope claims with its own step, so a
+            // miss here means a weakened profile let an incomplete envelope through - and a token
+            // replay accounting cannot track must not slip past it. The miss fails closed.
+            if (validated!.Token is not { Issuer: { } issuer, JwtId: { } jwtId, IssuedAt: { } issuedAt })
+            {
+                return PushDeliveryResult.BadRequest(new DeliveryError(
+                    DeliveryErrorCodes.InvalidRequest,
+                    "The SET lacks an envelope claim replay accounting keys on: 'iss', 'jti' and "
+                    + "'iat' are REQUIRED (RFC 8417 Section 2.2)."));
+            }
+
+            if (!await replayCache.TryRegisterAsync(issuer, jwtId, issuedAt, cancellationToken))
+            {
+                // A redelivery of something already processed: acknowledged, never re-consumed.
+                return PushDeliveryResult.Accepted;
+            }
         }
 
         var refusal = await sink.ConsumeAsync(validated!, cancellationToken);

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
@@ -135,6 +135,7 @@ public class SecurityEventTokenValidatorTests
             new TypHeaderStep(),
             new ExpAbsenceStep(),
             new EventsPresenceStep(),
+            new JwtIdPresenceStep(),
             new IssuerAllowlistStep(),
             new SignatureStep(verifier ?? new AcceptingVerifier()),
             new AudienceStep(),
@@ -268,6 +269,23 @@ public class SecurityEventTokenValidatorTests
 
         var error = await ValidateExpectingError($"{header}.{payload}.sig");
         Assert.Equal(SecurityEventTokenErrorCode.MissingEvents, error.Code);
+    }
+
+    [Theory]
+    // Absent, empty, and non-string "jti" are three spellings of the same defect.
+    [InlineData("""{"iss":"https://tenant.example.com","iat":1754040000,"aud":"https://receiver.example.com/events","events":{"https://tenant.example.com/events/membership-changed":{}}}""")]
+    [InlineData("""{"iss":"https://tenant.example.com","jti":"","iat":1754040000,"aud":"https://receiver.example.com/events","events":{"https://tenant.example.com/events/membership-changed":{}}}""")]
+    [InlineData("""{"iss":"https://tenant.example.com","jti":42,"iat":1754040000,"aud":"https://receiver.example.com/events","events":{"https://tenant.example.com/events/membership-changed":{}}}""")]
+    public async Task MissingOrEmptyOrNonStringJwtId_IsMalformed(string claimsJson)
+    {
+        // RFC 8417 Section 2.2 on "jti": "This claim is REQUIRED." A SET without a usable
+        // identifier cannot be tracked by any receiver-side replay accounting, so the profile
+        // rejects it before spending a signature verification on it.
+        var header = Base64Url.EncodeToString("""{"typ":"secevent+jwt","alg":"none"}"""u8);
+        var payload = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(claimsJson));
+
+        var error = await ValidateExpectingError($"{header}.{payload}.sig");
+        Assert.Equal(SecurityEventTokenErrorCode.MalformedToken, error.Code);
     }
 
     [Fact]

--- a/tests/Abblix.SecurityEvents.UnitTests/ValidationCompositionTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/ValidationCompositionTests.cs
@@ -67,7 +67,7 @@ public class ValidationCompositionTests
             .ToArray();
 
     [Fact]
-    public void DefaultPipeline_HoldsTheNineStepsInOrder()
+    public void DefaultPipeline_HoldsTheTenStepsInOrder()
     {
         Assert.Equal(
             [
@@ -75,6 +75,7 @@ public class ValidationCompositionTests
                 typeof(TypHeaderStep),
                 typeof(ExpAbsenceStep),
                 typeof(EventsPresenceStep),
+                typeof(JwtIdPresenceStep),
                 typeof(IssuerAllowlistStep),
                 typeof(SignatureStep),
                 typeof(AudienceStep),

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliveryHandlerTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliveryHandlerTests.cs
@@ -187,6 +187,31 @@ public class PushDeliveryHandlerTests
     }
 
     [Fact]
+    public async Task UntrackableEnvelope_WithReplayCache_FailsClosed()
+    {
+        // The default profile requires "iss", "jti" and "iat" (RFC 8417 Section 2.2), so this
+        // token can only come from a weakened profile - and a token replay accounting cannot
+        // track must not slip past it. The safe direction is rejection, not consumption.
+        var jtiless = new SecurityEventToken(new Abblix.Jwt.JsonWebToken
+        {
+            Payload = { Issuer = "https://tr.example.com" },
+        });
+        var sink = new RecordingSink();
+        var handler = new PushDeliveryHandler(
+            new StubValidator(error: null, token: jtiless),
+            new SsfValidationOptions(),
+            sink,
+            new FakeReplayCache());
+
+        var result = await handler.HandleAsync(
+            SetMediaType, "a.b.c", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.Equal(DeliveryErrorCodes.InvalidRequest, result.Error!.Error);
+        Assert.Empty(sink.Consumed);
+    }
+
+    [Fact]
     public async Task Redelivery_IsAcknowledged_WithoutReprocessing()
     {
         // RFC 8935 Section 2 lets a transmitter redeliver regardless of earlier responses: the


### PR DESCRIPTION
Two defects surfaced by the adversarial README audit, fixed at their proper depth.

## jti is REQUIRED, and untrackable envelopes now fail closed

RFC 8417 Section 2.2 makes `jti` REQUIRED, yet no default validation step read it: a signed SET without an identifier passed the whole receiver profile, and the push handler's replay guard - written on the assumption the profile had verified the envelope - silently fell through to the sink, so such a token could be replayed without limit. Two changes close both doors:

- `JwtIdPresenceStep` joins the default profile among the cheap unverified checks, rejecting an absent, empty or non-string `jti` before a signature verification is spent on the token. It carries the security-critical marker, so a profile that drops it must acknowledge the weakening explicitly.
- The push handler fails closed: with a replay cache present, an envelope the accounting cannot key on is rejected as `invalid_request` instead of being consumed, so a weakened profile no longer converts missing claims into unlimited replays.

Both changes were reproduced red-first: three malformed-`jti` spellings passed validation, and the untrackable-envelope token reached the sink, before the fixes turned the same tests green.

## Compose XML doc corrected

The `Compose` remarks claimed a family with mixed lifetimes throws; the code adopts the shortest member lifetime and lets members keep their own, rejecting only a member shorter-lived than the composite. The doc now says what the code does.
