### PR TITLE
Gateway-friendly SSF discovery: suppress or internally re-route the configuration document

### DIFF
--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -29,6 +29,8 @@ One call maps the whole management surface under the prefix - streams, status, s
 
 The well-known endpoint stays outside the returned group on purpose: discovery must answer before any receiver has credentials, so the authorization you attach to the group does not cover it. What it serves is public metadata - issuer, JWKS location, endpoint addresses, supported delivery methods and authorization schemes - and nothing stream- or receiver-specific; poll delivery sits inside the group, which is where SSF 1.0 Section 7.1.1 wants it.
 
+A gateway-fronted deployment adjusts this without moving the protocol address: `MapSsfTransmitterEndpoints(prefix, mapWellKnownConfiguration: false)` leaves the canonical route to the gateway or CDN in front, and `MapSsfConfigurationDocument(advertisedPrefix, pattern)` serves the same document on an internal route a rewriting proxy maps the canonical address onto - advertising the external prefix, whatever was mapped internally. The external address never moves, because receivers derive it from the issuer.
+
 Receivers are told apart by identity: the endpoints read it from the authenticated principal (the `sub` claim, then the identity name), and `SsfEndpointOptions.ReceiverIdSelector` replaces that mapping when the host's authentication carries the identity elsewhere.
 
 What one call maps, relative to the prefix:

--- a/src/Abblix.SharedSignals.MinimalApi/SsfEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SsfEndpointRouteBuilderExtensions.cs
@@ -70,18 +70,24 @@ public static class SsfEndpointRouteBuilderExtensions
     /// </remarks>
     /// <param name="endpoints">The route builder.</param>
     /// <param name="prefix">The route prefix of the management surface.</param>
+    /// <param name="mapWellKnownConfiguration">
+    /// False leaves the well-known address unmapped - for a host whose gateway or CDN answers
+    /// the canonical address itself. The address is fixed by SSF 1.0 Section 7.2 and receivers
+    /// derive it from the issuer, so the flag only suppresses the route, never moves it; a host
+    /// that must serve the document on another internal path - a reverse proxy rewriting paths
+    /// in front of the transmitter - pairs this with
+    /// <see cref="MapSsfConfigurationDocument"/>.</param>
     public static RouteGroupBuilder MapSsfTransmitterEndpoints(
         this IEndpointRouteBuilder endpoints,
-        string prefix = "/ssf")
+        string prefix = "/ssf",
+        bool mapWellKnownConfiguration = true)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
-        var options = endpoints.ServiceProvider.GetRequiredService<SsfTransmitterOptions>();
-        var issuer = new Uri(options.Issuer, UriKind.Absolute);
-
-        endpoints.MapGet(
-            TransmitterConfiguration.WellKnownAddress(issuer).AbsolutePath,
-            (SsfTransmitterOptions current) => Results.Json(ConfigurationDocumentOf(current, prefix)));
+        if (mapWellKnownConfiguration)
+        {
+            endpoints.MapSsfConfigurationDocument(prefix);
+        }
 
         var group = endpoints.MapGroup(prefix);
 
@@ -106,6 +112,43 @@ public static class SsfEndpointRouteBuilderExtensions
         group.MapPost(Routes.Poll + "/{streamId}", PollAsync);
 
         return group;
+    }
+
+    /// <summary>
+    /// Maps the transmitter's configuration document (SSF 1.0 Section 7.2) on its own: at the
+    /// well-known address the issuer resolves to, or at a host-chosen internal route.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MapSsfTransmitterEndpoints"/> calls this by default, so a plain host never
+    /// needs it. It exists for the deployment where the canonical address is answered by
+    /// something in front of the application: a gateway or CDN serving a cached copy (suppress
+    /// the default mapping and do not call this), or a reverse proxy rewriting paths, where the
+    /// document must exist on an internal route the proxy maps the canonical address onto. The
+    /// EXTERNAL address never moves - receivers derive it from the issuer, not from
+    /// configuration - so <paramref name="pattern"/> is deployment plumbing, not a protocol
+    /// choice.
+    /// </remarks>
+    /// <param name="endpoints">The route builder.</param>
+    /// <param name="advertisedPrefix">
+    /// The management-surface prefix the document advertises, as the OUTSIDE world reaches it -
+    /// behind a rewriting proxy that is the external prefix, whatever
+    /// <see cref="MapSsfTransmitterEndpoints"/> mapped internally.</param>
+    /// <param name="pattern">
+    /// The route the document is served on; null takes the canonical well-known address derived
+    /// from the issuer.</param>
+    public static IEndpointConventionBuilder MapSsfConfigurationDocument(
+        this IEndpointRouteBuilder endpoints,
+        string advertisedPrefix = "/ssf",
+        string? pattern = null)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var options = endpoints.ServiceProvider.GetRequiredService<SsfTransmitterOptions>();
+        var issuer = new Uri(options.Issuer, UriKind.Absolute);
+
+        return endpoints.MapGet(
+            pattern ?? TransmitterConfiguration.WellKnownAddress(issuer).AbsolutePath,
+            (SsfTransmitterOptions current) => Results.Json(ConfigurationDocumentOf(current, advertisedPrefix)));
     }
 
     /// <summary>

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -14,7 +14,7 @@ The transmitter side:
 
 The receiver side:
 
-- `TransmitterConfigurationClient` discovers a transmitter, `StreamManagementClient` drives its management API, `PollClient` fetches and acknowledges events - transport only, so a poll-based receiver runs the validation profile and the sink itself.
+- `TransmitterConfigurationClient` discovers a transmitter at the address its issuer resolves to, with an explicit-address overload for transmitters that publish the document elsewhere - the issuer identity check binds either way. `StreamManagementClient` drives the management API, `PollClient` fetches and acknowledges events - transport only, so a poll-based receiver runs the validation profile and the sink itself.
 - A push intake that runs the full validation profile of Abblix.SecurityEvents - typ, `exp` absence, events, the REQUIRED `jti`, issuer, signature, audience, `iat` freshness - and hands each accepted event to the host's `ISecurityEventSink`. Duplicate suppression rides alongside the profile: the opt-in replay cache is consulted after the verdict, so a rejected token can never burn an identifier.
 
 The endpoints themselves are mapped by the ASP.NET Core adapter package, [Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi); this package is host-framework-neutral.

--- a/src/Abblix.SharedSignals/Receiver/TransmitterConfigurationClient.cs
+++ b/src/Abblix.SharedSignals/Receiver/TransmitterConfigurationClient.cs
@@ -53,13 +53,46 @@ public sealed class TransmitterConfigurationClient(HttpClient httpClient)
     /// SSF counterpart of the identity check every discovery protocol makes, without which a
     /// document served on one issuer's path could impersonate another issuer of the same host.
     /// </exception>
-    public async Task<TransmitterConfiguration> GetAsync(
+    public Task<TransmitterConfiguration> GetAsync(
         Uri issuer,
         CancellationToken cancellationToken = default)
     {
-        var address = TransmitterConfiguration.WellKnownAddress(issuer);
+        ArgumentNullException.ThrowIfNull(issuer);
 
-        using var response = await httpClient.GetAsync(address, cancellationToken);
+        return GetAsync(issuer, TransmitterConfiguration.WellKnownAddress(issuer), cancellationToken);
+    }
+
+    /// <summary>
+    /// Fetches the Transmitter Configuration Metadata for <paramref name="issuer"/> from an
+    /// explicitly named address instead of the one the issuer resolves to.
+    /// </summary>
+    /// <remarks>
+    /// The insertion-derived well-known address is the conformant location (SSF 1.0
+    /// Section 7.2) and the parameterless overload is the normal door. This one exists for
+    /// transmitters that publish the document elsewhere - a non-conformant implementation, or a
+    /// deployment quirk the receiver cannot fix from its side. Every check stays in force, the
+    /// issuer identity above all: the address only says where the bytes come from, never who
+    /// they speak for.
+    /// </remarks>
+    /// <param name="issuer">The transmitter's issuer identifier, from a trusted source - still
+    /// the identity the document must assert.</param>
+    /// <param name="metadataAddress">Where the document is fetched from.</param>
+    /// <param name="cancellationToken">Cancels the fetch.</param>
+    /// <returns>The metadata document, its issuer identity confirmed.</returns>
+    /// <exception cref="HttpRequestException">The transmitter answered with an error status.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The document is empty, arrives under a media type other than "application/json", or
+    /// asserts an issuer other than <paramref name="issuer"/>.</exception>
+    public async Task<TransmitterConfiguration> GetAsync(
+        Uri issuer,
+        Uri metadataAddress,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(issuer);
+        ArgumentNullException.ThrowIfNull(metadataAddress);
+
+        using var response = await httpClient.GetAsync(metadataAddress, cancellationToken);
         response.EnsureSuccessStatusCode();
 
         // Section 7.2 requires the document be returned as "application/json", and the check is
@@ -70,13 +103,13 @@ public sealed class TransmitterConfigurationClient(HttpClient httpClient)
         if (!string.Equals(mediaType, MediaTypeNames.Application.Json, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(
-                $"The document at '{address}' arrived as '{mediaType ?? "(no content type)"}', where "
+                $"The document at '{metadataAddress}' arrived as '{mediaType ?? "(no content type)"}', where "
                 + "SSF 1.0 Section 7.2 requires \"application/json\".");
         }
 
         var metadata = await response.Content.ReadFromJsonAsync<TransmitterConfiguration>(cancellationToken)
             ?? throw new InvalidOperationException(
-                $"The transmitter configuration document at '{address}' deserialized to null.");
+                $"The transmitter configuration document at '{metadataAddress}' deserialized to null.");
 
         // Compared as normalized absolute URIs, not with Uri.Equals: Uri equality disregards
         // userinfo and fragment, so "https://evil@tr.example.com" would pass for
@@ -87,7 +120,7 @@ public sealed class TransmitterConfigurationClient(HttpClient httpClient)
             || !string.Equals(declaredIssuer.AbsoluteUri, issuer.AbsoluteUri, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
-                $"The document at '{address}' asserts the issuer '{metadata.Issuer}', not the "
+                $"The document at '{metadataAddress}' asserts the issuer '{metadata.Issuer}', not the "
                 + $"'{issuer}' it was fetched for; accepting it would let one issuer of a host "
                 + "answer for another (SSF 1.0 Sections 7.1, 7.2).");
         }

--- a/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Net;
 using System.Runtime.CompilerServices;
 using Abblix.Jwt;
 using Abblix.SecurityEvents.Abstractions;
@@ -219,6 +220,52 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
         Assert.Equal(0, await dispatcher.DispatchAsync(
             new SecurityEventDescriptor { EventType = MembershipChanged, Subject = Jdoe() },
             cancellationToken));
+    }
+
+    [Fact]
+    public async Task GatewayFrontedTransmitter_SuppressesWellKnown_AndServesTheDocumentOnItsOwnRoute()
+    {
+        // The deployment behind a rewriting proxy: the canonical well-known address is answered
+        // by the gateway, the application serves the same document on an internal route, and the
+        // document advertises the EXTERNAL prefix the proxy exposes.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSecurityEvents(options =>
+            options.SigningKeySource = _ => ValueTask.FromResult(_key));
+        builder.Services.AddSsfTransmitter(new SsfTransmitterOptions
+        {
+            Issuer = TransmitterIssuer,
+            EventsSupported = [MembershipChanged],
+        });
+        builder.Services.AddSingleton(new SsfEndpointOptions { ReceiverIdSelector = _ => ReceiverId });
+
+        await using var app = builder.Build();
+        app.MapSsfTransmitterEndpoints("/internal/ssf", mapWellKnownConfiguration: false);
+        app.MapSsfConfigurationDocument("/api/ssf", "/internal/ssf-config");
+        await app.StartAsync(cancellationToken);
+
+        var http = app.GetTestClient();
+
+        // The canonical address is deliberately silent here - the gateway in front owns it.
+        using var wellKnown = await http.GetAsync("/.well-known/ssf-configuration", cancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, wellKnown.StatusCode);
+
+        // The receiver's client reads the internal route through its explicit-address overload,
+        // and the identity check still binds the document to the issuer.
+        var metadata = await new TransmitterConfigurationClient(http).GetAsync(
+            new Uri(TransmitterIssuer),
+            new Uri($"{TransmitterIssuer}/internal/ssf-config"),
+            cancellationToken);
+
+        Assert.Equal(TransmitterIssuer, metadata.Issuer);
+        Assert.StartsWith(
+            $"{TransmitterIssuer}/api/ssf/",
+            metadata.ConfigurationEndpoint!.AbsoluteUri);
+
+        // The management surface itself answers where it was actually mapped.
+        using var streams = await http.GetAsync("/internal/ssf/stream", cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, streams.StatusCode);
     }
 
     private sealed record ManagementSurface(StreamManagementClient Client, StreamConfiguration Created);

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterConfigurationClientTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterConfigurationClientTests.cs
@@ -59,6 +59,50 @@ public class TransmitterConfigurationClientTests
     }
 
     [Fact]
+    public async Task GetFromExplicitAddress_FetchesThatAddress_AndStillReturnsTheMetadata()
+    {
+        // The overload for transmitters publishing the document off the well-known path: the
+        // address changes, nothing else does.
+        var handler = new StubHttpHandler().Enqueue(
+            HttpStatusCode.OK,
+            """
+            {
+                "issuer": "https://tr.example.com/issuer1",
+                "jwks_uri": "https://tr.example.com/issuer1/jwks.json"
+            }
+            """);
+        var client = new TransmitterConfigurationClient(handler.CreateClient());
+
+        var metadata = await client.GetAsync(
+            new Uri("https://tr.example.com/issuer1"),
+            new Uri("https://tr.example.com/internal/ssf-config"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            new Uri("https://tr.example.com/internal/ssf-config"),
+            Assert.Single(handler.Requests).Address);
+        Assert.Equal("https://tr.example.com/issuer1", metadata.Issuer);
+    }
+
+    [Fact]
+    public async Task GetFromExplicitAddress_DocumentAssertingAnotherIssuer_IsStillRefused()
+    {
+        // The address says where the bytes come from, never who they speak for: the issuer
+        // identity check binds this overload exactly as it binds the well-known one.
+        var handler = new StubHttpHandler().Enqueue(
+            HttpStatusCode.OK, """{"issuer": "https://tr.example.com/issuer2"}""");
+        var client = new TransmitterConfigurationClient(handler.CreateClient());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await client.GetAsync(
+                new Uri("https://tr.example.com/issuer1"),
+                new Uri("https://tr.example.com/internal/ssf-config"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("issuer2", exception.Message);
+    }
+
+    [Fact]
     public async Task Get_DocumentAssertingAnotherIssuer_IsRefused()
     {
         // Without the identity check, a document served on one issuer's well-known path could


### PR DESCRIPTION
The SSF configuration document's address is fixed by SSF 1.0 Section 7.2 and receivers derive it from the issuer, so it must never move - but the deployment in front of the application needs room. Two narrow options provide it without a rename knob:

- `MapSsfTransmitterEndpoints(prefix, mapWellKnownConfiguration: false)` leaves the canonical well-known route unmapped, for a host whose gateway or CDN answers that address itself.
- The new `MapSsfConfigurationDocument(advertisedPrefix, pattern)` serves the same document on an internal route a rewriting proxy maps the canonical address onto, advertising the external prefix rather than the internally mapped one. The external address never moves.
- On the receiver side, `TransmitterConfigurationClient` gains an explicit-address overload for transmitters that publish the document off the well-known path. The media-type and issuer identity checks bind it exactly as they bind the derived address: the address says where the bytes come from, never who they speak for.

Covered by two client unit tests (explicit fetch, identity refusal) and an end-to-end scenario: canonical address 404s, the internal route serves the document advertising the external prefix, the management surface answers where it was mapped, and the receiver's client reads it all through the shipped overload.
