### PR TITLE
fix(shared-signals): the transmitter under concurrency, in one process and across replicas

### DIFF
--- a/src/Abblix.SecurityEvents.MinimalApi/BackChannelLogoutEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SecurityEvents.MinimalApi/BackChannelLogoutEndpointRouteBuilderExtensions.cs
@@ -48,7 +48,6 @@ public static class BackChannelLogoutEndpointRouteBuilderExtensions
         string pattern)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
-
         return endpoints.MapPost(pattern, HandleAsync);
     }
 

--- a/src/Abblix.SecurityEvents.MinimalApi/PushDeliveryEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SecurityEvents.MinimalApi/PushDeliveryEndpointRouteBuilderExtensions.cs
@@ -49,7 +49,6 @@ public static class PushDeliveryEndpointRouteBuilderExtensions
         string pattern)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
-
         return endpoints.MapPost(pattern, HandleAsync);
     }
 

--- a/src/Abblix.SecurityEvents.MinimalApi/ResultHeaderExtensions.cs
+++ b/src/Abblix.SecurityEvents.MinimalApi/ResultHeaderExtensions.cs
@@ -52,12 +52,12 @@ public static class ResultHeaderExtensions
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(configure);
 
-        return new HeadersAttached(result, configure);
+        return new HeadersAttachedDecorator(result, configure);
     }
 
     /// <param name="inner">The answer being rendered.</param>
     /// <param name="configure">Sets the headers on the response.</param>
-    private sealed class HeadersAttached(IResult inner, Action<IHeaderDictionary> configure) : IResult
+    private sealed class HeadersAttachedDecorator(IResult inner, Action<IHeaderDictionary> configure) : IResult
     {
         public Task ExecuteAsync(HttpContext httpContext)
         {

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -12,7 +12,7 @@ dotnet add package Abblix.SharedSignals.Redis
 
 The in-package distributed-cache outbox stores each queue as one value, so its mutations are read-modify-write - correct for a single transmitter instance serializing them in-process, and silently lossy the day the transmitter scales to replicas: one replica's enqueue overwrites another's. This outbox appends, removes by value and deletes fields on the server, inside a transaction, so concurrent replicas compose instead of overwriting each other.
 
-What that buys is that no enqueue or acknowledgement is lost; what it does not buy is single delivery, because a delivery pass reads and then acknowledges rather than leasing. Both replicas read the whole queue and both walk all of it, so with N replicas draining one stream each SET is transmitted N times - measured, not occasional. RFC 8935 Section 2 permits redelivery ("The SET Transmitter MAY transmit the same SET to the SET Recipient multiple times, regardless of the response"), and the receiver's replay cache absorbs it; but the same section adds that a transmitter "SHOULD NOT retransmit a SET" outside a suspected recoverable failure, and should delay retransmission "to avoid overwhelming the SET Recipient". A same-instant race between replicas is neither. Take this outbox for the concurrency safety of its mutations; if the duplication matters at your replica count, lease the items instead of reading them - `LMOVE` into a per-replica in-flight list turns N transmissions into one in the common case.
+Composing mutations is one half. The other is single delivery, and it is a separate call: `AddSsfRedisDeliveryLease()`. A delivery pass reads a stream's queue and acknowledges what the receiver takes, so without a claim every replica reads the same pending SETs and every one of them POSTs them - N transmissions of each event, by construction rather than occasionally. RFC 8935 Section 2 permits redelivery ("The SET Transmitter MAY transmit the same SET to the SET Recipient multiple times, regardless of the response"), but the same section binds the transmitter the other way: it "SHOULD NOT retransmit a SET" outside a suspected recoverable failure, and should delay retransmission "to avoid overwhelming the SET Recipient". Replicas duplicating each other's work suspect nothing, so that is the SHOULD NOT rather than a matter of traffic.
 
 ## Usage
 
@@ -43,6 +43,25 @@ builder.Services
 ```
 
 The key carries the transmitter's own issuer, so two deployments sharing one Redis keep separate registries; without that they would read each other's streams and deliver their own signed events to each other's receivers.
+
+## Single delivery across replicas
+
+`AddSsfRedisDeliveryLease()` is what makes several replicas a division of the streams rather than N copies of the work. Before sweeping a stream a replica claims it with a write conditional on the key not existing - the one Redis primitive that can decide between askers sharing nothing else - and a replica told no passes that stream by and takes one the others have not reached.
+
+```csharp
+builder.Services
+    .AddSecurityEvents(...)
+    .AddSsfTransmitter(...)
+    .AddSsfRedisOutbox()
+    .AddSsfRedisStreamStore()
+    .AddSsfRedisDeliveryLease();
+```
+
+Without this call the claim is `ProcessLocalDeliveryLease`, which reaches inside one process and no further, so every replica believes it holds every stream. The transmitter names the implementation in its startup log for exactly that reason - a deployment can read which one it wired rather than infer it.
+
+The claim expires, because expiry is the only release a replica that died mid-pass can perform, and that makes `SsfTransmitterOptions.PushDeliveryLeaseDuration` two limits at once: the claim's life and the longest one pass may run. A pass reaching the deadline is cut off there, since past it the stream belongs to whoever takes it next; what it did not deliver goes out on a later pass. Both directions are safe - too short redoes work, too long parks a stream after a replica dies - so set it by which one the deployment minds less. The default is one minute.
+
+This is also why the lease is not offered over `IDistributedCache`. That interface writes whole values unconditionally and has no set-if-absent, so a claim built on it would be granted to every replica that asked - a lock everyone holds, behaving exactly like no lock while reading as coordination.
 
 Two properties of the shape are worth knowing before adopting it. The whole registry travels on every dispatched event and lives on one cluster slot, which suits the tens of receivers a transmitter serves and does not suit thousands. And registrations carry the receivers' delivery credentials, so this Redis holds secrets and deserves the protection of one.
 

--- a/src/Abblix.SharedSignals.Redis/RedisDeliveryLease.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisDeliveryLease.cs
@@ -1,0 +1,92 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SharedSignals.Transmitter;
+using StackExchange.Redis;
+
+namespace Abblix.SharedSignals.Redis;
+
+/// <summary>
+/// The delivery lease across instances, on the one Redis primitive that can express it: a write
+/// conditional on the key not existing, carrying its own expiry. Every transmitter instance asks
+/// the same server, so exactly one of them is told yes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is why the lease is not offered over <c>IDistributedCache</c>. That interface writes whole
+/// values unconditionally - it has no set-if-absent - so a lease built on it would be taken by
+/// every instance that asked, and a lock everyone holds is worse than none: the sweep would look
+/// coordinated while behaving exactly as it does with no lease at all.
+/// </para>
+/// <para>
+/// Releasing compares before deleting, and the case it exists for is the ordinary one rather than
+/// an exotic race: a holder whose pass ran past the deadline no longer owns the name, another
+/// instance has taken it, and an unconditional delete would hand the name to a third while the
+/// second was still working. The comparison and the delete are one script because reading and then
+/// deleting is that same defect with a smaller window.
+/// </para>
+/// <para>
+/// One key per name, so the script is single-key and needs no cluster hash tag to stay valid under
+/// Redis Cluster.
+/// </para>
+/// </remarks>
+/// <param name="connection">The Redis connection; opening and configuring it is the host's.</param>
+public sealed class RedisDeliveryLease(IConnectionMultiplexer connection) : IDeliveryLease
+{
+    private const string KeyPrefix = $"{nameof(Abblix)}.{nameof(SharedSignals)}:{nameof(RedisDeliveryLease)}:";
+
+    /// <summary>Deletes the claim only while it is still the one this holder took.</summary>
+    private const string ReleaseScript =
+        """
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('DEL', KEYS[1])
+        end
+        return 0
+        """;
+
+    private readonly IDatabase _database = connection.GetDatabase();
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable?> TryAcquireAsync(
+        string name,
+        TimeSpan duration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(duration, TimeSpan.Zero);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // The token is what makes the claim THIS taking of the name rather than the name itself,
+        // which is the whole basis of the conditional release below.
+        var token = Guid.NewGuid().ToString("N");
+
+        var taken = await _database.StringSetAsync(KeyPrefix + name, token, duration, When.NotExists);
+
+        return taken ? new Handle(_database, KeyPrefix + name, token) : null;
+    }
+
+    private sealed class Handle(IDatabase database, string key, string token) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+            => await database.ScriptEvaluateAsync(ReleaseScript, [key], [token]);
+    }
+}

--- a/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
@@ -64,4 +64,21 @@ public static class ServiceCollectionExtensions
         services.Replace(ServiceDescriptor.Singleton<IStreamStore, RedisStreamStore>());
         return services;
     }
+
+    /// <summary>
+    /// Puts the push delivery claim on Redis, which is what stops several transmitter instances
+    /// from delivering one stream's queue to its receiver several times over. A deployment running
+    /// more than one instance needs this call: the default claim reaches only inside a process, so
+    /// without it every instance believes it holds every stream.
+    /// </summary>
+    /// <remarks>
+    /// Replace for the same reason as its siblings above - it IS the host's explicit choice and
+    /// wins in any order relative to the role registration.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddSsfRedisDeliveryLease(this IServiceCollection services)
+    {
+        services.Replace(ServiceDescriptor.Singleton<IDeliveryLease, RedisDeliveryLease>());
+        return services;
+    }
 }

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -66,6 +66,12 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IStreamStore, InMemoryStreamStore>();
         services.TryAddSingleton<IEventOutbox, InMemoryEventOutbox>();
 
+        // Every instance of the application runs the sweep below, so something must decide which
+        // one delivers a given stream. The default reaches only inside this process, which is
+        // right for one instance and named so a deployment reading its own startup log can see
+        // that it is what got wired; AddSsfRedisDeliveryLease is the one that spans instances.
+        services.TryAddSingleton<IDeliveryLease, ProcessLocalDeliveryLease>();
+
         // The issuer is a value, not a service, so the dispatcher is built through the factory
         // that overrides exactly that one parameter and resolves the rest - including the
         // sharing policy, which stays optional: a host that registered none runs without one.
@@ -226,6 +232,12 @@ public static class ServiceCollectionExtensions
     /// TryAdd for the same reason as <see cref="AddSsfConfiguredStreams"/>: an explicit choice
     /// wins in any order.
     /// </summary>
+    /// <remarks>
+    /// Surviving a restart and surviving a second instance are different properties, and this call
+    /// buys the first only. <c>IDistributedCache</c> writes whole values with no compare-and-set,
+    /// so two instances editing one stream's queue overwrite each other; a transmitter running
+    /// more than one instance takes <c>AddSsfRedisOutbox</c> instead.
+    /// </remarks>
     /// <param name="services">The service collection.</param>
     public static IServiceCollection AddSsfDistributedOutbox(this IServiceCollection services)
     {

--- a/src/Abblix.SharedSignals/LogEvents.cs
+++ b/src/Abblix.SharedSignals/LogEvents.cs
@@ -46,5 +46,14 @@ public static class LogEvents
 
         /// <summary>An event could not be queued for one stream; the fan-out reached the others.</summary>
         public const int StreamNotReached = Base + 3;
+
+        /// <summary>This instance began sweeping push streams, and by what it claims them.</summary>
+        public const int PushSweepingStarted = Base + 4;
+
+        /// <summary>Another instance holds this stream's delivery claim, so this one passed it by.</summary>
+        public const int PushStreamClaimedElsewhere = Base + 5;
+
+        /// <summary>A delivery pass outlived its claim and was cut off at the deadline.</summary>
+        public const int PushPassCutOff = Base + 6;
     }
 }

--- a/src/Abblix.SharedSignals/LogEvents.cs
+++ b/src/Abblix.SharedSignals/LogEvents.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -43,5 +43,8 @@ public static class LogEvents
 
         /// <summary>One stream's delivery failed; the sweep carried on with the rest.</summary>
         public const int PushStreamFailed = Base + 2;
+
+        /// <summary>An event could not be queued for one stream; the fan-out reached the others.</summary>
+        public const int StreamNotReached = Base + 3;
     }
 }

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -77,6 +77,7 @@ Stream state and the outbox are deliberately separate tiers, and both default to
 
 - Streams can live in configuration: `AddSsfConfiguredStreams` accepts streams the host declares - typically bound from `appsettings.json` into `ConfiguredStream[]` - which suits a closed deployment where the receivers are known: nothing to back up or migrate.
 - The outbox holds events between minting and delivery. `AddSsfDistributedOutbox()` moves it onto the host's `IDistributedCache` - correct for a single transmitter instance; a transmitter running replicas takes [Abblix.SharedSignals.Redis](https://www.nuget.org/packages/Abblix.SharedSignals.Redis), whose server-side transactions survive concurrency. Losing the outbox loses pending events, and the protocol tolerates that: SSF 1.0 Section 8.1.2.1 lets a transmitter drop events held for a paused stream, and neither delivery RFC requires durable queues - so the queue belongs beside caches, the tier that earns no backups.
+- Push delivery runs on a timer in every instance, so a stream is claimed before it is swept and only the holder delivers it. The default claim, `ProcessLocalDeliveryLease`, reaches inside one process: right for a single instance, and believed by every replica once there are several. A transmitter running replicas takes `AddSsfRedisDeliveryLease()` from the same Redis package. The transmitter names the claim's implementation in its startup log, so which one a deployment wired is readable rather than assumed.
 
 ## Event dictionaries
 

--- a/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
@@ -38,6 +38,15 @@ namespace Abblix.SharedSignals.Transmitter;
 /// verification throttle, tolerates loss by construction (one extra verification is allowed),
 /// and everything durable is the operator's file. A deployment that needs receiver-driven
 /// lifecycle registers a durable <see cref="IStreamStore"/> instead.
+/// <para>
+/// Across INSTANCES the same trade reads differently, and it is the sharper limit of the two.
+/// The declared set is identical everywhere, since it comes from one file, so delivery is
+/// consistent - but a mutation lands in one instance's memory and nowhere else. A receiver
+/// pausing its stream is honoured by whichever instance took the request while the rest keep
+/// delivering, and because the delivery claim moves between instances from pass to pass, the
+/// pause appears to be respected intermittently rather than not at all, which is the harder
+/// shape to diagnose. A transmitter running more than one instance takes a shared store.
+/// </para>
 /// </remarks>
 public sealed class ConfigurationStreamStore : IStreamStore
 {

--- a/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
@@ -36,11 +36,14 @@ namespace Abblix.SharedSignals.Transmitter;
 /// the cache tier rather than beside data that earns backups.
 /// </summary>
 /// <remarks>
-/// <see cref="IDistributedCache"/> reads and writes whole values with no compare-and-set, so
-/// queue mutations are serialized through an in-process gate per stream. That makes this
-/// implementation correct for a SINGLE transmitter instance; replicas mutating one stream's
-/// queue would overwrite each other's writes. A scaled-out transmitter needs a backend-aware
-/// outbox - native list operations - behind the same interface.
+/// <see cref="IDistributedCache"/> reads and writes whole values with no compare-and-set, so queue
+/// mutations are serialized through an in-process gate per stream. That gate excludes this
+/// instance's threads from each other and reaches no further, which makes this implementation
+/// correct for a SINGLE transmitter instance and only that: two instances mutating one stream's
+/// queue read the same value, each writes its own edit over the whole entry, and the later write
+/// silently discards the earlier one's. No compare-and-set means the interface cannot express the
+/// fix either - it is not a gap in this class. A transmitter running more than one instance takes
+/// the outbox built on native list operations, <c>AddSsfRedisOutbox</c>.
 /// </remarks>
 /// <param name="cache">The distributed cache the queues live in; the store is the host's
 /// choice.</param>

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.Logging.cs
@@ -1,0 +1,35 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+partial class EventDispatcher
+{
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.StreamNotReached,
+        Level = LogLevel.Error,
+        Message = "The event {EventType} could not be queued for stream {StreamId}; "
+            + "the fan-out continued with the remaining streams")]
+    private partial void LogStreamNotReached(Exception exception, string StreamId, string EventType);
+}

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -25,6 +25,8 @@ using Abblix.SecurityEvents.Abstractions;
 using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Model;
 
+using Microsoft.Extensions.Logging;
+
 namespace Abblix.SharedSignals.Transmitter;
 
 /// <summary>
@@ -45,7 +47,9 @@ namespace Abblix.SharedSignals.Transmitter;
 /// honest default only for a transmitter whose events carry nothing the receiver may not see.
 /// </param>
 /// <param name="clock">Supplies "iat"; null takes the system clock.</param>
-public sealed class EventDispatcher(
+/// <param name="logger">Records the streams a fan-out could not reach.</param>
+public sealed partial class EventDispatcher(
+    ILogger<EventDispatcher> logger,
     IStreamStore streams,
     IEventOutbox outbox,
     ISecurityEventTokenSigner signer,
@@ -99,8 +103,18 @@ public sealed class EventDispatcher(
                 continue;
             }
 
-            await MintAndEnqueueAsync(stream, descriptor, asStatusAnnouncement: false, cancellationToken);
-            reached++;
+            // One stream's failure is one stream's. Letting it out of the loop would drop the
+            // fan-out to every stream after it AND lose the count with the exception, so a caller
+            // would learn neither who received the event nor that anybody had.
+            try
+            {
+                await MintAndEnqueueAsync(stream, descriptor, asStatusAnnouncement: false, cancellationToken);
+                reached++;
+            }
+            catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                LogStreamNotReached(exception, stream.StreamId, descriptor.EventType);
+            }
         }
 
         return reached;

--- a/src/Abblix.SharedSignals/Transmitter/IDeliveryLease.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IDeliveryLease.cs
@@ -1,0 +1,71 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// A claim on one named piece of delivery work, held for a bounded time, so that among however
+/// many transmitter instances are running exactly one performs it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Push delivery reads a stream's queue and empties it as receipts come back, so two instances
+/// sweeping one stream both read the same pending SETs and both POST them. RFC 8935 Section 2
+/// permits a receiver to be sent the same SET again - "The SET Recipient MUST respond as it would
+/// if the SET had not been previously received" - but binds the transmitter the other way: it
+/// "should not retransmit a SET unless the SET Transmitter suspects that previous transmissions
+/// may have failed due to potentially recoverable errors", and "in all other cases, the SET
+/// Transmitter SHOULD NOT retransmit a SET". Instances duplicating each other's work suspect
+/// nothing, so this is that SHOULD NOT rather than a matter of wasted traffic.
+/// </para>
+/// <para>
+/// The claim EXPIRES, and that is what separates it from a lock. Expiry is what lets an instance
+/// that died mid-pass release its claim without running any code - nothing else would - and it is
+/// therefore also the point past which the holder has no claim at all. So a holder must stop the
+/// work at its deadline rather than treat the lease as advice: whoever comes next is entitled to
+/// start, and two workers overlapping is the very thing being prevented.
+/// </para>
+/// </remarks>
+public interface IDeliveryLease
+{
+    /// <summary>
+    /// Claims <paramref name="name"/> for at most <paramref name="duration"/>.
+    /// </summary>
+    /// <param name="name">
+    /// What is being claimed. Callers scope it themselves, so two kinds of work over one stream do
+    /// not collide.</param>
+    /// <param name="duration">
+    /// How long the claim holds without being released. It bounds two opposite costs: too short
+    /// cuts a legitimate pass off and the work is redone next time, too long parks the work for
+    /// the remainder after the holder dies. Both are safe, so err on whichever the deployment
+    /// minds less.</param>
+    /// <param name="cancellationToken">Cancels the I/O a shared implementation performs.</param>
+    /// <returns>
+    /// A handle that releases the claim when disposed, or null when someone else holds it - which
+    /// is an ordinary outcome and not a failure. Releasing is conditional on still holding it, so
+    /// a handle disposed after its deadline cannot revoke the claim of whoever took over.
+    /// </returns>
+    Task<IAsyncDisposable?> TryAcquireAsync(
+        string name,
+        TimeSpan duration,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Abblix.SharedSignals/Transmitter/InMemoryEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/InMemoryEventOutbox.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -42,10 +42,23 @@ public sealed class InMemoryEventOutbox : IEventOutbox
         ArgumentException.ThrowIfNullOrEmpty(streamId);
         ArgumentNullException.ThrowIfNull(item);
 
-        var queue = _queues.GetOrAdd(streamId, _ => []);
-        lock (queue)
+        // Re-checked under the lock, because a clear between the lookup and here removes the list
+        // from the dictionary: adding to it then puts the event where nothing can read it, and this
+        // method has no way to say so - it would report success into a queue that no longer exists.
+        // The retry lands the event in whatever list is current, which is the right place for one
+        // enqueued after a clear. It spins only while clears keep interleaving, and a clear is an
+        // administrative act rather than traffic.
+        while (true)
         {
-            queue.Add(item);
+            var queue = _queues.GetOrAdd(streamId, _ => []);
+            lock (queue)
+            {
+                if (_queues.TryGetValue(streamId, out var current) && ReferenceEquals(current, queue))
+                {
+                    queue.Add(item);
+                    break;
+                }
+            }
         }
 
         return Task.CompletedTask;

--- a/src/Abblix.SharedSignals/Transmitter/PollEndpointHandler.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PollEndpointHandler.cs
@@ -73,8 +73,11 @@ public sealed class PollEndpointHandler(IEventOutbox outbox)
         }
 
         // Zero asks for nothing: the acknowledge-only poll (RFC 8936 Section 2.2). The "sets"
-        // object still travels, empty - it is never absent (Section 2.3).
-        if (request.MaxEvents is 0)
+        // object still travels, empty - it is never absent (Section 2.3). A negative value asks
+        // for nothing either, and is answered the same way rather than falling through: Take with
+        // a negative count yields nothing while the "moreAvailable" below still reports a queue,
+        // and a receiver reading that answer polls again forever with no way to see why.
+        if (request.MaxEvents is <= 0)
         {
             return new PollResponse();
         }

--- a/src/Abblix.SharedSignals/Transmitter/ProcessLocalDeliveryLease.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ProcessLocalDeliveryLease.cs
@@ -1,0 +1,111 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections.Concurrent;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+/// <summary>
+/// The lease inside one process, which is the whole of its reach: it excludes the threads of this
+/// instance from each other and nothing else. A second instance of the application holds its own
+/// dictionary and sees none of these claims, so every instance believes it holds every lease.
+/// </summary>
+/// <remarks>
+/// The name says the boundary because that is the only thing a reader must not get wrong. It is
+/// the honest default for a single instance and for tests, and it is the wrong one the moment a
+/// deployment scales out - <c>AddSsfRedisDeliveryLease</c> is the implementation that spans
+/// instances, and a deployment already sharing its outbox needs it.
+/// </remarks>
+/// <param name="timeProvider">The clock the deadlines are read from; a test hands in a fake.</param>
+public sealed class ProcessLocalDeliveryLease(TimeProvider timeProvider) : IDeliveryLease
+{
+    private readonly ConcurrentDictionary<string, Claim> _claims = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public Task<IAsyncDisposable?> TryAcquireAsync(
+        string name,
+        TimeSpan duration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(duration, TimeSpan.Zero);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var mine = new Claim(timeProvider.GetUtcNow() + duration);
+        Task<IAsyncDisposable?> Acquired() => Task.FromResult<IAsyncDisposable?>(new Handle(this, name, mine));
+
+        while (true)
+        {
+            if (_claims.TryAdd(name, mine))
+            {
+                return Acquired();
+            }
+
+            if (!_claims.TryGetValue(name, out var held))
+            {
+                // Released between the two calls, so the name is free again and the add above is
+                // worth another attempt. This arm is the only one that can repeat without either
+                // taking the claim or conceding it, and it repeats only while someone else keeps
+                // releasing - which is progress, not a spin.
+                continue;
+            }
+
+            if (timeProvider.GetUtcNow() < held.ExpiresAt)
+            {
+                return Task.FromResult<IAsyncDisposable?>(null);
+            }
+
+            // The holder's time has run out. Replacing it is conditional on it still being the
+            // claim just read, so of two threads finding the same expired claim exactly one wins
+            // and the other comes round to find a live claim and concede.
+            if (_claims.TryUpdate(name, mine, held))
+            {
+                return Acquired();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drops the claim only while it is still the one taken, which is what keeps a handle disposed
+    /// after its deadline from revoking the claim of whoever took the name over.
+    /// </summary>
+    private void Release(string name, Claim claim)
+        => _claims.TryRemove(new KeyValuePair<string, Claim>(name, claim));
+
+    /// <summary>
+    /// One taking of a name. Identity is the reference, so no two takings are ever equal and the
+    /// conditional replace and remove above compare what they mean to compare.
+    /// </summary>
+    private sealed class Claim(DateTimeOffset expiresAt)
+    {
+        public DateTimeOffset ExpiresAt { get; } = expiresAt;
+    }
+
+    private sealed class Handle(ProcessLocalDeliveryLease lease, string name, Claim claim) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            lease.Release(name, claim);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.Logging.cs
@@ -37,4 +37,23 @@ partial class PushDeliveryScheduler
         Level = LogLevel.Warning,
         Message = "Push delivery failed for stream {StreamId}; the sweep continued with the rest")]
     private partial void LogStreamFailed(Exception exception, string StreamId);
+
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.PushSweepingStarted,
+        Level = LogLevel.Information,
+        Message = "Sweeping push streams every {Interval}, claiming each through {LeaseImplementation}")]
+    private partial void LogSweepingStarted(TimeSpan Interval, string LeaseImplementation);
+
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.PushStreamClaimedElsewhere,
+        Level = LogLevel.Debug,
+        Message = "Stream {StreamId} is being delivered by another instance; skipped this round")]
+    private partial void LogStreamClaimedElsewhere(string StreamId);
+
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.PushPassCutOff,
+        Level = LogLevel.Warning,
+        Message = "Delivery of stream {StreamId} outlived its {LeaseDuration} claim and was cut off; "
+                  + "what it did not deliver goes out on a later pass")]
+    private partial void LogStreamPassCutOff(string StreamId, TimeSpan LeaseDuration);
 }

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.cs
@@ -40,16 +40,26 @@ namespace Abblix.SharedSignals.Transmitter;
 /// caught and logged and the sweep continues; the sender itself decides what a failed delivery
 /// means for the queue, keeping a transient refusal and dropping a final one.
 /// </para>
+/// <para>
+/// Every instance of the application runs this, so each stream is claimed through an
+/// <see cref="IDeliveryLease"/> before it is swept. Without that, a pass reads a queue the other
+/// instances are reading at the same moment and every one of them POSTs the same SETs - which
+/// RFC 8935 Section 2 tells a transmitter not to do outside a suspected recoverable failure. The
+/// claim is what makes running N instances a division of the streams rather than N copies of the
+/// work.
+/// </para>
 /// </remarks>
 /// <param name="logger">Records what a pass did, and what it could not do.</param>
 /// <param name="store">Where the streams to sweep are read from.</param>
 /// <param name="sender">Performs one stream's pass.</param>
-/// <param name="options">Carries the interval between passes.</param>
-/// <param name="timeProvider">The clock the timer runs on; a test hands in a fake.</param>
+/// <param name="lease">Decides which instance sweeps a given stream this round.</param>
+/// <param name="options">Carries the interval between passes and the claim's duration.</param>
+/// <param name="timeProvider">The clock the timer and the deadlines run on; a test hands in a fake.</param>
 public sealed partial class PushDeliveryScheduler(
     ILogger<PushDeliveryScheduler> logger,
     IStreamStore store,
     PushDeliverySender sender,
+    IDeliveryLease lease,
     SsfTransmitterOptions options,
     TimeProvider timeProvider) : BackgroundService
 {
@@ -58,6 +68,11 @@ public sealed partial class PushDeliveryScheduler(
     {
         if (options.PushDeliveryInterval is not { } interval)
             return;
+
+        // Named rather than described, because the name of the implementation is the fact an
+        // operator needs: a sweep coordinated by ProcessLocalDeliveryLease is one instance's,
+        // whatever the deployment believes it is running.
+        LogSweepingStarted(interval, lease.GetType().Name);
 
         using var timer = new PeriodicTimer(interval, timeProvider);
 
@@ -77,7 +92,7 @@ public sealed partial class PushDeliveryScheduler(
     }
 
     /// <summary>
-    /// Delivers what is pending on every enabled push stream.
+    /// Delivers what is pending on every enabled push stream this instance can claim.
     /// </summary>
     private async Task SweepAsync(CancellationToken cancellationToken)
     {
@@ -86,15 +101,57 @@ public sealed partial class PushDeliveryScheduler(
             if (stream.Configuration.Delivery is not PushDeliveryMethod)
                 continue;
 
-            try
-            {
-                await sender.SendPendingAsync(stream, cancellationToken);
-            }
-            catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
-            {
-                // One receiver being unreachable says nothing about the next one's stream.
-                LogStreamFailed(exception, stream.StreamId);
-            }
+            await SweepStreamAsync(stream, cancellationToken);
         }
     }
+
+    /// <summary>
+    /// Claims one stream and delivers its queue, or leaves it to whoever holds the claim.
+    /// </summary>
+    /// <remarks>
+    /// The claim is per stream rather than per sweep, which is what turns several instances from
+    /// duplicates into a division of labour: each takes the streams the others have not reached,
+    /// and a stream whose receiver is slow holds up only itself.
+    /// </remarks>
+    private async Task SweepStreamAsync(StreamState stream, CancellationToken cancellationToken)
+    {
+        var duration = options.PushDeliveryLeaseDuration;
+
+        await using var claim = await lease.TryAcquireAsync(
+            LeaseNameOf(stream.StreamId), duration, cancellationToken);
+
+        if (claim is null)
+        {
+            LogStreamClaimedElsewhere(stream.StreamId);
+            return;
+        }
+
+        // The claim runs out whether or not the pass has finished, and past that moment another
+        // instance is entitled to this stream. So the pass is cut at the same deadline: one that
+        // kept POSTing beyond it would be the duplicate delivery the claim exists to prevent,
+        // and what it drops is redelivered on the next pass, which the queue is built for.
+        using var deadline = new CancellationTokenSource(duration, timeProvider);
+        using var bounded = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
+
+        try
+        {
+            await sender.SendPendingAsync(stream, bounded.Token);
+        }
+        catch (OperationCanceledException)
+            when (deadline.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            LogStreamPassCutOff(stream.StreamId, duration);
+        }
+        catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // One receiver being unreachable says nothing about the next one's stream.
+            LogStreamFailed(exception, stream.StreamId);
+        }
+    }
+
+    /// <summary>
+    /// Scopes the claim to this work, so a later claim over the same stream - a retention sweep,
+    /// a verification - does not silently exclude delivery by sharing its name.
+    /// </summary>
+    private static string LeaseNameOf(string streamId) => $"push:{streamId}";
 }

--- a/src/Abblix.SharedSignals/Transmitter/SsfTransmitterOptions.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SsfTransmitterOptions.cs
@@ -124,6 +124,21 @@ public sealed record SsfTransmitterOptions
     public TimeSpan? PushDeliveryInterval { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// How long one instance's claim on a stream's delivery holds, and therefore the longest a
+    /// single pass over that stream may run.
+    /// </summary>
+    /// <remarks>
+    /// The claim keeps concurrent instances off one another's streams, and it expires because
+    /// expiry is the only release an instance that died mid-pass can perform. That makes this one
+    /// value two limits at once, erring in opposite directions and both of them safe: too short
+    /// cuts a legitimate pass off at the deadline and its remainder goes out on the next one, too
+    /// long parks a stream for the rest of the claim after the instance holding it dies. The
+    /// default is comfortably longer than a pass over a responsive receiver and well short of an
+    /// outage anybody would sit through.
+    /// </remarks>
+    public TimeSpan PushDeliveryLeaseDuration { get; init; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
     /// The "default_subjects" value the mode advertises, kept beside the enum so the wire word
     /// and the behavior cannot drift apart.
     /// </summary>

--- a/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
@@ -108,10 +108,34 @@ public sealed class StreamManagementService(
             SubjectsMode = options.DefaultSubjectsMode,
         };
 
-        return await store.TryCreateAsync(created, cancellationToken)
-            ? ManagementResult<StreamConfiguration>.Created(configuration)
-            : ManagementResult<StreamConfiguration>.Conflict(
+        if (!await store.TryCreateAsync(created, cancellationToken))
+        {
+            return ManagementResult<StreamConfiguration>.Conflict(
                 "A stream with the generated identifier already exists.");
+        }
+
+        // The count above was read before this stream existed, and the identifier is freshly
+        // generated, so nothing collides and two creates arriving together both pass. Re-read now
+        // that ours is on record: without this the one-per-receiver policy never refuses anything,
+        // and an option that cannot fire is a promise the deployment cannot keep.
+        if (!options.AllowMultipleStreamsPerReceiver)
+        {
+            var streams = await store.ListAsync(receiverId, cancellationToken);
+
+            // The lowest identifier stays, whoever asked first. A rule both racers can evaluate
+            // the same way is what keeps them from both withdrawing and leaving the receiver with
+            // no stream at all.
+            if (streams.Count > 1
+                && streams.Select(existing => existing.StreamId).Order(StringComparer.Ordinal).First() != streamId)
+            {
+                await store.DeleteAsync(receiverId, streamId, cancellationToken);
+                return ManagementResult<StreamConfiguration>.Conflict(
+                    "The receiver already has a stream, and this transmitter allows one per receiver "
+                    + "(SSF 1.0 Section 8.1.1.1); read it and update or replace what differs.");
+            }
+        }
+
+        return ManagementResult<StreamConfiguration>.Created(configuration);
     }
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisDeliveryLeaseTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisDeliveryLeaseTests.cs
@@ -1,0 +1,117 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Xunit;
+
+namespace Abblix.SharedSignals.Redis.UnitTests;
+
+/// <summary>
+/// Pins the delivery claim against a REAL Redis-protocol server - the embedded Garnet the fixture
+/// starts - because the property being claimed is server-side: one conditional write decides
+/// between askers that share nothing else. A mock of the client API would agree with whatever this
+/// implementation asked it, which is the one thing that must not decide the answer.
+/// </summary>
+/// <remarks>
+/// Each test names its own claim, since the fixture is one shared server and a collision between
+/// tests would read as a product defect.
+/// </remarks>
+public sealed class RedisDeliveryLeaseTests(GarnetFixture garnet) : IClassFixture<GarnetFixture>
+{
+    private static readonly TimeSpan Minute = TimeSpan.FromMinutes(1);
+
+    private static string NewName() => $"push:{Guid.NewGuid():N}";
+
+    private RedisDeliveryLease NewLease() => new(garnet.Connection);
+
+    [Fact]
+    public async Task OfTwoInstancesAskingForOneName_ExactlyOneIsAccepted()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var name = NewName();
+
+        // Two lease objects rather than one, because two instances of the application is what this
+        // is modelling: they share the server and nothing else.
+        var first = NewLease();
+        var second = NewLease();
+
+        await using var held = await first.TryAcquireAsync(name, Minute, cancellationToken);
+        Assert.NotNull(held);
+
+        Assert.Null(await second.TryAcquireAsync(name, Minute, cancellationToken));
+
+        // A different stream is different work and must not queue behind this one.
+        await using var other = await second.TryAcquireAsync(NewName(), Minute, cancellationToken);
+        Assert.NotNull(other);
+    }
+
+    [Fact]
+    public async Task AReleasedClaim_IsTakenByTheOtherInstance()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var name = NewName();
+        var first = NewLease();
+        var second = NewLease();
+
+        var held = await first.TryAcquireAsync(name, Minute, cancellationToken);
+        Assert.NotNull(held);
+        await held.DisposeAsync();
+
+        await using var taken = await second.TryAcquireAsync(name, Minute, cancellationToken);
+        Assert.NotNull(taken);
+    }
+
+    /// <summary>
+    /// The reason the release compares before deleting, tested through the case it exists for: a
+    /// pass that ran past its deadline finishes and lets go, by which time the name belongs to
+    /// somebody else.
+    /// </summary>
+    /// <remarks>
+    /// Releasing by name alone would pass every other test in this class and fail only here - and
+    /// in production only as a receiver occasionally getting one stream's events twice, from two
+    /// instances, with nothing in either one's log looking wrong.
+    /// </remarks>
+    [Fact]
+    public async Task AClaimReleasedAfterItExpired_LeavesTheSuccessorsStanding()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var name = NewName();
+        var first = NewLease();
+        var second = NewLease();
+
+        // Short because the server's own clock is what expires it - there is no fake clock behind
+        // a real Redis - and the wait below is several times the claim to keep the test honest
+        // rather than fast.
+        var brief = TimeSpan.FromMilliseconds(200);
+
+        var expiring = await first.TryAcquireAsync(name, brief, cancellationToken);
+        Assert.NotNull(expiring);
+
+        await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+
+        await using var successor = await second.TryAcquireAsync(name, Minute, cancellationToken);
+        Assert.NotNull(successor);
+
+        await expiring.DisposeAsync();
+
+        Assert.Null(await first.TryAcquireAsync(name, Minute, cancellationToken));
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -26,6 +26,7 @@ using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -104,7 +105,7 @@ public class EventDispatcherTests
 
         var outbox = new InMemoryEventOutbox();
         var signer = new CapturingSigner();
-        return (new EventDispatcher(store, outbox, signer, Issuer, policy), outbox, signer);
+        return (new EventDispatcher(NullLogger<EventDispatcher>.Instance, store, outbox, signer, Issuer, policy), outbox, signer);
     }
 
     [Fact]

--- a/tests/Abblix.SharedSignals.UnitTests/ProcessLocalDeliveryLeaseTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ProcessLocalDeliveryLeaseTests.cs
@@ -1,0 +1,125 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// The claim's rules, on the implementation whose reach is one process. They are the contract every
+/// implementation owes, so the Redis one is held to the same list against a real server.
+/// </summary>
+public class ProcessLocalDeliveryLeaseTests
+{
+    private static readonly TimeSpan Minute = TimeSpan.FromMinutes(1);
+
+    private static FakeTimeProvider NewClock()
+        => new(DateTimeOffset.FromUnixTimeSeconds(1754040000));
+
+    [Fact]
+    public async Task ASecondAsker_IsRefused_WhileTheFirstHolds()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var lease = new ProcessLocalDeliveryLease(NewClock());
+
+        await using var held = await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken);
+        Assert.NotNull(held);
+
+        Assert.Null(await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken));
+
+        // A different name is different work: refusing it too would serialize every stream behind
+        // whichever one is being delivered.
+        await using var other = await lease.TryAcquireAsync("push:s-2", Minute, cancellationToken);
+        Assert.NotNull(other);
+    }
+
+    [Fact]
+    public async Task AReleasedClaim_IsTakenByTheNextAsker()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var lease = new ProcessLocalDeliveryLease(NewClock());
+
+        var first = await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken);
+        Assert.NotNull(first);
+        await first.DisposeAsync();
+
+        await using var second = await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken);
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task AnExpiredClaim_IsTakenByTheNextAsker_WithoutTheHolderReleasingIt()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var clock = NewClock();
+        var lease = new ProcessLocalDeliveryLease(clock);
+
+        // Never disposed, which is the case expiry exists for: an instance that died mid-pass runs
+        // no code, so nothing but the deadline can free the stream it was delivering.
+        Assert.NotNull(await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken));
+
+        Assert.Null(await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken));
+
+        clock.Advance(Minute);
+
+        await using var afterExpiry = await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken);
+        Assert.NotNull(afterExpiry);
+    }
+
+    [Fact]
+    public async Task AHandleDisposedAfterItsDeadline_LeavesTheSuccessorsClaimStanding()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var clock = NewClock();
+        var lease = new ProcessLocalDeliveryLease(clock);
+
+        var expired = await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken);
+        Assert.NotNull(expired);
+
+        clock.Advance(Minute);
+
+        await using var successor = await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken);
+        Assert.NotNull(successor);
+
+        // The first holder finishes and lets go, unaware it stopped owning the name a moment ago.
+        // Releasing by name alone would hand the stream to a third instance while the second is
+        // still delivering it - which is the duplicate delivery the claim exists to prevent,
+        // reintroduced by the release.
+        await expired.DisposeAsync();
+
+        Assert.Null(await lease.TryAcquireAsync("push:s-1", Minute, cancellationToken));
+    }
+
+    [Fact]
+    public async Task ADurationThatCannotHold_IsRefusedRatherThanTakenAndInstantlyLost()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var lease = new ProcessLocalDeliveryLease(NewClock());
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => lease.TryAcquireAsync("push:s-1", TimeSpan.Zero, cancellationToken));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => lease.TryAcquireAsync("push:s-1", TimeSpan.FromSeconds(-1), cancellationToken));
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliverySchedulerTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliverySchedulerTests.cs
@@ -59,6 +59,171 @@ public class PushDeliverySchedulerTests
         }
     }
 
+    /// <summary>Never answers, so a pass reaching it runs until something stops it.</summary>
+    private sealed class HangingOrigin : HttpMessageHandler
+    {
+        private int _requests;
+
+        public int Requests => Volatile.Read(ref _requests);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requests);
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.Accepted);
+        }
+    }
+
+    /// <summary>
+    /// One stream, one queued event, and a transmitter wired the way the tests below need it.
+    /// </summary>
+    private static ServiceProvider NewTransmitter(
+        HttpMessageHandler origin,
+        TimeProvider clock,
+        TimeSpan interval,
+        TimeSpan leaseDuration)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(clock);
+        services.AddSecurityEvents();
+        services.AddSsfTransmitter(new SsfTransmitterOptions
+        {
+            Issuer = Issuer,
+            PushDeliveryInterval = interval,
+            PushDeliveryLeaseDuration = leaseDuration,
+
+            // The receiver is a stub rather than a host on the network, so it is permitted the way
+            // an operator permits a receiver of its own.
+            AllowedReceiverAddresses = [new Uri(ReceiverEndpoint)],
+        });
+        services.AddHttpClient(PushDeliveryTransport.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => origin);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static StreamState NewPushStream() => new()
+    {
+        ReceiverId = "receiver-a",
+        Status = StreamStatuses.Enabled,
+        SubjectsMode = StreamSubjectsMode.None,
+        Configuration = new StreamConfiguration
+        {
+            StreamId = "s-1",
+            Issuer = Issuer,
+            Audiences = ["https://receiver.test"],
+            EventsDelivered = [],
+            Delivery = new PushDeliveryMethod(new Uri(ReceiverEndpoint)),
+        },
+    };
+
+    /// <summary>
+    /// Every instance of the application runs the scheduler, so what keeps two of them from POSTing
+    /// one stream's queue twice over is the claim - and the case is modelled by holding that claim
+    /// the way another instance would.
+    /// </summary>
+    /// <remarks>
+    /// The "nothing was delivered" half is a negative, so the same test releases the claim and
+    /// requires the delivery to happen: one setup, both verdicts, and neither reading as the other.
+    /// </remarks>
+    [Fact]
+    public async Task AStreamClaimedByAnotherInstance_IsPassedBy_AndDeliveredOnceTheClaimIsReleased()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754040000));
+        var origin = new AcceptingOrigin();
+        var interval = TimeSpan.FromSeconds(30);
+
+        // Far longer than the whole test advances the clock, so nothing here turns on a deadline
+        // firing: this test is about the claim being held, not about it running out.
+        await using var provider = NewTransmitter(origin, clock, interval, TimeSpan.FromHours(1));
+
+        await provider.GetRequiredService<IStreamStore>().TryCreateAsync(NewPushStream(), cancellationToken);
+        await provider.GetRequiredService<IEventOutbox>()
+            .EnqueueAsync("s-1", new OutboxItem("jti-1", "a.a.a"), cancellationToken);
+
+        // The same singleton the scheduler resolves, which is what makes this the other instance
+        // rather than a second lock nobody consults.
+        var lease = provider.GetRequiredService<IDeliveryLease>();
+        var claim = await lease.TryAcquireAsync("push:s-1", TimeSpan.FromHours(1), cancellationToken);
+        Assert.NotNull(claim);
+
+        var scheduler = provider.GetServices<IHostedService>().OfType<PushDeliveryScheduler>().Single();
+        await scheduler.StartAsync(cancellationToken);
+
+        try
+        {
+            for (var attempt = 0; attempt < 10; attempt++)
+            {
+                clock.Advance(interval);
+                await Task.Delay(10, cancellationToken);
+            }
+
+            Assert.Equal(0, origin.Requests);
+            Assert.Single(await provider.GetRequiredService<IEventOutbox>()
+                .PendingAsync("s-1", null, cancellationToken));
+
+            await claim.DisposeAsync();
+
+            for (var attempt = 0; attempt < 50 && origin.Requests == 0; attempt++)
+            {
+                clock.Advance(interval);
+                await Task.Delay(10, cancellationToken);
+            }
+
+            Assert.Equal(1, origin.Requests);
+        }
+        finally
+        {
+            await scheduler.StopAsync(cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// A claim expires whether or not the pass holding it has finished, so the pass is cut at the
+    /// same deadline - otherwise the instance taking the stream over next would be delivering it
+    /// alongside one still POSTing, which is what the claim exists to prevent.
+    /// </summary>
+    /// <remarks>
+    /// The verdict is a SECOND request rather than the absence of anything: a pass that was never
+    /// cut off is still inside the first one, so the sweep never comes round again and the counter
+    /// cannot reach two by any other route.
+    /// </remarks>
+    [Fact]
+    public async Task APassOutlivingItsClaim_IsCutOff_SoTheSweepComesRoundAgain()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754040000));
+        var origin = new HangingOrigin();
+        var interval = TimeSpan.FromSeconds(10);
+
+        await using var provider = NewTransmitter(origin, clock, interval, TimeSpan.FromSeconds(30));
+
+        await provider.GetRequiredService<IStreamStore>().TryCreateAsync(NewPushStream(), cancellationToken);
+        await provider.GetRequiredService<IEventOutbox>()
+            .EnqueueAsync("s-1", new OutboxItem("jti-1", "a.a.a"), cancellationToken);
+
+        var scheduler = provider.GetServices<IHostedService>().OfType<PushDeliveryScheduler>().Single();
+        await scheduler.StartAsync(cancellationToken);
+
+        try
+        {
+            for (var attempt = 0; attempt < 100 && origin.Requests < 2; attempt++)
+            {
+                clock.Advance(interval);
+                await Task.Delay(10, cancellationToken);
+            }
+
+            Assert.Equal(2, origin.Requests);
+        }
+        finally
+        {
+            await scheduler.StopAsync(cancellationToken);
+        }
+    }
+
     [Fact]
     public async Task AQueuedEvent_IsDelivered_WithoutAnybodyAskingForAPass()
     {

--- a/tests/Abblix.SharedSignals.UnitTests/SsfServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SsfServiceCollectionTests.cs
@@ -83,6 +83,33 @@ public class SsfServiceCollectionTests
         Assert.Same(hostStore, provider.GetRequiredService<IStreamStore>());
     }
 
+    /// <summary>
+    /// The claim deciding which instance delivers a stream is a default like the stores, and it is
+    /// the one a scaled-out deployment MUST replace - so a host's own must win here for the same
+    /// reason and by the same rule.
+    /// </summary>
+    [Fact]
+    public void Transmitter_ClaimsStreams_AndAHostLeaseWins()
+    {
+        var services = SecurityEventsBase();
+
+        using var defaults = services
+            .AddSsfTransmitter(TransmitterOptions)
+            .BuildServiceProvider();
+
+        Assert.IsType<ProcessLocalDeliveryLease>(defaults.GetRequiredService<IDeliveryLease>());
+
+        var withHostLease = SecurityEventsBase();
+        var hostLease = new ProcessLocalDeliveryLease(TimeProvider.System);
+        withHostLease.AddSingleton<IDeliveryLease>(hostLease);
+
+        using var provider = withHostLease
+            .AddSsfTransmitter(TransmitterOptions)
+            .BuildServiceProvider();
+
+        Assert.Same(hostLease, provider.GetRequiredService<IDeliveryLease>());
+    }
+
     [Fact]
     public void WithoutTheSecurityEventsCore_TheRoleRefuses_NamingThePrerequisite()
     {

--- a/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -28,6 +28,7 @@ using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -75,7 +76,8 @@ public class StreamManagementServiceTests
         var outbox = new InMemoryEventOutbox();
         var signer = new StubSigner();
         var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754200000));
-        var dispatcher = new EventDispatcher(store, outbox, signer, options.Issuer, clock: clock);
+        var dispatcher = new EventDispatcher(
+            NullLogger<EventDispatcher>.Instance, store, outbox, signer, options.Issuer, clock: clock);
 
         return new Harness(
             new StreamManagementService(store, outbox, dispatcher, options, clock),

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
@@ -26,6 +26,7 @@ using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
 using Abblix.SecurityEvents.Delivery;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -264,7 +265,8 @@ public class TransmitterDeliveryTests
         var outbox = await OutboxWithAsync(new OutboxItem("jti-held", "h.h.h"));
         var signer = new FakeSigner();
         var options = new SsfTransmitterOptions { Issuer = "https://tr.example.com" };
-        var dispatcher = new EventDispatcher(store, outbox, signer, options.Issuer);
+        var dispatcher = new EventDispatcher(
+            NullLogger<EventDispatcher>.Instance, store, outbox, signer, options.Issuer);
         var service = new StreamManagementService(store, outbox, dispatcher, options);
 
         Assert.True(await service.ChangeStreamStatusAsync(


### PR DESCRIPTION
Concurrency in the transmitter, from two directions: what the independent review found inside one process, and what the scheduler does once the application runs on more than one.

## Several instances delivered the same events

The push delivery scheduler is a hosted service, so every instance of the application runs it. A pass reads a stream's queue and acknowledges what the receiver takes, which means N instances read the same pending SETs and every one of them POSTs them - by construction, not occasionally.

RFC 8935 Section 2 permits a receiver to be sent the same SET again, and requires it to answer as though it had not seen it. It binds the transmitter the other way: it "SHOULD NOT retransmit a SET" outside a suspected recoverable failure, and should delay retransmission "to avoid overwhelming the SET Recipient". Instances duplicating each other's work suspect nothing, so this was that SHOULD NOT rather than a matter of traffic.

A stream is claimed before it is swept, and only the holder delivers it. Per stream rather than per sweep, which turns several instances into a division of labour: each takes the streams the others have not reached, and a slow receiver holds up only its own stream.

The claim expires, because expiry is the only release an instance that died mid-pass can perform. That makes `PushDeliveryLeaseDuration` two limits at once - the claim's life and the longest a pass may run - and the pass is cut off at the same deadline: past it the stream belongs to whoever takes it next, and a pass still POSTing would be exactly the duplicate the claim prevents. What it drops goes out on a later pass, which the queue is built for.

Two implementations, because the boundary is what a deployment must not get wrong:

- `ProcessLocalDeliveryLease` reaches inside one process and is named so. The scheduler writes the implementation's name into its startup log, so a deployment reads which one it wired rather than assuming.
- `RedisDeliveryLease` is a write conditional on the key not existing, the one primitive that decides between askers sharing nothing else. Releasing compares before deleting, so a handle disposed past its deadline cannot revoke the claim of whoever took over.

There is deliberately no version over `IDistributedCache`: that interface writes whole values with no set-if-absent, so a claim built on it would be granted to every asker - a lock everyone holds, reading as coordination and behaving as none. The distributed-cache outbox keeps its in-process gate and now says more plainly why the interface cannot express the fix.

The Redis README described this duplication as a known limitation with a suggested workaround. That paragraph is the wiring instead.

## The queue and the fan-out

- **An enqueue could land in a detached list.** A concurrent `ClearAsync` removes the list from the dictionary between the lookup and the lock; adding to it then puts the event where nothing can read it, and the method has no way to say so. It re-checks under the lock and retries, so the event lands in whatever list is current - the right place for one enqueued after a clear. The loop spins only while clears keep interleaving, and a clear is an administrative act rather than traffic.
- **One stream's failure aborted the whole fan-out.** Every stream after it lost the event, and the count of who did receive it left with the exception, so a caller learned neither. Each stream is caught and logged on its own now, the same shape the delivery sweep uses one level up.
- **A negative page size fell past the zero check** into `Take`, which yields nothing while the response still reports a queue - a receiver reading that polls again forever with no way to see why. It is answered like zero: an acknowledge-only poll.

## The single-stream policy

`AllowMultipleStreamsPerReceiver = false` counted the receiver's streams and then created one under a freshly generated identifier, so nothing could ever collide: two creates arriving together both read zero, both created, and the 409 that is the whole of the option never fired.

The count is re-read once the new stream is on record, and the loser withdraws its own. Which one loses is decided by a rule both racers evaluate the same way - the lowest identifier stays - so they cannot both withdraw and leave the receiver with no stream at all. Compensation rather than a store primitive: "create only if this receiver has none" would put a transmitter policy inside the store's contract.

## One finding rejected

The review called the null test on `EventsDelivered` dead, since the member is `required` and non-nullable. It is left in place: a stream is read back from a store as JSON, and `required` is not enforced at run time, so the check reads a wire value rather than restating a compiler guarantee.
