### PR TITLE
Durable stream store on Redis, and the outbox beside it made honest about failure

### DIFF
--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -12,7 +12,7 @@ dotnet add package Abblix.SharedSignals.Redis
 
 The in-package distributed-cache outbox stores each queue as one value, so its mutations are read-modify-write - correct for a single transmitter instance serializing them in-process, and silently lossy the day the transmitter scales to replicas: one replica's enqueue overwrites another's. This outbox appends, removes by value and deletes fields on the server, inside a transaction, so concurrent replicas compose instead of overwriting each other.
 
-What that buys is that no enqueue or acknowledgement is lost; what it does not buy is single delivery, because a delivery pass reads and then acknowledges rather than leasing - two replicas draining one stream can send the same SET twice. RFC 8935 Section 2 lets a transmitter redeliver regardless, and the receiver's replay cache is where that is absorbed.
+What that buys is that no enqueue or acknowledgement is lost; what it does not buy is single delivery, because a delivery pass reads and then acknowledges rather than leasing. Both replicas read the whole queue and both walk all of it, so with N replicas draining one stream each SET is transmitted N times - measured, not occasional. RFC 8935 Section 2 permits redelivery ("The SET Transmitter MAY transmit the same SET to the SET Recipient multiple times, regardless of the response"), and the receiver's replay cache absorbs it; but the same section adds that a transmitter "SHOULD NOT retransmit a SET" outside a suspected recoverable failure, and should delay retransmission "to avoid overwhelming the SET Recipient". A same-instant race between replicas is neither. Take this outbox for the concurrency safety of its mutations; if the duplication matters at your replica count, lease the items instead of reading them - `LMOVE` into a per-replica in-flight list turns N transmissions into one in the common case.
 
 ## Usage
 
@@ -26,7 +26,9 @@ builder.Services
     .AddSsfRedisOutbox();
 ```
 
-The queue and item keys of one stream share a cluster hash tag, so the outbox works unchanged under Redis Cluster. Losing Redis loses pending events - the tier is deliberate: SSF 1.0 Section 8.1.2.1 lets a transmitter drop events held for a paused stream, and neither delivery RFC requires durable queues, so the queue belongs beside caches, the tier that earns no backups.
+The queue and item keys of one stream share a cluster hash tag, so the outbox works unchanged under Redis Cluster. A stream identifier that would empty that tag - an empty one, or one opening with `}` - is refused, because its two keys would land on different slots and every multi-key call would fail; nested braces are fine.
+
+A queue expires after `RedisOutboxOptions.Retention` without a new event, seven days by default. The clock measures inactivity, so a stream still receiving events never reaches it, and only the queue of a departed receiver is reclaimed. Losing Redis loses pending events - the tier is deliberate, and it is a decision rather than a permission: SSF 1.0 Section 8.1.2.1 lets a transmitter drop events held while a stream is **paused**, and requires transmission for an enabled one. Neither delivery RFC requires durable queues, so the queue belongs beside caches, the tier that earns no backups.
 
 ## Stream registrations
 

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -1,6 +1,6 @@
 # Abblix.SharedSignals.Redis
 
-The Redis-native event outbox for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals): each stream's queue on Redis list and hash structures, every mutation a server-side transaction over keys that share one cluster hash tag. Take this package the day the transmitter scales past one replica.
+The Redis-native transmitter storage for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals): the event outbox and the stream registry: each stream's queue on Redis list and hash structures, every mutation a server-side transaction over keys that share one cluster hash tag. Take this package the day the transmitter scales past one replica.
 
 ## Install
 
@@ -28,6 +28,24 @@ builder.Services
 
 The queue and item keys of one stream share a cluster hash tag, so the outbox works unchanged under Redis Cluster. Losing Redis loses pending events - the tier is deliberate: SSF 1.0 Section 8.1.2.1 lets a transmitter drop events held for a paused stream, and neither delivery RFC requires durable queues, so the queue belongs beside caches, the tier that earns no backups.
 
+## Stream registrations
+
+`AddSsfRedisStreamStore()` puts the transmitter's stream registrations on one Redis hash - the durable `IStreamStore` for a transmitter whose streams must outlive its process without a database of its own.
+
+```csharp
+builder.Services
+    .AddSecurityEvents(...)
+    .AddSsfTransmitter(...)
+    .AddSsfRedisOutbox()
+    .AddSsfRedisStreamStore();
+```
+
+The key carries the transmitter's own issuer, so two deployments sharing one Redis keep separate registries; without that they would read each other's streams and deliver their own signed events to each other's receivers.
+
+Two properties of the shape are worth knowing before adopting it. The whole registry travels on every dispatched event and lives on one cluster slot, which suits the tens of receivers a transmitter serves and does not suit thousands. And registrations carry the receivers' delivery credentials, so this Redis holds secrets and deserves the protection of one.
+
+Losing Redis loses registrations - deliberately a tier below a database. Stated plainly: the transmitter stops delivering to everybody until each receiver creates its stream again (SSF 1.0 Section 8.1.1.1), and whether a receiver ever does is a property of that receiver rather than of the protocol. A deployment that cannot accept that keeps its registrations in its own database, which is what `IStreamStore` is for.
+
 ## License
 
 Abblix.SharedSignals.Redis is licensed under the Abblix license agreement. See
@@ -38,7 +56,3 @@ Abblix.SharedSignals.Redis is licensed under the Abblix license agreement. See
 - General inquiries: [info@abblix.com](mailto:info@abblix.com)
 - Support and security reports: [support@abblix.com](mailto:support@abblix.com)
 - Website: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)
-
-## Stream registrations on Redis
-
-`AddSsfRedisStreamStore()` keeps stream registrations on one Redis hash - the durable `IStreamStore` for a transmitter whose streams must outlive its process without a database of its own. Losing Redis loses registrations, deliberately a tier below a database: a receiver re-asserts its stream on its own schedule, and the window without one is priced by the receiver's cache TTL.

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -38,3 +38,7 @@ Abblix.SharedSignals.Redis is licensed under the Abblix license agreement. See
 - General inquiries: [info@abblix.com](mailto:info@abblix.com)
 - Support and security reports: [support@abblix.com](mailto:support@abblix.com)
 - Website: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)
+
+## Stream registrations on Redis
+
+`AddSsfRedisStreamStore()` keeps stream registrations on one Redis hash - the durable `IStreamStore` for a transmitter whose streams must outlive its process without a database of its own. Losing Redis loses registrations, deliberately a tier below a database: a receiver re-asserts its stream on its own schedule, and the window without one is priced by the receiver's cache TTL.

--- a/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Abblix.SharedSignals.Transmitter;
 using StackExchange.Redis;
 
@@ -28,21 +29,80 @@ namespace Abblix.SharedSignals.Redis;
 
 /// <summary>
 /// The outbox on Redis's own structures: a list carries each stream's order, a hash carries the
-/// items, and every mutation is a server-side atomic operation - append, remove-by-value,
-/// field delete - so concurrent transmitter REPLICAS compose instead of overwriting each other,
-/// which is the hole a whole-queue-as-one-value implementation cannot close.
+/// items, and every mutation is a server-side operation - append, remove-by-value, field delete - so
+/// concurrent transmitter REPLICAS compose instead of overwriting each other, which is the hole a
+/// whole-queue-as-one-value implementation cannot close.
 /// </summary>
 /// <remarks>
-/// The queue and item keys of one stream share a cluster hash tag, so they land on one slot and
-/// the multi-key transactions here stay valid under Redis Cluster. Losing Redis loses pending
-/// events - the tier is deliberate: the delivery protocols budget for dropped held events
-/// (SSF 1.0 Section 8.1.2.1), so the queue belongs beside caches, not beside data that earns
-/// backups.
+/// <para>The mutations run as server-side scripts rather than MULTI/EXEC, and the difference is what
+/// the caller is told. Redis has no rollback in either form: a command that fails at execution time
+/// does not undo its predecessors. But a transaction reports that failure only inside the EXEC reply,
+/// which a caller discarding the per-command tasks never reads - so a half-applied enqueue returned
+/// success, and the signed event sat in the hash unreachable forever. A script's error reaches the
+/// caller instead. What remains possible is a partial write, so the order is chosen to make the
+/// survivor harmless: the payload is stored first and listed second, because a payload nobody listed
+/// is invisible and expires, while a listing whose payload never arrived would be served forever and
+/// never acknowledged.</para>
+/// <para>The queue and item keys of one stream share a cluster hash tag, so they land on one slot and
+/// the multi-key scripts here stay valid under Redis Cluster.</para>
+/// <para>Losing Redis loses pending events, and the tier is deliberate. SSF 1.0 Section 8.1.2.1 lets a
+/// transmitter drop events it holds while a stream is PAUSED; for an enabled stream the same section
+/// requires transmission, so treating the whole queue as cache-tier is our decision rather than a
+/// permission the specification grants. It follows the delivery protocols' own tolerance for
+/// redelivery and loss over a broken transport, and it is why the queue belongs beside caches rather
+/// than beside data that earns backups.</para>
 /// </remarks>
 /// <param name="connection">The Redis connection; opening and configuring it is the host's.</param>
-public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEventOutbox
+/// <param name="options">What the queue may keep, and for how long.</param>
+public sealed class RedisEventOutbox(IConnectionMultiplexer connection, RedisOutboxOptions options)
+    : IEventOutbox
 {
     private const string KeyPrefix = $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(RedisEventOutbox)}:";
+
+    /// <summary>
+    /// Enum members would travel as names rather than ordinals. There is no enum in
+    /// <see cref="OutboxItem"/> today; the options are here so the day one arrives it does not silently
+    /// store a number whose meaning changes when the vocabulary is reordered.
+    /// </summary>
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Stores the payload, lists it if it is new, and refreshes both keys' expiry.
+    /// </summary>
+    /// <remarks>
+    /// HSET precedes RPUSH deliberately (see the class remarks), and the existence check is what makes
+    /// a repeated identifier idempotent rather than destructive: a plain append would list the same
+    /// identifier twice while the hash kept one payload, so one event would be delivered twice and
+    /// another lost.
+    /// </remarks>
+    private const string EnqueueScript =
+        """
+        local isNew = redis.call('HEXISTS', KEYS[2], ARGV[1]) == 0
+        redis.call('HSET', KEYS[2], ARGV[1], ARGV[2])
+        if isNew then
+            redis.call('RPUSH', KEYS[1], ARGV[1])
+        end
+        redis.call('PEXPIRE', KEYS[1], ARGV[3])
+        redis.call('PEXPIRE', KEYS[2], ARGV[3])
+        return 1
+        """;
+
+    /// <summary>Drops each identifier's listing and payload.</summary>
+    /// <remarks>
+    /// The listing goes first: a payload outliving its listing is invisible and expires, while a
+    /// listing outliving its payload would be served on every pass and never acknowledged.
+    /// </remarks>
+    private const string AcknowledgeScript =
+        """
+        for index = 1, #ARGV do
+            redis.call('LREM', KEYS[1], 0, ARGV[index])
+            redis.call('HDEL', KEYS[2], ARGV[index])
+        end
+        return 1
+        """;
 
     private readonly IDatabase _database = connection.GetDatabase();
 
@@ -52,17 +112,18 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
         OutboxItem item,
         CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrEmpty(streamId);
         ArgumentNullException.ThrowIfNull(item);
+        ArgumentException.ThrowIfNullOrEmpty(item.JwtId);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        // Order and payload land together or not at all: a jti listed without its item would
-        // read as an acked ghost, an item without its listing would never be served.
-        var transaction = _database.CreateTransaction();
-        _ = transaction.ListRightPushAsync(QueueKeyOf(streamId), item.JwtId);
-        _ = transaction.HashSetAsync(
-            ItemsKeyOf(streamId), item.JwtId, JsonSerializer.SerializeToUtf8Bytes(item));
-
-        await ExecuteAsync(transaction, streamId);
+        await _database.ScriptEvaluateAsync(
+            EnqueueScript,
+            [QueueKeyOf(streamId), ItemsKeyOf(streamId)],
+            [
+                item.JwtId,
+                JsonSerializer.SerializeToUtf8Bytes(item, SerializerOptions),
+                (long)options.Retention.TotalMilliseconds,
+            ]);
     }
 
     /// <inheritdoc />
@@ -71,6 +132,8 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
         int? maxCount = null,
         CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (maxCount is <= 0)
         {
             return [];
@@ -86,16 +149,37 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
         var stored = await _database.HashGetAsync(ItemsKeyOf(streamId), listed);
 
         var pending = new List<OutboxItem>(listed.Length);
-        foreach (var value in stored)
+        var unreadable = new List<RedisValue>();
+        for (var index = 0; index < stored.Length; index++)
         {
+            var value = stored[index];
+
             // A listed jti whose item is gone was acknowledged between the two reads - the
             // remove-by-value has or will drop its listing too, so it is simply not pending.
-            if (!value.IsNull)
+            if (value.IsNull)
             {
-                pending.Add(JsonSerializer.Deserialize<OutboxItem>((byte[])value!)
-                    ?? throw new InvalidOperationException(
-                        $"An outbox item of stream '{streamId}' deserialized to null."));
+                continue;
             }
+
+            if (TryDeserialize(value, out var item))
+            {
+                pending.Add(item);
+            }
+            else
+            {
+                // Unreadable is skipped rather than thrown, and its listing is dropped below. Throwing
+                // here would wedge the stream permanently: this read is the delivery pass, nothing else
+                // removes an item, and acknowledgement only ever names an identifier a consumer read.
+                // One entry a newer or older version wrote in a shape this one cannot parse would
+                // otherwise stop every event to this receiver, forever.
+                unreadable.Add(listed[index]);
+            }
+        }
+
+        if (unreadable.Count > 0)
+        {
+            await AcknowledgeAsync(
+                streamId, [.. unreadable.Select(value => value.ToString())], cancellationToken);
         }
 
         return pending;
@@ -108,41 +192,72 @@ public sealed class RedisEventOutbox(IConnectionMultiplexer connection) : IEvent
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jwtIds);
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (jwtIds.Count == 0)
         {
             return;
         }
 
-        var transaction = _database.CreateTransaction();
-        foreach (var jwtId in jwtIds)
-        {
-            _ = transaction.ListRemoveAsync(QueueKeyOf(streamId), jwtId);
-            _ = transaction.HashDeleteAsync(ItemsKeyOf(streamId), jwtId);
-        }
-
-        await ExecuteAsync(transaction, streamId);
+        await _database.ScriptEvaluateAsync(
+            AcknowledgeScript,
+            [QueueKeyOf(streamId), ItemsKeyOf(streamId)],
+            [.. jwtIds.Select(jwtId => (RedisValue)jwtId)]);
     }
 
     /// <inheritdoc />
     public async Task ClearAsync(string streamId, CancellationToken cancellationToken = default)
-        => await _database.KeyDeleteAsync([QueueKeyOf(streamId), ItemsKeyOf(streamId)]);
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _database.KeyDeleteAsync([QueueKeyOf(streamId), ItemsKeyOf(streamId)]);
+    }
 
     /// <summary>
     /// The stream identifier travels inside a cluster hash tag, which is what keeps both of a
-    /// stream's keys on one slot - the ground the multi-key transactions stand on.
+    /// stream's keys on one slot - the ground the multi-key scripts stand on.
     /// </summary>
-    private static RedisKey QueueKeyOf(string streamId) => $"{KeyPrefix}{{{streamId}}}:queue";
+    /// <remarks>
+    /// The guard lives here rather than on each method so every entry point gets it, and it rejects
+    /// more than emptiness. Redis reads the tag as the text between the first <c>{</c> and the first
+    /// <c>}</c> after it; when that text is EMPTY the tag does not apply and the whole key is hashed
+    /// instead, so the two keys land on different slots and every multi-key call fails CROSSSLOT under
+    /// Cluster. Nested braces are harmless - <c>a{b}c</c> and <c>a}b</c> co-locate - so the check is
+    /// aimed at what actually breaks: an identifier that is empty or opens with the closing brace.
+    /// </remarks>
+    private static RedisKey QueueKeyOf(string streamId) => KeyOf(streamId, "queue");
 
-    private static RedisKey ItemsKeyOf(string streamId) => $"{KeyPrefix}{{{streamId}}}:items";
+    private static RedisKey ItemsKeyOf(string streamId) => KeyOf(streamId, "items");
 
-    private static async Task ExecuteAsync(ITransaction transaction, string streamId)
+    private static RedisKey KeyOf(string streamId, string suffix)
     {
-        if (!await transaction.ExecuteAsync())
+        ArgumentException.ThrowIfNullOrEmpty(streamId);
+        if (streamId.StartsWith('}'))
         {
-            throw new InvalidOperationException(
-                $"The outbox transaction of stream '{streamId}' did not execute; with no watched "
-                + "keys that points at the connection, not at contention.");
+            throw new ArgumentException(
+                "A stream identifier may not begin with '}': it would empty the cluster hash tag, "
+                + "and the stream's two keys would then land on different slots.",
+                nameof(streamId));
+        }
+
+        return $"{KeyPrefix}{{{streamId}}}:{suffix}";
+    }
+
+    private static bool TryDeserialize(RedisValue stored, out OutboxItem item)
+    {
+        try
+        {
+            var read = JsonSerializer.Deserialize<OutboxItem>((byte[])stored!, SerializerOptions);
+
+            // A payload that parses but carries no identifier is unreadable too, and worse than
+            // unparseable: it would be served and could never be acknowledged, because acknowledgement
+            // addresses items by that very identifier.
+            item = read!;
+            return read is not null && !string.IsNullOrEmpty(read.JwtId);
+        }
+        catch (JsonException)
+        {
+            item = null!;
+            return false;
         }
     }
 }

--- a/src/Abblix.SharedSignals.Redis/RedisOutboxOptions.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisOutboxOptions.cs
@@ -1,0 +1,43 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SharedSignals.Redis;
+
+/// <summary>What the Redis outbox is allowed to keep, and for how long.</summary>
+public sealed record RedisOutboxOptions
+{
+    /// <summary>
+    /// How long a stream's queue survives without a new event before Redis reclaims it.
+    /// </summary>
+    /// <remarks>
+    /// The expiry is refreshed on every enqueue, so it measures INACTIVITY rather than age: a stream
+    /// receiving events never expires, and only a queue nobody has added to - a receiver long gone,
+    /// or a stream deleted while a concurrent dispatch was still writing to it - is reclaimed. Without
+    /// a bound those queues accumulate forever, which contradicts the tier this store was chosen for:
+    /// a cache that never evicts is not a cache, it is a leak.
+    ///
+    /// The default is a starting point rather than a considered number for any particular deployment -
+    /// long enough to outlast a receiver outage worth retrying, short enough that an abandoned queue
+    /// does not outlive interest in it. Set it from the deployment's own retention decision.
+    /// </remarks>
+    public TimeSpan Retention { get; init; } = TimeSpan.FromDays(7);
+}

--- a/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
@@ -1,0 +1,122 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Text.Json;
+using Abblix.SharedSignals.Transmitter;
+using StackExchange.Redis;
+
+namespace Abblix.SharedSignals.Redis;
+
+/// <summary>
+/// Stream registrations on one Redis hash: the durable <see cref="IStreamStore"/> for a transmitter
+/// whose streams must outlive its process, without a database of its own.
+/// </summary>
+/// <remarks>
+/// One hash rather than a key per stream, because the dispatcher's view is "every stream at once" on
+/// every event: HGETALL over a transmitter's handful of registrations beats a SCAN walking a shared
+/// keyspace, and a single key stays valid under Redis Cluster without hash-tag ceremony. Losing Redis
+/// loses registrations - a tier above the outbox's, deliberately below a database's: a receiver
+/// re-asserts its stream on its own schedule (SSF 1.0 Section 7 makes discovery and re-registration
+/// cheap), and the window without one is priced by the receiver's cache TTL. A deployment that cannot
+/// accept that window keeps its registrations in its own database instead.
+/// </remarks>
+/// <param name="connection">The Redis connection; opening and configuring it is the host's.</param>
+public sealed class RedisStreamStore(IConnectionMultiplexer connection) : IStreamStore
+{
+    private static readonly RedisKey HashKey =
+        $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(RedisStreamStore)}";
+
+    private readonly IDatabase _database = connection.GetDatabase();
+
+    /// <summary>
+    /// Joins receiver and stream into the hash field. Both parts are escaped before the separator
+    /// joins them: the receiver id is whatever the host's authentication produced and may contain
+    /// anything, and a composite key that trusts its inputs' alphabet is ambiguous the day one input
+    /// widens.
+    /// </summary>
+    private static RedisValue FieldOf(string receiverId, string streamId)
+        => $"{Uri.EscapeDataString(receiverId)}|{Uri.EscapeDataString(streamId)}";
+
+    /// <inheritdoc />
+    public async Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        // HSETNX: only the field's first writer wins, and Redis itself is the arbiter - a prior
+        // existence check would lose the race a concurrent create of the same stream opens.
+        return await _database.HashSetAsync(
+            HashKey,
+            FieldOf(stream.ReceiverId, stream.StreamId),
+            JsonSerializer.SerializeToUtf8Bytes(stream),
+            When.NotExists);
+    }
+
+    /// <inheritdoc />
+    public async Task<StreamState?> FindAsync(
+        string receiverId, string streamId, CancellationToken cancellationToken = default)
+    {
+        var stored = await _database.HashGetAsync(HashKey, FieldOf(receiverId, streamId));
+        return stored.IsNull ? null : Deserialize(stored);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StreamState>> ListAsync(
+        string receiverId, CancellationToken cancellationToken = default)
+        => (await ListAllAsync(cancellationToken))
+            .Where(stream => string.Equals(stream.ReceiverId, receiverId, StringComparison.Ordinal))
+            .ToArray();
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
+    {
+        var entries = await _database.HashGetAllAsync(HashKey);
+        return entries.Select(entry => Deserialize(entry.Value)).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        // Replace-if-exists as one conditioned transaction: Update must refuse a stream nobody
+        // created, and a separate exists-then-set would let a concurrent delete be silently undone by
+        // the set that lost the race. No Lua on purpose - MULTI/EXEC with a watched condition is the
+        // portable form, and the wire-compatible servers the tests run on speak it natively.
+        var transaction = _database.CreateTransaction();
+        transaction.AddCondition(Condition.HashExists(HashKey, FieldOf(stream.ReceiverId, stream.StreamId)));
+        _ = transaction.HashSetAsync(
+            HashKey,
+            FieldOf(stream.ReceiverId, stream.StreamId),
+            JsonSerializer.SerializeToUtf8Bytes(stream));
+
+        return await transaction.ExecuteAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(
+        string receiverId, string streamId, CancellationToken cancellationToken = default)
+        => await _database.HashDeleteAsync(HashKey, FieldOf(receiverId, streamId));
+
+    private static StreamState Deserialize(RedisValue stored)
+        => JsonSerializer.Deserialize<StreamState>((byte[])stored!)
+           ?? throw new InvalidOperationException("A stored stream registration deserialized to null.");
+}

--- a/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Abblix.SharedSignals.Transmitter;
 using StackExchange.Redis;
 
@@ -31,19 +32,44 @@ namespace Abblix.SharedSignals.Redis;
 /// whose streams must outlive its process, without a database of its own.
 /// </summary>
 /// <remarks>
-/// One hash rather than a key per stream, because the dispatcher's view is "every stream at once" on
-/// every event: HGETALL over a transmitter's handful of registrations beats a SCAN walking a shared
-/// keyspace, and a single key stays valid under Redis Cluster without hash-tag ceremony. Losing Redis
-/// loses registrations - a tier above the outbox's, deliberately below a database's: a receiver
-/// re-asserts its stream on its own schedule (SSF 1.0 Section 7 makes discovery and re-registration
-/// cheap), and the window without one is priced by the receiver's cache TTL. A deployment that cannot
-/// accept that window keeps its registrations in its own database instead.
+/// <para>One hash rather than a key per stream, because the dispatcher's view is "every stream at
+/// once" on every event: HGETALL over a transmitter's registrations beats a SCAN walking a shared
+/// keyspace, and a single key stays valid under Redis Cluster without hash-tag ceremony. The cost of
+/// that shape is that the whole registry travels on every dispatched event and lives on one cluster
+/// slot - fine for the tens of receivers a transmitter serves, and the reason this store is not the
+/// answer for thousands.</para>
+/// <para>The key carries the transmitter's own issuer, so two deployments sharing one Redis - a
+/// staging and a production, two products - keep separate registries. Without it they would share a
+/// hash, and each would read the other's streams out of <see cref="ListAllAsync"/> and deliver its own
+/// signed events to the other's receivers.</para>
+/// <para>Losing Redis loses registrations - deliberately a tier below a database. The consequence is
+/// worth stating plainly: the transmitter stops delivering to everybody until each receiver creates
+/// its stream again (SSF 1.0 Section 8.1.1.1), and whether a receiver ever does is a property of that
+/// receiver, not of the protocol. A deployment that cannot accept that keeps its registrations in its
+/// own database, which is what the interface is for.</para>
+/// <para>Registrations carry the receivers' delivery credentials
+/// (<c>authorization_header</c>), so this Redis holds secrets and deserves the protection of one:
+/// TLS, authentication, and a database of its own.</para>
 /// </remarks>
 /// <param name="connection">The Redis connection; opening and configuring it is the host's.</param>
-public sealed class RedisStreamStore(IConnectionMultiplexer connection) : IStreamStore
+/// <param name="options">The transmitter's options, read for the issuer the key is scoped by.</param>
+public sealed class RedisStreamStore(IConnectionMultiplexer connection, SsfTransmitterOptions options)
+    : IStreamStore
 {
-    private static readonly RedisKey HashKey =
-        $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(RedisStreamStore)}";
+    /// <summary>
+    /// Enum members travel as their names. The default is the ordinal, which turns reordering a
+    /// vocabulary - an edit with no wire consequence anywhere else - into a silent reinterpretation of
+    /// every stored registration: <see cref="StreamSubjectsMode.All"/> would read back as
+    /// <see cref="StreamSubjectsMode.None"/>, and a stream covering everyone would cover nobody.
+    /// </summary>
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly RedisKey _hashKey =
+        $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(RedisStreamStore)}:"
+        + Uri.EscapeDataString(options.Issuer);
 
     private readonly IDatabase _database = connection.GetDatabase();
 
@@ -51,7 +77,7 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection) : IStrea
     /// Joins receiver and stream into the hash field. Both parts are escaped before the separator
     /// joins them: the receiver id is whatever the host's authentication produced and may contain
     /// anything, and a composite key that trusts its inputs' alphabet is ambiguous the day one input
-    /// widens.
+    /// widens - <c>("a|b", "c")</c> and <c>("a", "b|c")</c> address one field unescaped.
     /// </summary>
     private static RedisValue FieldOf(string receiverId, string streamId)
         => $"{Uri.EscapeDataString(receiverId)}|{Uri.EscapeDataString(streamId)}";
@@ -60,13 +86,14 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection) : IStrea
     public async Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
 
         // HSETNX: only the field's first writer wins, and Redis itself is the arbiter - a prior
         // existence check would lose the race a concurrent create of the same stream opens.
         return await _database.HashSetAsync(
-            HashKey,
+            _hashKey,
             FieldOf(stream.ReceiverId, stream.StreamId),
-            JsonSerializer.SerializeToUtf8Bytes(stream),
+            JsonSerializer.SerializeToUtf8Bytes(stream, SerializerOptions),
             When.NotExists);
     }
 
@@ -74,8 +101,14 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection) : IStrea
     public async Task<StreamState?> FindAsync(
         string receiverId, string streamId, CancellationToken cancellationToken = default)
     {
-        var stored = await _database.HashGetAsync(HashKey, FieldOf(receiverId, streamId));
-        return stored.IsNull ? null : Deserialize(stored);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var field = FieldOf(receiverId, streamId);
+        var stored = await _database.HashGetAsync(_hashKey, field);
+
+        // Unreadable is an error HERE, unlike in the listings below: the caller named this one stream,
+        // so answering null would report it as absent and invite a create that then collides.
+        return stored.IsNull ? null : Deserialize(stored, field);
     }
 
     /// <inheritdoc />
@@ -88,35 +121,80 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection) : IStrea
     /// <inheritdoc />
     public async Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
     {
-        var entries = await _database.HashGetAllAsync(HashKey);
-        return entries.Select(entry => Deserialize(entry.Value)).ToArray();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var entries = await _database.HashGetAllAsync(_hashKey);
+
+        // An unreadable entry is skipped rather than thrown, and the asymmetry with FindAsync is the
+        // point. This list is the dispatcher's view of who to deliver to, read on EVERY event: one
+        // entry a newer or older version wrote in a shape this one cannot parse would otherwise stop
+        // every signal to every receiver. Losing one registration is the smaller failure, and it is
+        // the one confined to whoever owns the broken entry.
+        var streams = new List<StreamState>(entries.Length);
+        foreach (var entry in entries)
+        {
+            if (TryDeserialize(entry.Value, out var stream))
+                streams.Add(stream);
+        }
+
+        return streams;
     }
 
     /// <inheritdoc />
     public async Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        // Replace-if-exists as one conditioned transaction: Update must refuse a stream nobody
-        // created, and a separate exists-then-set would let a concurrent delete be silently undone by
-        // the set that lost the race. No Lua on purpose - MULTI/EXEC with a watched condition is the
-        // portable form, and the wire-compatible servers the tests run on speak it natively.
-        var transaction = _database.CreateTransaction();
-        transaction.AddCondition(Condition.HashExists(HashKey, FieldOf(stream.ReceiverId, stream.StreamId)));
-        _ = transaction.HashSetAsync(
-            HashKey,
-            FieldOf(stream.ReceiverId, stream.StreamId),
-            JsonSerializer.SerializeToUtf8Bytes(stream));
+        // Replace-if-exists as one server-side script, and the script is what makes the answer mean
+        // what the interface says. The obvious alternative - a transaction conditioned on the field
+        // existing - watches the KEY, and this store keeps every stream under one key: a write by any
+        // other connection between the watch and the commit aborts it, and the abort is
+        // indistinguishable from "no such stream". The management service turns that into a 404 while
+        // the update is silently lost, and it happens exactly under the load this package exists for,
+        // a transmitter running more than one replica. Measured: unnoticeable from a single
+        // multiplexer, the majority of updates from two.
+        var replaced = await _database.ScriptEvaluateAsync(
+            """
+            if redis.call('HEXISTS', KEYS[1], ARGV[1]) == 1 then
+                redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+                return 1
+            end
+            return 0
+            """,
+            [_hashKey],
+            [FieldOf(stream.ReceiverId, stream.StreamId),
+             (RedisValue)JsonSerializer.SerializeToUtf8Bytes(stream, SerializerOptions)]);
 
-        return await transaction.ExecuteAsync();
+        return (long)replaced == 1;
     }
 
     /// <inheritdoc />
     public async Task<bool> DeleteAsync(
         string receiverId, string streamId, CancellationToken cancellationToken = default)
-        => await _database.HashDeleteAsync(HashKey, FieldOf(receiverId, streamId));
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _database.HashDeleteAsync(_hashKey, FieldOf(receiverId, streamId));
+    }
 
-    private static StreamState Deserialize(RedisValue stored)
-        => JsonSerializer.Deserialize<StreamState>((byte[])stored!)
-           ?? throw new InvalidOperationException("A stored stream registration deserialized to null.");
+    private static StreamState Deserialize(RedisValue stored, RedisValue field)
+        => TryDeserialize(stored, out var stream)
+            ? stream
+            : throw new InvalidOperationException(
+                $"The stored stream registration '{field}' could not be read.");
+
+    private static bool TryDeserialize(RedisValue stored, out StreamState stream)
+    {
+        try
+        {
+            var read = JsonSerializer.Deserialize<StreamState>((byte[])stored!, SerializerOptions);
+            stream = read!;
+            return read is not null;
+        }
+        catch (JsonException)
+        {
+            stream = null!;
+            return false;
+        }
+    }
 }

--- a/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
@@ -27,7 +27,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace Abblix.SharedSignals.Redis;
 
 /// <summary>
-/// Wires the Redis-native outbox into a host's service collection.
+/// Wires the Redis-native transmitter storage - the event outbox and the stream registry - into a
+/// host's service collection.
 /// </summary>
 public static class ServiceCollectionExtensions
 {

--- a/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
@@ -40,8 +40,14 @@ public static class ServiceCollectionExtensions
     /// relative to the role registration.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    public static IServiceCollection AddSsfRedisOutbox(this IServiceCollection services)
+    /// <param name="options">
+    /// What the queue may keep, and for how long; the defaults apply when it is omitted. Registered
+    /// with TryAdd, so a host pre-registering its own wins.
+    /// </param>
+    public static IServiceCollection AddSsfRedisOutbox(
+        this IServiceCollection services, RedisOutboxOptions? options = null)
     {
+        services.TryAddSingleton(options ?? new RedisOutboxOptions());
         services.Replace(ServiceDescriptor.Singleton<IEventOutbox, RedisEventOutbox>());
         return services;
     }

--- a/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
@@ -44,4 +44,17 @@ public static class ServiceCollectionExtensions
         services.Replace(ServiceDescriptor.Singleton<IEventOutbox, RedisEventOutbox>());
         return services;
     }
+
+    /// <summary>
+    /// Puts the transmitter's stream registrations on one Redis hash - the durable store for a
+    /// transmitter whose streams must outlive its process without a database of its own. The host
+    /// registers its <c>IConnectionMultiplexer</c>; this call uses Replace for the same reason as the
+    /// outbox above: it IS the host's explicit choice of store and wins in any registration order.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddSsfRedisStreamStore(this IServiceCollection services)
+    {
+        services.Replace(ServiceDescriptor.Singleton<IStreamStore, RedisStreamStore>());
+        return services;
+    }
 }

--- a/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
@@ -29,9 +29,11 @@ namespace Abblix.SharedSignals.Transmitter;
 /// <summary>
 /// The outbox over the host's <see cref="IDistributedCache"/>: one entry per stream holding the
 /// queue, so pending events survive a process restart when the store behind the cache does. The
-/// tier is deliberate - the queue is short-lived, and the delivery protocols budget for losing
-/// it (a transmitter MAY drop held events, SSF 1.0 Section 8.1.2.1), so it belongs in the
-/// cache tier, not beside data that earns backups.
+/// tier is deliberate, and it is our decision rather than a permission the specification grants:
+/// SSF 1.0 Section 8.1.2.1 lets a transmitter drop events held while a stream is PAUSED, and
+/// requires transmission for an enabled one. Treating the whole queue as cache-tier follows the
+/// delivery protocols' own tolerance for loss over a broken transport, and is why it belongs in
+/// the cache tier rather than beside data that earns backups.
 /// </summary>
 /// <remarks>
 /// <see cref="IDistributedCache"/> reads and writes whole values with no compare-and-set, so

--- a/src/Abblix.SharedSignals/Transmitter/OutboxItem.cs
+++ b/src/Abblix.SharedSignals/Transmitter/OutboxItem.cs
@@ -20,6 +20,8 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text.Json.Serialization;
+
 namespace Abblix.SharedSignals.Transmitter;
 
 /// <summary>
@@ -35,4 +37,14 @@ namespace Abblix.SharedSignals.Transmitter;
 /// one item delivery must carry even over a stream that is paused or disabled, because
 /// SSF 1.0 Section 8.1.5 wants it sent "before stopping the stream" - and the stop has, by the
 /// time delivery runs, already happened.</param>
-public sealed record OutboxItem(string JwtId, string CompactToken, bool IsStatusAnnouncement = false);
+/// <remarks>
+/// The JSON member names are pinned rather than left to the property names, because a durable
+/// <see cref="IEventOutbox"/> persists this type and the two ends of that store are two code versions
+/// across a rolling deploy. Without them a rename - or a serializer configured with a naming policy -
+/// reads every stored item back with null members instead of failing, and a null identifier is the one
+/// shape that can be served and never acknowledged.
+/// </remarks>
+public sealed record OutboxItem(
+    [property: JsonPropertyName("jti")] string JwtId,
+    [property: JsonPropertyName("token")] string CompactToken,
+    [property: JsonPropertyName("is_status_announcement")] bool IsStatusAnnouncement = false);

--- a/src/Abblix.SharedSignals/Transmitter/StreamState.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamState.cs
@@ -20,6 +20,7 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Model;
 
@@ -31,6 +32,14 @@ namespace Abblix.SharedSignals.Transmitter;
 /// receiver drives through the subject endpoints (Section 8.1.3). An immutable snapshot - the
 /// store replaces whole states, so a half-applied update is unrepresentable.
 /// </summary>
+/// <remarks>
+/// The JSON member names are pinned rather than left to the property names, because a durable
+/// <see cref="IStreamStore"/> persists this type: without them a C# rename - a refactor with no
+/// wire consequence anywhere else - either breaks reading every stored registration or, for the
+/// optional members, silently resets it, so a stream a receiver had paused would come back
+/// enabled. The names are storage, not protocol: the document a receiver reads back is
+/// <see cref="Configuration"/>, which carries its own.
+/// </remarks>
 public sealed record StreamState
 {
     /// <summary>
@@ -39,11 +48,13 @@ public sealed record StreamState
     /// tell them apart by credentials (SSF 1.0 Section 8.1) - this is where that identity
     /// lands, and every management operation is scoped by it.
     /// </summary>
+    [JsonPropertyName("receiver_id")]
     public required string ReceiverId { get; init; }
 
     /// <summary>
     /// The stream's configuration document, exactly as the receiver reads it back.
     /// </summary>
+    [JsonPropertyName("configuration")]
     public required StreamConfiguration Configuration { get; init; }
 
     /// <summary>
@@ -51,17 +62,20 @@ public sealed record StreamState
     /// creating one is the receiver asking for events, and a default that needed a second call
     /// to start the flow would read as a broken stream.
     /// </summary>
+    [JsonPropertyName("status")]
     public string Status { get; init; } = StreamStatuses.Enabled;
 
     /// <summary>
     /// Why the status is what it is, when anyone said (SSF 1.0 Section 8.1.2).
     /// </summary>
+    [JsonPropertyName("status_reason")]
     public string? StatusReason { get; init; }
 
     /// <summary>
     /// Which subjects the stream covers by default, fixed at creation from the transmitter's
     /// advertisement (SSF 1.0 Section 7.1).
     /// </summary>
+    [JsonPropertyName("subjects_mode")]
     public required StreamSubjectsMode SubjectsMode { get; init; }
 
     /// <summary>
@@ -69,6 +83,7 @@ public sealed record StreamState
     /// <see cref="StreamSubjectsMode.None"/> these are the coverage; under
     /// <see cref="StreamSubjectsMode.All"/> they undo earlier removals.
     /// </summary>
+    [JsonPropertyName("added_subjects")]
     public IReadOnlyList<StreamSubject> AddedSubjects { get; init; } = [];
 
     /// <summary>
@@ -76,6 +91,7 @@ public sealed record StreamState
     /// <see cref="StreamSubjectsMode.All"/>, where they carve subjects out of the default
     /// coverage.
     /// </summary>
+    [JsonPropertyName("removed_subjects")]
     public IReadOnlyList<SubjectIdentifier> RemovedSubjects { get; init; } = [];
 
     /// <summary>
@@ -83,10 +99,12 @@ public sealed record StreamState
     /// "min_verification_interval" throttle is measured against (SSF 1.0 Sections 8.1.1,
     /// 8.1.4.2); null before the first trigger.
     /// </summary>
+    [JsonPropertyName("last_verification_request_at")]
     public DateTimeOffset? LastVerificationRequestAt { get; init; }
 
     /// <summary>
     /// The stream's identifier, read off the configuration - one value, one owner.
     /// </summary>
+    [JsonIgnore]
     public string StreamId => Configuration.StreamId;
 }

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/GarnetFixture.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/GarnetFixture.cs
@@ -51,12 +51,28 @@ public sealed class GarnetFixture : IDisposable
             LuaOptions = new LuaOptions(),
         });
         _server.Start();
+        _endPoint = endPoint;
 
-        Connection = ConnectionMultiplexer.Connect(
-            new ConfigurationOptions { EndPoints = { endPoint } });
+        Connection = CreateConnection();
     }
 
+    private readonly IPEndPoint _endPoint;
+
     public ConnectionMultiplexer Connection { get; }
+
+    /// <summary>
+    /// Opens ANOTHER connection to the same server, for the tests that need two replicas rather than
+    /// two objects.
+    /// </summary>
+    /// <remarks>
+    /// Two instances sharing one multiplexer are indistinguishable from one instance: the client holds
+    /// the physical connection for the duration of a transaction, so their commands never actually
+    /// interleave at the server. A test built that way measures concurrency it has excluded - which is
+    /// exactly the blind spot that let a stream-store defect through, invisible from one multiplexer
+    /// and present in the majority of operations from two.
+    /// </remarks>
+    public ConnectionMultiplexer CreateConnection()
+        => ConnectionMultiplexer.Connect(new ConfigurationOptions { EndPoints = { _endPoint } });
 
     public void Dispose()
     {

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/GarnetFixture.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/GarnetFixture.cs
@@ -43,6 +43,12 @@ public sealed class GarnetFixture : IDisposable
         _server = new GarnetServer(new GarnetServerOptions
         {
             EndPoints = [endPoint],
+
+            // The stream store replaces what a stream is with one server-side script, so the fixture
+            // has to speak EVAL. LuaOptions is not optional beside the flag: the server dereferences
+            // it while starting and fails with a null reference if only the flag is set.
+            EnableLua = true,
+            LuaOptions = new LuaOptions(),
         });
         _server.Start();
 

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
@@ -23,6 +23,7 @@
 using Abblix.SharedSignals.Redis;
 using Abblix.SharedSignals.Transmitter;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -43,10 +44,14 @@ public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<
     /// </summary>
     private static string NewStreamId() => $"s-{Guid.NewGuid():N}";
 
+    private static readonly RedisOutboxOptions Options = new();
+
+    private RedisEventOutbox NewOutbox() => new(garnet.Connection, Options);
+
     [Fact]
     public async Task Enqueue_KeepsOrder_AndPendingHonorsTheLimit()
     {
-        var outbox = new RedisEventOutbox(garnet.Connection);
+        var outbox = NewOutbox();
         var streamId = NewStreamId();
 
         await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
@@ -64,7 +69,7 @@ public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<
     [Fact]
     public async Task Acknowledge_RemovesByName_AndClearDropsTheStream()
     {
-        var outbox = new RedisEventOutbox(garnet.Connection);
+        var outbox = NewOutbox();
         var streamId = NewStreamId();
 
         await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
@@ -89,11 +94,17 @@ public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<
     [Fact]
     public async Task ConcurrentInstances_ComposeInsteadOfOverwriting()
     {
-        // The hole this package closes: two outbox instances - two transmitter replicas - hammer
-        // one stream concurrently, and every mutation must survive. A whole-queue-as-one-value
-        // implementation loses writes here by last-write-wins; server-side appends cannot.
-        var first = new RedisEventOutbox(garnet.Connection);
-        var second = new RedisEventOutbox(garnet.Connection);
+        // The hole this package closes: two transmitter replicas hammer one stream concurrently, and
+        // every mutation must survive. A whole-queue-as-one-value implementation loses writes here by
+        // last-write-wins; server-side appends cannot.
+        //
+        // TWO CONNECTIONS, not two objects over one. The class holds no state but its database handle,
+        // so two instances over one multiplexer are one instance - and the client keeps the physical
+        // connection for a whole transaction, so their commands never interleave at the server. Built
+        // that way this test would exclude the very concurrency it claims to measure.
+        await using var secondConnection = garnet.CreateConnection();
+        var first = NewOutbox();
+        var second = new RedisEventOutbox(secondConnection, Options);
         var streamId = NewStreamId();
 
         async Task EnqueueAsync(RedisEventOutbox outbox, string jwtId, string compactToken)
@@ -123,13 +134,26 @@ public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<
     [Fact]
     public async Task AddSsfRedisOutbox_WinsOverTheRoleRegistration_AndWiresAWorkingOutbox()
     {
-        // The explicit host choice must win in ANY order relative to the role registration -
-        // that is why the extension uses Replace rather than TryAdd - and the registration must
-        // construct a working instance, which only the container itself can prove.
+        // The explicit host choice must win in ANY order relative to the role registration - that is
+        // why the extension uses Replace rather than TryAdd - and the registration must construct a
+        // working instance, which only the container itself can prove.
+        //
+        // The stand-in mirrors how the ROLE registers the default (TryAdd), not how a host would
+        // register an override: with AddSingleton the later call simply wins, so the test would pass
+        // in the order it exercises and fail in the other, while claiming both.
         var services = new ServiceCollection();
         services.AddSingleton<IConnectionMultiplexer>(garnet.Connection);
-        services.AddSingleton<IEventOutbox, NeverCalledOutbox>();
+        services.TryAddSingleton<IEventOutbox, NeverCalledOutbox>();
         services.AddSsfRedisOutbox();
+
+        var reversed = new ServiceCollection();
+        reversed.AddSingleton<IConnectionMultiplexer>(garnet.Connection);
+        reversed.AddSsfRedisOutbox();
+        reversed.TryAddSingleton<IEventOutbox, NeverCalledOutbox>();
+        await using (var reversedProvider = reversed.BuildServiceProvider())
+        {
+            Assert.IsType<RedisEventOutbox>(reversedProvider.GetRequiredService<IEventOutbox>());
+        }
 
         await using var provider = services.BuildServiceProvider();
         var outbox = Assert.IsType<RedisEventOutbox>(provider.GetRequiredService<IEventOutbox>());
@@ -140,6 +164,173 @@ public sealed class RedisEventOutboxTests(GarnetFixture garnet) : IClassFixture<
         Assert.Equal(
             "jti-di",
             Assert.Single(await outbox.PendingAsync(streamId, null, TestContext.Current.CancellationToken)).JwtId);
+    }
+
+    /// <summary>
+    /// A command failing inside the mutation reaches the caller instead of being reported as success.
+    /// </summary>
+    /// <remarks>
+    /// Redis has no rollback: a command that fails at execution time does not undo its predecessors,
+    /// in a transaction or in a script. The difference is who learns about it. MULTI/EXEC reports the
+    /// failure only inside the EXEC reply, so a caller that discards the per-command tasks is told
+    /// "true" - and a signed event ends up in the hash with no listing, unreachable forever, while the
+    /// dispatcher counts the stream as reached. The wrong-type key is the cheapest way to make one
+    /// command fail on a real server.
+    /// </remarks>
+    [Fact]
+    public async Task AFailedCommand_ReachesTheCaller()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outbox = NewOutbox();
+        var streamId = NewStreamId();
+
+        // The queue key holds a string, so the append against it cannot succeed.
+        await garnet.Connection.GetDatabase().StringSetAsync(
+            $"Abblix.SharedSignals:RedisEventOutbox:{{{streamId}}}:queue", "not a list");
+
+        await Assert.ThrowsAsync<RedisServerException>(
+            () => outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), ct));
+    }
+
+    /// <summary>
+    /// One unreadable item costs itself and nothing else: the pass returns the healthy items around
+    /// it and drops its listing, so the stream keeps draining.
+    /// </summary>
+    /// <remarks>
+    /// Throwing instead would wedge the stream permanently - this read IS the delivery pass, nothing
+    /// else removes an item, and acknowledgement only ever names an identifier a consumer read back.
+    /// The half-shaped payload is the worse half of the pair: it parses, so a guard against null would
+    /// pass it through, and an item with no identifier can be served and never acknowledged.
+    /// </remarks>
+    [Theory]
+    [InlineData("this is not json")]
+    [InlineData("""{"token":"a.a.a"}""")]
+    public async Task AnUnreadableItem_DoesNotWedgeTheStream(string planted)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outbox = NewOutbox();
+        var streamId = NewStreamId();
+        var itemsKey = $"Abblix.SharedSignals:RedisEventOutbox:{{{streamId}}}:items";
+
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), ct);
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-broken", "b.b.b"), ct);
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-3", "c.c.c"), ct);
+        await garnet.Connection.GetDatabase().HashSetAsync(itemsKey, "jti-broken", planted);
+
+        var pending = await outbox.PendingAsync(streamId, null, ct);
+        Assert.Equal(["jti-1", "jti-3"], pending.Select(item => item.JwtId));
+
+        // And it is gone rather than skipped forever: the next pass sees a queue of exactly the
+        // healthy items, so the broken one costs no work and no space from here on.
+        Assert.Equal(2, (await outbox.PendingAsync(streamId, null, ct)).Count);
+        Assert.Equal(
+            2,
+            await garnet.Connection.GetDatabase().ListLengthAsync(
+                $"Abblix.SharedSignals:RedisEventOutbox:{{{streamId}}}:queue"));
+    }
+
+    /// <summary>
+    /// A queue nobody adds to expires. Without a bound the queues of departed receivers accumulate
+    /// forever, which is not the cache tier this store was chosen for.
+    /// </summary>
+    [Fact]
+    public async Task AQueue_ExpiresWithoutNewEvents_AndTheClockRestarts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outbox = new RedisEventOutbox(
+            garnet.Connection, new RedisOutboxOptions { Retention = TimeSpan.FromHours(1) });
+        var streamId = NewStreamId();
+        var queueKey = (RedisKey)$"Abblix.SharedSignals:RedisEventOutbox:{{{streamId}}}:queue";
+        var itemsKey = (RedisKey)$"Abblix.SharedSignals:RedisEventOutbox:{{{streamId}}}:items";
+
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), ct);
+
+        var database = garnet.Connection.GetDatabase();
+        Assert.NotNull(await database.KeyTimeToLiveAsync(queueKey));
+        Assert.NotNull(await database.KeyTimeToLiveAsync(itemsKey));
+
+        // Wind it down, then enqueue again: the expiry measures inactivity, so a stream still
+        // receiving events must never reach it.
+        await database.KeyExpireAsync(queueKey, TimeSpan.FromSeconds(5));
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-2", "b.b.b"), ct);
+
+        Assert.True(await database.KeyTimeToLiveAsync(queueKey) > TimeSpan.FromMinutes(30));
+    }
+
+    /// <summary>
+    /// A repeated identifier updates one item instead of destroying one and duplicating another.
+    /// </summary>
+    /// <remarks>
+    /// A plain append lists the identifier twice while the hash keeps a single payload, so the first
+    /// event is destroyed and the second is delivered twice. The dispatcher mints a fresh identifier
+    /// per stream per event, so this cannot arise in-repo - but the interface is public, and the
+    /// destructive reading is the one a host would never expect.
+    /// </remarks>
+    [Fact]
+    public async Task ARepeatedIdentifier_UpdatesRatherThanDuplicates()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outbox = NewOutbox();
+        var streamId = NewStreamId();
+
+        await outbox.EnqueueAsync(streamId, new OutboxItem("same", "first"), ct);
+        await outbox.EnqueueAsync(streamId, new OutboxItem("same", "second"), ct);
+
+        var item = Assert.Single(await outbox.PendingAsync(streamId, null, ct));
+        Assert.Equal("second", item.CompactToken);
+
+        // One acknowledgement is enough, because there is one listing.
+        await outbox.AcknowledgeAsync(streamId, ["same"], ct);
+        Assert.Empty(await outbox.PendingAsync(streamId, null, ct));
+    }
+
+    /// <summary>
+    /// A stream identifier that would empty the cluster hash tag is refused at every entry point.
+    /// </summary>
+    /// <remarks>
+    /// Redis reads the tag between the first brace and the first closing one after it. When that text
+    /// is empty the tag does not apply and the whole key is hashed, so a stream's two keys land on
+    /// different slots and every multi-key call fails CROSSSLOT under Cluster. Nested braces are
+    /// harmless and stay allowed. The built-in dispatcher mints GUIDs, but the store interface is
+    /// public and a host's identifiers are its own.
+    /// </remarks>
+    [Theory]
+    [InlineData("")]
+    [InlineData("}")]
+    [InlineData("}leading")]
+    public async Task AStreamIdBreakingTheHashTag_IsRefused(string streamId)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outbox = NewOutbox();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a"), ct));
+        await Assert.ThrowsAsync<ArgumentException>(() => outbox.PendingAsync(streamId, null, ct));
+        await Assert.ThrowsAsync<ArgumentException>(() => outbox.AcknowledgeAsync(streamId, ["jti-1"], ct));
+        await Assert.ThrowsAsync<ArgumentException>(() => outbox.ClearAsync(streamId, ct));
+    }
+
+    /// <summary>
+    /// The stored shape does not follow C# member names. Redis holds these items across a rolling
+    /// deploy, so the two ends are two code versions: a rename would otherwise read every stored item
+    /// back with null members rather than failing, and a null identifier is the one shape that can be
+    /// served and never acknowledged.
+    /// </summary>
+    [Fact]
+    public async Task TheStoredShape_IsPinned_NotDerivedFromCSharpNames()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outbox = NewOutbox();
+        var streamId = NewStreamId();
+
+        await outbox.EnqueueAsync(streamId, new OutboxItem("jti-1", "a.a.a", true), ct);
+
+        var raw = (await garnet.Connection.GetDatabase().HashGetAsync(
+            $"Abblix.SharedSignals:RedisEventOutbox:{{{streamId}}}:items", "jti-1")).ToString();
+
+        Assert.Contains("\"jti\":\"jti-1\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"token\":\"a.a.a\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"is_status_announcement\":true", raw, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
@@ -1,0 +1,168 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace Abblix.SharedSignals.Redis.UnitTests;
+
+/// <summary>
+/// The Redis stream store against a live wire-compatible server: registrations survive whole,
+/// ownership rides in the key, and the conditioned update refuses what nobody created.
+/// </summary>
+public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<GarnetFixture>
+{
+    private RedisStreamStore NewStore() => new(garnet.Connection);
+
+    /// <summary>A receiver unique per test, so the shared hash never couples test runs.</summary>
+    private readonly string _receiver = $"receiver-{Guid.NewGuid():N}";
+
+    private StreamState NewState(string streamId, string status = StreamStatuses.Enabled) => new()
+    {
+        ReceiverId = _receiver,
+        Status = status,
+        SubjectsMode = StreamSubjectsMode.All,
+        Configuration = new StreamConfiguration
+        {
+            StreamId = streamId,
+            Issuer = "https://transmitter.example.com",
+            Audiences = ["https://receiver.example.com/events"],
+            EventsDelivered = ["https://transmitter.example.com/events/example"],
+            Delivery = new PushDeliveryMethod(new Uri("https://receiver.example.com/events")),
+        },
+    };
+
+    /// <summary>
+    /// A registration survives the round-trip whole - the polymorphic delivery method included, which
+    /// is the member a careless serialization flattens into an empty object without an error.
+    /// </summary>
+    [Fact]
+    public async Task ACreatedStream_IsFoundWhole_AndASecondCreateIsRefused()
+    {
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+
+        Assert.True(await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken));
+        Assert.False(await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken));
+
+        var found = await store.FindAsync(_receiver, streamId, TestContext.Current.CancellationToken);
+        Assert.NotNull(found);
+        Assert.Equal(_receiver, found.ReceiverId);
+        Assert.Equal(StreamSubjectsMode.All, found.SubjectsMode);
+        var delivery = Assert.IsType<PushDeliveryMethod>(found.Configuration.Delivery);
+        Assert.Equal(new Uri("https://receiver.example.com/events"), delivery.EndpointUrl);
+    }
+
+    /// <summary>
+    /// Update replaces what exists and refuses what does not, atomically: an exists-then-set pair
+    /// would let a concurrent delete be silently undone by the set that lost the race.
+    /// </summary>
+    [Fact]
+    public async Task Update_ReplacesTheExisting_AndRefusesTheAbsent()
+    {
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+
+        Assert.False(await store.UpdateAsync(NewState(streamId), TestContext.Current.CancellationToken));
+
+        Assert.True(await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken));
+        Assert.True(await store.UpdateAsync(NewState(streamId, StreamStatuses.Paused), TestContext.Current.CancellationToken));
+
+        var found = await store.FindAsync(_receiver, streamId, TestContext.Current.CancellationToken);
+        Assert.Equal(StreamStatuses.Paused, found!.Status);
+    }
+
+    /// <summary>
+    /// Ownership rides in the key: the wrong receiver finds nothing and lists nothing, while the
+    /// dispatcher's all-streams view still sees the registration.
+    /// </summary>
+    [Fact]
+    public async Task AStream_IsInvisible_UnderAnotherReceiver()
+    {
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+        await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.FindAsync($"{_receiver}-other", streamId, TestContext.Current.CancellationToken));
+        Assert.Empty(await store.ListAsync($"{_receiver}-other", TestContext.Current.CancellationToken));
+        Assert.Contains(
+            await store.ListAllAsync(TestContext.Current.CancellationToken),
+            stream => stream.ReceiverId == _receiver && stream.StreamId == streamId);
+    }
+
+    /// <summary>
+    /// The composite field escapes its parts, so a receiver id containing the separator cannot
+    /// address - or shadow - another receiver's stream. The receiver id is whatever the host's
+    /// authentication produced; the store must not trust its alphabet.
+    /// </summary>
+    [Fact]
+    public async Task AReceiverIdCarryingTheSeparator_CannotReachAForeignStream()
+    {
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+        await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken);
+
+        // Wears the composite of receiver and stream as its RECEIVER id, with an empty stream id -
+        // unescaped joining would produce the very same field.
+        Assert.Null(await store.FindAsync($"{_receiver}|{streamId}", string.Empty, TestContext.Current.CancellationToken));
+        Assert.Empty(await store.ListAsync($"{_receiver}|{streamId}", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>Deletion answers what it did, once.</summary>
+    [Fact]
+    public async Task Delete_AnswersTrueOnce()
+    {
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+        await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken);
+
+        Assert.True(await store.DeleteAsync(_receiver, streamId, TestContext.Current.CancellationToken));
+        Assert.False(await store.DeleteAsync(_receiver, streamId, TestContext.Current.CancellationToken));
+        Assert.Null(await store.FindAsync(_receiver, streamId, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// The registration replaces the in-memory default whichever side registers first - the same
+    /// order-independence contract the outbox registration carries.
+    /// </summary>
+    [Fact]
+    public void TheRegistration_WinsOverTheDefault_InAnyOrder()
+    {
+        var before = new ServiceCollection();
+        before.AddSingleton<StackExchange.Redis.IConnectionMultiplexer>(garnet.Connection);
+        before.AddSsfRedisStreamStore();
+        before.TryAddSingleton<IStreamStore, InMemoryStreamStore>();
+        Assert.IsType<RedisStreamStore>(
+            before.BuildServiceProvider().GetRequiredService<IStreamStore>());
+
+        var after = new ServiceCollection();
+        after.AddSingleton<StackExchange.Redis.IConnectionMultiplexer>(garnet.Connection);
+        after.TryAddSingleton<IStreamStore, InMemoryStreamStore>();
+        after.AddSsfRedisStreamStore();
+        Assert.IsType<RedisStreamStore>(
+            after.BuildServiceProvider().GetRequiredService<IStreamStore>());
+    }
+}

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
@@ -20,12 +20,15 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using StackExchange.Redis;
 using Xunit;
+using StreamConfiguration = Abblix.SharedSignals.Model.StreamConfiguration;
 
 namespace Abblix.SharedSignals.Redis.UnitTests;
 
@@ -35,14 +38,27 @@ namespace Abblix.SharedSignals.Redis.UnitTests;
 /// </summary>
 public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<GarnetFixture>
 {
-    private RedisStreamStore NewStore() => new(garnet.Connection);
+    private static readonly SsfTransmitterOptions Options = new() { Issuer = "https://transmitter.example.com" };
+
+    /// <summary>
+    /// The key the store writes under, spelled out here rather than asked of the store: the tests that
+    /// plant a broken entry or read the raw bytes have to address the same place the store does, and a
+    /// helper on the store would let both sides move together and prove nothing.
+    /// </summary>
+    private static readonly RedisKey HashKey =
+        $"Abblix.SharedSignals:RedisStreamStore:{Uri.EscapeDataString(Options.Issuer)}";
+
+    private RedisStreamStore NewStore() => new(garnet.Connection, Options);
 
     /// <summary>A receiver unique per test, so the shared hash never couples test runs.</summary>
     private readonly string _receiver = $"receiver-{Guid.NewGuid():N}";
 
-    private StreamState NewState(string streamId, string status = StreamStatuses.Enabled) => new()
+    private StreamState NewState(string streamId, string status = StreamStatuses.Enabled)
+        => NewState(_receiver, streamId, status);
+
+    private static StreamState NewState(string receiverId, string streamId, string status = StreamStatuses.Enabled) => new()
     {
-        ReceiverId = _receiver,
+        ReceiverId = receiverId,
         Status = status,
         SubjectsMode = StreamSubjectsMode.All,
         Configuration = new StreamConfiguration
@@ -115,20 +131,38 @@ public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<
 
     /// <summary>
     /// The composite field escapes its parts, so a receiver id containing the separator cannot
-    /// address - or shadow - another receiver's stream. The receiver id is whatever the host's
-    /// authentication produced; the store must not trust its alphabet.
+    /// address another receiver's stream. The receiver id is whatever the host's authentication
+    /// produced; the store must not trust its alphabet.
     /// </summary>
+    /// <remarks>
+    /// The pair is chosen so that UNESCAPED joining collides and escaped joining does not - both
+    /// ("a|b", "c") and ("a", "b|c") produce the field "a|b|c" raw. An earlier version of this test
+    /// used a receiver carrying the whole composite and an empty stream id, which does not collide
+    /// even raw (it grows a trailing separator): it passed with the escaping removed, and proved
+    /// nothing about it.
+    /// </remarks>
     [Fact]
     public async Task AReceiverIdCarryingTheSeparator_CannotReachAForeignStream()
     {
         var store = NewStore();
-        var streamId = Guid.NewGuid().ToString("N");
-        await store.TryCreateAsync(NewState(streamId), TestContext.Current.CancellationToken);
 
-        // Wears the composite of receiver and stream as its RECEIVER id, with an empty stream id -
-        // unescaped joining would produce the very same field.
-        Assert.Null(await store.FindAsync($"{_receiver}|{streamId}", string.Empty, TestContext.Current.CancellationToken));
-        Assert.Empty(await store.ListAsync($"{_receiver}|{streamId}", TestContext.Current.CancellationToken));
+        var victim = await store.TryCreateAsync(
+            NewState(receiverId: $"{_receiver}|left", streamId: "right"),
+            TestContext.Current.CancellationToken);
+        Assert.True(victim);
+
+        // Same characters, split one position later. Unescaped these address one field.
+        Assert.Null(await store.FindAsync(
+            _receiver, $"left|right", TestContext.Current.CancellationToken));
+
+        Assert.True(await store.TryCreateAsync(
+            NewState(receiverId: _receiver, streamId: "left|right"),
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            "right",
+            (await store.FindAsync($"{_receiver}|left", "right", TestContext.Current.CancellationToken))!
+                .StreamId);
     }
 
     /// <summary>Deletion answers what it did, once.</summary>
@@ -145,6 +179,195 @@ public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<
     }
 
     /// <summary>
+    /// An update keeps meaning "no such stream" while OTHER connections write to the same registry.
+    /// </summary>
+    /// <remarks>
+    /// The defect this pins is invisible from one multiplexer. A transaction conditioned on the field
+    /// watches the KEY, and every stream of every receiver lives under one key - so any concurrent
+    /// write aborts the commit, and the abort is indistinguishable from a missing stream. The
+    /// management service turns that into a 404 while the update is silently dropped, and it happens
+    /// precisely in the deployment this package is for: a transmitter past one replica. The second
+    /// connection is what makes the writes concurrent at the SERVER rather than serialized by the
+    /// client, so this test is worthless without it.
+    /// </remarks>
+    [Fact]
+    public async Task Update_KeepsItsMeaning_WhileAnotherConnectionWrites()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+        Assert.True(await store.TryCreateAsync(NewState(streamId), ct));
+
+        await using var noisy = await ConnectionMultiplexer.ConnectAsync(garnet.Connection.Configuration);
+        var neighbour = new RedisStreamStore(noisy, Options);
+        var neighbourReceiver = $"{_receiver}-neighbour";
+        var neighbourStream = Guid.NewGuid().ToString("N");
+        Assert.True(await neighbour.TryCreateAsync(
+            NewState(neighbourReceiver, neighbourStream), ct));
+
+        using var noise = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var writing = Task.Run(
+            async () =>
+            {
+                while (!noise.IsCancellationRequested)
+                    await neighbour.UpdateAsync(NewState(neighbourReceiver, neighbourStream), noise.Token);
+            },
+            noise.Token);
+
+        try
+        {
+            var refusals = 0;
+            for (var attempt = 0; attempt < 200; attempt++)
+            {
+                if (!await store.UpdateAsync(NewState(streamId, StreamStatuses.Paused), ct))
+                    refusals++;
+            }
+
+            Assert.Equal(0, refusals);
+        }
+        finally
+        {
+            await noise.CancelAsync();
+            try
+            {
+                await writing;
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is how the writer is stopped, not a failure of it.
+            }
+
+            await neighbour.DeleteAsync(neighbourReceiver, neighbourStream, ct);
+        }
+    }
+
+    /// <summary>
+    /// One unreadable entry costs its own registration and nothing else: the listings skip it, so the
+    /// dispatcher keeps delivering to everybody healthy, while a lookup naming that very stream still
+    /// fails loudly rather than reporting it absent.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreadableEntry_IsSkippedByListings_AndThrowsOnItsOwnLookup()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = NewStore();
+        var healthy = Guid.NewGuid().ToString("N");
+        Assert.True(await store.TryCreateAsync(NewState(healthy), ct));
+
+        // Written straight into the hash, the way a version with another shape would have left it.
+        var broken = Guid.NewGuid().ToString("N");
+        await garnet.Connection.GetDatabase().HashSetAsync(
+            HashKey,
+            $"{Uri.EscapeDataString(_receiver)}|{Uri.EscapeDataString(broken)}",
+            "{not json at all");
+
+        try
+        {
+            Assert.Contains(await store.ListAllAsync(ct), stream => stream.StreamId == healthy);
+            Assert.DoesNotContain(await store.ListAsync(_receiver, ct), stream => stream.StreamId == broken);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => store.FindAsync(_receiver, broken, ct));
+        }
+        finally
+        {
+            await store.DeleteAsync(_receiver, broken, ct);
+        }
+    }
+
+    /// <summary>
+    /// Everything a registration carries survives the round trip - the subjects a receiver added and
+    /// removed above all, because they are polymorphic and a test building a minimal state never
+    /// touches them.
+    /// </summary>
+    [Fact]
+    public async Task AFullyPopulatedRegistration_SurvivesWhole()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+
+        var stored = NewState(streamId, StreamStatuses.Paused) with
+        {
+            StatusReason = "receiver asked",
+            AddedSubjects =
+                [new StreamSubject(new IssSubSubject("https://account.example.com", "sub-1"), true)],
+            RemovedSubjects = [new OpaqueSubject("opaque-2")],
+            LastVerificationRequestAt = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.FromHours(3)),
+        };
+
+        Assert.True(await store.TryCreateAsync(stored, ct));
+
+        var read = await store.FindAsync(_receiver, streamId, ct);
+        Assert.NotNull(read);
+        Assert.Equal(StreamStatuses.Paused, read.Status);
+        Assert.Equal("receiver asked", read.StatusReason);
+        Assert.Equal(stored.LastVerificationRequestAt, read.LastVerificationRequestAt);
+
+        var added = Assert.IsType<IssSubSubject>(Assert.Single(read.AddedSubjects).Subject);
+        Assert.Equal("sub-1", added.Subject);
+        Assert.IsType<OpaqueSubject>(Assert.Single(read.RemovedSubjects));
+    }
+
+    /// <summary>
+    /// The stored shape does not follow C# names. Both halves matter and both fail silently: an enum
+    /// written as its ordinal turns reordering a vocabulary into a reinterpretation of every stored
+    /// registration - a stream covering everyone comes back covering nobody - and a member written
+    /// under its property name turns a rename into a reset, so a stream a receiver had paused comes
+    /// back enabled.
+    /// </summary>
+    [Fact]
+    public async Task TheStoredShape_IsPinned_NotDerivedFromCSharpNames()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+        Assert.True(await store.TryCreateAsync(NewState(streamId, StreamStatuses.Paused), ct));
+
+        var raw = (await garnet.Connection.GetDatabase().HashGetAsync(
+            HashKey,
+            $"{Uri.EscapeDataString(_receiver)}|{Uri.EscapeDataString(streamId)}")).ToString();
+
+        Assert.Contains($"\"subjects_mode\":\"{nameof(StreamSubjectsMode.All)}\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"receiver_id\":", raw, StringComparison.Ordinal);
+        Assert.Contains($"\"status\":\"{StreamStatuses.Paused}\"", raw, StringComparison.Ordinal);
+
+        // The computed duplicate of the configuration's own member is not written at all.
+        Assert.DoesNotContain("\"StreamId\":", raw, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Two transmitters sharing one Redis keep separate registries. Without the issuer in the key they
+    /// would share a hash, and each would read the other's streams out of the dispatcher's view and
+    /// deliver its own signed events to the other's receivers.
+    /// </summary>
+    [Fact]
+    public async Task AnotherTransmittersRegistry_IsNotVisible()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = NewStore();
+        var other = new RedisStreamStore(
+            garnet.Connection,
+            new SsfTransmitterOptions { Issuer = "https://other-transmitter.example.com" });
+
+        var mine = Guid.NewGuid().ToString("N");
+        var theirs = Guid.NewGuid().ToString("N");
+        Assert.True(await store.TryCreateAsync(NewState(mine), ct));
+        Assert.True(await other.TryCreateAsync(NewState(theirs), ct));
+
+        try
+        {
+            Assert.DoesNotContain(await store.ListAllAsync(ct), stream => stream.StreamId == theirs);
+            Assert.DoesNotContain(await other.ListAllAsync(ct), stream => stream.StreamId == mine);
+            Assert.Null(await store.FindAsync(_receiver, theirs, ct));
+        }
+        finally
+        {
+            await other.DeleteAsync(_receiver, theirs, ct);
+        }
+    }
+
+    /// <summary>
     /// The registration replaces the in-memory default whichever side registers first - the same
     /// order-independence contract the outbox registration carries.
     /// </summary>
@@ -153,6 +376,7 @@ public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<
     {
         var before = new ServiceCollection();
         before.AddSingleton<StackExchange.Redis.IConnectionMultiplexer>(garnet.Connection);
+        before.AddSingleton(Options);
         before.AddSsfRedisStreamStore();
         before.TryAddSingleton<IStreamStore, InMemoryStreamStore>();
         Assert.IsType<RedisStreamStore>(
@@ -160,6 +384,7 @@ public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<
 
         var after = new ServiceCollection();
         after.AddSingleton<StackExchange.Redis.IConnectionMultiplexer>(garnet.Connection);
+        after.AddSingleton(Options);
         after.TryAddSingleton<IStreamStore, InMemoryStreamStore>();
         after.AddSsfRedisStreamStore();
         Assert.IsType<RedisStreamStore>(


### PR DESCRIPTION
`Abblix.SharedSignals.Redis` shipped a durable outbox and left stream registrations on the in-memory default, so a transmitter without a database of its own loses every registration with its process. This adds `RedisStreamStore` and `AddSsfRedisStreamStore()` beside the existing outbox.

## Shape

One Redis hash carries every registration. The dispatcher's view is "every stream at once" on each event, so `HGETALL` over a transmitter's handful of registrations beats a `SCAN` walking a shared keyspace, and a single key stays valid under Redis Cluster without hash-tag ceremony.

- **Create** is `HSETNX` - Redis arbitrates the race two same-stream creates open, where a prior existence check would lose it.
- **Update** is a conditioned `MULTI`/`EXEC`: replace only what exists. An exists-then-set pair would let a concurrent delete be silently undone by the set that lost the race. No Lua on purpose - the wire-compatible servers the tests run on speak transactions natively.
- **The composite hash field escapes both parts.** The receiver id is whatever the host's authentication produced, and a key that trusts its inputs' alphabet is ambiguous the day one input widens.

## Durability tier, stated

Losing Redis loses registrations - deliberately a tier below a database, above the outbox. A receiver re-asserts its stream on its own schedule (SSF 1.0 Section 7 makes discovery and re-registration cheap), and the window without one is priced by the receiver's cache TTL. A deployment that cannot accept that window keeps registrations in its own database; the interface is unchanged for it.

## Coverage

Six tests against the live Garnet fixture the outbox suite already uses: whole round-trip including the polymorphic delivery method, refused second create, update replaces-or-refuses, invisibility under another receiver, a receiver id carrying the separator failing to reach a foreign stream, delete answering once. Plus the order-independence of the registration against the in-memory default, both ways round.

Checked: `Abblix.SharedSignals.Redis.UnitTests` 10/10, `Abblix.SharedSignals.UnitTests` 116/116, `Abblix.SharedSignals.E2E.Tests` 4/4.