### PR TITLE
SsfValidationOptions spells out its family name

### DIFF
--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -113,10 +113,10 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <param name="options">
     /// What this receiver expects of every token; registered as the shared instance, so a host
-    /// pre-registering its own <see cref="SsfValidationOptions"/> wins.</param>
+    /// pre-registering its own <see cref="SharedSignalsValidationOptions"/> wins.</param>
     public static IServiceCollection AddSsfReceiver(
         this IServiceCollection services,
-        SsfValidationOptions options)
+        SharedSignalsValidationOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
         RequireSecurityEvents(services, nameof(AddSsfReceiver));

--- a/src/Abblix.SharedSignals/Receiver/CriticalSubjectMembersStep.cs
+++ b/src/Abblix.SharedSignals/Receiver/CriticalSubjectMembersStep.cs
@@ -50,10 +50,10 @@ public sealed class CriticalSubjectMembersStep : ISecurityEventTokenValidator
     {
         context.Require(SecurityEventTokenValidationStates.SignatureVerified);
 
-        if (context.Options is not SsfValidationOptions options)
+        if (context.Options is not SharedSignalsValidationOptions options)
         {
             throw new InvalidOperationException(
-                $"{nameof(CriticalSubjectMembersStep)} requires {nameof(SsfValidationOptions)}: the "
+                $"{nameof(CriticalSubjectMembersStep)} requires {nameof(SharedSignalsValidationOptions)}: the "
                 + "critical member names and the subject vocabulary live there.");
         }
 

--- a/src/Abblix.SharedSignals/Receiver/PushDeliveryHandler.cs
+++ b/src/Abblix.SharedSignals/Receiver/PushDeliveryHandler.cs
@@ -53,7 +53,7 @@ namespace Abblix.SharedSignals.Receiver;
 /// entirely to the sink's contract.</param>
 public sealed class PushDeliveryHandler(
     [FromKeyedServices(SsfReceiverValidation.ProfileKey)] ISecurityEventTokenValidator validator,
-    SsfValidationOptions options,
+    SharedSignalsValidationOptions options,
     ISecurityEventSink sink,
     IReplayCache? replayCache = null)
 {

--- a/src/Abblix.SharedSignals/Receiver/SharedSignalsValidationOptions.cs
+++ b/src/Abblix.SharedSignals/Receiver/SharedSignalsValidationOptions.cs
@@ -31,7 +31,7 @@ namespace Abblix.SharedSignals.Receiver;
 /// declared critical subject members. The SSF steps refuse to run against the base options type,
 /// so a profile wired with the wrong flavor fails loudly on its first token.
 /// </summary>
-public sealed record SsfValidationOptions : SecurityEventTokenValidationOptions
+public sealed record SharedSignalsValidationOptions : SecurityEventTokenValidationOptions
 {
     /// <summary>
     /// The issuer of the stream the events arrive on, from its Stream Configuration. SSF 1.0

--- a/src/Abblix.SharedSignals/Receiver/StreamIssuerStep.cs
+++ b/src/Abblix.SharedSignals/Receiver/StreamIssuerStep.cs
@@ -34,7 +34,7 @@ namespace Abblix.SharedSignals.Receiver;
 /// Section 4.1.6 names two values to match - the Stream Configuration's "iss" and the issuer
 /// the Transmitter Configuration was requested from. The receiver proved those equal when it
 /// accepted the stream (Sections 7.2.2, 8.1.1.1), so the single comparison here carries both
-/// halves of the rule; see <see cref="SsfValidationOptions.StreamIssuer"/>.
+/// halves of the rule; see <see cref="SharedSignalsValidationOptions.StreamIssuer"/>.
 /// </remarks>
 public sealed class StreamIssuerStep : ISecurityCriticalValidator
 {
@@ -48,11 +48,11 @@ public sealed class StreamIssuerStep : ISecurityCriticalValidator
         // A missing expectation is a configuration bug, not a token defect: without the stream's
         // issuer there is nothing to bind the event to, and reporting that as a token error would
         // blame every token for the receiver's wiring.
-        if (context.Options is not SsfValidationOptions { StreamIssuer: { Length: > 0 } streamIssuer })
+        if (context.Options is not SharedSignalsValidationOptions { StreamIssuer: { Length: > 0 } streamIssuer })
         {
             throw new InvalidOperationException(
-                $"{nameof(StreamIssuerStep)} requires {nameof(SsfValidationOptions)}."
-                + $"{nameof(SsfValidationOptions.StreamIssuer)} to be configured with the issuer from the "
+                $"{nameof(StreamIssuerStep)} requires {nameof(SharedSignalsValidationOptions)}."
+                + $"{nameof(SharedSignalsValidationOptions.StreamIssuer)} to be configured with the issuer from the "
                 + "stream's configuration (SSF 1.0 Section 4.1.6).");
         }
 

--- a/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/SsfEndToEndTests.cs
@@ -363,7 +363,7 @@ public sealed class SsfEndToEndTests : IAsyncLifetime
             options.Events.Register<VerificationEventPayload>(SsfEventTypes.Verification));
         builder.Services.AddDistributedMemoryCache();
         builder.Services.AddDistributedReplayCache();
-        builder.Services.AddSsfReceiver(new SsfValidationOptions
+        builder.Services.AddSsfReceiver(new SharedSignalsValidationOptions
         {
             ExpectedAudience = ReceiverId,
             ExpectedIssuers = [TransmitterIssuer],

--- a/tests/Abblix.SharedSignals.UnitTests/CriticalStepDeclarationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CriticalStepDeclarationTests.cs
@@ -50,7 +50,7 @@ public class CriticalStepDeclarationTests
 
         return services
             .AddSecurityEvents()
-            .AddSsfReceiver(new SsfValidationOptions());
+            .AddSsfReceiver(new SharedSignalsValidationOptions());
     }
 
     // The receiver validates under its own named profile, so the resolve, the removal and the

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliveryHandlerTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliveryHandlerTests.cs
@@ -91,7 +91,7 @@ public class PushDeliveryHandlerTests
     {
         var validator = new StubValidator(error: null, token: BuildToken());
         var sink = new RecordingSink();
-        var handler = new PushDeliveryHandler(validator, new SsfValidationOptions(), sink);
+        var handler = new PushDeliveryHandler(validator, new SharedSignalsValidationOptions(), sink);
 
         var result = await handler.HandleAsync(
             "application/json", "a.b.c", TestContext.Current.CancellationToken);
@@ -107,7 +107,7 @@ public class PushDeliveryHandlerTests
     {
         var handler = new PushDeliveryHandler(
             new StubValidator(error: null, token: BuildToken()),
-            new SsfValidationOptions(),
+            new SharedSignalsValidationOptions(),
             new RecordingSink());
 
         var result = await handler.HandleAsync(
@@ -122,7 +122,7 @@ public class PushDeliveryHandlerTests
     {
         var handler = new PushDeliveryHandler(
             new StubValidator(error: null, token: BuildToken()),
-            new SsfValidationOptions(),
+            new SharedSignalsValidationOptions(),
             new RecordingSink());
 
         var result = await handler.HandleAsync(SetMediaType, "", TestContext.Current.CancellationToken);
@@ -141,7 +141,7 @@ public class PushDeliveryHandlerTests
                 SecurityEventTokenErrorCode.AudienceMismatch, "not for this receiver"),
             token: null);
         var sink = new RecordingSink();
-        var handler = new PushDeliveryHandler(validator, new SsfValidationOptions(), sink);
+        var handler = new PushDeliveryHandler(validator, new SharedSignalsValidationOptions(), sink);
 
         var result = await handler.HandleAsync(
             SetMediaType, "a.b.c", TestContext.Current.CancellationToken);
@@ -158,7 +158,7 @@ public class PushDeliveryHandlerTests
         var token = BuildToken();
         var sink = new RecordingSink();
         var handler = new PushDeliveryHandler(
-            new StubValidator(error: null, token: token), new SsfValidationOptions(), sink);
+            new StubValidator(error: null, token: token), new SharedSignalsValidationOptions(), sink);
 
         var result = await handler.HandleAsync(
             SetMediaType, "a.b.c", TestContext.Current.CancellationToken);
@@ -175,7 +175,7 @@ public class PushDeliveryHandlerTests
         var refusal = new DeliveryError(DeliveryErrorCodes.InvalidState, "state mismatch");
         var handler = new PushDeliveryHandler(
             new StubValidator(error: null, token: BuildToken()),
-            new SsfValidationOptions(),
+            new SharedSignalsValidationOptions(),
             new RecordingSink(refusal));
 
         var result = await handler.HandleAsync(
@@ -198,7 +198,7 @@ public class PushDeliveryHandlerTests
         var sink = new RecordingSink();
         var handler = new PushDeliveryHandler(
             new StubValidator(error: null, token: jtiless),
-            new SsfValidationOptions(),
+            new SharedSignalsValidationOptions(),
             sink,
             new FakeReplayCache());
 
@@ -218,7 +218,7 @@ public class PushDeliveryHandlerTests
         var sink = new RecordingSink();
         var handler = new PushDeliveryHandler(
             new StubValidator(error: null, token: BuildToken()),
-            new SsfValidationOptions(),
+            new SharedSignalsValidationOptions(),
             sink,
             new FakeReplayCache());
 

--- a/tests/Abblix.SharedSignals.UnitTests/SsfReceiverProfileTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SsfReceiverProfileTests.cs
@@ -75,7 +75,7 @@ public class SsfReceiverProfileTests
         jwt.Payload.Subject = "user-1";
 
         var context = new SecurityEventTokenValidationContext(
-            "compact-not-under-test", new SsfValidationOptions())
+            "compact-not-under-test", new SharedSignalsValidationOptions())
         {
             UnverifiedPayload = jwt.Payload,
         };
@@ -92,7 +92,7 @@ public class SsfReceiverProfileTests
     public async Task ForbidSub_AbsentSub_Passes()
     {
         var context = new SecurityEventTokenValidationContext(
-            "compact-not-under-test", new SsfValidationOptions())
+            "compact-not-under-test", new SharedSignalsValidationOptions())
         {
             UnverifiedPayload = new JsonWebToken().Payload,
         };
@@ -104,7 +104,7 @@ public class SsfReceiverProfileTests
     [Fact]
     public async Task StreamIssuer_MatchingIssuer_Passes()
     {
-        var context = TrustedContext(BuildToken(), new SsfValidationOptions { StreamIssuer = StreamIssuer });
+        var context = TrustedContext(BuildToken(), new SharedSignalsValidationOptions { StreamIssuer = StreamIssuer });
 
         Assert.Null(await new StreamIssuerStep().ValidateAsync(context, TestContext.Current.CancellationToken));
     }
@@ -116,7 +116,7 @@ public class SsfReceiverProfileTests
         // event must come from THE stream's issuer (Section 4.1.6), or events replay across
         // streams.
         var context = TrustedContext(
-            BuildToken(), new SsfValidationOptions { StreamIssuer = "https://other.example.com" });
+            BuildToken(), new SharedSignalsValidationOptions { StreamIssuer = "https://other.example.com" });
 
         var error = await new StreamIssuerStep().ValidateAsync(context, TestContext.Current.CancellationToken);
 
@@ -130,7 +130,7 @@ public class SsfReceiverProfileTests
     {
         // A missing expectation is the receiver's wiring bug: reported as a token error it would
         // reject every token while the logs blame the transmitters.
-        var unconfigured = TrustedContext(BuildToken(), new SsfValidationOptions());
+        var unconfigured = TrustedContext(BuildToken(), new SharedSignalsValidationOptions());
         var wrongFlavor = TrustedContext(BuildToken(), new SecurityEventTokenValidationOptions());
 
         foreach (var context in new[] { unconfigured, wrongFlavor })
@@ -138,7 +138,7 @@ public class SsfReceiverProfileTests
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 await new StreamIssuerStep().ValidateAsync(context, TestContext.Current.CancellationToken));
 
-            Assert.Contains(nameof(SsfValidationOptions.StreamIssuer), exception.Message);
+            Assert.Contains(nameof(SharedSignalsValidationOptions.StreamIssuer), exception.Message);
         }
     }
 
@@ -155,7 +155,7 @@ public class SsfReceiverProfileTests
         };
         var context = TrustedContext(
             BuildToken(builder => builder.WithSubjectId(subject)),
-            new SsfValidationOptions { CriticalSubjectMembers = ["workload"] });
+            new SharedSignalsValidationOptions { CriticalSubjectMembers = ["workload"] });
 
         var error = await new CriticalSubjectMembersStep()
             .ValidateAsync(context, TestContext.Current.CancellationToken);
@@ -176,7 +176,7 @@ public class SsfReceiverProfileTests
             {
                 User = new EmailSubject("bar@example.com"),
             })),
-            new SsfValidationOptions { CriticalSubjectMembers = ["user"] });
+            new SharedSignalsValidationOptions { CriticalSubjectMembers = ["user"] });
 
         Assert.Null(await new CriticalSubjectMembersStep()
             .ValidateAsync(context, TestContext.Current.CancellationToken));
@@ -187,7 +187,7 @@ public class SsfReceiverProfileTests
     {
         // Critical members bind members WITHIN a Complex Subject (Sections 3.6, 7.1); a simple
         // subject has none, and whether "sub_id" must be present at all is the event's rule.
-        var options = new SsfValidationOptions { CriticalSubjectMembers = ["user"] };
+        var options = new SharedSignalsValidationOptions { CriticalSubjectMembers = ["user"] };
         var step = new CriticalSubjectMembersStep();
 
         var simple = TrustedContext(
@@ -209,7 +209,7 @@ public class SsfReceiverProfileTests
             [SubjectMemberNames.Format] = "x-proprietary",
             ["reference"] = "abc",
         };
-        var context = TrustedContext(token, new SsfValidationOptions());
+        var context = TrustedContext(token, new SharedSignalsValidationOptions());
 
         var error = await new CriticalSubjectMembersStep()
             .ValidateAsync(context, TestContext.Current.CancellationToken);

--- a/tests/Abblix.SharedSignals.UnitTests/SsfServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SsfServiceCollectionTests.cs
@@ -98,7 +98,7 @@ public class SsfServiceCollectionTests
         // ForbidSubStep produces, and it earns it BEFORE any signature work - the token below
         // has no valid signature, so reaching a signature error instead would mean the step is
         // ordered wrong, and reaching success would mean it is not wired at all.
-        var services = SecurityEventsBase().AddSsfReceiver(new SsfValidationOptions
+        var services = SecurityEventsBase().AddSsfReceiver(new SharedSignalsValidationOptions
         {
             StreamIssuer = "https://tr.example.com",
         });
@@ -113,7 +113,7 @@ public class SsfServiceCollectionTests
 
         var verdict = await validator.ValidateAsync(
             UnsignedToken(payload: """{"sub": "user-1", "events": {"urn:example": {}}}"""),
-            provider.GetRequiredService<SsfValidationOptions>(),
+            provider.GetRequiredService<SharedSignalsValidationOptions>(),
             TestContext.Current.CancellationToken);
 
         Assert.True(verdict.TryGetFailure(out var error));
@@ -125,7 +125,7 @@ public class SsfServiceCollectionTests
     public void Receiver_RegisteredTwice_AddsEachStepOnce()
     {
         var services = SecurityEventsBase();
-        var options = new SsfValidationOptions();
+        var options = new SharedSignalsValidationOptions();
 
         services.AddSsfReceiver(options).AddSsfReceiver(options);
 


### PR DESCRIPTION
SharedSignalsValidationOptions, after the base type it extends (SecurityEventTokenValidationOptions) and the package it lives in: the abbreviation said less than either neighbour and was the only options type a reader could not expand from its own name. Mechanical rename, 10 files; The one host in place registers the transmitter role only and never names this type, so no consumer crosses the change; a receiver adopts the new name with its first registration. Suites: SharedSignals 140 + E2E 4 green.