### PR TITLE
Take the keys a server already signs with into an empty ring

### DIFF
--- a/src/Abblix.Jwt/ExternalKeys/ExternalKeysServiceCollectionExtensions.cs
+++ b/src/Abblix.Jwt/ExternalKeys/ExternalKeysServiceCollectionExtensions.cs
@@ -255,14 +255,27 @@ public static class ExternalKeysServiceCollectionExtensions
     {
         services.TryAddSingleton<KeyEnvelope>();
 
+        // Both the ring and the loop that keeps it current read the clock, and this package is consumable without
+        // the registrations that would otherwise have supplied one. TryAdd, so a host's own clock still wins.
+        services.TryAddSingleton(TimeProvider.System);
+
+        var builder = new MintedKeysBuilder(services, policy);
+
         // CreateService, unlike the plain registrations around it, because the policy is a per-call value the
-        // container knows nothing about: everything else the ring needs is resolved normally.
-        services.TryAddSingleton<IKeyRing>(
-            serviceProvider => serviceProvider.CreateService<KeyRing>(Dependency.Override(policy)));
+        // container knows nothing about: everything else the ring needs is resolved normally. It is read off the
+        // builder rather than captured, so a call chained after this one - AdoptExistingKeys - still reaches the
+        // ring: this factory runs when the container builds, by which time the whole chain has run.
+        services.TryAddSingleton(
+            serviceProvider => serviceProvider.CreateService<KeyRing>(Dependency.Override(builder.Policy)));
+
+        // The concrete type is what is constructed, and the contract is an alias to it. Registering the contract
+        // with its own factory instead would build a SECOND ring: the refresh service would keep one current
+        // while every consumer read the other, which fails as a server publishing keys it never rotates.
+        services.TryAddSingleton<IKeyRing>(serviceProvider => serviceProvider.GetRequiredService<KeyRing>());
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, KeyRingRefreshService>());
 
-        return new MintedKeysBuilder(services);
+        return builder;
     }
 
     /// <summary>
@@ -294,6 +307,10 @@ public static class ExternalKeysServiceCollectionExtensions
                 + $"{nameof(IKeyRingStore)} is registered, which is how keys are shared between processes. "
                 + $"The store would be ignored. Use {nameof(AddKeyRing)} with a custodian to share keys, or "
                 + "drop the store if a single instance is intended.");
+
+        // The ring reads the clock, and this package is consumable without the registrations that would otherwise
+        // have supplied one.
+        services.TryAddSingleton(TimeProvider.System);
 
         services.TryAddSingleton<IKeyRing>(
             serviceProvider => serviceProvider.CreateService<InMemoryKeyRing>(Dependency.Override(policy)));

--- a/src/Abblix.Jwt/ExternalKeys/IMintedKeysBuilder.cs
+++ b/src/Abblix.Jwt/ExternalKeys/IMintedKeysBuilder.cs
@@ -37,4 +37,18 @@ public interface IMintedKeysBuilder
 {
     /// <summary>The collection a <c>PersistRingTo...</c> call registers the store into.</summary>
     IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Takes keys the server already signs with into the ring, so that switching to minted keys does not change
+    /// which key produces on the day it happens.
+    /// </summary>
+    /// <param name="keys">The keys to take, private halves included - the ring seals what it is given, and a key
+    /// without its private half can be published but cannot sign.</param>
+    /// <returns>The same builder, so the <c>PersistRingTo...</c> call follows.</returns>
+    /// <remarks>
+    /// This is a migration call and is meant to be deleted once the ring has rotated past the keys it names, but
+    /// nothing breaks if it is not: keys are taken only into an EMPTY ring, so from the first entry onward the
+    /// call does nothing. See <see cref="MintedKeys.AdoptedKeys"/> for what adoption does to the ordering.
+    /// </remarks>
+    IMintedKeysBuilder AdoptExistingKeys(params JsonWebKey[] keys);
 }

--- a/src/Abblix.Jwt/ExternalKeys/KeyRing.cs
+++ b/src/Abblix.Jwt/ExternalKeys/KeyRing.cs
@@ -89,9 +89,13 @@ internal sealed class KeyRing(
     {
         var entries = await store.LoadAsync(cancellationToken);
 
-        if (await MintDueKeysAsync(entries, cancellationToken))
+        // Adoption first, and in the same refresh as the first mint: the adopted key is dated a period back, so
+        // the key minted below trails it rather than taking over the instant it appears.
+        var adopted = await AdoptExistingKeysAsync(entries, cancellationToken);
+
+        if (await MintDueKeysAsync(entries, cancellationToken) || adopted)
         {
-            // Something was minted, by this pod or by another that won the race: re-read so the ring holds the
+            // Something was written, by this pod or by another that won the race: re-read so the ring holds the
             // winner's key rather than the one generated here.
             entries = await store.LoadAsync(cancellationToken);
         }
@@ -199,15 +203,69 @@ internal sealed class KeyRing(
         return minted;
     }
 
+    /// <summary>
+    /// Takes the keys the server already signs with into an empty ring, and reports whether anything was written.
+    /// </summary>
+    /// <remarks>
+    /// Only into an EMPTY ring, which is what lets the call stay in a host's registration forever: the moment the
+    /// ring holds anything, adoption is over. A key that has since retired is therefore not brought back, and the
+    /// ring cannot empty itself to make it look otherwise - the newest key serving a role never retires.
+    /// <para>
+    /// The entry is named after the key's own thumbprint (RFC 7638), so every pod computes the same id for the
+    /// same key and the store's insert-if-absent settles the race exactly as it does for minting. The id also
+    /// cannot collide with a period id, which is built from a role and an instant.
+    /// </para>
+    /// </remarks>
+    private async Task<bool> AdoptExistingKeysAsync(
+        IReadOnlyList<StoredKey> entries,
+        CancellationToken cancellationToken)
+    {
+        if (entries.Count > 0 || policy.AdoptedKeys.Count == 0)
+            return false;
+
+        // Dated one rotation period back, which is what makes it the active key: the key minted in this same
+        // refresh is younger than the propagation window, so it is published and verifiable while this one keeps
+        // producing, and it takes over once the window has passed.
+        var createdAt = timeProvider.GetUtcNow() - policy.RotateEvery;
+        var keyEncryptionKey = await NewestKeyEncryptionKeyAsync(cancellationToken);
+        var adopted = false;
+
+        foreach (var key in policy.AdoptedKeys)
+        {
+            if (!key.HasPrivateKey)
+            {
+                throw new InvalidOperationException(
+                    $"The key '{key.KeyId}' has no private half, so it cannot be adopted: an adopted key is the " +
+                    "one that produces until the minted key's propagation window has passed, and producing needs " +
+                    "the private half. Pass the key as it is loaded from its certificate or store.");
+            }
+
+            var entry = new StoredKey
+            {
+                Id = $"adopted-{key.ComputeJwkThumbprintBase64Url()}",
+                Jwe = await SealAsync(key, keyEncryptionKey, cancellationToken),
+                CreatedAt = createdAt,
+            };
+
+            adopted |= await store.TryAddAsync(entry, cancellationToken);
+        }
+
+        return adopted;
+    }
+
     /// <summary>Generates a key for the role and seals it to the newest KEK version.</summary>
     private async Task<string> SealNewKeyAsync(string usage, string algorithm, CancellationToken cancellationToken)
     {
         var key = JsonWebKeyFactory.CreateRsa(usage, algorithm, policy.RsaKeySize);
         var keyEncryptionKey = await NewestKeyEncryptionKeyAsync(cancellationToken);
 
-        return await envelope.SealAsync(
-            key, keyEncryptionKey, policy.KeyWrapAlgorithm, policy.ContentEncryptionAlgorithm, cancellationToken);
+        return await SealAsync(key, keyEncryptionKey, cancellationToken);
     }
+
+    /// <summary>Seals a key to the given KEK version, which is what the ring stores.</summary>
+    private Task<string> SealAsync(JsonWebKey key, JsonWebKey keyEncryptionKey, CancellationToken cancellationToken)
+        => envelope.SealAsync(
+            key, keyEncryptionKey, policy.KeyWrapAlgorithm, policy.ContentEncryptionAlgorithm, cancellationToken);
 
     /// <summary>
     /// The KEK version to seal with: the newest one. A KEK needs no propagation window, unlike a signing key,

--- a/src/Abblix.Jwt/ExternalKeys/MintedKeys.cs
+++ b/src/Abblix.Jwt/ExternalKeys/MintedKeys.cs
@@ -90,4 +90,24 @@ public sealed record MintedKeys
 
     /// <summary>The JWE <c>enc</c> sealing an entry: how the key itself is encrypted.</summary>
     public string ContentEncryptionAlgorithm { get; init; } = EncryptionAlgorithms.ContentEncryption.Aes256Gcm;
+
+    /// <summary>
+    /// Keys the server already signs with, taken into an EMPTY ring so the move to minted keys does not change
+    /// which key is producing on the day it happens. Normally set through
+    /// <see cref="IMintedKeysBuilder.AdoptExistingKeys"/> rather than written here.
+    /// </summary>
+    /// <remarks>
+    /// Without this the ring starts empty, and a ring of one key has nothing to trail behind: the freshly minted
+    /// key produces from its first second, so every client whose JWKS copy predates that second meets a token it
+    /// cannot verify. An adopted key is dated one rotation period back, which is what makes it the active one
+    /// while the minted key serves out its propagation window - the old key keeps signing, the new one is
+    /// published, and the changeover happens once clients have had the window to fetch it.
+    /// <para>
+    /// Adoption happens only into an empty ring. That is what makes leaving the call in place harmless: once the
+    /// ring holds anything the keys are never taken again, so a key that has since retired is not resurrected,
+    /// and pods racing to adopt settle it the same way they settle minting - one insert wins and the rest drop
+    /// what they built.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<JsonWebKey> AdoptedKeys { get; init; } = [];
 }

--- a/src/Abblix.Jwt/ExternalKeys/MintedKeysBuilder.cs
+++ b/src/Abblix.Jwt/ExternalKeys/MintedKeysBuilder.cs
@@ -25,8 +25,23 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Abblix.Jwt.ExternalKeys;
 
 /// <inheritdoc />
-internal sealed class MintedKeysBuilder(IServiceCollection services) : IMintedKeysBuilder
+/// <remarks>
+/// The builder owns the policy rather than handing it straight to the ring, because a call after the placement can
+/// still change it. The ring reads <see cref="Policy"/> when the container builds it, which is long after every
+/// such call has run.
+/// </remarks>
+internal sealed class MintedKeysBuilder(IServiceCollection services, MintedKeys policy) : IMintedKeysBuilder
 {
     /// <inheritdoc />
     public IServiceCollection Services { get; } = services;
+
+    /// <summary>The policy as it stands, including whatever later calls have added to it.</summary>
+    public MintedKeys Policy { get; private set; } = policy;
+
+    /// <inheritdoc />
+    public IMintedKeysBuilder AdoptExistingKeys(params JsonWebKey[] keys)
+    {
+        Policy = Policy with { AdoptedKeys = [..Policy.AdoptedKeys, ..keys] };
+        return this;
+    }
 }

--- a/tests/Abblix.Jwt.UnitTests/KeyRingTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/KeyRingTests.cs
@@ -23,6 +23,7 @@
 using System.Diagnostics;
 using Abblix.Jwt.ExternalKeys;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -119,7 +120,8 @@ public sealed class KeyRingTests : IDisposable
         DateTimeOffset? now = null,
         string? encryptionAlgorithm = null,
         TimeSpan? keepRetiredFor = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        IReadOnlyList<JsonWebKey>? adoptedKeys = null)
     {
         store ??= new FakeStore();
 
@@ -160,6 +162,7 @@ public sealed class KeyRingTests : IDisposable
                 RotateEvery = TimeSpan.FromDays(30),
                 EncryptionAlgorithm = encryptionAlgorithm,
                 KeepRetiredFor = keepRetiredFor,
+                AdoptedKeys = adoptedKeys ?? [],
             },
             Options.Create(new KeyRingOptions { KeyRolloverPropagation = propagation ?? TimeSpan.FromHours(1) }),
             time);
@@ -463,6 +466,162 @@ public sealed class KeyRingTests : IDisposable
                 TestContext.Current.CancellationToken),
             CreatedAt = createdAt,
         });
+    }
+
+    /// <summary>
+    /// An adopted key keeps producing while the key minted alongside it serves out its propagation window. That
+    /// is the whole reason adoption exists: into an empty ring a minted key would produce from its first second,
+    /// and every client holding a JWKS copy from the second before would meet a token it cannot verify.
+    /// </summary>
+    [Fact]
+    public async Task AnAdoptedKeyProduces_WhileTheKeyMintedBesideItIsStillAnnounced()
+    {
+        var existing = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            with { KeyId = "from-certificate" };
+
+        var (ring, store) = CreateRing(adoptedKeys: [existing]);
+
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        // Both are published - that is the overlap - and the adopted one leads, so it is the one signing.
+        var published = ring.Get(PublicKeyUsages.Signature, includePrivateKeys: false).ToList();
+        Assert.Equal(2, published.Count);
+        Assert.Equal("from-certificate", published[0].KeyId);
+
+        // The store holds ciphertext for the adopted key too: it is sealed on the way in like any other entry.
+        var adopted = Assert.Single(store.Entries, entry => entry.Id.StartsWith("adopted-"));
+        Assert.Equal(5, adopted.Jwe.Split('.').Length);
+    }
+
+    /// <summary>
+    /// The control for the test above, and the reason adoption dates the key backwards: once the propagation
+    /// window has passed, the minted key takes over and the adopted one merely stays published.
+    /// </summary>
+    [Fact]
+    public async Task TheMintedKeyTakesOver_OnceThePropagationWindowHasPassed()
+    {
+        var existing = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            with { KeyId = "from-certificate" };
+
+        var propagation = TimeSpan.FromHours(1);
+        var store = new FakeStore();
+        var (ring, _) = CreateRing(store, propagation: propagation, adoptedKeys: [existing]);
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        var (later, _) = CreateRing(
+            store, propagation: propagation, now: Now + propagation + TimeSpan.FromMinutes(1));
+        await later.RefreshAsync(TestContext.Current.CancellationToken);
+
+        var published = later.Get(PublicKeyUsages.Signature, includePrivateKeys: false).ToList();
+        Assert.Equal(2, published.Count);
+        Assert.NotEqual("from-certificate", published[0].KeyId);
+        Assert.Contains(published, key => key.KeyId == "from-certificate");
+    }
+
+    /// <summary>
+    /// Adoption happens only into an empty ring, which is what makes leaving the call in a host's registration
+    /// harmless: a key the ring has since retired is not brought back by the next refresh.
+    /// </summary>
+    [Fact]
+    public async Task AnAdoptedKeyIsNotTakenAgain_OnceTheRingHoldsAnything()
+    {
+        var existing = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            with { KeyId = "from-certificate" };
+
+        var store = new FakeStore();
+        var (ring, _) = CreateRing(store, adoptedKeys: [existing]);
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        // Stands in for the day the adopted key retires: the ring still holds the minted key, so it is not empty.
+        var adopted = Assert.Single(store.Entries, entry => entry.Id.StartsWith("adopted-"));
+        store.Entries.Remove(adopted);
+
+        await ring.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(store.Entries, entry => entry.Id.StartsWith("adopted-"));
+    }
+
+    /// <summary>
+    /// A key with no private half is refused where it is named, not where it fails. Adopted dated backwards, it
+    /// would be the ACTIVE key, so accepting it would mean a server that publishes a full ring and cannot sign.
+    /// </summary>
+    [Fact]
+    public async Task AKeyWithNoPrivateHalfIsRefused()
+    {
+        var publicOnly = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            .Sanitize(includePrivateKeys: false) with { KeyId = "public-only" };
+
+        var (ring, _) = CreateRing(adoptedKeys: [publicOnly]);
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ring.RefreshAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("public-only", refusal.Message);
+    }
+
+    /// <summary>
+    /// The builder call reaches the ring. Everything above constructs the ring directly, which proves the
+    /// behaviour and nothing about the wiring - and a registration method that quietly reaches nobody reads
+    /// exactly like one that works.
+    /// </summary>
+    [Fact]
+    public async Task AdoptExistingKeys_ReachesTheRing_ThroughTheHostedService()
+    {
+        var existing = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)
+            with { KeyId = "from-certificate" };
+
+        var store = new FakeStore();
+        var time = new Mock<TimeProvider>();
+        time.Setup(t => t.GetUtcNow()).Returns(Now);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        services.AddSingleton(StubCustodian(_keyEncryptionKey));
+        services.AddSingleton<IKeyRingStore>(store);
+        services.AddSingleton(time.Object);
+        services.ComposeExternalKeyBackends();
+        services
+            .AddKeyRing(new MintedKeys { KeyEncryptionKeyName = KeyEncryptionKeyName })
+            .AdoptExistingKeys(existing);
+
+        var provider = services.BuildServiceProvider();
+        _providers.Add(provider);
+
+        // Started the way a host starts it: the first refresh runs in StartAsync, which is the door production
+        // walks through.
+        var refresher = provider.GetServices<IHostedService>().Single();
+        await refresher.StartAsync(TestContext.Current.CancellationToken);
+        await refresher.StopAsync(TestContext.Current.CancellationToken);
+
+        var published = provider.GetRequiredService<IKeyRing>()
+            .Get(PublicKeyUsages.Signature, includePrivateKeys: false).ToList();
+
+        Assert.Equal(2, published.Count);
+        Assert.Equal("from-certificate", published[0].KeyId);
+    }
+
+    /// <summary>
+    /// The refresh service resolves, and over the same ring every consumer reads. Registering the contract with
+    /// its own factory would build a second ring, and nothing at runtime would say so: the loop would keep one
+    /// current while the JWKS endpoint served the other, which surfaces as keys that never rotate.
+    /// </summary>
+    [Fact]
+    public void TheRefreshServiceResolves_OverTheRingEveryoneElseReads()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        services.AddSingleton(StubCustodian(_keyEncryptionKey));
+        services.AddSingleton<IKeyRingStore>(new FakeStore());
+        services.ComposeExternalKeyBackends();
+        services.AddKeyRing(new MintedKeys { KeyEncryptionKeyName = KeyEncryptionKeyName });
+
+        var provider = services.BuildServiceProvider();
+        _providers.Add(provider);
+
+        Assert.IsType<KeyRingRefreshService>(Assert.Single(provider.GetServices<IHostedService>()));
+        Assert.Same(provider.GetRequiredService<KeyRing>(), provider.GetRequiredService<IKeyRing>());
     }
 
     /// <summary>


### PR DESCRIPTION
Stacked on #349, which is stacked on #348. Bases retarget automatically as those merge; the diff here is this change alone.

## What changes

`AdoptExistingKeys` on the minted-keys builder takes the keys a server already signs with into the ring, once, while it is empty.

## Why

Switching a running provider to a minted ring changed which key produces at that instant. The ring starts empty, and a ring of one has nothing to trail behind: the first minted key is active from its first second, so every client whose JWKS copy predates that second meets a token it cannot verify.

An adopted key is sealed like any other entry and dated one rotation period back. That is what makes it the active one while the key minted in the same refresh serves out its propagation window - the old key keeps signing, the new one is published, and the changeover happens once clients have had the window to fetch it.

## Only into an empty ring

Which is what lets the call stay in a host's registration after the migration:

- a key the ring has since retired is not resurrected, and the ring cannot empty itself to make it look otherwise - the newest key serving a role never retires;
- pods racing settle it the way they settle minting, since the entry is named after the key's own thumbprint (RFC 7638) and one insert wins.

The role is not part of that id, because a key imported from a certificate may carry no `use` at all (#348).

## Refusals

A key without its private half is refused where it is named. Dated backwards it would be the active key, so accepting it would mean a server that publishes a full ring and cannot sign.

## The placement did not resolve at all

Found by writing the wiring test, and worth reading on its own: `KeyRingRefreshService` asks for the concrete `KeyRing` while only `IKeyRing` was registered, and neither ring registered a `TimeProvider`. Any host choosing this placement died at startup.

The ring is now registered by its own type with the contract aliased to it. Registering the contract with its own factory instead would build a *second* ring - the refresh loop keeping one current while every consumer reads the other, which fails as a server whose keys never rotate and says nothing.

## Coverage

- the adopted key produces while the minted one is announced, and both are published;
- the minted key takes over once the propagation window has passed (the control - the pair holds equally for a ring that adopted nothing);
- a second refresh does not take the key again once the ring holds anything;
- a key with no private half is refused;
- the builder call reaches the ring through the hosted service, which is the door a host walks;
- the refresh service resolves, over the same ring instance every consumer reads.

Each decision is red on its own mutation. 570 `Abblix.Jwt` and 2613 `Abblix.Oidc.Server` tests green.