### PR TITLE
A key naming no role serves both roles, and retires when both have moved on

### DIFF
--- a/src/Abblix.Jwt/ExternalKeys/KeyRing.cs
+++ b/src/Abblix.Jwt/ExternalKeys/KeyRing.cs
@@ -91,10 +91,39 @@ internal sealed class KeyRing(
         foreach (var entry in entries)
         {
             var key = await envelope.OpenAsync(entry.Jwe, versions.ToAsyncEnumerable(), cancellationToken);
+            RequireNamedRole(key, entry.Id);
             opened.Add(new OpenedKey(entry.Id, key, entry.CreatedAt));
         }
 
         _keys = await RetireExpiredAsync(opened, cancellationToken);
+    }
+
+    /// <summary>
+    /// Refuses a ring entry whose key does not name the role it serves.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Get"/> selects by an exact match on the role, so a key naming none matches neither and leaves
+    /// the ring through a hole rather than a door: the JWKS quietly loses an entry, the role it was meant to fill
+    /// ends up with nothing to produce with, and the cause sits in a stored envelope nobody reads. Refusing here
+    /// costs one comparison and names the entry.
+    ///
+    /// A certificate is the way this arrives. A JWK derived from one that permits both signing and encipherment
+    /// carries no <c>use</c> at all, because RFC 7517 section 4.2 makes the member a single value and expresses
+    /// "unrestricted" by omitting it. The same section allows an application to require its presence, and this
+    /// ring does: a key it cannot file under a role is a key it cannot serve.
+    /// </remarks>
+    /// <param name="key">The key just opened from its envelope.</param>
+    /// <param name="entryId">The ring entry it came from, so the message points at something addressable.</param>
+    private static void RequireNamedRole(JsonWebKey key, string entryId)
+    {
+        if (key.Usage is PublicKeyUsages.Signature or PublicKeyUsages.Encryption)
+            return;
+
+        throw new InvalidOperationException(
+            $"The key in ring entry '{entryId}' names no role: its '{nameof(JsonWebKey.Usage)}' is " +
+            $"'{key.Usage ?? "(none)"}', while the ring serves only '{PublicKeyUsages.Signature}' and " +
+            $"'{PublicKeyUsages.Encryption}'. A key derived from a certificate that permits both signing and " +
+            "encipherment carries no role, so set one explicitly before storing it.");
     }
 
     /// <summary>

--- a/src/Abblix.Jwt/ExternalKeys/KeyRing.cs
+++ b/src/Abblix.Jwt/ExternalKeys/KeyRing.cs
@@ -64,10 +64,22 @@ internal sealed class KeyRing(
     /// decryption do. Publication must not.</param>
     public IEnumerable<JsonWebKey> Get(string usage, bool includePrivateKeys)
         => _keys
-            .Where(opened => opened.Key.Usage == usage)
+            .Where(opened => Serves(opened.Key, usage))
             .ToList()
             .ProduceFirst(opened => opened.CreatedAt, timeProvider.GetUtcNow(), options.Value.KeyRolloverPropagation)
             .Select(opened => opened.Key.Sanitize(includePrivateKeys));
+
+    /// <summary>
+    /// Whether a key may serve a role: either it names that role, or it names none and is therefore unrestricted.
+    /// </summary>
+    /// <remarks>
+    /// RFC 7517 section 4.2 makes <c>use</c> OPTIONAL and single-valued, so a key permitted to both sign and
+    /// encrypt is expressed by omitting the member, never by a multi-valued one. Reading an absent <c>use</c> as
+    /// "no role" rather than "any role" would drop exactly those keys, and silently: they match no role, so they
+    /// leave the published set without anything reporting a loss. A certificate permitting both signing and
+    /// encipherment produces precisely such a key.
+    /// </remarks>
+    private static bool Serves(JsonWebKey key, string usage) => key.Usage is null || key.Usage == usage;
 
     /// <summary>
     /// Mints whatever the current period is missing, then reloads and opens the ring into memory.
@@ -91,39 +103,10 @@ internal sealed class KeyRing(
         foreach (var entry in entries)
         {
             var key = await envelope.OpenAsync(entry.Jwe, versions.ToAsyncEnumerable(), cancellationToken);
-            RequireNamedRole(key, entry.Id);
             opened.Add(new OpenedKey(entry.Id, key, entry.CreatedAt));
         }
 
         _keys = await RetireExpiredAsync(opened, cancellationToken);
-    }
-
-    /// <summary>
-    /// Refuses a ring entry whose key does not name the role it serves.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="Get"/> selects by an exact match on the role, so a key naming none matches neither and leaves
-    /// the ring through a hole rather than a door: the JWKS quietly loses an entry, the role it was meant to fill
-    /// ends up with nothing to produce with, and the cause sits in a stored envelope nobody reads. Refusing here
-    /// costs one comparison and names the entry.
-    ///
-    /// A certificate is the way this arrives. A JWK derived from one that permits both signing and encipherment
-    /// carries no <c>use</c> at all, because RFC 7517 section 4.2 makes the member a single value and expresses
-    /// "unrestricted" by omitting it. The same section allows an application to require its presence, and this
-    /// ring does: a key it cannot file under a role is a key it cannot serve.
-    /// </remarks>
-    /// <param name="key">The key just opened from its envelope.</param>
-    /// <param name="entryId">The ring entry it came from, so the message points at something addressable.</param>
-    private static void RequireNamedRole(JsonWebKey key, string entryId)
-    {
-        if (key.Usage is PublicKeyUsages.Signature or PublicKeyUsages.Encryption)
-            return;
-
-        throw new InvalidOperationException(
-            $"The key in ring entry '{entryId}' names no role: its '{nameof(JsonWebKey.Usage)}' is " +
-            $"'{key.Usage ?? "(none)"}', while the ring serves only '{PublicKeyUsages.Signature}' and " +
-            $"'{PublicKeyUsages.Encryption}'. A key derived from a certificate that permits both signing and " +
-            "encipherment carries no role, so set one explicitly before storing it.");
     }
 
     /// <summary>
@@ -148,12 +131,20 @@ internal sealed class KeyRing(
         var propagation = options.Value.KeyRolloverPropagation;
         var keepRetiredFor = policy.KeepRetiredFor ?? policy.RotateEvery;
 
-        var live = new List<OpenedKey>(opened.Count);
-        foreach (var group in opened.GroupBy(key => key.Key.Usage))
+        // Retirement is decided per ROLE, and a key is kept if any role it serves still needs it. That is what
+        // makes an unrestricted key (no `use`, so it serves both) safe to hold: it leaves only once BOTH roles
+        // have moved on, and a role nobody mints for - encryption, when no encryption algorithm is named - keeps
+        // it indefinitely, which is correct, since it is the only key that role has.
+        var expired = new HashSet<string>(opened.Select(key => key.Id));
+
+        foreach (var usage in new[] { PublicKeyUsages.Signature, PublicKeyUsages.Encryption })
         {
-            // Oldest first, so each key's successor is simply the next one along. The newest of a role has no
-            // successor and therefore never retires: it is the key currently signing, or the one about to.
-            var byOldest = group.OrderBy(key => key.CreatedAt).ToList();
+            // Oldest first, so each key's successor is simply the next one along. The newest serving a role has
+            // no successor and therefore never retires: it is the key currently producing, or the one about to.
+            var byOldest = opened
+                .Where(key => Serves(key.Key, usage))
+                .OrderBy(key => key.CreatedAt)
+                .ToList();
 
             for (var index = 0; index < byOldest.Count; index++)
             {
@@ -161,13 +152,20 @@ internal sealed class KeyRing(
                 var successor = index + 1 < byOldest.Count ? byOldest[index + 1] : null;
 
                 if (successor is null || now <= successor.CreatedAt + propagation + keepRetiredFor)
-                {
-                    live.Add(key);
-                    continue;
-                }
-
-                await store.RemoveAsync(key.Id, cancellationToken);
+                    expired.Remove(key.Id);
             }
+        }
+
+        var live = new List<OpenedKey>(opened.Count);
+        foreach (var key in opened)
+        {
+            if (!expired.Contains(key.Id))
+            {
+                live.Add(key);
+                continue;
+            }
+
+            await store.RemoveAsync(key.Id, cancellationToken);
         }
 
         return live;

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -270,4 +270,67 @@ public static class JsonWebKeyExtensions
 			D = key.PrivateKey, // Optional private key component
 		};
 	}
+
+	/// <summary>
+	/// Whether this key can carry out the given algorithm - JWS signing or JWE key management - judged by the
+	/// key's own material rather than by what it declares.
+	/// </summary>
+	/// <remarks>
+	/// RFC 7517 section 4.4 makes <c>alg</c> OPTIONAL, so a key may simply not say what it is for - and a key
+	/// imported from a certificate never does. Such a key is not "unknown", it is answerable: RFC 7518 section 3.1
+	/// binds each algorithm to a key type, and section 3.4 binds each ECDSA algorithm to one curve. Asking the
+	/// material is therefore exact, and it is the only question that matters at the point of use, since a
+	/// declaration is a claim while the material is the fact.
+	/// </remarks>
+	/// <param name="key">The key to test.</param>
+	/// <param name="algorithm">The JWS algorithm the caller needs.</param>
+	/// <returns>True when the key's type, and for ECDSA its curve, match what the algorithm requires.</returns>
+	public static bool SupportsAlgorithm(this JsonWebKey key, string algorithm)
+		=> algorithm switch
+		{
+			SigningAlgorithms.RS256 or SigningAlgorithms.RS384 or SigningAlgorithms.RS512 or
+			SigningAlgorithms.PS256 or SigningAlgorithms.PS384 or SigningAlgorithms.PS512
+				=> key.KeyType == JsonWebKeyTypes.Rsa,
+
+			SigningAlgorithms.ES256 => key.IsCurve(EllipticCurveTypes.P256),
+			SigningAlgorithms.ES384 => key.IsCurve(EllipticCurveTypes.P384),
+			SigningAlgorithms.ES512 => key.IsCurve(EllipticCurveTypes.P521),
+
+			SigningAlgorithms.HS256 or SigningAlgorithms.HS384 or SigningAlgorithms.HS512
+				=> key.KeyType == JsonWebKeyTypes.Octet,
+
+			// JWE key management, RFC 7518 section 4.1. The same question, asked of the recipient's key.
+			EncryptionAlgorithms.KeyManagement.Rsa1_5 or
+			EncryptionAlgorithms.KeyManagement.RsaOaep or
+			EncryptionAlgorithms.KeyManagement.RsaOaep256
+				=> key.KeyType == JsonWebKeyTypes.Rsa,
+
+			// Key agreement needs a curve, and any of the three will do: unlike ECDSA, the algorithm name does
+			// not pin one, so the curve is carried in the ephemeral key instead.
+			EncryptionAlgorithms.KeyManagement.EcdhEs or
+			EncryptionAlgorithms.KeyManagement.EcdhEsAes128KW or
+			EncryptionAlgorithms.KeyManagement.EcdhEsAes192KW or
+			EncryptionAlgorithms.KeyManagement.EcdhEsAes256KW
+				=> key.KeyType == JsonWebKeyTypes.EllipticCurve,
+
+			EncryptionAlgorithms.KeyManagement.Aes128KW or
+			EncryptionAlgorithms.KeyManagement.Aes192KW or
+			EncryptionAlgorithms.KeyManagement.Aes256KW or
+			EncryptionAlgorithms.KeyManagement.Aes128Gcmkw or
+			EncryptionAlgorithms.KeyManagement.Aes192Gcmkw or
+			EncryptionAlgorithms.KeyManagement.Aes256Gcmkw or
+			EncryptionAlgorithms.KeyManagement.Dir or
+			EncryptionAlgorithms.KeyManagement.Pbes2HmacSha256Aes128KW or
+			EncryptionAlgorithms.KeyManagement.Pbes2HmacSha384Aes192KW or
+			EncryptionAlgorithms.KeyManagement.Pbes2HmacSha512Aes256KW
+				=> key.KeyType == JsonWebKeyTypes.Octet,
+
+			// "none" carries no key, and an unregistered name is one this library cannot perform: in both cases
+			// no key qualifies, which is the answer rather than a reason to guess.
+			_ => false,
+		};
+
+	/// <summary>Whether the key is an elliptic-curve key on exactly the named curve.</summary>
+	private static bool IsCurve(this JsonWebKey key, string curve)
+		=> key is EllipticCurveJsonWebKey ec && ec.Curve == curve;
 }

--- a/src/Abblix.Oidc.Server/Common/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Oidc.Server/Common/JsonWebKeyExtensions.cs
@@ -31,14 +31,23 @@ namespace Abblix.Oidc.Server.Common;
 public static class JsonWebKeyExtensions
 {
     /// <summary>
-    /// Asynchronously retrieves the first <see cref="JsonWebKey"/> with the specified algorithm from the sequence.
-    /// Prioritizes keys with exact algorithm match, then falls back to algorithm-agnostic keys (Algorithm == null)
-    /// per RFC 7517, which allows keys without 'alg' parameter to be used with any compatible algorithm.
+    /// Asynchronously retrieves the first <see cref="JsonWebKey"/> able to perform the specified algorithm.
     /// </summary>
+    /// <remarks>
+    /// A key qualifies by declaring the algorithm, or - when it declares none, which RFC 7517 section 4.4 permits
+    /// and a certificate-imported key always does - by its material being able to perform it, per
+    /// <see cref="Abblix.Jwt.JsonWebKeyExtensions.SupportsAlgorithm"/>.
+    /// <para>
+    /// Order is left to the caller, deliberately. Ranking a declared <c>alg</c> above an undeclared one would
+    /// override the order the provider handed down, and that order is load-bearing: a key ring returns the active
+    /// key first, so reordering here would pick a key the ring deliberately kept behind - during a rollover, the
+    /// newcomer instead of the key clients still expect. Whether a key names its algorithm says nothing about
+    /// which key should produce.
+    /// </para>
+    /// </remarks>
     /// <param name="credentials">The asynchronous sequence of <see cref="JsonWebKey"/> objects.</param>
     /// <param name="algorithm">The algorithm to match. Returns null if <see cref="SigningAlgorithms.None"/> is provided.</param>
-    /// <returns>The first <see cref="JsonWebKey"/> with the specified algorithm or null if not found.</returns>
-
+    /// <returns>The first <see cref="JsonWebKey"/> able to perform the algorithm.</returns>
     public static async Task<JsonWebKey?> FirstByAlgorithmAsync(
         this IAsyncEnumerable<JsonWebKey> credentials,
         string? algorithm)
@@ -48,10 +57,7 @@ public static class JsonWebKeyExtensions
 
         if (algorithm.HasValue())
         {
-            // Prioritize exact algorithm match, then fall back to algorithm-agnostic keys (Algorithm == null)
-            credentials = credentials
-                .Where(key => key.Algorithm == algorithm || key.Algorithm == null)
-                .OrderBy(key => key.Algorithm == algorithm ? 0 : 1); // Exact match first (0), then null (1)
+            credentials = credentials.Where(key => key.CanPerform(algorithm));
         }
 
         var key = await credentials.FirstOrDefaultAsync();
@@ -71,9 +77,9 @@ public static class JsonWebKeyExtensions
     /// (the key-management <c>alg</c> is derived from the chosen key afterwards) and only the pinned <c>kid</c>.
     /// </summary>
     /// <param name="credentials">The asynchronous sequence of <see cref="JsonWebKey"/> objects.</param>
-    /// <param name="algorithm">The algorithm to match, or <c>null</c> to not filter by algorithm. Prioritizes
-    /// keys declaring an exact match, then algorithm-agnostic keys (Algorithm == null) per RFC 7517
-    /// Section 4.4. Returns <c>null</c> for <see cref="SigningAlgorithms.None"/>.</param>
+    /// <param name="algorithm">The algorithm to match, or <c>null</c> to not filter by algorithm. A key qualifies
+    /// by declaring it or, declaring none, by being able to perform it. Returns <c>null</c> for
+    /// <see cref="SigningAlgorithms.None"/>.</param>
     /// <param name="keyId">The <c>kid</c> to match, or <c>null</c> to not filter by key id.</param>
     /// <returns>The first matching key, or <c>null</c> when the sequence yields none and neither filter was
     /// applied. Throws when a filter was applied but nothing matched, so a pinned key id or a required
@@ -91,10 +97,7 @@ public static class JsonWebKeyExtensions
 
         if (algorithm.HasValue())
         {
-            // Prioritize exact algorithm match, then fall back to algorithm-agnostic keys (Algorithm == null)
-            credentials = credentials
-                .Where(key => key.Algorithm == algorithm || key.Algorithm == null)
-                .OrderBy(key => key.Algorithm == algorithm ? 0 : 1); // Exact match first (0), then null (1)
+            credentials = credentials.Where(key => key.CanPerform(algorithm));
         }
 
         var key = await credentials.FirstOrDefaultAsync();
@@ -106,4 +109,18 @@ public static class JsonWebKeyExtensions
         }
         return key;
     }
+
+    /// <summary>
+    /// Whether a key may be used for an algorithm: it either declares that algorithm, or declares none and its
+    /// material can perform it.
+    /// </summary>
+    /// <remarks>
+    /// RFC 7517 section 4.4 makes <c>alg</c> OPTIONAL, and a key imported from a certificate never carries one.
+    /// Treating an undeclared algorithm as a disqualification would drop exactly those keys; treating it as
+    /// "anything goes" would hand an RSA key to an ECDSA algorithm and fail at the signature instead of at the
+    /// selection. Asking the material settles it, and RFC 7518 sections 3.1 and 3.4 make the answer exact.
+    /// </remarks>
+    private static bool CanPerform(this JsonWebKey key, string algorithm)
+        => key.Algorithm == algorithm ||
+           (key.Algorithm is null && key.SupportsAlgorithm(algorithm));
 }

--- a/tests/Abblix.Jwt.UnitTests/JsonWebKeyExtensionsTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/JsonWebKeyExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -76,5 +76,46 @@ public class JsonWebKeyExtensionsTests
         var notBefore = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var notAfter = new DateTimeOffset(2100, 1, 1, 0, 0, 0, TimeSpan.Zero);
         return request.CreateSelfSigned(notBefore, notAfter);
+    }
+
+    /// <summary>
+    /// A key declaring no algorithm is answerable, not unknown: RFC 7518 section 3.1 binds each signature
+    /// algorithm to a key type and section 3.4 binds each ECDSA one to a single curve, so the material settles
+    /// what the declaration left open. This is the ordinary case for a certificate-imported key, which never
+    /// carries an <c>alg</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.RS256, true)]
+    [InlineData(SigningAlgorithms.PS512, true)]
+    [InlineData(SigningAlgorithms.ES256, false)]   // needs an EC key on P-256
+    [InlineData(SigningAlgorithms.HS256, false)]   // needs a symmetric key
+    [InlineData(EncryptionAlgorithms.KeyManagement.RsaOaep256, true)]
+    [InlineData(EncryptionAlgorithms.KeyManagement.EcdhEs, false)]
+    [InlineData(SigningAlgorithms.None, false)]
+    [InlineData("made-up", false)]
+    public void RsaKey_SupportsExactlyTheAlgorithmsItsMaterialCanPerform(string algorithm, bool expected)
+    {
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256);
+
+        Assert.Equal(expected, key.SupportsAlgorithm(algorithm));
+    }
+
+    /// <summary>
+    /// ECDSA is the case where the key type is not enough: the algorithm names the curve, so a P-256 key
+    /// performs ES256 and neither of the other two. Getting this wrong would surface as a signature failure
+    /// rather than a selection failure, one layer away from the cause.
+    /// </summary>
+    [Theory]
+    [InlineData(EllipticCurveTypes.P256, SigningAlgorithms.ES256, true)]
+    [InlineData(EllipticCurveTypes.P256, SigningAlgorithms.ES384, false)]
+    [InlineData(EllipticCurveTypes.P384, SigningAlgorithms.ES384, true)]
+    [InlineData(EllipticCurveTypes.P521, SigningAlgorithms.ES512, true)]
+    [InlineData(EllipticCurveTypes.P256, SigningAlgorithms.RS256, false)]
+    [InlineData(EllipticCurveTypes.P256, EncryptionAlgorithms.KeyManagement.EcdhEs, true)]
+    public void EllipticCurveKey_IsJudgedByItsCurve(string curve, string algorithm, bool expected)
+    {
+        var key = JsonWebKeyFactory.CreateEllipticCurve(curve, SigningAlgorithms.ES256);
+
+        Assert.Equal(expected, key.SupportsAlgorithm(algorithm));
     }
 }

--- a/tests/Abblix.Jwt.UnitTests/KeyRingTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/KeyRingTests.cs
@@ -318,56 +318,107 @@ public sealed class KeyRingTests : IDisposable
     }
 
     /// <summary>
-    /// A key naming no role must be refused loudly, because <see cref="KeyRing.Get"/> selects by an exact match:
-    /// such a key belongs to neither role and would leave the ring silently, taking its JWKS entry with it and
-    /// leaving the role with nothing to produce. This is how a certificate arrives - one permitting both signing
-    /// and encipherment maps to no <c>use</c> at all, per RFC 7517 section 4.2 - so the refusal has to name the
-    /// entry rather than let the set come back one shorter than it went in.
+    /// A key naming no role serves BOTH, because RFC 7517 section 4.2 makes <c>use</c> optional and
+    /// single-valued: a key permitted to sign and to encrypt is expressed by omitting the member, never by a
+    /// multi-valued one. Reading its absence as "no role" would drop exactly those keys from the published set,
+    /// and silently. A certificate permitting both signing and encipherment produces precisely such a key.
     /// </summary>
     [Fact]
-    public async Task RefusesAnEntry_WhoseKeyNamesNoRole()
+    public async Task AKeyNamingNoRole_ServesBoth()
     {
         var store = new FakeStore();
         var (ring, _) = CreateRing(store);
 
-        // Sealed the same way the ring seals its own, so only the missing role distinguishes it.
-        var roleless = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
-            with { Usage = null, KeyId = "roleless" };
+        await AddUnrestrictedKey(store, "adopted", Now);
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
 
-        var envelope = new KeyEnvelope(
-            _providers[^1].GetRequiredService<IJsonWebTokenEncryptor>());
+        Assert.Contains(
+            ring.Get(PublicKeyUsages.Signature, includePrivateKeys: false),
+            key => key.KeyId == "unrestricted");
+
+        Assert.Contains(
+            ring.Get(PublicKeyUsages.Encryption, includePrivateKeys: false),
+            key => key.KeyId == "unrestricted");
+    }
+
+    /// <summary>
+    /// Retirement is decided per role, and a key is kept while ANY role it serves still needs it. So an
+    /// unrestricted key outlives its signing successor: the encryption role has not moved on, and dropping the
+    /// key would leave that role with nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task AKeyNamingNoRole_OutlivesASuccessorInOneRoleOnly()
+    {
+        var store = new FakeStore();
+
+        // The ring mints signing keys only - no encryption algorithm is named - so the unrestricted key is the
+        // one and only key the encryption role has.
+        await AddUnrestrictedKey(store, "adopted", Now.AddDays(-400));
+
+        var (ring, _) = CreateRing(store, now: Now);
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.Contains(
+            ring.Get(PublicKeyUsages.Encryption, includePrivateKeys: false),
+            key => key.KeyId == "unrestricted");
+
+        Assert.Contains(store.Entries, entry => entry.Id == "adopted");
+    }
+
+    /// <summary>
+    /// The control for the pair above: once BOTH roles have a successor past the window, the unrestricted key
+    /// does leave. Without this the tests would hold equally for a ring that never retires anything.
+    /// </summary>
+    [Fact]
+    public async Task AKeyNamingNoRole_RetiresOnceBothRolesMovedOn()
+    {
+        var store = new FakeStore();
+        await AddUnrestrictedKey(store, "adopted", Now.AddDays(-400));
+
+        // Both roles mint here, so both gain a successor; then time passes far beyond window plus retention.
+        var (ring, _) = CreateRing(
+            store,
+            now: Now,
+            encryptionAlgorithm: EncryptionAlgorithms.KeyManagement.RsaOaep256);
+
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        var (later, _) = CreateRing(
+            store,
+            now: Now.AddDays(120),
+            encryptionAlgorithm: EncryptionAlgorithms.KeyManagement.RsaOaep256);
+
+        await later.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(store.Entries, entry => entry.Id == "adopted");
+    }
+
+    /// <summary>Seals a key carrying no role and stores it, the way an existing certificate would arrive.</summary>
+    private async Task AddUnrestrictedKey(FakeStore store, string entryId, DateTimeOffset createdAt)
+    {
+        var unrestricted = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            with { Usage = null, KeyId = "unrestricted" };
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        services.AddSingleton(StubCustodian(_keyEncryptionKey));
+        services.ComposeExternalKeyBackends();
+        var provider = services.BuildServiceProvider();
+        _providers.Add(provider);
+
+        var envelope = new KeyEnvelope(provider.GetRequiredService<IJsonWebTokenEncryptor>());
 
         store.Entries.Add(new StoredKey
         {
-            Id = "adopted-no-role",
+            Id = entryId,
             Jwe = await envelope.SealAsync(
-                roleless,
+                unrestricted,
                 _keyEncryptionKey,
                 EncryptionAlgorithms.KeyManagement.RsaOaep256,
                 EncryptionAlgorithms.ContentEncryption.Aes256Gcm,
                 TestContext.Current.CancellationToken),
-            CreatedAt = Now,
+            CreatedAt = createdAt,
         });
-
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ring.RefreshAsync(TestContext.Current.CancellationToken));
-
-        // The message must point at something addressable: the operator's next step is to find that entry.
-        Assert.Contains("adopted-no-role", error.Message, StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// The control for the test above: the same path with a role named must succeed. Without it, a ring that
-    /// threw on every entry would satisfy the refusal test and the assertion would measure nothing.
-    /// </summary>
-    [Fact]
-    public async Task AcceptsAnEntry_WhoseKeyNamesItsRole()
-    {
-        var store = new FakeStore();
-        var (ring, _) = CreateRing(store);
-
-        await ring.RefreshAsync(TestContext.Current.CancellationToken);
-
-        Assert.Single(ring.Get(PublicKeyUsages.Signature, includePrivateKeys: false));
     }
 }

--- a/tests/Abblix.Jwt.UnitTests/KeyRingTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/KeyRingTests.cs
@@ -316,4 +316,58 @@ public sealed class KeyRingTests : IDisposable
         await with.RefreshAsync(TestContext.Current.CancellationToken);
         Assert.Single(with.Get(PublicKeyUsages.Encryption, includePrivateKeys: false));
     }
+
+    /// <summary>
+    /// A key naming no role must be refused loudly, because <see cref="KeyRing.Get"/> selects by an exact match:
+    /// such a key belongs to neither role and would leave the ring silently, taking its JWKS entry with it and
+    /// leaving the role with nothing to produce. This is how a certificate arrives - one permitting both signing
+    /// and encipherment maps to no <c>use</c> at all, per RFC 7517 section 4.2 - so the refusal has to name the
+    /// entry rather than let the set come back one shorter than it went in.
+    /// </summary>
+    [Fact]
+    public async Task RefusesAnEntry_WhoseKeyNamesNoRole()
+    {
+        var store = new FakeStore();
+        var (ring, _) = CreateRing(store);
+
+        // Sealed the same way the ring seals its own, so only the missing role distinguishes it.
+        var roleless = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            with { Usage = null, KeyId = "roleless" };
+
+        var envelope = new KeyEnvelope(
+            _providers[^1].GetRequiredService<IJsonWebTokenEncryptor>());
+
+        store.Entries.Add(new StoredKey
+        {
+            Id = "adopted-no-role",
+            Jwe = await envelope.SealAsync(
+                roleless,
+                _keyEncryptionKey,
+                EncryptionAlgorithms.KeyManagement.RsaOaep256,
+                EncryptionAlgorithms.ContentEncryption.Aes256Gcm,
+                TestContext.Current.CancellationToken),
+            CreatedAt = Now,
+        });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ring.RefreshAsync(TestContext.Current.CancellationToken));
+
+        // The message must point at something addressable: the operator's next step is to find that entry.
+        Assert.Contains("adopted-no-role", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The control for the test above: the same path with a role named must succeed. Without it, a ring that
+    /// threw on every entry would satisfy the refusal test and the assertion would measure nothing.
+    /// </summary>
+    [Fact]
+    public async Task AcceptsAnEntry_WhoseKeyNamesItsRole()
+    {
+        var store = new FakeStore();
+        var (ring, _) = CreateRing(store);
+
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.Single(ring.Get(PublicKeyUsages.Signature, includePrivateKeys: false));
+    }
 }


### PR DESCRIPTION
## What changes

A key naming no role now serves **both** roles, and retires only once both have moved on.

## Why

RFC 7517 section 4.2 makes `use` OPTIONAL and single-valued: a key permitted to sign and to encrypt is expressed by omitting the member, never by a multi-valued one. The ring read its absence as "no role" - such a key matched neither, so it left the published set silently, taking with it the role it was meant to fill.

This is not hypothetical. The certificate a live deployment uses for encryption carries `Digital Signature, Key Encipherment`, which maps to no `use` at all. Stored in a ring, it would have taken the encryption role down with it, and the first visible symptom would have been failing tokens, two steps from the cause.

## The half that could not be a widened comparison

Selection was the easy part. Retirement grouped by role, so an unrestricted key formed a group of one, never gained a successor, and would have stayed in the ring forever - a worse outcome than being dropped, because it is permanent and invisible.

Retirement is now decided per role over the keys serving that role, and a key is kept while **any** role it serves still needs it. A role nobody mints for - encryption, when no encryption algorithm is named - keeps such a key indefinitely, which is correct: it is the only key that role has.

## Coverage

Three tests, because the first two hold equally for a ring that never retires anything:

- the key serves both roles;
- it outlives a successor in one role only;
- it does leave once both roles have a successor past the window.

Proven by mutation: restoring the strict comparison turns two of them red, and the whole suite (548) is green on the fix.

## History of this branch

The first commit took the opposite approach - refusing such a key outright, on the reading that an application may require `use` to be present. That is permitted by the same section, but it is a restriction the library has no reason to impose, and it would have pushed the problem onto every consumer holding a dual-purpose certificate. The second commit replaces it with support.
