### PR TITLE
Cover the guard against a payload borrowed from another token

### DIFF
--- a/src/Abblix.SecurityEvents/EventsCollection.cs
+++ b/src/Abblix.SecurityEvents/EventsCollection.cs
@@ -116,7 +116,7 @@ public sealed class EventsCollection(JsonObject json) : IReadOnlyCollection<KeyV
 
         // Without this check the serializer throws its own "node already has a parent", which
         // names neither the event nor the way out.
-        if (payload?.Parent is not null)
+        if (payload is { Parent: not null })
         {
             throw new ArgumentException(
                 $"The payload for '{eventType}' is attached to another JSON tree - typically a "

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
@@ -141,6 +141,35 @@ public class SecurityEventTokenBuilderTests
     }
 
     [Fact]
+    public void WithEvent_PayloadTakenFromAnotherToken_IsRejected_NamingTheWayOut()
+    {
+        // Moving a node between JSON trees is what parsing a token and reusing its payload does. The
+        // serializer's own complaint names neither the event nor the remedy, so the collection refuses first.
+        var parsed = JsonNode.Parse("""{"events":{"https://example.com/events/other":{"a":1}}}""")!.AsObject();
+        var attached = parsed["events"]!["https://example.com/events/other"]!.AsObject();
+
+        var builder = MinimalValidBuilder();
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => builder.WithEvent("https://example.com/events/second", attached));
+
+        Assert.Contains(nameof(JsonNode.DeepClone), exception.Message);
+    }
+
+    [Fact]
+    public void WithEvent_PayloadOfItsOwn_IsAccepted()
+    {
+        // The other side of the same guard: a payload with no parent is the ordinary case, and a check written
+        // to reject "attached" must not reject "absent" along with it.
+        var token = MinimalValidBuilder()
+            .WithEvent("https://example.com/events/second", new JsonObject { ["a"] = 1 })
+            .Build();
+
+        Assert.True(token.Events!.TryGetPayload("https://example.com/events/second", out var payload));
+        Assert.Equal(1, payload["a"]!.GetValue<int>());
+    }
+
+    [Fact]
     public void WithEvent_WithoutPayload_WritesTheEmptyObject()
     {
         // "An event with no payload claims SHALL be represented as the empty JSON object"


### PR DESCRIPTION
test(securityevents): cover the guard against a payload borrowed from another token

Moving a JSON node between trees is what parsing a token and reusing its payload
does, and the serializer's own complaint names neither the event nor the remedy,
which is why EventsCollection refuses first. Nothing exercised that refusal, so
the branch shipped unexecuted and could have been deleted without a single test
noticing.

Both sides are covered now, because a check written to reject an attached payload
must not reject an absent one along with it: a borrowed payload is refused naming
DeepClone, and a payload of its own goes through.

The condition itself reads as one question - a payload that has a parent - rather
than as a null-conditional whose answer for null has to be worked out.
