### PR TITLE
Publish a name for every outbound HTTP client, and close two gaps in SSF push delivery

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Pin transitives too: a new transitive that is not declared in this file
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />

--- a/src/Abblix.Jwt.Azure/AzureKeyRingTransport.cs
+++ b/src/Abblix.Jwt.Azure/AzureKeyRingTransport.cs
@@ -1,0 +1,46 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Jwt.Azure;
+
+/// <summary>
+/// The HTTP transport the key ring's blob calls travel on.
+/// </summary>
+/// <remarks>
+/// Named rather than typed, because the store it serves takes a container client rather than an
+/// <see cref="HttpClient"/>. The custodian's own client needs no such name: it is typed, reached as
+/// <c>AddHttpClient&lt;KeyVaultClient&gt;()</c>.
+/// </remarks>
+public static class AzureKeyRingTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(AzureKeyRingTransport.HttpClientName)</c> reaches the same client the
+    /// ring resolves, and whatever it chains - a resilience pipeline, a proxy, a client certificate - applies to
+    /// every blob call.
+    /// </summary>
+    /// <remarks>
+    /// The credential authenticates over a transport of its own, so what a host chains here does not cover the
+    /// token requests.
+    /// </remarks>
+    public const string HttpClientName = "Abblix.Jwt.Azure.KeyRing";
+}

--- a/src/Abblix.Jwt.Azure/AzureKeyVaultTransport.cs
+++ b/src/Abblix.Jwt.Azure/AzureKeyVaultTransport.cs
@@ -1,0 +1,41 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Jwt.Azure;
+
+/// <summary>
+/// The HTTP transport the custodian's Key Vault calls travel on.
+/// </summary>
+public static class AzureKeyVaultTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(AzureKeyVaultTransport.HttpClientName)</c> reaches the same client the
+    /// custodian resolves.
+    /// </summary>
+    /// <remarks>
+    /// The value is the client type's name because this is a typed client, and that is the logical name
+    /// <c>AddHttpClient&lt;TClient&gt;</c> gives it. The credential authenticates over a transport of its own, so
+    /// what a host chains here does not cover the token requests.
+    /// </remarks>
+    public const string HttpClientName = nameof(KeyVaultClient);
+}

--- a/src/Abblix.Jwt.Azure/README.md
+++ b/src/Abblix.Jwt.Azure/README.md
@@ -98,14 +98,22 @@ Blank is an opt-in, and it looks identical to a typo: a misspelled configuration
 
 ### The HTTP pipeline
 
-Both transports come from the host's `IHttpClientFactory`, so retries, timeouts, a proxy or a client certificate are configured without copying a string. The vault client is a typed one; the key ring rides a named client whose name is published:
+Both transports come from the host's `IHttpClientFactory`, so retries, a circuit breaker, timeouts, a proxy or a client certificate are added with the standard APIs and nothing of ours.
+
+To make every outbound client of your application resilient, including these two, name none of them:
 
 ```csharp
-services.AddHttpClient<KeyVaultClient>().AddStandardResilienceHandler();
+services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
+```
+
+To configure one alone, name it. The vault client is typed; the key ring rides a named client:
+
+```csharp
+services.AddHttpClient(AzureKeyVaultTransport.HttpClientName).AddStandardResilienceHandler();
 services.AddHttpClient(AzureKeyRingTransport.HttpClientName).AddStandardResilienceHandler();
 ```
 
-Call either before or after the registration - `AddHttpClient` adds to the same client. Note that the credential authenticates over its own transport, so what you chain here does not cover the token requests.
+Either call goes before or after the registration; both reach the same client. Note that the credential authenticates over a transport of its own, so what you chain here does not cover the token requests.
 
 ## Rotation
 

--- a/src/Abblix.Jwt.Azure/README.md
+++ b/src/Abblix.Jwt.Azure/README.md
@@ -1,4 +1,4 @@
-# Abblix.Jwt.Azure
+﻿# Abblix.Jwt.Azure
 
 **Abblix.Jwt.Azure** lets any [Abblix.JWT](https://www.nuget.org/packages/Abblix.JWT) host - the [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) included, but equally a service that only signs tokens - sign and decrypt with keys protected by Azure Key Vault, in either of two postures. Hold the keys in the vault, so their private halves never enter your process and every signature is a Key Vault round-trip; or mint them in-process and seal each to a vault key, so signing stays local and only the sealed copies leave the process. Either way only public halves are published, and signature verification runs locally and never calls the vault. The Azure SDK is driven through the host's `IHttpClientFactory` pipeline, so it inherits your HTTP handlers, logging and connection policy. No provider private key crosses that pipeline; what does is the signing input, the wrapped keys, and the plaintext key an unwrap returns, which a handler on this pipeline can observe, so scope logging accordingly.
 
@@ -95,6 +95,17 @@ builder.Services
 When the tenant, client and secret are all set, the custodian authenticates with a client-secret credential. Leave all three blank to fall back to `DefaultAzureCredential`, which covers a managed identity in production, an Azure CLI sign-in during development, or the `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` environment variables.
 
 Blank is an opt-in, and it looks identical to a typo: a misspelled configuration key leaves the field empty and silently selects the credential chain instead of the service principal you meant. Prefer a managed identity and leave all three unset, or bind them from a source that fails when a key is missing. Source the secret from the environment or a secret store, never hardcode it; this package reads it at startup and neither logs nor persists it.
+
+### The HTTP pipeline
+
+Both transports come from the host's `IHttpClientFactory`, so retries, timeouts, a proxy or a client certificate are configured without copying a string. The vault client is a typed one; the key ring rides a named client whose name is published:
+
+```csharp
+services.AddHttpClient<KeyVaultClient>().AddStandardResilienceHandler();
+services.AddHttpClient(AzureKeyRingTransport.HttpClientName).AddStandardResilienceHandler();
+```
+
+Call either before or after the registration - `AddHttpClient` adds to the same client. Note that the credential authenticates over its own transport, so what you chain here does not cover the token requests.
 
 ## Rotation
 

--- a/src/Abblix.Jwt.Azure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Jwt.Azure/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -36,9 +36,6 @@ namespace Abblix.Jwt.Azure;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    /// <summary>Names the HTTP client the blob ring rides, so it shares the package's pipeline conventions.</summary>
-    private const string BlobRingClient = "Abblix.Jwt.Azure.KeyRing";
-
     /// <summary>
     /// Registers Azure Key Vault as the custodian of the host's keys and opens the placement choice that completes
     /// the wiring. This call is only the transport: it registers the vault client and its credential. Which keys
@@ -135,7 +132,7 @@ public static class ServiceCollectionExtensions
         // promises it, and without it the ring gets none of the host's handlers or logging, and no
         // PooledConnectionLifetime to recycle connections for DNS changes.
         services
-            .AddHttpClient(BlobRingClient)
+            .AddHttpClient(AzureKeyRingTransport.HttpClientName)
             .ConfigurePrimaryHttpMessageHandler(provider =>
             {
                 var options = provider.GetRequiredService<IOptions<AzureKeyVaultOptions>>();
@@ -155,7 +152,7 @@ public static class ServiceCollectionExtensions
             var credential = KeyVaultClient.BuildCredential(
                 provider.GetRequiredService<IOptions<AzureKeyVaultOptions>>().Value);
 
-            var httpClient = provider.GetRequiredService<IHttpClientFactory>().CreateClient(BlobRingClient);
+            var httpClient = provider.GetRequiredService<IHttpClientFactory>().CreateClient(AzureKeyRingTransport.HttpClientName);
             var options = new BlobClientOptions { Transport = new HttpClientTransport(httpClient) };
 
             var service = new BlobServiceClient(ring.ServiceUri, credential, options);

--- a/src/Abblix.Jwt.Vault/KeyValueStore.cs
+++ b/src/Abblix.Jwt.Vault/KeyValueStore.cs
@@ -48,7 +48,7 @@ internal sealed partial class KeyValueStore(
     : IKeyRingStore
 {
     /// <summary>The shared client, held for this singleton's lifetime; see the custodian for why it is by name.</summary>
-    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(Transport.ClientName);
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(VaultTransport.HttpClientName);
 
     private VaultKeyValueOptions Options => options.Value;
 

--- a/src/Abblix.Jwt.Vault/README.md
+++ b/src/Abblix.Jwt.Vault/README.md
@@ -113,6 +113,17 @@ The `Token` is presented as the `X-Vault-Token` header. Source it from the envir
 
 Reach Vault over TLS in every environment that is not a local dev container: the header is a bearer credential, and anyone who reads it off the wire can sign tokens as your provider until it expires. Vault's own `vault server -dev` mode issues a well-known root token and listens on plaintext `http://127.0.0.1:8200`; that combination suits a throwaway dev server and nothing else. In production, authenticate through AppRole or Kubernetes auth, mint a short-lived token, and scope it with the policy for the placement you chose above.
 
+### The HTTP pipeline
+
+Both engines share one named client from the host's `IHttpClientFactory`, and its name is published, so retries, timeouts, a proxy or a client certificate are configured without copying a string:
+
+```csharp
+services.AddHttpClient(VaultTransport.HttpClientName)
+    .AddStandardResilienceHandler();   // Microsoft.Extensions.Http.Resilience
+```
+
+Call it before or after `AddVaultCustodian` - `AddHttpClient` adds to the same client either way. What you chain applies to every Vault call the custodian and the key ring make.
+
 ## Rotation
 
 With `UseKeysInCustodian`, rotate in Transit:

--- a/src/Abblix.Jwt.Vault/README.md
+++ b/src/Abblix.Jwt.Vault/README.md
@@ -115,14 +115,22 @@ Reach Vault over TLS in every environment that is not a local dev container: the
 
 ### The HTTP pipeline
 
-Both engines share one named client from the host's `IHttpClientFactory`, and its name is published, so retries, timeouts, a proxy or a client certificate are configured without copying a string:
+Both engines share one client from the host's `IHttpClientFactory`, so retries, a circuit breaker, timeouts, a proxy or a client certificate are added with the standard APIs and nothing of ours.
+
+To make every outbound client of your application resilient, including this one, name none of them:
+
+```csharp
+services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
+```
+
+To configure this package's client alone - a longer retry for Vault than for anything else, say - name it:
 
 ```csharp
 services.AddHttpClient(VaultTransport.HttpClientName)
     .AddStandardResilienceHandler();   // Microsoft.Extensions.Http.Resilience
 ```
 
-Call it before or after `AddVaultCustodian` - `AddHttpClient` adds to the same client either way. What you chain applies to every Vault call the custodian and the key ring make.
+Either call goes before or after `AddVaultCustodian`; both reach the same client. What you chain applies to every Vault call the custodian and the key ring make, and to no other client.
 
 ## Rotation
 

--- a/src/Abblix.Jwt.Vault/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Jwt.Vault/ServiceCollectionExtensions.cs
@@ -116,7 +116,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddTransient<TokenHandler>();
 
-        services.AddHttpClient(Transport.ClientName, (provider, http) =>
+        services.AddHttpClient(VaultTransport.HttpClientName, (provider, http) =>
         {
             // The address stops at the server root: a mount belongs to an engine, and Transit and KV are on
             // different ones, so each spells its own into every path.

--- a/src/Abblix.Jwt.Vault/TransitCustodian.cs
+++ b/src/Abblix.Jwt.Vault/TransitCustodian.cs
@@ -50,7 +50,7 @@ internal sealed partial class TransitCustodian(
     /// The shared client, held for this singleton's lifetime. Resolved by name rather than injected, because the
     /// factory's own clients are transient and the key ring shares this one.
     /// </summary>
-    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(Transport.ClientName);
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(VaultTransport.HttpClientName);
 
     /// <summary>
     /// The Transit mount, spelled into every path. The client stops at <c>/v1/</c> because it is shared with the

--- a/src/Abblix.Jwt.Vault/VaultTransport.cs
+++ b/src/Abblix.Jwt.Vault/VaultTransport.cs
@@ -33,14 +33,25 @@ namespace Abblix.Jwt.Vault;
 /// token, so they resolve one named client from <see cref="IHttpClientFactory"/> and share its connection pool and
 /// the one place where the auth header, its redaction and the connection lifetime are settled. The send itself is a
 /// function over an <see cref="HttpClient"/>, with no state of its own, so it is an extension rather than a service.
+/// <para>
+/// The type is public for one member, <see cref="HttpClientName"/>: the transport is what a host configures, and
+/// its consumers are internal, so there is nowhere narrower to publish the name from. Everything else stays
+/// internal.
+/// </para>
 /// </remarks>
-internal static class Transport
+public static class VaultTransport
 {
     /// <summary>
-    /// The name the shared client is registered and resolved under. It is a name of its own rather than a typed
-    /// client of whichever engine came first, because both engines share it.
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(VaultTransport.HttpClientName)</c> reaches the same client both
+    /// engines resolve, and whatever it chains - a resilience pipeline, a proxy, a client certificate - applies to
+    /// every Vault call.
     /// </summary>
-    internal const string ClientName = "Abblix.Jwt.Vault";
+    /// <remarks>
+    /// It is a name of its own rather than a typed client of whichever engine came first, because both engines
+    /// share it.
+    /// </remarks>
+    public const string HttpClientName = "Abblix.Jwt.Vault";
 
     /// <summary>
     /// Sends a request and hands back what Vault answered, whatever the status. A failure status is not thrown on,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelNotificationTransport.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelNotificationTransport.cs
@@ -1,0 +1,48 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.BackChannelAuthentication;
+
+/// <summary>
+/// The HTTP transport CIBA ping and push notifications travel on, to the endpoint a client registered.
+/// </summary>
+public static class BackChannelNotificationTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(BackChannelNotificationTransport.HttpClientName)</c> reaches the same
+    /// client the delivery service resolves, and whatever it chains - a resilience pipeline, a proxy - applies to
+    /// every notification.
+    /// </summary>
+    /// <remarks>
+    /// Whatever a host chains runs OUTSIDE the SSRF validation, because that validation is the client's primary
+    /// handler and therefore the innermost one. So every attempt a resilience pipeline makes is validated afresh -
+    /// which is what the address of a client-supplied endpoint requires, since it can start resolving to an
+    /// internal one between attempts - and no ordering of the host's own calls can move the check out of the way.
+    /// <para>
+    /// The value is the delivery service's type name because that is what shipped, and a host already configuring
+    /// the client spells it literally. Changing it would break such a host in the one way nothing reports: the
+    /// configuration would bind to a client no longer resolved, leaving the build green and the pipeline gone.
+    /// </para>
+    /// </remarks>
+    public const string HttpClientName = nameof(HttpNotificationDeliveryService);
+}

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/HttpNotificationDeliveryService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/HttpNotificationDeliveryService.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -31,6 +31,12 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication;
 /// HTTP-based implementation of backchannel notification service for CIBA ping and push modes.
 /// Sends HTTP POST notifications to client endpoints with authentication request status updates or token delivery.
 /// </summary>
+/// <remarks>
+/// Delivery is a single attempt, deliberately: a notification is best-effort, and what a failed one costs is the
+/// client waiting out its own timeout rather than a lost protocol state. A deployment that wants more configures the
+/// named client - see <see cref="BackChannelNotificationTransport.HttpClientName"/> - and gets retries without this
+/// type holding any state.
+/// </remarks>
 /// <param name="logger">Logger for tracking notification attempts and failures.</param>
 /// <param name="httpClientFactory">Factory for creating HTTP clients.</param>
 public partial class HttpNotificationDeliveryService(
@@ -53,7 +59,7 @@ public partial class HttpNotificationDeliveryService(
     {
         try
         {
-            var httpClient = httpClientFactory.CreateClient(nameof(HttpNotificationDeliveryService));
+            var httpClient = httpClientFactory.CreateClient(BackChannelNotificationTransport.HttpClientName);
 
             var request = new HttpRequestMessage(HttpMethod.Post, clientNotificationEndpoint);
             request.AddBearerToken(clientNotificationToken);

--- a/src/Abblix.Oidc.Server/Features/LogoutNotification/BackChannelLogoutTransport.cs
+++ b/src/Abblix.Oidc.Server/Features/LogoutNotification/BackChannelLogoutTransport.cs
@@ -1,0 +1,41 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.LogoutNotification;
+
+/// <summary>
+/// The HTTP transport back-channel logout tokens travel on, to the URI a client registered.
+/// </summary>
+public static class BackChannelLogoutTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(BackChannelLogoutTransport.HttpClientName)</c> reaches the same client
+    /// the sender resolves.
+    /// </summary>
+    /// <remarks>
+    /// The value is the contract's name because this is a typed client, and that is the logical name
+    /// <c>AddHttpClient&lt;TClient, TImplementation&gt;</c> gives it. Reference the constant rather than spelling
+    /// that rule out at every call site.
+    /// </remarks>
+    public const string HttpClientName = nameof(ILogoutTokenSender);
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureFetchTransport.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureFetchTransport.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+/// <summary>
+/// The HTTP transport the server's metadata fetches travel on: a client's key set, a request object behind a
+/// "request_uri", a software statement's issuer keys.
+/// </summary>
+public static class SecureFetchTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(SecureFetchTransport.HttpClientName)</c> reaches the same client the
+    /// fetcher resolves.
+    /// </summary>
+    /// <remarks>
+    /// The value is the contract's name because this is a typed client, and that is the logical name
+    /// <c>AddHttpClient&lt;TClient, TImplementation&gt;</c> gives it. Whatever a host chains runs outside the SSRF
+    /// validation, which is this client's primary handler, so every retried attempt is validated afresh.
+    /// </remarks>
+    public const string HttpClientName = nameof(ISecureHttpFetcher);
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
@@ -99,18 +99,18 @@ public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISec
     /// Checks if a hostname appears to be internal or non-public.
     /// </summary>
     /// <remarks>
-    /// The rules live in <see cref="InternalNetworkAddresses"/>, where every package that must refuse an internal
+    /// The rules live in <see cref="PrivateNetworks"/>, where every package that must refuse an internal
     /// address reads them, so a name added there takes effect here too.
     /// </remarks>
     public static bool IsInternalHostname(string hostname)
-        => InternalNetworkAddresses.IsInternalHostname(hostname);
+        => PrivateNetworks.IsInternalHostname(hostname);
 
     /// <summary>
     /// Checks if an IP address is private, loopback, link-local, or otherwise reserved.
     /// </summary>
     /// <remarks>
-    /// Delegates to <see cref="InternalNetworkAddresses"/> for the same reason as the hostname rules above.
+    /// Delegates to <see cref="PrivateNetworks"/> for the same reason as the hostname rules above.
     /// </remarks>
     public static bool IsPrivateOrReservedAddress(IPAddress address)
-        => InternalNetworkAddresses.IsPrivateOrReserved(address);
+        => PrivateNetworks.IsPrivateOrReserved(address);
 }

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -21,7 +21,7 @@
 // info@abblix.com
 
 using System.Net;
-using System.Net.Sockets;
+using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
@@ -32,35 +32,6 @@ namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
 /// </summary>
 public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISecureUriValidator
 {
-    /// <summary>
-    /// Common hostnames that typically resolve to internal/private networks.
-    /// </summary>
-    private static readonly string[] BlockedHostnames = [
-        "localhost",
-        "loopback",
-        "broadcasthost",
-        "local",
-        "internal",
-        "intranet",
-        "private",
-        "corp",
-        "home",
-        "lan"
-    ];
-
-    /// <summary>
-    /// Top-level domains (TLDs) commonly used for internal networks.
-    /// </summary>
-    private static readonly string[] BlockedTlds = [
-        ".local",
-        ".localhost",
-        ".internal",
-        ".intranet",
-        ".corp",
-        ".home",
-        ".lan"
-    ];
-
     /// <summary>
     /// Reports whether a URI is one of the destinations named in
     /// <see cref="SecureHttpFetchOptions.AllowedDestinations"/>.
@@ -127,74 +98,19 @@ public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISec
     /// <summary>
     /// Checks if a hostname appears to be internal or non-public.
     /// </summary>
+    /// <remarks>
+    /// The rules live in <see cref="InternalNetworkAddresses"/>, where every package that must refuse an internal
+    /// address reads them, so a name added there takes effect here too.
+    /// </remarks>
     public static bool IsInternalHostname(string hostname)
-    {
-        // Normalize to lowercase for comparison
-        var normalizedHost = hostname.ToLowerInvariant();
-
-        // Block common internal hostnames
-        if (BlockedHostnames.Contains(normalizedHost))
-            return true;
-
-        // Block hostnames that end with common internal TLDs
-        if (BlockedTlds.Any(normalizedHost.EndsWith))
-            return true;
-
-        // Block single-label hostnames (no dots) as they're typically internal
-        // Exception: Allow if it's a valid IP address
-        if (!normalizedHost.Contains('.') && !IPAddress.TryParse(normalizedHost, out _))
-            return true;
-
-        return false;
-    }
+        => InternalNetworkAddresses.IsInternalHostname(hostname);
 
     /// <summary>
     /// Checks if an IP address is private, loopback, link-local, or otherwise reserved.
     /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="InternalNetworkAddresses"/> for the same reason as the hostname rules above.
+    /// </remarks>
     public static bool IsPrivateOrReservedAddress(IPAddress address)
-    {
-        // Collapse an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1 / ::ffff:169.254.169.254) to its IPv4 form
-        // FIRST - RFC 4291 §2.5.5 - so every rule below, including the loopback check, inspects the embedded IPv4
-        // address. Without this an attacker reaches loopback, cloud metadata or private ranges through the IPv6 arm,
-        // which never inspects the embedded IPv4 address.
-        if (address.IsIPv4MappedToIPv6)
-            address = address.MapToIPv4();
-
-        // Loopback addresses (127.0.0.0/8 for IPv4, ::1 for IPv6)
-        if (IPAddress.IsLoopback(address))
-            return true;
-
-        var bytes = address.GetAddressBytes();
-
-        return address.AddressFamily switch
-        {
-            AddressFamily.InterNetwork =>
-                // "This host on this network": 0.0.0.0/8 (0.0.0.0 routes to loopback on Linux)
-                bytes[0] == 0 ||
-                // Private: 10.0.0.0/8
-                bytes[0] == 10 ||
-                // Carrier-grade NAT shared space: 100.64.0.0/10 (RFC 6598)
-                (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
-                // Private: 172.16.0.0/12
-                (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
-                // Private: 192.168.0.0/16
-                (bytes[0] == 192 && bytes[1] == 168) ||
-                // Link-local: 169.254.0.0/16 (AWS/Azure metadata)
-                (bytes[0] == 169 && bytes[1] == 254) ||
-                // Multicast: 224.0.0.0/4
-                bytes[0] >= 224,
-
-            AddressFamily.InterNetworkV6 =>
-                // Unspecified address: ::
-                address.Equals(IPAddress.IPv6Any) ||
-                // Link-local: fe80::/10
-                (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80) ||
-                // Unique local: fc00::/7
-                (bytes[0] & 0xfe) == 0xfc ||
-                // Multicast: ff00::/8
-                bytes[0] == 0xff,
-
-            _ => true,
-        };
-    }
+        => InternalNetworkAddresses.IsPrivateOrReserved(address);
 }

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SecureUriValidator.cs
@@ -99,11 +99,12 @@ public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISec
     /// Checks if a hostname appears to be internal or non-public.
     /// </summary>
     /// <remarks>
-    /// The rules live in <see cref="PrivateNetworks"/>, where every package that must refuse an internal
-    /// address reads them, so a name added there takes effect here too.
+    /// The rules live in <see cref="PrivateNetworks"/>, where every package that must refuse such an address
+    /// reads them, so a name added there takes effect here too. The wording of this member is kept as shipped:
+    /// it is public, and a rename would break a host that calls it for nothing but a synonym.
     /// </remarks>
     public static bool IsInternalHostname(string hostname)
-        => PrivateNetworks.IsInternalHostname(hostname);
+        => PrivateNetworks.IsPrivateHostname(hostname);
 
     /// <summary>
     /// Checks if an IP address is private, loopback, link-local, or otherwise reserved.
@@ -112,5 +113,5 @@ public class SecureUriValidator(IOptions<SecureHttpFetchOptions> options) : ISec
     /// Delegates to <see cref="PrivateNetworks"/> for the same reason as the hostname rules above.
     /// </remarks>
     public static bool IsPrivateOrReservedAddress(IPAddress address)
-        => PrivateNetworks.IsPrivateOrReserved(address);
+        => PrivateNetworks.IsPrivateOrReservedAddress(address);
 }

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfGuardWatch.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfGuardWatch.Logging.cs
@@ -1,0 +1,37 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+partial class SsrfGuardWatch
+{
+    [LoggerMessage(
+        EventId = LogEvents.HttpFetch.SsrfGuardWatch.ValidationReplaced,
+        Level = LogLevel.Warning,
+        Message = "HTTP client '{ClientName}' was registered with SSRF address validation, and its primary handler "
+            + "is now {PrimaryHandler}. Requests on this client address a URI supplied by an OAuth client, and that "
+            + "address is no longer validated before each attempt. Configure the handler the validation wraps "
+            + "instead of replacing it, or silence this message by its own log category if the change was intended.")]
+    private partial void LogValidationReplaced(string clientName, string primaryHandler);
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfGuardWatch.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfGuardWatch.cs
@@ -1,0 +1,63 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+/// <summary>
+/// Reports, once per handler build, a client that was registered with SSRF validation and no longer has it.
+/// </summary>
+/// <remarks>
+/// The validation is a client's primary handler, so a host that sets its own primary handler on such a client
+/// replaces it. That call is the ordinary way to configure a proxy, a client certificate or connection pooling,
+/// which is exactly why the substitution deserves to be said out loud: the build stays green and the address of a
+/// client-supplied endpoint stops being checked.
+/// <para>
+/// This is a report, not a veto. A deployment that made the swap deliberately silences this one message by its own
+/// category, leaving every other log this library writes untouched:
+/// <c>"Logging": { "LogLevel": { "Abblix.Oidc.Server.Features.SecureHttpFetch.SsrfGuardWatch": "None" } }</c>.
+/// </para>
+/// </remarks>
+/// <param name="logger">Writes under this type's own category, which is what makes the message separately
+/// silenceable.</param>
+/// <param name="guardedClients">The clients registered through <c>AddSsrfHttpClient</c>.</param>
+internal sealed partial class SsrfGuardWatch(
+    ILogger<SsrfGuardWatch> logger,
+    SsrfGuardedClients guardedClients) : IHttpMessageHandlerBuilderFilter
+{
+    /// <inheritdoc />
+    public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next)
+        => builder =>
+        {
+            // Everything the library and the host asked for runs first, so the primary handler below is final.
+            next(builder);
+
+            if (builder.Name is { } name
+                && guardedClients.Contains(name)
+                && builder.PrimaryHandler is not SsrfValidatingHttpMessageHandler)
+            {
+                LogValidationReplaced(name, builder.PrimaryHandler?.GetType().Name ?? "none");
+            }
+        };
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfGuardedClients.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfGuardedClients.cs
@@ -1,0 +1,43 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
+
+/// <summary>
+/// The names of the clients registered with SSRF address validation, recorded as they are registered.
+/// </summary>
+/// <remarks>
+/// The registration is the only place that knows which clients these are, so it writes the name down rather than
+/// leaving anything downstream to infer it from a list that would drift as clients are added.
+/// </remarks>
+internal sealed class SsrfGuardedClients
+{
+    private readonly HashSet<string> _names = new(StringComparer.Ordinal);
+
+    /// <summary>Records a client as one whose primary handler carries the address validation.</summary>
+    /// <param name="name">The client's logical name, as <c>IHttpClientFactory</c> keys it.</param>
+    public void Add(string name) => _names.Add(name);
+
+    /// <summary>Tells whether a client was registered with the validation.</summary>
+    /// <param name="name">The client's logical name.</param>
+    public bool Contains(string name) => _names.Contains(name);
+}

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfHttpClientServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfHttpClientServiceCollectionExtensions.cs
@@ -21,6 +21,8 @@
 // info@abblix.com
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http;
 
 namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
 
@@ -40,9 +42,14 @@ public static class SsrfHttpClientServiceCollectionExtensions
         Action<IServiceProvider, HttpClient> configureClient)
         where TClient : class
         where TImplementation : class, TClient
-        => services
+    {
+        var builder = services
             .AddHttpClient<TClient, TImplementation>(configureClient)
             .ConfigurePrimaryHttpMessageHandler<SsrfValidatingHttpMessageHandler>();
+
+        services.WatchTheGuardOn(builder.Name);
+        return builder;
+    }
 
     /// <summary>
     /// Registers a named HTTP client whose primary handler is the SSRF-validating handler.
@@ -51,7 +58,36 @@ public static class SsrfHttpClientServiceCollectionExtensions
         this IServiceCollection services,
         string name,
         Action<IServiceProvider, HttpClient> configureClient)
-        => services
+    {
+        var builder = services
             .AddHttpClient(name, configureClient)
             .ConfigurePrimaryHttpMessageHandler<SsrfValidatingHttpMessageHandler>();
+
+        services.WatchTheGuardOn(builder.Name);
+        return builder;
+    }
+
+    /// <summary>
+    /// Records the client as guarded and installs the watch that reports the guard's absence at handler-build time.
+    /// </summary>
+    /// <remarks>
+    /// The registry is resolved out of the collection rather than through the provider, because the names have to
+    /// accumulate across every registration call while the collection is still being built.
+    /// </remarks>
+    private static void WatchTheGuardOn(this IServiceCollection services, string name)
+    {
+        var guarded = services.FirstOrDefault(
+            descriptor => descriptor.ServiceType == typeof(SsrfGuardedClients))?.ImplementationInstance
+            as SsrfGuardedClients;
+
+        if (guarded is null)
+        {
+            guarded = new SsrfGuardedClients();
+            services.AddSingleton(guarded);
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IHttpMessageHandlerBuilderFilter, SsrfGuardWatch>());
+        }
+
+        guarded.Add(name);
+    }
 }

--- a/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/SecureHttpFetch/SsrfValidatingHttpMessageHandler.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Net;
+using Abblix.Utils;
 using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
@@ -51,33 +52,16 @@ namespace Abblix.Oidc.Server.Features.SecureHttpFetch;
 /// </remarks>
 public class SsrfValidatingHttpMessageHandler(
     IOptions<SecureHttpFetchOptions> options,
-    ISecureUriValidator uriValidator) : DelegatingHandler(
-    new HttpClientHandler
-    {
-        // CRITICAL: Disable automatic redirects to prevent SSRF bypass via redirect chains
-        // Attackers could redirect from public URL to private network (e.g., 169.254.169.254)
-        AllowAutoRedirect = false,
-
-        // Use system default credentials (none) - prevent NTLM auth to internal servers
-        UseDefaultCredentials = false,
-
-        // Disable decompression to prevent zip bomb attacks
-        AutomaticDecompression = DecompressionMethods.None,
-    })
+    ISecureUriValidator uriValidator) : AddressValidatingHttpMessageHandler
 {
     /// <summary>
-    /// Sends HTTP request with comprehensive SSRF validation immediately before making the request.
-    /// Validates both hostname patterns and DNS resolution to prevent SSRF and DNS rebinding attacks.
+    /// Applies comprehensive SSRF validation immediately before the request leaves: the synchronous scheme,
+    /// hostname and IP-literal rules, then a DNS re-resolution that catches rebinding. The base handler owns the
+    /// no-redirect, no-decompression transport and calls this once per send.
     /// </summary>
-    protected override async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
+    protected override async Task GuardAsync(Uri requestUri, CancellationToken cancellationToken)
     {
-        var uri = request.RequestUri;
-        if (uri == null)
-        {
-            throw new InvalidOperationException("Request URI cannot be null");
-        }
+        var uri = requestUri;
 
         // Synchronous policy (scheme, internal hostname, private/reserved IP literal), shared with
         // registration-time validation. A null result means the URI passed these checks.
@@ -120,8 +104,5 @@ public class SsrfValidatingHttpMessageHandler(
                     $"a public IP during initial validation but now resolves to a private IP.");
             }
         }
-
-        // All checks passed, proceed with request
-        return await base.SendAsync(request, cancellationToken);
     }
 }

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -639,7 +639,7 @@ public static class ServiceCollectionExtensions
 
         // Register HTTP client for backchannel notifications (ping and push modes) with configurable handler lifetime
         // Use configuration callback to get handler lifetime from OidcOptions
-        services.AddOptions<HttpClientFactoryOptions>(nameof(HttpNotificationDeliveryService))
+        services.AddOptions<HttpClientFactoryOptions>(BackChannelNotificationTransport.HttpClientName)
             .Configure<IOptions<OidcOptions>>((httpOptions, oidcOptions) =>
             {
                 httpOptions.HandlerLifetime = oidcOptions.Value.BackChannelAuthentication.NotificationHttpClientHandlerLifetime;
@@ -648,7 +648,7 @@ public static class ServiceCollectionExtensions
         // The notification endpoint is a client-supplied URL, so server-initiated POSTs to it must
         // run through the SSRF-validating handler (blocks internal hosts, private IPs, DNS rebinding)
         // and carry a bounded timeout, exactly like every other outbound fetch in this library.
-        services.AddSsrfHttpClient(nameof(HttpNotificationDeliveryService), (serviceProvider, client) =>
+        services.AddSsrfHttpClient(BackChannelNotificationTransport.HttpClientName, (serviceProvider, client) =>
         {
             client.Timeout = serviceProvider.GetRequiredService<IOptions<OidcOptions>>()
                 .Value.BackChannelAuthentication.NotificationHttpClientTimeout;

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -436,6 +436,17 @@ internal static class LogEvents
             public const int JwksEmpty = Base + 2;
             public const int JwksFetchFailed = Base + 3;
         }
+
+        /// <summary>
+        /// <c>Features/SecureHttpFetch/SsrfGuardWatch.cs</c> - reports a client whose SSRF validation
+        /// was replaced by the host's own primary handler (sub-range 6040-6059).
+        /// </summary>
+        public static class SsrfGuardWatch
+        {
+            private const int Base = 6040;
+
+            public const int ValidationReplaced = Base + 1;
+        }
     }
 
     /// <summary>

--- a/src/Abblix.SecurityEvents/Delivery/DeliveryErrorCodes.cs
+++ b/src/Abblix.SecurityEvents/Delivery/DeliveryErrorCodes.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -75,6 +75,30 @@ public static class DeliveryErrorCodes
     /// holding the expected state can reach, which is why no validation error maps to it.
     /// </summary>
     public const string InvalidState = "invalid_state";
+
+    /// <summary>
+    /// Tells whether a receiver's verdict would still hold if the same bytes arrived again.
+    /// </summary>
+    /// <remarks>
+    /// RFC 8935 Section 4 draws this line for the transmitter and gives both directions by example:
+    /// "invalid_request" indicates a structural error "that is likely to remain when retransmitting the same SET",
+    /// while others "such as 'access_denied' may be transient, for example, if the SET Transmitter refreshes
+    /// expired credentials prior to retransmission". So the verdicts about the TOKEN are final, and the verdicts
+    /// about the transmitter's standing with the receiver are not: credentials get refreshed and grants get fixed
+    /// without the event changing at all.
+    /// <para>
+    /// An unrecognised code counts as final. The registry is extensible (Section 2.4), so a code from outside it
+    /// says nothing about repeatability, and keeping the event would hold the head of a queue on a verdict nobody
+    /// can interpret.
+    /// </para>
+    /// </remarks>
+    /// <param name="errorCode">The "err" value the receiver answered with.</param>
+    /// <returns>True when redelivery cannot change the answer.</returns>
+    public static bool IsFinal(string? errorCode) => errorCode switch
+    {
+        AuthenticationFailed or AccessDenied => false,
+        _ => true,
+    };
 
     /// <summary>
     /// Translates a validation verdict into the registry code a delivery response carries.

--- a/src/Abblix.SecurityEvents/Infrastructure/JwksIssuerKeyResolver.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/JwksIssuerKeyResolver.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -49,7 +49,7 @@ namespace Abblix.SecurityEvents.Infrastructure;
 /// </para>
 /// </remarks>
 /// <param name="httpClientFactory">
-/// Supplies the HTTP client, created per fetch under <see cref="HttpClientName"/> so a host can
+/// Supplies the HTTP client, created per fetch under <see cref="JwksTransport.HttpClientName"/> so a host can
 /// configure the named client - timeouts, proxy, resilience - without touching this type.</param>
 /// <param name="clock">Drives cache expiry and the rollover cooldown.</param>
 /// <param name="options">Where key sets live and how long they answer from cache.</param>
@@ -58,12 +58,6 @@ public sealed class JwksIssuerKeyResolver(
     TimeProvider clock,
     IOptions<JwksKeyResolutionOptions> options) : IIssuerKeyResolver
 {
-    /// <summary>
-    /// The name of the HTTP client this resolver fetches with; configure the named client to
-    /// shape its networking.
-    /// </summary>
-    public const string HttpClientName = "Abblix.SecurityEvents.Jwks";
-
     private sealed record CachedKeySet(IReadOnlyList<JsonWebKey> Keys, DateTimeOffset FetchedAt);
 
     private readonly ConcurrentDictionary<string, CachedKeySet> _cache = new(StringComparer.Ordinal);
@@ -122,7 +116,7 @@ public sealed class JwksIssuerKeyResolver(
                 + "or use a loopback address for local development.");
         }
 
-        using var client = httpClientFactory.CreateClient(HttpClientName);
+        using var client = httpClientFactory.CreateClient(JwksTransport.HttpClientName);
         var keySet = await client.GetFromJsonAsync<JsonWebKeySet>(jwksUri, cancellationToken)
             ?? throw new InvalidOperationException($"The JWK Set document at '{jwksUri}' deserialized to null.");
 

--- a/src/Abblix.SecurityEvents/Infrastructure/JwksTransport.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/JwksTransport.cs
@@ -1,0 +1,36 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SecurityEvents.Infrastructure;
+
+/// <summary>
+/// The HTTP transport key-set fetches travel on, to the "jwks_uri" of an issuer whose events this host verifies.
+/// </summary>
+public static class JwksTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(JwksTransport.HttpClientName)</c> reaches the same client the
+    /// resolver fetches with, and whatever it chains - a resilience pipeline, a proxy - applies to every fetch.
+    /// </summary>
+    public const string HttpClientName = "Abblix.SecurityEvents.Jwks";
+}

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -69,6 +69,10 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<StreamManagementService>();
         services.TryAddSingleton<PollEndpointHandler>();
+
+        // A receiver names the address its stream is delivered to, so that address is input from outside and is
+        // judged before every delivery.
+        services.TryAddSingleton<ReceiverAddressPolicy>();
         services.AddHttpClient<PushDeliverySender>();
 
         return services;

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -70,10 +70,15 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<StreamManagementService>();
         services.TryAddSingleton<PollEndpointHandler>();
 
-        // A receiver names the address its stream is delivered to, so that address is input from outside and is
-        // judged before every delivery.
+        // A receiver names the address its stream is delivered to, so that address is input from outside. The
+        // policy judges it, and the validating handler puts that judgement on the connection itself - refusing
+        // redirects and re-checking the address before every send - so a redirect or a DNS rebinding cannot carry
+        // a delivery past the check.
         services.TryAddSingleton<ReceiverAddressPolicy>();
-        services.AddHttpClient<PushDeliverySender>();
+        services.TryAddTransient<ReceiverAddressValidatingHandler>();
+        services
+            .AddHttpClient<PushDeliverySender>()
+            .ConfigurePrimaryHttpMessageHandler<ReceiverAddressValidatingHandler>();
 
         return services;
     }

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
@@ -22,8 +22,10 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Text;
+using System.Text.Json;
 using Abblix.SecurityEvents.Delivery;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
@@ -39,7 +41,11 @@ namespace Abblix.SharedSignals.Transmitter;
 /// </summary>
 /// <param name="httpClient">The client transmissions travel through.</param>
 /// <param name="outbox">The queues being drained.</param>
-public sealed class PushDeliverySender(HttpClient httpClient, IEventOutbox outbox)
+/// <param name="addressPolicy">Judges the receiver's address before anything is sent to it.</param>
+public sealed class PushDeliverySender(
+    HttpClient httpClient,
+    IEventOutbox outbox,
+    ReceiverAddressPolicy addressPolicy)
 {
     /// <summary>
     /// Sends what one stream has pending.
@@ -48,9 +54,15 @@ public sealed class PushDeliverySender(HttpClient httpClient, IEventOutbox outbo
     /// A stream that is not enabled sends nothing except status announcements - holding is the
     /// pause's meaning (SSF 1.0 Section 8.1.2.1), and the announcement is the one item that
     /// must still go out, since Section 8.1.5 wants it with the receiver although the stop has
-    /// already happened here. A "400 Bad Request" is the receiver's terminal judgment of that
-    /// SET (RFC 8935 Section 2.3): retrying the same bytes cannot succeed and would poison the
-    /// head of the queue, so the item is dropped and counted rejected.
+    /// already happened here.
+    /// <para>
+    /// A "400 Bad Request" carries the receiver's verdict in its body (RFC 8935 Section 2.3), and the verdict
+    /// rather than the status decides what happens to the event. RFC 8935 Section 4 separates the two cases:
+    /// a structural complaint "is likely to remain when retransmitting the same SET", so the event is dropped
+    /// instead of poisoning the head of the queue, while a complaint about the transmitter's credentials or
+    /// authorization "may be transient" and the event stays queued for a pass made after the deployment fixes
+    /// what the receiver objected to.
+    /// </para>
     /// </remarks>
     /// <param name="stream">The stream whose queue is drained.</param>
     /// <param name="cancellationToken">Cancels the pass between transmissions.</param>
@@ -64,6 +76,16 @@ public sealed class PushDeliverySender(HttpClient httpClient, IEventOutbox outbo
         if (stream.Configuration.Delivery is not PushDeliveryMethod push)
         {
             return new PushDeliveryPassOutcome(0, 0);
+        }
+
+        // The receiver chose this address, so it is judged before anything is sent and on every pass: a name that
+        // was public when the stream was created can resolve inside the network by the time an event is delivered.
+        // A refusal holds the queue rather than emptying it, because the events are still owed to a receiver whose
+        // configuration an operator can put right.
+        if (await addressPolicy.RejectionOf(push.EndpointUrl, cancellationToken) is { } rejection)
+        {
+            throw new InvalidOperationException(
+                $"Refusing to deliver stream '{stream.StreamId}' to '{push.EndpointUrl}': {rejection}.");
         }
 
         IEnumerable<OutboxItem> pending = await outbox.PendingAsync(stream.StreamId, null, cancellationToken);
@@ -92,6 +114,14 @@ public sealed class PushDeliverySender(HttpClient httpClient, IEventOutbox outbo
             {
                 if (response.StatusCode == HttpStatusCode.BadRequest)
                 {
+                    var verdict = await ReadVerdictAsync(response, cancellationToken);
+                    if (!DeliveryErrorCodes.IsFinal(verdict?.Error))
+                    {
+                        // The receiver objects to this transmitter, not to this event: leave it queued so a
+                        // later pass can deliver it once the credentials or the grant are put right.
+                        break;
+                    }
+
                     await outbox.AcknowledgeAsync(stream.StreamId, [item.JwtId], cancellationToken);
                     rejected++;
                     continue;
@@ -108,6 +138,28 @@ public sealed class PushDeliverySender(HttpClient httpClient, IEventOutbox outbo
         }
 
         return new PushDeliveryPassOutcome(delivered, rejected);
+    }
+
+    /// <summary>
+    /// Reads the error body a receiver owes with a 400 (RFC 8935 Section 2.3).
+    /// </summary>
+    /// <remarks>
+    /// A body that is missing, malformed or of another media type yields null, which the caller treats as final.
+    /// The alternative, treating an unreadable verdict as transient, would let a receiver answering 400 with an
+    /// HTML error page hold the head of the queue for as long as it kept doing so.
+    /// </remarks>
+    private static async Task<DeliveryError?> ReadVerdictAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await response.Content.ReadFromJsonAsync<DeliveryError>(cancellationToken);
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException or HttpRequestException)
+        {
+            return null;
+        }
     }
 
     private async Task<HttpResponseMessage> SendAsync(

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryTransport.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryTransport.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// The HTTP transport pushed security event tokens travel on, to the endpoint a receiver configured for its stream.
+/// </summary>
+public static class PushDeliveryTransport
+{
+    /// <summary>
+    /// The name the transport's client is registered under, published so a host can configure it without copying
+    /// the string: <c>services.AddHttpClient(PushDeliveryTransport.HttpClientName)</c> reaches the same client the
+    /// sender delivers over.
+    /// </summary>
+    /// <remarks>
+    /// The value is the sender's name because this is a typed client, and that is the logical name
+    /// <c>AddHttpClient&lt;TClient&gt;</c> gives it. A delivery pass makes one attempt per pending token, so a
+    /// resilience pipeline here is what turns a transient receiver failure into a retry rather than a wait for the
+    /// next pass.
+    /// </remarks>
+    public const string HttpClientName = nameof(PushDeliverySender);
+}

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
@@ -65,14 +65,14 @@ public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
                 + "a subject, and cleartext exposes them to anyone on the path";
         }
 
-        if (PrivateNetworks.IsInternalHostname(endpoint.Host))
+        if (PrivateNetworks.IsPrivateHostname(endpoint.Host))
         {
             return $"the host '{endpoint.Host}' names the deployment's own network rather than a public receiver";
         }
 
         if (IPAddress.TryParse(endpoint.Host, out var literal))
         {
-            return PrivateNetworks.IsPrivateOrReserved(literal)
+            return PrivateNetworks.IsPrivateOrReservedAddress(literal)
                 ? $"the address '{literal}' is private or reserved"
                 : null;
         }
@@ -91,7 +91,7 @@ public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
 
         // Every answer has to be acceptable, not just the first: a name answering with one public address and one
         // private address would otherwise be reachable by whichever the connection happened to pick.
-        var refused = Array.Find(addresses, PrivateNetworks.IsPrivateOrReserved);
+        var refused = Array.Find(addresses, PrivateNetworks.IsPrivateOrReservedAddress);
         return refused is null
             ? null
             : $"the host '{endpoint.Host}' resolves to '{refused}', which is private or reserved";

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
@@ -1,0 +1,105 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Sockets;
+using Abblix.Utils;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// Decides whether the transmitter may deliver to the address a receiver put in its stream configuration.
+/// </summary>
+/// <remarks>
+/// A receiver names its own delivery endpoint (SSF 1.0 Section 8.1.1.1), so that address is input from outside,
+/// and the transmitter POSTs security event tokens to it. Without this check a receiver could point a stream at a
+/// cloud metadata service and have the transmitter fetch it, which is server-side request forgery with the
+/// transmitter's own network position.
+/// <para>
+/// The rules about which addresses are internal are shared with every other outbound caller in this family, so
+/// they come from <see cref="InternalNetworkAddresses"/> rather than being restated here.
+/// </para>
+/// </remarks>
+public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
+{
+    /// <summary>
+    /// Judges the address of a delivery endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint a receiver configured for its stream.</param>
+    /// <param name="cancellationToken">Cancels the name resolution.</param>
+    /// <returns>Null when delivery may proceed; otherwise why it may not, in a form fit for a log.</returns>
+    public async Task<string?> RejectionOf(Uri endpoint, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (options.AllowedReceiverAddresses is { Count: > 0 } allowed
+            && allowed.Any(permitted => IsSameOrigin(endpoint, permitted)))
+        {
+            // An operator naming a destination outranks everything below, and it has to: a receiver deployed
+            // inside the same network is reached at a private address by definition.
+            return null;
+        }
+
+        if (endpoint.Scheme != Uri.UriSchemeHttps)
+        {
+            return $"delivery over '{endpoint.Scheme}' is refused: a security event token carries claims about "
+                + "a subject, and cleartext exposes them to anyone on the path";
+        }
+
+        if (InternalNetworkAddresses.IsInternalHostname(endpoint.Host))
+        {
+            return $"the host '{endpoint.Host}' names the deployment's own network rather than a public receiver";
+        }
+
+        if (IPAddress.TryParse(endpoint.Host, out var literal))
+        {
+            return InternalNetworkAddresses.IsPrivateOrReserved(literal)
+                ? $"the address '{literal}' is private or reserved"
+                : null;
+        }
+
+        // Resolved here rather than at configuration time, because the name is resolved again for every delivery
+        // and an answer that passed once says nothing about what it resolves to now.
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(endpoint.Host, cancellationToken);
+        }
+        catch (Exception exception) when (exception is SocketException or ArgumentException)
+        {
+            return $"the host '{endpoint.Host}' does not resolve: {exception.Message}";
+        }
+
+        // Every answer has to be acceptable, not just the first: a name answering with one public address and one
+        // private address would otherwise be reachable by whichever the connection happened to pick.
+        var refused = Array.Find(addresses, InternalNetworkAddresses.IsPrivateOrReserved);
+        return refused is null
+            ? null
+            : $"the host '{endpoint.Host}' resolves to '{refused}', which is private or reserved";
+    }
+
+    private static bool IsSameOrigin(Uri endpoint, Uri permitted)
+        => permitted.IsAbsoluteUri
+           && string.Equals(endpoint.Scheme, permitted.Scheme, StringComparison.OrdinalIgnoreCase)
+           && string.Equals(endpoint.Host, permitted.Host, StringComparison.OrdinalIgnoreCase)
+           && endpoint.Port == permitted.Port;
+}

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -39,8 +39,24 @@ namespace Abblix.SharedSignals.Transmitter;
 /// they come from <see cref="PrivateNetworks"/> rather than being restated here.
 /// </para>
 /// </remarks>
-public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
+/// <param name="options">The deployment's transmitter settings, including the operator's allow-list.</param>
+/// <param name="resolveHost">
+/// Resolves a hostname to its addresses; defaults to <see cref="Dns.GetHostAddressesAsync(string,
+/// CancellationToken)"/>. A test supplies its own so the resolved-address branch, the only part of this policy
+/// that is not a string comparison, can be driven in both directions without a live DNS.</param>
+public sealed class ReceiverAddressPolicy(
+    SsfTransmitterOptions options,
+    ReceiverAddressPolicy.HostResolver? resolveHost = null)
 {
+    /// <summary>
+    /// Resolves a hostname to the addresses a connection to it would use.
+    /// </summary>
+    /// <param name="host">The hostname to resolve.</param>
+    /// <param name="cancellationToken">Cancels the resolution.</param>
+    public delegate Task<IPAddress[]> HostResolver(string host, CancellationToken cancellationToken);
+
+    private readonly HostResolver _resolveHost = resolveHost ?? Dns.GetHostAddressesAsync;
+
     /// <summary>
     /// Judges the address of a delivery endpoint.
     /// </summary>
@@ -82,7 +98,7 @@ public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
         IPAddress[] addresses;
         try
         {
-            addresses = await Dns.GetHostAddressesAsync(endpoint.Host, cancellationToken);
+            addresses = await _resolveHost(endpoint.Host, cancellationToken);
         }
         catch (Exception exception) when (exception is SocketException or ArgumentException)
         {

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
@@ -36,7 +36,7 @@ namespace Abblix.SharedSignals.Transmitter;
 /// transmitter's own network position.
 /// <para>
 /// The rules about which addresses are internal are shared with every other outbound caller in this family, so
-/// they come from <see cref="InternalNetworkAddresses"/> rather than being restated here.
+/// they come from <see cref="PrivateNetworks"/> rather than being restated here.
 /// </para>
 /// </remarks>
 public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
@@ -65,14 +65,14 @@ public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
                 + "a subject, and cleartext exposes them to anyone on the path";
         }
 
-        if (InternalNetworkAddresses.IsInternalHostname(endpoint.Host))
+        if (PrivateNetworks.IsInternalHostname(endpoint.Host))
         {
             return $"the host '{endpoint.Host}' names the deployment's own network rather than a public receiver";
         }
 
         if (IPAddress.TryParse(endpoint.Host, out var literal))
         {
-            return InternalNetworkAddresses.IsPrivateOrReserved(literal)
+            return PrivateNetworks.IsPrivateOrReserved(literal)
                 ? $"the address '{literal}' is private or reserved"
                 : null;
         }
@@ -91,7 +91,7 @@ public sealed class ReceiverAddressPolicy(SsfTransmitterOptions options)
 
         // Every answer has to be acceptable, not just the first: a name answering with one public address and one
         // private address would otherwise be reachable by whichever the connection happened to pick.
-        var refused = Array.Find(addresses, InternalNetworkAddresses.IsPrivateOrReserved);
+        var refused = Array.Find(addresses, PrivateNetworks.IsPrivateOrReserved);
         return refused is null
             ? null
             : $"the host '{endpoint.Host}' resolves to '{refused}', which is private or reserved";

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressValidatingHandler.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressValidatingHandler.cs
@@ -1,0 +1,49 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Utils;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// Puts <see cref="ReceiverAddressPolicy"/> on every push delivery request, redirects and rebinding included.
+/// </summary>
+/// <remarks>
+/// The delivery endpoint comes from the receiver, so the address has to be judged on the connection the socket
+/// actually makes, not only on the URL the receiver configured. The shared base
+/// (<see cref="AddressValidatingHttpMessageHandler"/>) refuses redirects and calls the policy immediately before
+/// each send; the policy is the same one the sender consults up front, so a statically bad endpoint is refused
+/// early and loudly, and a redirect or a rebinding is caught here on the request that would have carried it.
+/// </remarks>
+/// <param name="addressPolicy">Judges the address of a delivery endpoint.</param>
+public sealed class ReceiverAddressValidatingHandler(ReceiverAddressPolicy addressPolicy)
+    : AddressValidatingHttpMessageHandler
+{
+    /// <inheritdoc />
+    protected override async Task GuardAsync(Uri requestUri, CancellationToken cancellationToken)
+    {
+        if (await addressPolicy.RejectionOf(requestUri, cancellationToken) is { } rejection)
+        {
+            throw new HttpRequestException($"Refusing push delivery to '{requestUri}': {rejection}.");
+        }
+    }
+}

--- a/src/Abblix.SharedSignals/Transmitter/SsfTransmitterOptions.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SsfTransmitterOptions.cs
@@ -98,6 +98,19 @@ public sealed record SsfTransmitterOptions
     public IReadOnlyList<JsonObject>? AuthorizationSchemes { get; init; }
 
     /// <summary>
+    /// The receiver origins this deployment may deliver to whatever their address, matched by scheme, host and
+    /// port. Empty leaves every receiver to the ordinary rules: HTTPS, and an address outside the deployment's
+    /// own network.
+    /// </summary>
+    /// <remarks>
+    /// A receiver names its own delivery endpoint, so the address arrives from outside and is refused when it
+    /// points inside the network. That refusal is wrong for exactly one deployment shape: a receiver of the
+    /// operator's own, reached at a private address. Naming it here is how an operator says so, and it is
+    /// deliberately an origin rather than a switch, so permitting one receiver does not permit the rest.
+    /// </remarks>
+    public IReadOnlyList<Uri> AllowedReceiverAddresses { get; init; } = [];
+
+    /// <summary>
     /// The "default_subjects" value the mode advertises, kept beside the enum so the wire word
     /// and the behavior cannot drift apart.
     /// </summary>

--- a/src/Abblix.Utils/AddressValidatingHttpMessageHandler.cs
+++ b/src/Abblix.Utils/AddressValidatingHttpMessageHandler.cs
@@ -1,0 +1,86 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+
+namespace Abblix.Utils;
+
+/// <summary>
+/// The message-handler half of protecting a server-initiated request whose address came from outside: it refuses
+/// redirects and re-checks the address immediately before every send, leaving only the policy - which addresses
+/// are refused - to the derived handler.
+/// </summary>
+/// <remarks>
+/// Two properties make this the right place for the check rather than a pre-flight in front of the client.
+/// <para>
+/// Redirects are not followed. A receiver that answers a delivery with a 3xx to an internal address would
+/// otherwise have the request re-sent there, past any address the caller vetted, so this is the difference
+/// between a check and a bypass. With the follow disabled the 3xx comes back as an ordinary non-success response
+/// and the caller decides what to do with it.
+/// </para>
+/// <para>
+/// The address is judged here, one call before the connection, rather than only when the request was scheduled.
+/// A name that resolved to a public address a moment ago can resolve to an internal one now, so the resolution a
+/// derived handler performs in <see cref="GuardAsync"/> is the one whose answer the socket actually uses.
+/// </para>
+/// </remarks>
+public abstract class AddressValidatingHttpMessageHandler : DelegatingHandler
+{
+    /// <summary>
+    /// Builds the handler over a primary transport that follows no redirects and decompresses nothing.
+    /// </summary>
+    protected AddressValidatingHttpMessageHandler()
+        : base(new HttpClientHandler
+        {
+            // Redirects are the bypass this whole type exists to stop: a followed 3xx reaches an address nothing
+            // vetted. Disabled, the 3xx surfaces as a response the caller handles.
+            AllowAutoRedirect = false,
+
+            // No ambient credentials, so a request cannot authenticate to an internal server by accident.
+            UseDefaultCredentials = false,
+
+            // No automatic decompression, so a hostile response cannot spend the caller's memory on a bomb.
+            AutomaticDecompression = DecompressionMethods.None,
+        })
+    {
+    }
+
+    /// <summary>
+    /// Judges the request's address and throws when it may not be reached. Returning normally lets the send
+    /// proceed.
+    /// </summary>
+    /// <param name="requestUri">The address this request is about to reach.</param>
+    /// <param name="cancellationToken">Cancels the check, including any name resolution it performs.</param>
+    protected abstract Task GuardAsync(Uri requestUri, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var requestUri = request.RequestUri
+            ?? throw new InvalidOperationException("A request through this handler must carry a target URI.");
+
+        await GuardAsync(requestUri, cancellationToken);
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Abblix.Utils/InternalNetworkAddresses.cs
+++ b/src/Abblix.Utils/InternalNetworkAddresses.cs
@@ -1,0 +1,147 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace Abblix.Utils;
+
+/// <summary>
+/// Tells an address inside the deployment's own network from one on the public internet.
+/// </summary>
+/// <remarks>
+/// Whenever a server is made to call an address that arrived from outside, this is the question that decides
+/// whether the call is a feature or a server-side request forgery. More than one package asks it, which is why the
+/// answer lives here rather than beside any one of them: a range added to the list below has to take effect
+/// everywhere at once, and a second copy of these rules would drift silently, since neither copy fails when they
+/// disagree.
+/// <para>
+/// What surrounds the question stays with each caller: which schemes are allowed, whether the check applies at
+/// all, and which destinations an operator has deliberately permitted are policy, and policy differs by feature.
+/// </para>
+/// </remarks>
+public static class InternalNetworkAddresses
+{
+    /// <summary>
+    /// Hostnames that typically resolve inside a private network.
+    /// </summary>
+    private static readonly string[] BlockedHostnames = [
+        "localhost",
+        "loopback",
+        "broadcasthost",
+        "local",
+        "internal",
+        "intranet",
+        "private",
+        "corp",
+        "home",
+        "lan"
+    ];
+
+    /// <summary>
+    /// Top-level domains commonly used for internal networks.
+    /// </summary>
+    private static readonly string[] BlockedTlds = [
+        ".local",
+        ".localhost",
+        ".internal",
+        ".intranet",
+        ".corp",
+        ".home",
+        ".lan"
+    ];
+
+    /// <summary>
+    /// Reports whether a hostname looks internal or otherwise non-public.
+    /// </summary>
+    /// <param name="hostname">The host component of the address about to be reached.</param>
+    /// <returns>True when the name should not be reached from a server-initiated request.</returns>
+    public static bool IsInternalHostname(string hostname)
+    {
+        var normalizedHost = hostname.ToLowerInvariant();
+
+        if (BlockedHostnames.Contains(normalizedHost))
+            return true;
+
+        if (BlockedTlds.Any(normalizedHost.EndsWith))
+            return true;
+
+        // A single label carries no domain, which in practice means a name resolved inside the network. An IP
+        // literal reaches here as a label too, and it is judged by its address instead.
+        if (!normalizedHost.Contains('.') && !IPAddress.TryParse(normalizedHost, out _))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reports whether an IP address is private, loopback, link-local or otherwise reserved.
+    /// </summary>
+    /// <param name="address">The address a name resolved to, or the literal in the URI.</param>
+    /// <returns>True when the address belongs to the deployment's own network rather than the internet.</returns>
+    public static bool IsPrivateOrReserved(IPAddress address)
+    {
+        // Collapse an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1 / ::ffff:169.254.169.254) to its IPv4 form
+        // FIRST - RFC 4291 Section 2.5.5 - so every rule below, including the loopback check, inspects the embedded
+        // IPv4 address. Without this an attacker reaches loopback, cloud metadata or private ranges through the IPv6
+        // arm, which never inspects the embedded IPv4 address.
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+
+        // Loopback addresses (127.0.0.0/8 for IPv4, ::1 for IPv6)
+        if (IPAddress.IsLoopback(address))
+            return true;
+
+        var bytes = address.GetAddressBytes();
+
+        return address.AddressFamily switch
+        {
+            AddressFamily.InterNetwork =>
+                // "This host on this network": 0.0.0.0/8 (0.0.0.0 routes to loopback on Linux)
+                bytes[0] == 0 ||
+                // Private: 10.0.0.0/8
+                bytes[0] == 10 ||
+                // Carrier-grade NAT shared space: 100.64.0.0/10 (RFC 6598)
+                (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
+                // Private: 172.16.0.0/12
+                (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
+                // Private: 192.168.0.0/16
+                (bytes[0] == 192 && bytes[1] == 168) ||
+                // Link-local: 169.254.0.0/16 (AWS/Azure metadata)
+                (bytes[0] == 169 && bytes[1] == 254) ||
+                // Multicast: 224.0.0.0/4
+                bytes[0] >= 224,
+
+            AddressFamily.InterNetworkV6 =>
+                // Unspecified address: ::
+                address.Equals(IPAddress.IPv6Any) ||
+                // Link-local: fe80::/10
+                (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80) ||
+                // Unique local: fc00::/7
+                (bytes[0] & 0xfe) == 0xfc ||
+                // Multicast: ff00::/8
+                bytes[0] == 0xff,
+
+            _ => true,
+        };
+    }
+}

--- a/src/Abblix.Utils/PrivateNetworks.cs
+++ b/src/Abblix.Utils/PrivateNetworks.cs
@@ -35,6 +35,12 @@ namespace Abblix.Utils;
 /// everywhere at once, and a second copy of these rules would drift silently, since neither copy fails when they
 /// disagree.
 /// <para>
+/// "Private" is this type's term and it is wider than the RFC 1918 ranges the phrase usually names: it covers
+/// everything a server-initiated request has no business reaching, so loopback, link-local (where a cloud's
+/// metadata service lives), carrier-grade NAT, multicast and the unspecified address count too, as do hostnames
+/// that resolve inside a network rather than on the internet.
+/// </para>
+/// <para>
 /// What surrounds the question stays with each caller: which schemes are allowed, whether the check applies at
 /// all, and which destinations an operator has deliberately permitted are policy, and policy differs by feature.
 /// </para>
@@ -42,7 +48,7 @@ namespace Abblix.Utils;
 public static class PrivateNetworks
 {
     /// <summary>
-    /// Hostnames that typically resolve inside a private network.
+    /// Hostnames that typically resolve inside a network rather than on the internet.
     /// </summary>
     private static readonly string[] BlockedHostnames = [
         "localhost",
@@ -58,7 +64,7 @@ public static class PrivateNetworks
     ];
 
     /// <summary>
-    /// Top-level domains commonly used for internal networks.
+    /// Top-level domains commonly used for networks of an organisation's own.
     /// </summary>
     private static readonly string[] BlockedTlds = [
         ".local",
@@ -71,11 +77,11 @@ public static class PrivateNetworks
     ];
 
     /// <summary>
-    /// Reports whether a hostname looks internal or otherwise non-public.
+    /// Reports whether a hostname belongs to a network rather than to the internet.
     /// </summary>
     /// <param name="hostname">The host component of the address about to be reached.</param>
     /// <returns>True when the name should not be reached from a server-initiated request.</returns>
-    public static bool IsInternalHostname(string hostname)
+    public static bool IsPrivateHostname(string hostname)
     {
         var normalizedHost = hostname.ToLowerInvariant();
 
@@ -98,7 +104,7 @@ public static class PrivateNetworks
     /// </summary>
     /// <param name="address">The address a name resolved to, or the literal in the URI.</param>
     /// <returns>True when the address belongs to the deployment's own network rather than the internet.</returns>
-    public static bool IsPrivateOrReserved(IPAddress address)
+    public static bool IsPrivateOrReservedAddress(IPAddress address)
     {
         // Collapse an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1 / ::ffff:169.254.169.254) to its IPv4 form
         // FIRST - RFC 4291 Section 2.5.5 - so every rule below, including the loopback check, inspects the embedded

--- a/src/Abblix.Utils/PrivateNetworks.cs
+++ b/src/Abblix.Utils/PrivateNetworks.cs
@@ -39,7 +39,7 @@ namespace Abblix.Utils;
 /// all, and which destinations an operator has deliberately permitted are policy, and policy differs by feature.
 /// </para>
 /// </remarks>
-public static class InternalNetworkAddresses
+public static class PrivateNetworks
 {
     /// <summary>
     /// Hostnames that typically resolve inside a private network.

--- a/tests/Abblix.Jwt.Azure.UnitTests/Abblix.Jwt.Azure.UnitTests.csproj
+++ b/tests/Abblix.Jwt.Azure.UnitTests/Abblix.Jwt.Azure.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="xunit.v3.mtp-v2" />
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
@@ -31,4 +32,9 @@
         <ProjectReference Include="..\..\src\Abblix.Jwt.Azure\Abblix.Jwt.Azure.csproj" />
     </ItemGroup>
 
+
+    <ItemGroup>
+        <!-- One statement of what a host is promised, compiled into every package's suite. -->
+        <Compile Include="../Shared/HostResilienceProbe.cs" Link="Shared/HostResilienceProbe.cs" />
+    </ItemGroup>
 </Project>

--- a/tests/Abblix.Jwt.Azure.UnitTests/AddAzureCustodianTests.cs
+++ b/tests/Abblix.Jwt.Azure.UnitTests/AddAzureCustodianTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -111,4 +111,50 @@ public class AddAzureCustodianTests
 
         Assert.Contains("ServiceUri", error.Message);
     }
+
+    /// <summary>
+    /// The published name is what a host configures the ring's transport through - a resilience pipeline, a proxy -
+    /// so what it names must be the client the ring registration builds.
+    /// </summary>
+    /// <remarks>
+    /// Asserted on the handler chain rather than by making the ring load: the store authenticates through a
+    /// credential of its own, which does not travel over this client, so driving a real load would reach for a
+    /// token over the network. Registration and consumption of this name sit in one method, so what a wider test
+    /// would add is the compiler's job here.
+    /// </remarks>
+    [Fact]
+    public void HostConfiguration_ByPublishedName_ReachesTheRingClient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        services.AddAzureCustodian(options => options.KeyVaultUri = new Uri("https://contoso.vault.azure.net/"));
+        services
+            .AddKeyRing(new MintedKeys { KeyEncryptionKeyName = "oidc-kek" })
+            .PersistRingToAzureBlob(blob => blob.ServiceUri = new Uri("https://contoso.blob.core.windows.net"));
+        services.AddOptions();
+        services.AddSingleton(TimeProvider.System);
+
+        // What a host writes to add a resilience pipeline, with a handler standing in for one.
+        services.AddHttpClient(AzureKeyRingTransport.HttpClientName)
+            .AddHttpMessageHandler(() => new HostHandler());
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler(AzureKeyRingTransport.HttpClientName);
+
+        Assert.Contains(Chain(handler), link => link is HostHandler);
+    }
+
+    private static IEnumerable<HttpMessageHandler> Chain(HttpMessageHandler handler)
+    {
+        for (var current = handler; current is not null;)
+        {
+            yield return current;
+            current = current is DelegatingHandler delegating ? delegating.InnerHandler : null;
+        }
+    }
+
+    /// <summary>Stands in for whatever a host chains onto the client - a resilience pipeline, a proxy.</summary>
+    private sealed class HostHandler : DelegatingHandler;
 }

--- a/tests/Abblix.Jwt.Azure.UnitTests/AddAzureCustodianTests.cs
+++ b/tests/Abblix.Jwt.Azure.UnitTests/AddAzureCustodianTests.cs
@@ -20,8 +20,11 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Net;
 using Abblix.Jwt.ExternalKeys;
+using Abblix.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -144,6 +147,43 @@ public class AddAzureCustodianTests
             .CreateHandler(AzureKeyRingTransport.HttpClientName);
 
         Assert.Contains(Chain(handler), link => link is HostHandler);
+    }
+
+    /// <summary>
+    /// The shortest path a host has to resilience on this package's clients: one call naming none of them, which
+    /// must cover the typed vault client and the named ring client alike.
+    /// </summary>
+    [Theory]
+    [InlineData(AzureKeyVaultTransport.HttpClientName)]
+    [InlineData(AzureKeyRingTransport.HttpClientName)]
+    public async Task OneHostCall_MakesEveryClientOfThisPackageResilient(string clientName)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJsonWebTokens();
+
+        // The whole of what a host writes, naming nothing this library owns.
+        services.ConfigureHttpClientDefaults(builder => builder.AddResilienceOfATypicalHost());
+
+        services.AddAzureCustodian(options => options.KeyVaultUri = new Uri("https://contoso.vault.azure.net/"));
+        services
+            .AddKeyRing(new MintedKeys { KeyEncryptionKeyName = "oidc-kek" })
+            .PersistRingToAzureBlob(blob => blob.ServiceUri = new Uri("https://contoso.blob.core.windows.net"));
+        services.AddOptions();
+        services.AddSingleton(TimeProvider.System);
+
+        var origin = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(clientName).ConfigurePrimaryHttpMessageHandler(() => origin);
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler(clientName);
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var response = await httpClient.GetAsync(
+            new Uri("https://origin.test/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, origin.Requests);
     }
 
     private static IEnumerable<HttpMessageHandler> Chain(HttpMessageHandler handler)

--- a/tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj
+++ b/tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -33,4 +33,9 @@
         <ProjectReference Include="..\..\src\Abblix.Jwt.Vault\Abblix.Jwt.Vault.csproj" />
     </ItemGroup>
 
+
+    <ItemGroup>
+        <!-- One statement of what a host is promised, compiled into every package's suite. -->
+        <Compile Include="../Shared/HostResilienceProbe.cs" Link="Shared/HostResilienceProbe.cs" />
+    </ItemGroup>
 </Project>

--- a/tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj
+++ b/tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="xunit.v3.mtp-v2" />
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />

--- a/tests/Abblix.Jwt.Vault.UnitTests/AddVaultCustodianTests.cs
+++ b/tests/Abblix.Jwt.Vault.UnitTests/AddVaultCustodianTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -20,10 +20,16 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Net;
+using System.Net.Mime;
+using System.Text;
 using Abblix.Jwt.ExternalKeys;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Retry;
 using Xunit;
 
 namespace Abblix.Jwt.Vault.UnitTests;
@@ -86,7 +92,7 @@ public class AddVaultCustodianTests
     {
         using var provider = Configure().BuildServiceProvider();
 
-        var http = provider.GetRequiredService<IHttpClientFactory>().CreateClient(Transport.ClientName);
+        var http = provider.GetRequiredService<IHttpClientFactory>().CreateClient(VaultTransport.HttpClientName);
 
         // The address stops at the server root rather than a mount: this one client also carries the key ring,
         // which lives on a different mount, so each engine spells its own into every path.
@@ -106,8 +112,115 @@ public class AddVaultCustodianTests
         // redacts nothing by default, and Trace is exactly what an operator turns on to debug a Vault problem.
         var options = provider
             .GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>()
-            .Get(Transport.ClientName);
+            .Get(VaultTransport.HttpClientName);
 
         Assert.True(options.ShouldRedactHeaderValue(TokenHandler.TokenHeaderName));
+    }
+
+    /// <summary>
+    /// The published name is what a host configures resilience through, so it must reach the very client the
+    /// custodian sends on - a name that reached anything else would configure a client nobody uses and still read
+    /// as success.
+    /// </summary>
+    [Fact]
+    public async Task HostConfiguration_ByPublishedName_ReachesTheClientTheCustodianSendsOn()
+    {
+        var services = Configure();
+
+        // What a host writes to add a resilience pipeline, with a stub standing in for one.
+        var hostHandler = new StubVaultHandler();
+        services.AddHttpClient(VaultTransport.HttpClientName).AddHttpMessageHandler(() => hostHandler);
+
+        using var provider = services.BuildServiceProvider();
+        var custodian = provider.GetRequiredService<IKeyCustodian>();
+
+        var signature = await custodian.SignAsync(
+            "oidc-sign:1", "RS256", [1, 2, 3], TestContext.Current.CancellationToken);
+
+        // The signature could only have come from the stub, so the custodian's request travelled through the
+        // handler the host chained onto the published name.
+        Assert.Equal(SignatureBytes, signature);
+        Assert.Equal(1, hostHandler.Requests);
+    }
+
+    /// <summary>
+    /// The point of publishing the name: a host adds a resilience pipeline to the transport and the custodian's
+    /// calls retry, with nothing in this package aware of it.
+    /// </summary>
+    /// <remarks>
+    /// Asserted against the real resilience package rather than a hand-written retry, because what is in question
+    /// is whether Polly composes onto this client at all - a stand-in would only prove a delegating handler does.
+    /// The stub fails twice and then answers, so the count separates a retry from a single attempt.
+    /// </remarks>
+    [Fact]
+    public async Task HostResiliencePipeline_ByPublishedName_RetriesTheCustodiansCalls()
+    {
+        var services = Configure();
+
+        var vault = new FlakyVaultHandler(failuresBeforeSuccess: 2);
+        var builder = services.AddHttpClient(VaultTransport.HttpClientName);
+        builder.AddResilienceHandler("test", pipeline => pipeline.AddRetry(new HttpRetryStrategyOptions
+        {
+            MaxRetryAttempts = 2,
+            Delay = TimeSpan.Zero,
+            BackoffType = DelayBackoffType.Constant,
+        }));
+        builder.AddHttpMessageHandler(() => vault);
+
+        using var provider = services.BuildServiceProvider();
+        var custodian = provider.GetRequiredService<IKeyCustodian>();
+
+        var signature = await custodian.SignAsync(
+            "oidc-sign:1", "RS256", [1, 2, 3], TestContext.Current.CancellationToken);
+
+        // Two failures were absorbed by the pipeline and the third attempt answered, so the custodian saw one
+        // successful signature where without the pipeline it would have seen the first failure.
+        Assert.Equal(SignatureBytes, signature);
+        Assert.Equal(3, vault.Requests);
+    }
+
+    private static readonly byte[] SignatureBytes = [9, 8, 7];
+
+    /// <summary>
+    /// Stands in for whatever a host chains onto the client, and answers as Transit does so the custodian
+    /// completes rather than failing for a reason of its own.
+    /// </summary>
+    private sealed class StubVaultHandler : DelegatingHandler
+    {
+        public int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests++;
+            return Task.FromResult(SignResponse());
+        }
+    }
+
+    /// <summary>Fails a set number of times before answering, so a retry is visible as a request count.</summary>
+    private sealed class FlakyVaultHandler(int failuresBeforeSuccess) : DelegatingHandler
+    {
+        public int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests++;
+            return Task.FromResult(Requests <= failuresBeforeSuccess
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                : SignResponse());
+        }
+    }
+
+    /// <summary>Transit answers a sign request with the signature under a "vault:v&lt;version&gt;:" prefix.</summary>
+    private static HttpResponseMessage SignResponse()
+    {
+        var body = $$$"""{"data":{"signature":"vault:v1:{{{Convert.ToBase64String(SignatureBytes)}}}"}}""";
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json),
+        };
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
@@ -41,4 +42,9 @@
     <ProjectReference Include="..\..\src\Abblix.Oidc.Server.AspNetCore\Abblix.Oidc.Server.AspNetCore.csproj" />
   </ItemGroup>
 
+
+    <ItemGroup>
+        <!-- One statement of what a host is promised, compiled into every package's suite. -->
+        <Compile Include="../Shared/HostResilienceProbe.cs" Link="Shared/HostResilienceProbe.cs" />
+    </ItemGroup>
 </Project>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/HttpNotificationDeliveryServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/HttpNotificationDeliveryServiceTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -78,7 +78,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
 // Act
@@ -115,7 +115,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NoContent));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act
@@ -152,7 +152,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act & Assert (should not throw)
@@ -189,7 +189,7 @@ public class HttpNotificationDeliveryServiceTests
             .ThrowsAsync(expectedException);
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act & Assert (should not throw)
@@ -226,7 +226,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act
@@ -257,7 +257,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act
@@ -266,7 +266,7 @@ public class HttpNotificationDeliveryServiceTests
 
         // Assert
         _httpClientFactory.Verify(
-            f => f.CreateClient(nameof(HttpNotificationDeliveryService)),
+            f => f.CreateClient(BackChannelNotificationTransport.HttpClientName),
             Times.Once);
     }
 
@@ -290,7 +290,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act
@@ -322,7 +322,7 @@ public class HttpNotificationDeliveryServiceTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
         var httpClient = new HttpClient(mockHandler.Object);
-        _httpClientFactory.Setup(f => f.CreateClient(nameof(HttpNotificationDeliveryService)))
+        _httpClientFactory.Setup(f => f.CreateClient(BackChannelNotificationTransport.HttpClientName))
             .Returns(httpClient);
 
         // Act

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientResilienceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientResilienceTests.cs
@@ -1,0 +1,175 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Features;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication;
+using Abblix.Oidc.Server.Features.LogoutNotification;
+using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Abblix.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.SecureHttpFetch;
+
+/// <summary>
+/// Every outbound client of this library must accept a resilience pipeline from its host - retries and a circuit
+/// breaker - without this library knowing about it. What makes that possible is the client coming from
+/// <see cref="IHttpClientFactory"/> under an identifier a host can name.
+/// </summary>
+/// <remarks>
+/// Asserted by driving the composed chain rather than by looking for a handler type: a pipeline that is present but
+/// not invoked would pass a structural check, and what a host is promised is behaviour. The primary handler is
+/// replaced with a stub, which is why the SSRF guarantee is not what this file measures - that belongs to
+/// <see cref="OutboundHttpClientSsrfWiringTests"/> and is asserted separately there.
+/// </remarks>
+public class OutboundHttpClientResilienceTests
+{
+    [Theory]
+    [InlineData(BackChannelNotificationTransport.HttpClientName)] // CIBA ping and push notifications
+    [InlineData(BackChannelLogoutTransport.HttpClientName)]                      // back-channel logout
+    [InlineData(SecureFetchTransport.HttpClientName)]                      // JWKS, request_uri, software statement
+    public async Task EveryOutboundClient_AcceptsAHostResiliencePipeline(string clientName)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+        services.AddBackChannelLogout();
+
+        var origin = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(clientName)
+            .AddResilienceOfATypicalHost()
+            .ConfigurePrimaryHttpMessageHandler(() => origin);
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler(clientName);
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var response = await httpClient.GetAsync(
+            new Uri("https://origin.test/"), TestContext.Current.CancellationToken);
+
+        // Two failures were absorbed and the third attempt answered, so the pipeline the host added is not merely
+        // registered on this client - it runs on this client's requests.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, origin.Requests);
+    }
+
+    /// <summary>
+    /// The shortest path of all, and the one to document: a host that wants every outbound call resilient names no
+    /// client at all.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="HttpClientFactoryServiceCollectionExtensions.ConfigureHttpClientDefaults"/> applies to clients
+    /// registered before and after it alike, so it holds however the host orders its registrations - which is what
+    /// makes it safe to recommend without a caveat about ordering.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackChannelNotificationTransport.HttpClientName)]
+    [InlineData(BackChannelLogoutTransport.HttpClientName)]
+    [InlineData(SecureFetchTransport.HttpClientName)]
+    public async Task OneHostCall_MakesEveryOutboundClientResilient(string clientName)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+
+        // The whole of what a host writes, naming nothing this library owns.
+        services.ConfigureHttpClientDefaults(builder => builder.AddResilienceOfATypicalHost());
+
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+        services.AddBackChannelLogout();
+
+        // Only to give the test an origin. It cannot be done through the defaults above: this library sets the
+        // primary handler of its client-callback clients to the SSRF validator, and a per-client setting wins over
+        // a default - which is the guarantee that no host-wide default can switch that validation off.
+        var origin = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(clientName).ConfigurePrimaryHttpMessageHandler(() => origin);
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler(clientName);
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var response = await httpClient.GetAsync(
+            new Uri("https://origin.test/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, origin.Requests);
+    }
+
+    /// <summary>
+    /// Each client is configured on its own: a pipeline put on one leaves its neighbours as they were, so a host
+    /// can retry a client's notifications hard while leaving a metadata fetch to fail fast.
+    /// </summary>
+    /// <remarks>
+    /// The untouched neighbour is what carries the claim. Asserting only that the configured client retries would
+    /// hold just as well if the setting had leaked onto every client in the host, which is the mistake this guards.
+    /// </remarks>
+    [Fact]
+    public async Task ConfiguringOneClient_LeavesItsNeighbourUntouched()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+        services.AddBackChannelLogout();
+
+        var notificationOrigin = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(BackChannelNotificationTransport.HttpClientName)
+            .AddResilienceOfATypicalHost()
+            .ConfigurePrimaryHttpMessageHandler(() => notificationOrigin);
+
+        // The neighbour gets an origin and nothing else - no pipeline of its own.
+        var logoutOrigin = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(BackChannelLogoutTransport.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => logoutOrigin);
+
+        using var provider = services.BuildServiceProvider();
+        var handlerFactory = provider.GetRequiredService<IHttpMessageHandlerFactory>();
+
+        using var notificationHandler =
+            handlerFactory.CreateHandler(BackChannelNotificationTransport.HttpClientName);
+        using var notifications = new HttpClient(notificationHandler, disposeHandler: false);
+        var notification = await notifications.GetAsync(
+            new Uri("https://origin.test/"), TestContext.Current.CancellationToken);
+
+        using var logoutHandler = handlerFactory.CreateHandler(BackChannelLogoutTransport.HttpClientName);
+        using var logouts = new HttpClient(logoutHandler, disposeHandler: false);
+        var logout = await logouts.GetAsync(
+            new Uri("https://origin.test/"), TestContext.Current.CancellationToken);
+
+        // The configured client rode out both failures; the neighbour took the first one as its answer.
+        Assert.Equal(HttpStatusCode.OK, notification.StatusCode);
+        Assert.Equal(3, notificationOrigin.Requests);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, logout.StatusCode);
+        Assert.Equal(1, logoutOrigin.Requests);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientResilienceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientResilienceTests.cs
@@ -124,6 +124,43 @@ public class OutboundHttpClientResilienceTests
     }
 
     /// <summary>
+    /// The path a host is told to take: adding the real resilience pipeline leaves the SSRF validation in place,
+    /// so retries and a circuit breaker cost nothing in security.
+    /// </summary>
+    /// <remarks>
+    /// Asserted with the shipping <c>AddStandardResilienceHandler</c> rather than a stand-in handler, because the
+    /// promise is about that call specifically: it adds to the chain instead of replacing the primary handler the
+    /// validation lives in.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackChannelNotificationTransport.HttpClientName)]
+    [InlineData(BackChannelLogoutTransport.HttpClientName)]
+    [InlineData(SecureFetchTransport.HttpClientName)]
+    public void AddingAResiliencePipeline_KeepsTheSsrfValidation(string clientName)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+        services.AddBackChannelLogout();
+
+        services.AddHttpClient(clientName).AddResilienceOfATypicalHost();
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler(clientName);
+
+        var guarded = false;
+        for (HttpMessageHandler? link = handler; link is not null;)
+        {
+            if (link is SsrfValidatingHttpMessageHandler) guarded = true;
+            link = link is DelegatingHandler delegating ? delegating.InnerHandler : null;
+        }
+
+        Assert.True(guarded, $"The resilience pipeline must not displace SSRF validation on '{clientName}'.");
+    }
+
+    /// <summary>
     /// Each client is configured on its own: a pipeline put on one leaves its neighbours as they were, so a host
     /// can retry a client's notifications hard while leaving a metadata fetch to fail fast.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientSsrfWiringTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientSsrfWiringTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -20,9 +20,12 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.BackChannelAuthentication;
+using Abblix.Oidc.Server.Features.LogoutNotification;
 using Abblix.Oidc.Server.Features.SecureHttpFetch;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -38,18 +41,11 @@ namespace Abblix.Oidc.Server.UnitTests.Features.SecureHttpFetch;
 public class OutboundHttpClientSsrfWiringTests
 {
     [Theory]
-    [InlineData(nameof(HttpNotificationDeliveryService))]
-    [InlineData("ILogoutTokenSender")] // default logical name of the typed BackChannelLogoutTokenSender client
+    [InlineData(BackChannelNotificationTransport.HttpClientName)]
+    [InlineData(nameof(ILogoutTokenSender))] // default logical name of the typed BackChannelLogoutTokenSender client
     public void ClientCallbackHttpClients_RouteThroughSsrfValidatingHandler(string clientName)
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddOptions();
-        services.AddSecureHttpFetch();
-        services.AddBackChannelAuthentication();
-        services.AddBackChannelLogout();
-
-        using var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = BuildHost().BuildServiceProvider();
         var handlerFactory = serviceProvider.GetRequiredService<IHttpMessageHandlerFactory>();
 
         using var handler = handlerFactory.CreateHandler(clientName);
@@ -59,14 +55,66 @@ public class OutboundHttpClientSsrfWiringTests
             $"HTTP client '{clientName}' must include {nameof(SsrfValidatingHttpMessageHandler)} in its handler chain.");
     }
 
-    private static bool ChainContainsSsrfHandler(HttpMessageHandler handler)
+    /// <summary>
+    /// The published client name is what a host configures resilience through, so it must reach the very client the
+    /// library resolves - and the SSRF validation must survive whatever the host chains onto it.
+    /// </summary>
+    /// <remarks>
+    /// Both halves are asserted on one chain because they are one guarantee. The host's handler being present proves
+    /// the name is the right one - a wrong name would configure a client nobody uses and read as success - and the
+    /// validation sitting DEEPER proves every attempt of a retry pipeline is validated afresh, which is what a
+    /// client-supplied address needs when it can start resolving to an internal one between attempts.
+    /// </remarks>
+    [Fact]
+    public void HostConfiguration_ByPublishedName_ReachesTheClient_AndStaysOutsideSsrfValidation()
     {
-        for (var current = handler; current is DelegatingHandler delegating; current = delegating.InnerHandler!)
-        {
-            if (current is SsrfValidatingHttpMessageHandler)
-                return true;
-        }
+        var services = BuildHost();
 
-        return false;
+        // What a host writes to add a resilience pipeline, with a handler standing in for one.
+        services.AddHttpClient(BackChannelNotificationTransport.HttpClientName)
+            .AddHttpMessageHandler(() => new HostHandler());
+
+        using var serviceProvider = services.BuildServiceProvider();
+        using var handler = serviceProvider.GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler(BackChannelNotificationTransport.HttpClientName);
+
+        var chain = Chain(handler).ToList();
+
+        var hostPosition = chain.FindIndex(link => link is HostHandler);
+        Assert.True(hostPosition >= 0, "The host's handler must be in the chain of the client the library resolves.");
+
+        var ssrfPosition = chain.FindIndex(link => link is SsrfValidatingHttpMessageHandler);
+        Assert.True(
+            ssrfPosition > hostPosition,
+            "SSRF validation must sit deeper than the host's handler, so a retried attempt is validated again.");
     }
+
+    private static ServiceCollection BuildHost()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+        services.AddBackChannelLogout();
+        return services;
+    }
+
+    private static bool ChainContainsSsrfHandler(HttpMessageHandler handler)
+        => Chain(handler).Any(link => link is SsrfValidatingHttpMessageHandler);
+
+    /// <summary>
+    /// Walks the handler chain from the outermost handler inwards, ending with the primary one.
+    /// </summary>
+    private static IEnumerable<HttpMessageHandler> Chain(HttpMessageHandler handler)
+    {
+        for (var current = handler; current is not null;)
+        {
+            yield return current;
+            current = current is DelegatingHandler delegating ? delegating.InnerHandler : null;
+        }
+    }
+
+    /// <summary>Stands in for whatever a host chains onto the client - a resilience pipeline, a proxy.</summary>
+    private sealed class HostHandler : DelegatingHandler;
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientSsrfWiringTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/OutboundHttpClientSsrfWiringTests.cs
@@ -42,7 +42,7 @@ public class OutboundHttpClientSsrfWiringTests
 {
     [Theory]
     [InlineData(BackChannelNotificationTransport.HttpClientName)]
-    [InlineData(nameof(ILogoutTokenSender))] // default logical name of the typed BackChannelLogoutTokenSender client
+    [InlineData(BackChannelLogoutTransport.HttpClientName)] // default logical name of the typed BackChannelLogoutTokenSender client
     public void ClientCallbackHttpClients_RouteThroughSsrfValidatingHandler(string clientName)
     {
         using var serviceProvider = BuildHost().BuildServiceProvider();

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SsrfGuardWatchTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/SecureHttpFetch/SsrfGuardWatchTests.cs
@@ -1,0 +1,128 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Abblix.Oidc.Server.Features;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication;
+using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Abblix.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.SecureHttpFetch;
+
+/// <summary>
+/// A host that replaces the primary handler of a client registered with SSRF validation removes that validation,
+/// and the build stays green. The library cannot forbid the swap without also forbidding a proxy or a client
+/// certificate, so it reports it instead.
+/// </summary>
+public class SsrfGuardWatchTests
+{
+    [Fact]
+    public void ReplacingThePrimaryHandler_IsReported()
+    {
+        var log = new CapturingLoggerProvider();
+        using var provider = BuildHost(log, services => services
+            .AddHttpClient(BackChannelNotificationTransport.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler()));
+
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler(BackChannelNotificationTransport.HttpClientName);
+
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains(BackChannelNotificationTransport.HttpClientName, entry.Message);
+        Assert.Contains(nameof(SocketsHttpHandler), entry.Message);
+
+        // The category is this type's own, which is what lets a host silence the message alone.
+        Assert.Equal(typeof(SsrfGuardWatch).FullName, entry.Category);
+    }
+
+    /// <summary>
+    /// The half that makes the report worth having: the ordinary way to add resilience does not trigger it, so the
+    /// warning means what it says rather than crying wolf on every configured client.
+    /// </summary>
+    [Fact]
+    public void AddingAResiliencePipeline_IsNotReported()
+    {
+        var log = new CapturingLoggerProvider();
+        using var provider = BuildHost(log, services => services
+            .AddHttpClient(BackChannelNotificationTransport.HttpClientName)
+            .AddResilienceOfATypicalHost());
+
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler(BackChannelNotificationTransport.HttpClientName);
+
+        Assert.Empty(log.Entries);
+    }
+
+    private static ServiceProvider BuildHost(
+        CapturingLoggerProvider log,
+        Action<IServiceCollection> configureHost)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddProvider(log).SetMinimumLevel(LogLevel.Trace));
+        services.AddOptions();
+        services.AddSecureHttpFetch();
+        services.AddBackChannelAuthentication();
+
+        configureHost(services);
+        return services.BuildServiceProvider();
+    }
+
+    private sealed record Entry(string Category, LogLevel Level, string Message);
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<Entry> _entries = [];
+
+        /// <summary>Only what this feature writes; the rest of the host's logging is noise here.</summary>
+        public IReadOnlyList<Entry> Entries
+            => _entries.Where(e => e.Category == typeof(SsrfGuardWatch).FullName).ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new Capturing(categoryName, _entries);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class Capturing(string category, List<Entry> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => entries.Add(new Entry(category, logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj
+++ b/tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
@@ -34,4 +35,9 @@
         <ProjectReference Include="..\..\src\Abblix.SecurityEvents\Abblix.SecurityEvents.csproj" />
     </ItemGroup>
 
+
+    <ItemGroup>
+        <!-- One statement of what a host is promised, compiled into every package's suite. -->
+        <Compile Include="../Shared/HostResilienceProbe.cs" Link="Shared/HostResilienceProbe.cs" />
+    </ItemGroup>
 </Project>

--- a/tests/Abblix.SecurityEvents.UnitTests/JwksFetchResilienceTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/JwksFetchResilienceTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -21,6 +21,10 @@
 // info@abblix.com
 
 using System.Net;
+using System.Net.Http;
+using System.Text;
+using Abblix.Jwt;
+using Abblix.SecurityEvents.Abstractions;
 using Abblix.SecurityEvents.Infrastructure;
 using Abblix.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,8 +40,14 @@ namespace Abblix.SecurityEvents.UnitTests;
 /// </summary>
 public class JwksFetchResilienceTests
 {
+    /// <summary>
+    /// Driven through the real consumer: the resolver fetches a key set through the flaky origin and only succeeds
+    /// because the host's retry absorbed the two failures. Anchoring on <see cref="IIssuerKeyResolver"/> rather
+    /// than on a handler read back by the same name is what makes a wrong <see cref="JwksTransport.HttpClientName"/>
+    /// fail this test: the resolver would then fetch through a client the stub never configured.
+    /// </summary>
     [Fact]
-    public async Task OneHostCall_MakesKeySetFetchesResilient()
+    public async Task OneHostCall_MakesTheResolversKeySetFetchResilient()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -49,18 +59,43 @@ public class JwksFetchResilienceTests
         services.AddSecurityEvents();
         services.AddJwksKeyResolution();
 
-        var issuer = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        var issuer = new FlakyKeySetOrigin(failuresBeforeSuccess: 2);
         services.AddHttpClient(JwksTransport.HttpClientName).ConfigurePrimaryHttpMessageHandler(() => issuer);
 
         using var provider = services.BuildServiceProvider();
-        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
-            .CreateHandler(JwksTransport.HttpClientName);
-        using var httpClient = new HttpClient(handler, disposeHandler: false);
+        var resolver = provider.GetRequiredService<IIssuerKeyResolver>();
 
-        var response = await httpClient.GetAsync(
-            new Uri("https://issuer.test/.well-known/jwks.json"), TestContext.Current.CancellationToken);
+        var keys = new List<JsonWebKey>();
+        await foreach (var key in resolver.ResolveSigningKeysAsync(
+                           "https://issuer.test", cancellationToken: TestContext.Current.CancellationToken))
+        {
+            keys.Add(key);
+        }
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        // The fetch completed, which it could only do after two failures were retried away.
+        Assert.Empty(keys);
         Assert.Equal(3, issuer.Requests);
+    }
+
+    /// <summary>Fails a set number of times, then answers with an empty but well-formed JWK Set.</summary>
+    private sealed class FlakyKeySetOrigin(int failuresBeforeSuccess) : HttpMessageHandler
+    {
+        public int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests++;
+            if (Requests <= failuresBeforeSuccess)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"keys":[]}""", Encoding.UTF8, "application/json"),
+            });
+        }
     }
 }

--- a/tests/Abblix.SecurityEvents.UnitTests/JwksFetchResilienceTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/JwksFetchResilienceTests.cs
@@ -1,0 +1,66 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Xunit;
+
+namespace Abblix.SecurityEvents.UnitTests;
+
+/// <summary>
+/// Key-set fetches must accept a resilience pipeline from the host, in the one call that covers every client
+/// without naming any: an issuer's endpoint is somebody else's infrastructure, and a fetch that fails takes a
+/// token's validation down with it.
+/// </summary>
+public class JwksFetchResilienceTests
+{
+    [Fact]
+    public async Task OneHostCall_MakesKeySetFetchesResilient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+
+        // The whole of what a host writes, naming nothing this library owns.
+        services.ConfigureHttpClientDefaults(builder => builder.AddResilienceOfATypicalHost());
+
+        services.AddSecurityEvents();
+        services.AddJwksKeyResolution();
+
+        var issuer = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(JwksTransport.HttpClientName).ConfigurePrimaryHttpMessageHandler(() => issuer);
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler(JwksTransport.HttpClientName);
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var response = await httpClient.GetAsync(
+            new Uri("https://issuer.test/.well-known/jwks.json"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, issuer.Requests);
+    }
+}

--- a/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -318,7 +318,8 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
 
         var sender = new PushDeliverySender(
             _receiver.GetTestClient(),
-            _transmitter.Services.GetRequiredService<IEventOutbox>());
+            _transmitter.Services.GetRequiredService<IEventOutbox>(),
+            _transmitter.Services.GetRequiredService<ReceiverAddressPolicy>());
 
         return await sender.SendPendingAsync(stream!, cancellationToken);
     }
@@ -334,6 +335,10 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
             Issuer = TransmitterIssuer,
             EventsSupported = [MembershipChanged],
             PollEndpointFactory = streamId => new Uri($"{TransmitterIssuer}/ssf/poll/{streamId}"),
+
+            // The receiver in this suite is a test server rather than a host on the network, so the address
+            // policy is told about it the way an operator tells it about a receiver of its own.
+            AllowedReceiverAddresses = [new Uri(PushEndpoint)],
         });
 
         // The test host's stand-in for authentication: every request is the one receiver. A

--- a/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
+++ b/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -18,6 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="Moq" />
@@ -34,4 +35,9 @@
         <ProjectReference Include="..\..\src\Abblix.SharedSignals\Abblix.SharedSignals.csproj" />
     </ItemGroup>
 
+
+    <ItemGroup>
+        <!-- One statement of what a host is promised, compiled into every package's suite. -->
+        <Compile Include="../Shared/HostResilienceProbe.cs" Link="Shared/HostResilienceProbe.cs" />
+    </ItemGroup>
 </Project>

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliveryResilienceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliveryResilienceTests.cs
@@ -1,0 +1,68 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.Transmitter;
+using Abblix.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// The transmitter's push sender must accept a resilience pipeline from its host, in the one call that covers
+/// every client without naming any: a receiver's endpoint is exactly where a transient failure is expected, and
+/// the sender itself makes one honest attempt by design.
+/// </summary>
+public class PushDeliveryResilienceTests
+{
+    [Fact]
+    public async Task OneHostCall_MakesThePushSenderResilient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+
+        // The whole of what a host writes, naming nothing this library owns.
+        services.ConfigureHttpClientDefaults(builder => builder.AddResilienceOfATypicalHost());
+
+        services.AddSecurityEvents();
+        services.AddSsfTransmitter(new SsfTransmitterOptions { Issuer = "https://transmitter.test" });
+
+        var receiver = new FlakyOriginHandler(failuresBeforeSuccess: 2);
+        services.AddHttpClient(PushDeliveryTransport.HttpClientName).ConfigurePrimaryHttpMessageHandler(() => receiver);
+
+        using var provider = services.BuildServiceProvider();
+        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
+            .CreateHandler(PushDeliveryTransport.HttpClientName);
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var response = await httpClient.GetAsync(
+            new Uri("https://receiver.test/events"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, receiver.Requests);
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliveryResilienceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliveryResilienceTests.cs
@@ -23,10 +23,11 @@
 using System.Net;
 using Abblix.SecurityEvents.Infrastructure;
 using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
 using Abblix.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -38,9 +39,17 @@ namespace Abblix.SharedSignals.UnitTests;
 /// </summary>
 public class PushDeliveryResilienceTests
 {
+    /// <summary>
+    /// Driven through the real <see cref="PushDeliverySender"/>: a delivery pass succeeds only because the host's
+    /// retry absorbed the receiver's two transient failures. Anchoring on the sender rather than on a handler read
+    /// back by the same name is what makes a wrong <see cref="PushDeliveryTransport.HttpClientName"/> fail this
+    /// test - the sender would then deliver through a client the stub never configured.
+    /// </summary>
     [Fact]
-    public async Task OneHostCall_MakesThePushSenderResilient()
+    public async Task OneHostCall_MakesThePushSendersDeliveryResilient()
     {
+        const string receiverEndpoint = "https://receiver.test/events";
+
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddOptions();
@@ -49,20 +58,43 @@ public class PushDeliveryResilienceTests
         services.ConfigureHttpClientDefaults(builder => builder.AddResilienceOfATypicalHost());
 
         services.AddSecurityEvents();
-        services.AddSsfTransmitter(new SsfTransmitterOptions { Issuer = "https://transmitter.test" });
+        services.AddSsfTransmitter(new SsfTransmitterOptions
+        {
+            Issuer = "https://transmitter.test",
+
+            // The test receiver is a stub, not a host on the network, so it is permitted the way an operator
+            // permits a receiver of its own; the resilience being measured is a separate concern.
+            AllowedReceiverAddresses = [new Uri(receiverEndpoint)],
+        });
 
         var receiver = new FlakyOriginHandler(failuresBeforeSuccess: 2);
         services.AddHttpClient(PushDeliveryTransport.HttpClientName).ConfigurePrimaryHttpMessageHandler(() => receiver);
 
         using var provider = services.BuildServiceProvider();
-        using var handler = provider.GetRequiredService<IHttpMessageHandlerFactory>()
-            .CreateHandler(PushDeliveryTransport.HttpClientName);
-        using var httpClient = new HttpClient(handler, disposeHandler: false);
 
-        var response = await httpClient.GetAsync(
-            new Uri("https://receiver.test/events"), TestContext.Current.CancellationToken);
+        var outbox = provider.GetRequiredService<IEventOutbox>();
+        await outbox.EnqueueAsync("s-1", new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var sender = provider.GetRequiredService<PushDeliverySender>();
+        var stream = new StreamState
+        {
+            ReceiverId = "receiver-a",
+            Status = StreamStatuses.Enabled,
+            SubjectsMode = StreamSubjectsMode.None,
+            Configuration = new StreamConfiguration
+            {
+                StreamId = "s-1",
+                Issuer = "https://transmitter.test",
+                Audiences = ["https://receiver.test"],
+                EventsDelivered = [],
+                Delivery = new PushDeliveryMethod(new Uri(receiverEndpoint)),
+            },
+        };
+
+        var outcome = await sender.SendPendingAsync(stream, TestContext.Current.CancellationToken);
+
+        // The one event was delivered, which the sender could only report after two failures were retried away.
+        Assert.Equal(new PushDeliveryPassOutcome(Delivered: 1, Rejected: 0), outcome);
         Assert.Equal(3, receiver.Requests);
     }
 }

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliverySsrfWiringTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliverySsrfWiringTests.cs
@@ -1,0 +1,110 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using System.Net.Http;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// A receiver chooses the address its stream is delivered to, so the address check has to live on the connection,
+/// not only in front of it: a redirect or a DNS rebinding would otherwise carry a delivery to an address nothing
+/// vetted. These tests pin that the transmitter registration installs
+/// <see cref="ReceiverAddressValidatingHandler"/> as the push client's primary handler, with redirects disabled.
+/// </summary>
+public class PushDeliverySsrfWiringTests
+{
+    private static IHttpMessageHandlerFactory HandlerFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSecurityEvents();
+        services.AddSsfTransmitter(new SsfTransmitterOptions { Issuer = "https://transmitter.test" });
+        return services.BuildServiceProvider().GetRequiredService<IHttpMessageHandlerFactory>();
+    }
+
+    private static IEnumerable<HttpMessageHandler> Chain(HttpMessageHandler handler)
+    {
+        for (var current = handler; current is not null;)
+        {
+            yield return current;
+            current = current is DelegatingHandler delegating ? delegating.InnerHandler : null;
+        }
+    }
+
+    [Fact]
+    public void ThePushClientRoutesThroughTheValidatingHandler_WithRedirectsDisabled()
+    {
+        using var handler = HandlerFactory().CreateHandler(PushDeliveryTransport.HttpClientName);
+        var chain = Chain(handler).ToList();
+
+        var guard = Assert.IsType<ReceiverAddressValidatingHandler>(
+            chain.Find(link => link is ReceiverAddressValidatingHandler));
+
+        // The redirect-following that would carry a delivery to an unvetted second address is off, so a receiver's
+        // 3xx comes back as an ordinary non-success response instead.
+        var transport = Assert.IsType<HttpClientHandler>(guard.InnerHandler);
+        Assert.False(transport.AllowAutoRedirect);
+    }
+
+    /// <summary>
+    /// The guard runs on the request itself, before the socket: an internal address is refused on the connection,
+    /// which is what a redirect target or a rebound name would present.
+    /// </summary>
+    [Fact]
+    public async Task TheValidatingHandler_RefusesAnInternalAddressBeforeConnecting()
+    {
+        var probe = new ConnectionProbe();
+        var guard = new ReceiverAddressValidatingHandler(
+            new ReceiverAddressPolicy(new SsfTransmitterOptions { Issuer = "https://transmitter.test" }))
+        {
+            InnerHandler = probe,
+        };
+        using var client = new HttpClient(guard);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(
+            new Uri("https://169.254.169.254/events"), TestContext.Current.CancellationToken));
+
+        // The refusal happened before anything reached the transport.
+        Assert.Equal(0, probe.Requests);
+    }
+
+    private sealed class ConnectionProbe : HttpMessageHandler
+    {
+        public int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Net;
+using System.Net.Sockets;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
@@ -40,6 +41,10 @@ public class ReceiverAddressPolicyTests
         Issuer = "https://tr.example.com",
         AllowedReceiverAddresses = allowed,
     });
+
+    private static ReceiverAddressPolicy PolicyResolving(params IPAddress[] answers) => new(
+        new SsfTransmitterOptions { Issuer = "https://tr.example.com" },
+        (_, _) => Task.FromResult(answers));
 
     [Theory]
     [InlineData("https://169.254.169.254/events")]     // cloud metadata
@@ -85,6 +90,57 @@ public class ReceiverAddressPolicyTests
 
         var rejection = await policy.RejectionOf(
             new Uri("https://10.1.2.4/events"), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(rejection);
+    }
+
+    /// <summary>
+    /// The only "allow" verdict production traffic actually reaches: an ordinary public receiver, whose name
+    /// resolves to a public address, is permitted. Without this case the resolved-address branch could be
+    /// inverted and the suite would stay green.
+    /// </summary>
+    [Fact]
+    public async Task AResolvedPublicAddressIsPermitted()
+    {
+        var policy = PolicyResolving(IPAddress.Parse("93.184.216.34"));
+
+        var rejection = await policy.RejectionOf(
+            new Uri("https://receiver.example.com/events"), TestContext.Current.CancellationToken);
+
+        Assert.Null(rejection);
+    }
+
+    /// <summary>
+    /// Every resolved address must be acceptable, not just the first: a name answering with one public and one
+    /// private address is refused, because the connection could take either.
+    /// </summary>
+    [Fact]
+    public async Task ANameResolvingToAnyPrivateAddressIsRefused()
+    {
+        var policy = PolicyResolving(IPAddress.Parse("93.184.216.34"), IPAddress.Parse("10.0.0.5"));
+
+        var rejection = await policy.RejectionOf(
+            new Uri("https://receiver.example.com/events"), TestContext.Current.CancellationToken);
+
+        // Named on the private answer, not the public one: the refusal is about the address that would have let
+        // the connection inside, which pins the "every answer" rule rather than "the first answer".
+        Assert.NotNull(rejection);
+        Assert.Contains("10.0.0.5", rejection);
+    }
+
+    /// <summary>
+    /// A name that does not resolve is refused rather than delivered to: an unresolvable endpoint is not a public
+    /// receiver.
+    /// </summary>
+    [Fact]
+    public async Task ANameThatDoesNotResolveIsRefused()
+    {
+        var policy = new ReceiverAddressPolicy(
+            new SsfTransmitterOptions { Issuer = "https://tr.example.com" },
+            (host, _) => throw new SocketException());
+
+        var rejection = await policy.RejectionOf(
+            new Uri("https://receiver.example.com/events"), TestContext.Current.CancellationToken);
 
         Assert.NotNull(rejection);
     }

--- a/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
@@ -1,0 +1,126 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Net;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+using Abblix.SharedSignals.Transmitter;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// A receiver names the address its stream is delivered to, so that address is input from outside: this is what
+/// stops a receiver from pointing a stream at the transmitter's own network and having security event tokens
+/// POSTed there.
+/// </summary>
+public class ReceiverAddressPolicyTests
+{
+    private static ReceiverAddressPolicy Policy(params Uri[] allowed) => new(new SsfTransmitterOptions
+    {
+        Issuer = "https://tr.example.com",
+        AllowedReceiverAddresses = allowed,
+    });
+
+    [Theory]
+    [InlineData("https://169.254.169.254/events")]     // cloud metadata
+    [InlineData("https://127.0.0.1/events")]           // loopback
+    [InlineData("https://10.1.2.3/events")]            // private
+    [InlineData("https://192.168.0.5/events")]         // private
+    [InlineData("https://[::1]/events")]               // loopback, IPv6
+    [InlineData("https://[::ffff:169.254.169.254]/events")] // metadata behind an IPv4-mapped IPv6 address
+    [InlineData("https://localhost/events")]           // internal name
+    [InlineData("https://vault.internal/events")]      // internal TLD
+    [InlineData("https://receiver/events")]            // single label
+    [InlineData("http://receiver.example.com/events")] // cleartext
+    public async Task AnAddressInsideTheNetworkIsRefused(string endpoint)
+    {
+        var rejection = await Policy().RejectionOf(
+            new Uri(endpoint), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(rejection);
+    }
+
+    /// <summary>
+    /// The half that keeps the policy honest: a permission an operator wrote reaches a receiver of its own, at an
+    /// address the rules above would refuse.
+    /// </summary>
+    [Fact]
+    public async Task AnAddressTheOperatorPermittedIsReached()
+    {
+        var policy = Policy(new Uri("https://10.1.2.3"));
+
+        var rejection = await policy.RejectionOf(
+            new Uri("https://10.1.2.3/events"), TestContext.Current.CancellationToken);
+
+        Assert.Null(rejection);
+    }
+
+    /// <summary>
+    /// A permission names one origin, not a posture: permitting one receiver must not permit its neighbour.
+    /// </summary>
+    [Fact]
+    public async Task APermissionDoesNotCoverAnotherAddress()
+    {
+        var policy = Policy(new Uri("https://10.1.2.3"));
+
+        var rejection = await policy.RejectionOf(
+            new Uri("https://10.1.2.4/events"), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(rejection);
+    }
+
+    /// <summary>
+    /// The sender refuses to spend a queue on a receiver whose address it may not reach, and holds the events
+    /// instead: an operator can put the configuration right, and the events are still owed.
+    /// </summary>
+    [Fact]
+    public async Task TheSenderRefusesToDeliverToARefusedAddress()
+    {
+        var handler = new StubHttpHandler().Enqueue(HttpStatusCode.Accepted);
+        var outbox = new InMemoryEventOutbox();
+        await outbox.EnqueueAsync("s-1", new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
+
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, Policy());
+        var stream = new StreamState
+        {
+            ReceiverId = "receiver-a",
+            Status = StreamStatuses.Enabled,
+            SubjectsMode = StreamSubjectsMode.None,
+            Configuration = new StreamConfiguration
+            {
+                StreamId = "s-1",
+                Issuer = "https://tr.example.com",
+                Audiences = ["https://receiver.example.com"],
+                EventsDelivered = [],
+                Delivery = new PushDeliveryMethod(new Uri("https://169.254.169.254/events")),
+            },
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sender.SendPendingAsync(stream, TestContext.Current.CancellationToken));
+
+        // Nothing was sent, and the event is still there for a pass made after the address is corrected.
+        Assert.Empty(handler.Requests);
+        Assert.Single(await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System.Net;
+using System.Net.Mime;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
@@ -55,6 +56,20 @@ public class TransmitterDeliveryTests
         },
     };
 
+    /// <summary>
+    /// Permits the receiver these tests deliver to, so the address policy is not what they are measuring.
+    /// </summary>
+    /// <remarks>
+    /// Named as an operator permission rather than a relaxation: without it the policy would resolve
+    /// "receiver.example.com" over the network, which is neither this suite's subject nor its business.
+    /// The policy's own rules are covered in <see cref="ReceiverAddressPolicyTests"/>.
+    /// </remarks>
+    private static ReceiverAddressPolicy ReachingTheTestReceiver => new(new SsfTransmitterOptions
+    {
+        Issuer = "https://tr.example.com",
+        AllowedReceiverAddresses = [new Uri("https://receiver.example.com")],
+    });
+
     private static async Task<InMemoryEventOutbox> OutboxWithAsync(params OutboxItem[] items)
     {
         var outbox = new InMemoryEventOutbox();
@@ -73,7 +88,7 @@ public class TransmitterDeliveryTests
             .Enqueue(HttpStatusCode.Accepted)
             .Enqueue(HttpStatusCode.Accepted);
         var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"), new OutboxItem("jti-2", "b.b.b"));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
 
         var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
@@ -95,7 +110,7 @@ public class TransmitterDeliveryTests
             new OutboxItem("jti-1", "a.a.a"),
             new OutboxItem("jti-2", "b.b.b"),
             new OutboxItem("jti-3", "c.c.c"));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
 
         var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
@@ -104,6 +119,54 @@ public class TransmitterDeliveryTests
             ["jti-2", "jti-3"],
             (await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken))
             .Select(item => item.JwtId));
+    }
+
+    /// <summary>
+    /// A 400 about the transmitter rather than about the event keeps the event queued: RFC 8935 Section 4 names
+    /// exactly this case as one a retransmission can succeed at, "if the SET Transmitter refreshes expired
+    /// credentials prior to retransmission".
+    /// </summary>
+    [Theory]
+    [InlineData(DeliveryErrorCodes.AuthenticationFailed)]
+    [InlineData(DeliveryErrorCodes.AccessDenied)]
+    public async Task Push_BadRequestAboutTheTransmitter_KeepsTheEventQueued(string errorCode)
+    {
+        var handler = new StubHttpHandler()
+            .Enqueue(HttpStatusCode.BadRequest, $$"""{"err": "{{errorCode}}", "description": "-"}""");
+        var outbox = await OutboxWithAsync(
+            new OutboxItem("jti-1", "a.a.a"),
+            new OutboxItem("jti-2", "b.b.b"));
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+
+        var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
+
+        // Nothing delivered, nothing dropped, and the pass stopped rather than spending the queue on a receiver
+        // that is refusing this transmitter for a reason a deployment can fix.
+        Assert.Equal(new PushDeliveryPassOutcome(Delivered: 0, Rejected: 0), outcome);
+        Assert.Equal(
+            ["jti-1", "jti-2"],
+            (await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken))
+            .Select(item => item.JwtId));
+    }
+
+    /// <summary>
+    /// A 400 whose body cannot be read as a verdict is treated as final, because the alternative lets a receiver
+    /// answering with an error page hold the head of the queue indefinitely.
+    /// </summary>
+    [Theory]
+    [InlineData("not json at all", MediaTypeNames.Text.Html)]
+    [InlineData("""{"err": "something_the_registry_does_not_have", "description": "-"}""",
+        MediaTypeNames.Application.Json)]
+    public async Task Push_BadRequestWithoutAReadableVerdict_DropsTheEvent(string body, string mediaType)
+    {
+        var handler = new StubHttpHandler().Enqueue(HttpStatusCode.BadRequest, body, mediaType);
+        var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"));
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+
+        var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(new PushDeliveryPassOutcome(Delivered: 0, Rejected: 1), outcome);
+        Assert.Empty(await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -115,7 +178,7 @@ public class TransmitterDeliveryTests
         var outbox = await OutboxWithAsync(
             new OutboxItem("jti-1", "a.a.a"),
             new OutboxItem("jti-2", "b.b.b", IsStatusAnnouncement: true));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
 
         var outcome = await sender.SendPendingAsync(
             PushStream(StreamStatuses.Paused), TestContext.Current.CancellationToken);

--- a/tests/Shared/HostResilienceProbe.cs
+++ b/tests/Shared/HostResilienceProbe.cs
@@ -1,0 +1,86 @@
+﻿// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+// Spelled out rather than left to ImplicitUsings, because this file is compiled into suites that do not enable it.
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
+
+namespace Abblix.Tests.Shared;
+
+/// <summary>
+/// What a host writes to make one of this library's outbound clients resilient, and the origin that proves it ran.
+/// </summary>
+/// <remarks>
+/// Shared by link across the test projects of every package that owns an outbound client, so each asserts the same
+/// promise in the same words: the promise is one, and a per-package rewrite of it would drift.
+/// </remarks>
+public static class HostResilienceProbe
+{
+    /// <summary>
+    /// Adds the resilience pipeline a typical host adds - retries and a circuit breaker among them - with the retry
+    /// delay removed so a test does not pay the production backoff.
+    /// </summary>
+    /// <param name="builder">The client builder returned by <c>AddHttpClient</c>.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static IHttpClientBuilder AddResilienceOfATypicalHost(this IHttpClientBuilder builder)
+    {
+        builder.AddStandardResilienceHandler(options =>
+        {
+            options.Retry.MaxRetryAttempts = 2;
+            options.Retry.Delay = TimeSpan.Zero;
+            options.Retry.BackoffType = DelayBackoffType.Constant;
+            options.Retry.UseJitter = false;
+        });
+
+        return builder;
+    }
+}
+
+/// <summary>
+/// An origin that fails a set number of times before answering, so a retry is visible as a request count rather
+/// than inferred from the presence of a handler.
+/// </summary>
+/// <param name="failuresBeforeSuccess">How many attempts are refused before one succeeds.</param>
+public sealed class FlakyOriginHandler(int failuresBeforeSuccess) : HttpMessageHandler
+{
+    /// <summary>How many attempts reached the origin.</summary>
+    public int Requests { get; private set; }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        Requests++;
+
+        // 503 is what the standard pipeline treats as worth retrying; a 400 would prove nothing, since the
+        // pipeline is right not to repeat it.
+        return Task.FromResult(new HttpResponseMessage(
+            Requests <= failuresBeforeSuccess ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+    }
+}


### PR DESCRIPTION
Four commits, each independently reviewable.

## Every outbound client has a published name

A host configuring resilience, a proxy or a certificate had to know that a typed client is keyed by its contract name, and to copy strings like `"Abblix.Jwt.Vault"` out of our source. Two of those names were not even reachable: `internal` in the Vault package, `private` in the Azure one.

Each of the eight clients now carries `HttpClientName` on a `<Feature>Transport` type in its own package. Shipped values are unchanged, because altering one would rebind an existing host's configuration to a client nobody resolves while the build stayed green.

## Proof that a resilience pipeline attaches

Each name is covered by a test that drives a real `AddStandardResilienceHandler` over an origin failing twice and requires the third attempt to arrive. Present-in-the-chain would have passed while never running.

One test configures a single client and requires its neighbour to stay unconfigured. Without that half, a setting leaking host-wide would read as success.

## A replaced address validation is reported

The SSRF validation is a client's primary handler, so a host setting its own primary handler on one of the three client-callback clients replaces it, silently. Forbidding that call would also forbid a proxy or a client certificate, so the library reports the substitution at `Warning` instead, naming the client and what replaced it.

It writes under its own log category, so a deployment that made the swap deliberately silences that one message and keeps every other log intact.

## SSF push: the verdict decides, and the address is checked

A 400 was treated as terminal whatever it said. RFC 8935 Section 4 separates a structural complaint, which survives redelivery, from one about the transmitter's credentials, which does not: an expired credential no longer empties a queue of events still deliverable.

A receiver names the address its stream is delivered to, so that address is now judged before every pass rather than once at configuration time. The rules for what counts as an internal address moved to `Abblix.Utils`, where both packages read them; the server package's public surface is unchanged and its validator delegates.

## Verification

3050 tests green across the affected suites. Each new guarantee was checked by mutation: inverting the rule, or removing it, makes the intended tests and only those fail.