### PR TITLE
Put the host-implemented seams on Task, keep ValueTask inside the validation pipeline

### DIFF
--- a/src/Abblix.SecurityEvents/Abstractions/IJtiReplayCache.cs
+++ b/src/Abblix.SecurityEvents/Abstractions/IJtiReplayCache.cs
@@ -56,7 +56,7 @@ public interface IJtiReplayCache
     /// <param name="cancellationToken">Cancels I/O a distributed implementation performs.</param>
     /// <returns>True when the identifier is new and now registered; false when it was seen before.
     /// </returns>
-    ValueTask<bool> TryRegisterAsync(
+    Task<bool> TryRegisterAsync(
         string issuer,
         string jwtId,
         DateTimeOffset issuedAt,

--- a/src/Abblix.SecurityEvents/Infrastructure/DefaultSecurityEventTokenSigner.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/DefaultSecurityEventTokenSigner.cs
@@ -38,7 +38,7 @@ namespace Abblix.SecurityEvents.Infrastructure;
 /// <param name="signingKeySource">Supplies the private key each signing uses.</param>
 public sealed class DefaultSecurityEventTokenSigner(
     IJsonWebTokenCreator creator,
-    Func<CancellationToken, ValueTask<JsonWebKey>> signingKeySource) : ISecurityEventTokenSigner
+    Func<CancellationToken, Task<JsonWebKey>> signingKeySource) : ISecurityEventTokenSigner
 {
     /// <inheritdoc />
     public async Task<string> SignAsync(SecurityEventToken token, CancellationToken cancellationToken = default)

--- a/src/Abblix.SecurityEvents/Infrastructure/DistributedJtiReplayCache.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/DistributedJtiReplayCache.cs
@@ -73,7 +73,7 @@ public sealed class DistributedJtiReplayCache(
         : retention;
 
     /// <inheritdoc />
-    public async ValueTask<bool> TryRegisterAsync(
+    public async Task<bool> TryRegisterAsync(
         string issuer,
         string jwtId,
         DateTimeOffset issuedAt,

--- a/src/Abblix.SecurityEvents/Infrastructure/SecurityEventsOptions.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/SecurityEventsOptions.cs
@@ -48,7 +48,7 @@ public sealed class SecurityEventsOptions
     /// and a pure receiver never does. Left null, resolving the signer fails loudly naming this
     /// property, instead of a transmitter discovering at first delivery that it signs nothing.
     /// </summary>
-    public Func<CancellationToken, ValueTask<JsonWebKey>>? SigningKeySource { get; set; }
+    public Func<CancellationToken, Task<JsonWebKey>>? SigningKeySource { get; set; }
 
     /// <summary>
     /// The reasons given for composing a validation pipeline without the default

--- a/src/Abblix.SecurityEvents/README.md
+++ b/src/Abblix.SecurityEvents/README.md
@@ -88,7 +88,7 @@ services.AddSecurityEvents(options =>
 {
     options.Events.Register<MembershipChangedPayload>(
         "https://tenant.example.com/events/membership-changed");
-    options.SigningKeySource = _ => ValueTask.FromResult(signingKey); // transmitters only
+    options.SigningKeySource = _ => Task.FromResult(signingKey); // transmitters only
 });
 services.AddJwksKeyResolution();      // receivers: issuers' keys from their published JWK Sets
 services.AddDistributedMemoryCache(); // or Redis: the replay cache rides the host's IDistributedCache

--- a/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
@@ -47,7 +47,7 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
     private readonly IDatabase _database = connection.GetDatabase();
 
     /// <inheritdoc />
-    public async ValueTask EnqueueAsync(
+    public async Task EnqueueAsync(
         string streamId,
         OutboxItem item,
         CancellationToken cancellationToken = default)
@@ -66,7 +66,7 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+    public async Task<IReadOnlyList<OutboxItem>> PendingAsync(
         string streamId,
         int? maxCount = null,
         CancellationToken cancellationToken = default)
@@ -102,7 +102,7 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
     }
 
     /// <inheritdoc />
-    public async ValueTask AcknowledgeAsync(
+    public async Task AcknowledgeAsync(
         string streamId,
         IReadOnlyCollection<string> jwtIds,
         CancellationToken cancellationToken = default)
@@ -125,7 +125,7 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
     }
 
     /// <inheritdoc />
-    public async ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default)
+    public async Task ClearAsync(string streamId, CancellationToken cancellationToken = default)
         => await _database.KeyDeleteAsync([QueueKeyOf(streamId), ItemsKeyOf(streamId)]);
 
     /// <summary>

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -30,7 +30,7 @@ dotnet add package Abblix.SecurityEvents.CAEP   # the samples below use the CAEP
 
 ```csharp
 builder.Services.AddSecurityEvents(options =>
-    options.SigningKeySource = _ => ValueTask.FromResult(signingKey));
+    options.SigningKeySource = _ => Task.FromResult(signingKey));
 
 builder.Services.AddSsfTransmitter(new SsfTransmitterOptions
 {

--- a/src/Abblix.SharedSignals/Receiver/ISecurityEventSink.cs
+++ b/src/Abblix.SharedSignals/Receiver/ISecurityEventSink.cs
@@ -54,7 +54,7 @@ public interface ISecurityEventSink
     /// <param name="cancellationToken">Cancels the processing.</param>
     /// <returns>Null to acknowledge the event, or the error the delivery response carries.
     /// </returns>
-    ValueTask<DeliveryError?> ConsumeAsync(
+    Task<DeliveryError?> ConsumeAsync(
         ValidatedSecurityEventToken token,
         CancellationToken cancellationToken = default);
 }

--- a/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
@@ -61,9 +61,9 @@ public sealed class ConfigurationStreamStore : IStreamStore
 
         foreach (var declared in streams)
         {
-            // The in-memory seed answers synchronously; AsTask keeps the wait an ordinary,
-            // rule-clean one for the constructor's single pass.
-            var created = _streams.TryCreateAsync(Materialize(options, declared)).AsTask();
+            // The in-memory seed answers synchronously, so the constructor's single-pass wait
+            // never blocks.
+            var created = _streams.TryCreateAsync(Materialize(options, declared));
             if (!created.GetAwaiter().GetResult())
             {
                 throw new InvalidOperationException(
@@ -74,32 +74,32 @@ public sealed class ConfigurationStreamStore : IStreamStore
     }
 
     /// <inheritdoc />
-    public ValueTask<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
+    public Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
         => _streams.TryCreateAsync(stream, cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<StreamState?> FindAsync(
+    public Task<StreamState?> FindAsync(
         string receiverId,
         string streamId,
         CancellationToken cancellationToken = default)
         => _streams.FindAsync(receiverId, streamId, cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<StreamState>> ListAsync(
+    public Task<IReadOnlyList<StreamState>> ListAsync(
         string receiverId,
         CancellationToken cancellationToken = default)
         => _streams.ListAsync(receiverId, cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
         => _streams.ListAllAsync(cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
+    public Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
         => _streams.UpdateAsync(stream, cancellationToken);
 
     /// <inheritdoc />
-    public ValueTask<bool> DeleteAsync(
+    public Task<bool> DeleteAsync(
         string receiverId,
         string streamId,
         CancellationToken cancellationToken = default)

--- a/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
@@ -55,7 +55,7 @@ public sealed class DistributedCacheEventOutbox(IDistributedCache cache) : IEven
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new();
 
     /// <inheritdoc />
-    public async ValueTask EnqueueAsync(
+    public async Task EnqueueAsync(
         string streamId,
         OutboxItem item,
         CancellationToken cancellationToken = default)
@@ -78,7 +78,7 @@ public sealed class DistributedCacheEventOutbox(IDistributedCache cache) : IEven
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+    public async Task<IReadOnlyList<OutboxItem>> PendingAsync(
         string streamId,
         int? maxCount = null,
         CancellationToken cancellationToken = default)
@@ -91,7 +91,7 @@ public sealed class DistributedCacheEventOutbox(IDistributedCache cache) : IEven
     }
 
     /// <inheritdoc />
-    public async ValueTask AcknowledgeAsync(
+    public async Task AcknowledgeAsync(
         string streamId,
         IReadOnlyCollection<string> jwtIds,
         CancellationToken cancellationToken = default)
@@ -121,7 +121,7 @@ public sealed class DistributedCacheEventOutbox(IDistributedCache cache) : IEven
     }
 
     /// <inheritdoc />
-    public async ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default)
+    public async Task ClearAsync(string streamId, CancellationToken cancellationToken = default)
         => await cache.RemoveAsync(CacheKeyPrefix + streamId, cancellationToken);
 
     /// <inheritdoc />

--- a/src/Abblix.SharedSignals/Transmitter/IEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IEventOutbox.cs
@@ -38,7 +38,7 @@ public interface IEventOutbox
     /// <param name="streamId">The stream the SET was minted for.</param>
     /// <param name="item">The minted SET.</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
-    ValueTask EnqueueAsync(string streamId, OutboxItem item, CancellationToken cancellationToken = default);
+    Task EnqueueAsync(string streamId, OutboxItem item, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Reads the unacknowledged head of a stream's queue, oldest first, without removing
@@ -49,7 +49,7 @@ public interface IEventOutbox
     /// The most items to return; null returns everything pending, mirroring an absent
     /// "maxEvents" (RFC 8936 Section 2.2).</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
-    ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+    Task<IReadOnlyList<OutboxItem>> PendingAsync(
         string streamId,
         int? maxCount = null,
         CancellationToken cancellationToken = default);
@@ -62,7 +62,7 @@ public interface IEventOutbox
     /// <param name="streamId">The stream whose queue is acknowledged.</param>
     /// <param name="jwtIds">The "jti" values being acknowledged.</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
-    ValueTask AcknowledgeAsync(
+    Task AcknowledgeAsync(
         string streamId,
         IReadOnlyCollection<string> jwtIds,
         CancellationToken cancellationToken = default);
@@ -73,5 +73,5 @@ public interface IEventOutbox
     /// </summary>
     /// <param name="streamId">The stream whose queue is dropped.</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
-    ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default);
+    Task ClearAsync(string streamId, CancellationToken cancellationToken = default);
 }

--- a/src/Abblix.SharedSignals/Transmitter/IEventSharingPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IEventSharingPolicy.cs
@@ -41,7 +41,7 @@ public interface IEventSharingPolicy
     /// <param name="cancellationToken">Cancels I/O the decision performs.</param>
     /// <returns>True to let the delivery proceed; false to withhold it, silently - a receiver
     /// learns nothing from what does not arrive (SSF 1.0 Section 9.2).</returns>
-    ValueTask<bool> IsSharingPermittedAsync(
+    Task<bool> IsSharingPermittedAsync(
         StreamState stream,
         SecurityEventDescriptor descriptor,
         CancellationToken cancellationToken = default);

--- a/src/Abblix.SharedSignals/Transmitter/IStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IStreamStore.cs
@@ -37,7 +37,7 @@ public interface IStreamStore
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
     /// <returns>True when stored; false when a stream with the same receiver and identifier
     /// already exists.</returns>
-    ValueTask<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default);
+    Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Finds one stream of one receiver.
@@ -47,7 +47,7 @@ public interface IStreamStore
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
     /// <returns>The stream's state, or null when no such stream exists for this receiver.
     /// </returns>
-    ValueTask<StreamState?> FindAsync(
+    Task<StreamState?> FindAsync(
         string receiverId,
         string streamId,
         CancellationToken cancellationToken = default);
@@ -58,7 +58,7 @@ public interface IStreamStore
     /// </summary>
     /// <param name="receiverId">The receiver whose streams are listed.</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
-    ValueTask<IReadOnlyList<StreamState>> ListAsync(
+    Task<IReadOnlyList<StreamState>> ListAsync(
         string receiverId,
         CancellationToken cancellationToken = default);
 
@@ -67,7 +67,7 @@ public interface IStreamStore
     /// against all streams at once.
     /// </summary>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
-    ValueTask<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Replaces a stream's state with a new snapshot, keyed by its receiver and identifier.
@@ -75,7 +75,7 @@ public interface IStreamStore
     /// <param name="stream">The new state.</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
     /// <returns>True when replaced; false when no such stream exists to replace.</returns>
-    ValueTask<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a stream (SSF 1.0 Section 8.1.1.5).
@@ -84,7 +84,7 @@ public interface IStreamStore
     /// <param name="streamId">The stream's identifier.</param>
     /// <param name="cancellationToken">Cancels I/O a durable implementation performs.</param>
     /// <returns>True when deleted; false when no such stream existed.</returns>
-    ValueTask<bool> DeleteAsync(
+    Task<bool> DeleteAsync(
         string receiverId,
         string streamId,
         CancellationToken cancellationToken = default);

--- a/src/Abblix.SharedSignals/Transmitter/InMemoryEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/InMemoryEventOutbox.cs
@@ -34,7 +34,7 @@ public sealed class InMemoryEventOutbox : IEventOutbox
     private readonly ConcurrentDictionary<string, List<OutboxItem>> _queues = new();
 
     /// <inheritdoc />
-    public ValueTask EnqueueAsync(
+    public Task EnqueueAsync(
         string streamId,
         OutboxItem item,
         CancellationToken cancellationToken = default)
@@ -48,18 +48,18 @@ public sealed class InMemoryEventOutbox : IEventOutbox
             queue.Add(item);
         }
 
-        return ValueTask.CompletedTask;
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+    public Task<IReadOnlyList<OutboxItem>> PendingAsync(
         string streamId,
         int? maxCount = null,
         CancellationToken cancellationToken = default)
     {
         if (!_queues.TryGetValue(streamId, out var queue))
         {
-            return ValueTask.FromResult<IReadOnlyList<OutboxItem>>([]);
+            return Task.FromResult<IReadOnlyList<OutboxItem>>([]);
         }
 
         lock (queue)
@@ -70,12 +70,12 @@ public sealed class InMemoryEventOutbox : IEventOutbox
                 head = head.Take(limit);
             }
 
-            return ValueTask.FromResult<IReadOnlyList<OutboxItem>>(head.ToArray());
+            return Task.FromResult<IReadOnlyList<OutboxItem>>(head.ToArray());
         }
     }
 
     /// <inheritdoc />
-    public ValueTask AcknowledgeAsync(
+    public Task AcknowledgeAsync(
         string streamId,
         IReadOnlyCollection<string> jwtIds,
         CancellationToken cancellationToken = default)
@@ -91,13 +91,13 @@ public sealed class InMemoryEventOutbox : IEventOutbox
             }
         }
 
-        return ValueTask.CompletedTask;
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
-    public ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default)
+    public Task ClearAsync(string streamId, CancellationToken cancellationToken = default)
     {
         _queues.TryRemove(streamId, out _);
-        return ValueTask.CompletedTask;
+        return Task.CompletedTask;
     }
 }

--- a/src/Abblix.SharedSignals/Transmitter/InMemoryStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/InMemoryStreamStore.cs
@@ -35,33 +35,33 @@ public sealed class InMemoryStreamStore : IStreamStore
     private readonly ConcurrentDictionary<(string ReceiverId, string StreamId), StreamState> _streams = new();
 
     /// <inheritdoc />
-    public ValueTask<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
+    public Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
 
-        return ValueTask.FromResult(_streams.TryAdd(KeyOf(stream), stream));
+        return Task.FromResult(_streams.TryAdd(KeyOf(stream), stream));
     }
 
     /// <inheritdoc />
-    public ValueTask<StreamState?> FindAsync(
+    public Task<StreamState?> FindAsync(
         string receiverId,
         string streamId,
         CancellationToken cancellationToken = default)
-        => ValueTask.FromResult(_streams.GetValueOrDefault((receiverId, streamId)));
+        => Task.FromResult(_streams.GetValueOrDefault((receiverId, streamId)));
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<StreamState>> ListAsync(
+    public Task<IReadOnlyList<StreamState>> ListAsync(
         string receiverId,
         CancellationToken cancellationToken = default)
-        => ValueTask.FromResult<IReadOnlyList<StreamState>>(
+        => Task.FromResult<IReadOnlyList<StreamState>>(
             _streams.Values.Where(stream => stream.ReceiverId == receiverId).ToArray());
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
-        => ValueTask.FromResult<IReadOnlyList<StreamState>>(_streams.Values.ToArray());
+    public Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<StreamState>>(_streams.Values.ToArray());
 
     /// <inheritdoc />
-    public ValueTask<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
+    public Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
 
@@ -71,19 +71,19 @@ public sealed class InMemoryStreamStore : IStreamStore
         {
             if (_streams.TryUpdate(KeyOf(stream), stream, existing))
             {
-                return ValueTask.FromResult(true);
+                return Task.FromResult(true);
             }
         }
 
-        return ValueTask.FromResult(false);
+        return Task.FromResult(false);
     }
 
     /// <inheritdoc />
-    public ValueTask<bool> DeleteAsync(
+    public Task<bool> DeleteAsync(
         string receiverId,
         string streamId,
         CancellationToken cancellationToken = default)
-        => ValueTask.FromResult(_streams.TryRemove((receiverId, streamId), out _));
+        => Task.FromResult(_streams.TryRemove((receiverId, streamId), out _));
 
     private static (string, string) KeyOf(StreamState stream) => (stream.ReceiverId, stream.StreamId);
 }

--- a/tests/Abblix.SecurityEvents.UnitTests/InfrastructureIntegrationTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/InfrastructureIntegrationTests.cs
@@ -102,7 +102,7 @@ public class InfrastructureIntegrationTests
         services.AddSingleton<IIssuerKeyResolver>(new FixedKeyResolver(verificationKey));
         services.AddSecurityEvents(options =>
         {
-            options.SigningKeySource = _ => ValueTask.FromResult(signingKey);
+            options.SigningKeySource = _ => Task.FromResult(signingKey);
         });
 
         return services.BuildServiceProvider();
@@ -192,7 +192,7 @@ public class InfrastructureIntegrationTests
         services.AddLogging();
         services.AddSingleton<TimeProvider>(new FakeTimeProvider(Now));
         services.AddSingleton<IIssuerKeyResolver>(new FixedKeyResolver());
-        services.AddSecurityEvents(options => options.SigningKeySource = _ => ValueTask.FromResult(key));
+        services.AddSecurityEvents(options => options.SigningKeySource = _ => Task.FromResult(key));
         await using var host = services.BuildServiceProvider();
 
         var compact = await SignedCompact(host);

--- a/tests/Abblix.SecurityEvents.UnitTests/TransmitterToReceiverScenarioTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/TransmitterToReceiverScenarioTests.cs
@@ -94,7 +94,7 @@ public class TransmitterToReceiverScenarioTests
         services.AddSingleton<IIssuerKeyResolver>(new FixedKeyResolver(key));
         services.AddSecurityEvents(options =>
         {
-            options.SigningKeySource = _ => ValueTask.FromResult(key);
+            options.SigningKeySource = _ => Task.FromResult(key);
             options.Events.Register<MembershipChangedPayload>(MembershipChanged);
         });
         services.AddDistributedMemoryCache();

--- a/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
@@ -232,7 +232,7 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddSecurityEvents(options =>
-            options.SigningKeySource = _ => ValueTask.FromResult(_key));
+            options.SigningKeySource = _ => Task.FromResult(_key));
         builder.Services.AddSsfTransmitter(new SsfTransmitterOptions
         {
             Issuer = TransmitterIssuer,
@@ -328,7 +328,7 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddSecurityEvents(options =>
-            options.SigningKeySource = _ => ValueTask.FromResult(_key));
+            options.SigningKeySource = _ => Task.FromResult(_key));
         builder.Services.AddSsfTransmitter(new SsfTransmitterOptions
         {
             Issuer = TransmitterIssuer,
@@ -378,12 +378,12 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
     {
         public List<ValidatedSecurityEventToken> Consumed { get; } = [];
 
-        public ValueTask<DeliveryError?> ConsumeAsync(
+        public Task<DeliveryError?> ConsumeAsync(
             ValidatedSecurityEventToken token,
             CancellationToken cancellationToken = default)
         {
             Consumed.Add(token);
-            return ValueTask.FromResult<DeliveryError?>(null);
+            return Task.FromResult<DeliveryError?>(null);
         }
     }
 

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
@@ -148,21 +148,21 @@ public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<
     /// </summary>
     private sealed class NeverCalledOutbox : IEventOutbox
     {
-        public ValueTask EnqueueAsync(
+        public Task EnqueueAsync(
             string streamId, OutboxItem item, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public ValueTask<IReadOnlyList<OutboxItem>> PendingAsync(
+        public Task<IReadOnlyList<OutboxItem>> PendingAsync(
             string streamId, int? maxCount = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public ValueTask AcknowledgeAsync(
+        public Task AcknowledgeAsync(
             string streamId,
             IReadOnlyCollection<string> jwtIds,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public ValueTask ClearAsync(string streamId, CancellationToken cancellationToken = default)
+        public Task ClearAsync(string streamId, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
     }
 }

--- a/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
@@ -57,11 +57,11 @@ public class EventDispatcherTests
 
     private sealed class DenyAllPolicy : IEventSharingPolicy
     {
-        public ValueTask<bool> IsSharingPermittedAsync(
+        public Task<bool> IsSharingPermittedAsync(
             StreamState stream,
             SecurityEventDescriptor descriptor,
             CancellationToken cancellationToken = default)
-            => ValueTask.FromResult(false);
+            => Task.FromResult(false);
     }
 
     private static StreamState CreateStream(

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliveryHandlerTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliveryHandlerTests.cs
@@ -66,12 +66,12 @@ public class PushDeliveryHandlerTests
     {
         public List<ValidatedSecurityEventToken> Consumed { get; } = [];
 
-        public ValueTask<DeliveryError?> ConsumeAsync(
+        public Task<DeliveryError?> ConsumeAsync(
             ValidatedSecurityEventToken token,
             CancellationToken cancellationToken = default)
         {
             Consumed.Add(token);
-            return ValueTask.FromResult(refusal);
+            return Task.FromResult(refusal);
         }
     }
 
@@ -79,12 +79,12 @@ public class PushDeliveryHandlerTests
     {
         private readonly HashSet<(string, string)> _seen = [];
 
-        public ValueTask<bool> TryRegisterAsync(
+        public Task<bool> TryRegisterAsync(
             string issuer,
             string jwtId,
             DateTimeOffset issuedAt,
             CancellationToken cancellationToken = default)
-            => ValueTask.FromResult(_seen.Add((issuer, jwtId)));
+            => Task.FromResult(_seen.Add((issuer, jwtId)));
     }
 
     [Fact]

--- a/tests/Abblix.SharedSignals.UnitTests/SsfServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SsfServiceCollectionTests.cs
@@ -135,10 +135,10 @@ public class SsfServiceCollectionTests
 
     private sealed class NullSink : ISecurityEventSink
     {
-        public ValueTask<DeliveryError?> ConsumeAsync(
+        public Task<DeliveryError?> ConsumeAsync(
             ValidatedSecurityEventToken token,
             CancellationToken cancellationToken = default)
-            => ValueTask.FromResult<DeliveryError?>(null);
+            => Task.FromResult<DeliveryError?>(null);
     }
 
     private sealed class FakeSigner : ISecurityEventTokenSigner


### PR DESCRIPTION
The dividing line is who implements the contract and what production does there. IStreamStore, IEventOutbox, IJtiReplayCache, ISecurityEventSink, IEventSharingPolicy and SigningKeySource are host-implemented seams whose production implementations - the Redis outbox, the distributed replay cache, database-backed sinks - always perform real I/O: ValueTask saves nothing there while its single-await restriction taxes implementors, and the sync implementations' boolean results ride the runtime's cached Task singletons for free. ISecurityEventTokenValidator deliberately stays on ValueTask: its steps are this package's own implementations, nine of ten complete synchronously on every deployment, and the composite awaits each exactly once. The old shape's friction disappears with it: the configuration store's constructor loses its AsTask bridge, and the Redis concurrency test feeds Task.WhenAll directly instead of through wrapper functions.