### PR TITLE
Scopes survive configuration binding and redefinition, and a keyless host is refused at startup

### DIFF
--- a/src/Abblix.Oidc.Server.Mvc/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server.Mvc/ServiceCollectionExtensions.cs
@@ -56,6 +56,15 @@ public static class ServiceCollectionExtensions
 	/// Adds OIDC server services to the specified <see cref="IServiceCollection"/> with provided configuration options.
 	/// This method allows for configuring OIDC options to tailor the authentication server to your specific needs.
 	/// </summary>
+	/// <remarks>
+	/// The request pipeline must call <c>app.UseCors()</c> after <c>app.UseRouting()</c>. The protocol
+	/// controllers carry CORS metadata, because browser-based clients read the discovery document, the
+	/// key set and the token endpoint cross-origin - and ASP.NET Core routing refuses to serve any
+	/// endpoint whose CORS metadata no middleware honours, so without that call every protocol endpoint
+	/// answers 500. The policy itself is registered here; only the middleware call belongs to the host,
+	/// since the framework accepts the middleware only when it runs after routing has selected an
+	/// endpoint - a place no library can insert it from.
+	/// </remarks>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
 	/// <param name="configureOptions">A delegate to configure the <see cref="OidcOptions"/>.</param>
 	/// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained.</returns>
@@ -67,6 +76,11 @@ public static class ServiceCollectionExtensions
 	/// <summary>
 	/// Adds OIDC server services to the specified <see cref="IServiceCollection"/> with provided configuration options and service provider.
 	/// </summary>
+	/// <remarks>
+	/// The request pipeline must call <c>app.UseCors()</c> after <c>app.UseRouting()</c>; see the
+	/// remarks on <see cref="AddOidcServices(IServiceCollection, Action{OidcOptions})"/> for why the
+	/// protocol endpoints refuse to answer without it.
+	/// </remarks>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
 	/// <param name="configureOptions">A delegate to configure the <see cref="OidcOptions"/> with the service provider.</param>
 	/// <returns>The <see cref="IServiceCollection"/> so additional calls can be chained.</returns>

--- a/src/Abblix.Oidc.Server/Common/Configuration/SigningKeysPresenceValidator.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/SigningKeysPresenceValidator.cs
@@ -1,0 +1,72 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Jwt.ExternalKeys;
+using Abblix.Oidc.Server.Common.Implementation;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Refuses to start a host that can never sign a token, instead of letting it come up healthy and
+/// fail at the first issuance - or, worse, serve an empty JWKS that every relying party caches.
+/// </summary>
+/// <remarks>
+/// The library deliberately never generates a signing key, so a host that supplies none has no
+/// fallback to land on. The refusal is confined to the one state that is provably hopeless without
+/// touching any backend: the resolved provider is the library's own static one, no custodian is
+/// wired, and <see cref="OidcOptions.SigningKeys"/> is empty - a condition fully known at startup.
+/// A host-supplied provider is trusted and never probed here, because its store may legitimately be
+/// unreachable while the host boots (pending migrations, a sealed vault), and a startup probe would
+/// turn that into a refusal to start. A custodian half-wired without its placement call is also left
+/// alone: the provider itself refuses that state with a message naming the missing call.
+/// </remarks>
+internal sealed class SigningKeysPresenceValidator(IServiceProvider serviceProvider)
+    : IValidateOptions<OidcOptions>
+{
+    public ValidateOptionsResult Validate(string? name, OidcOptions options)
+    {
+        // Resolved here rather than through the constructor: the options factory constructs every
+        // registered validator inside its own constructor, and the default keys provider takes
+        // IOptions<OidcOptions>, so a constructor dependency on the provider closes a cycle the
+        // container cannot see through the provider's factory lambda - it overflows the stack
+        // instead of reporting a circular dependency. By the time Validate runs the factory is
+        // fully built, and the same resolution completes without re-entering it.
+        var keysProvider = serviceProvider.GetRequiredService<IAuthServiceKeysProvider>();
+        var custodian = serviceProvider.GetService<IKeyCustodian>();
+
+        if (keysProvider is not OidcOptionsKeysProvider || custodian is not null)
+            return ValidateOptionsResult.Success;
+
+        if (options.SigningKeys.Count > 0)
+            return ValidateOptionsResult.Success;
+
+        return ValidateOptionsResult.Fail(
+            $"No signing key is configured, so the server cannot issue a single token and publishes an empty JWKS. " +
+            $"The library does not generate keys: supply at least one JWK with a private part in " +
+            $"{nameof(OidcOptions)}.{nameof(OidcOptions.SigningKeys)}, or register your own " +
+            $"{nameof(IAuthServiceKeysProvider)} that reads keys from where your deployment keeps them " +
+            "(the Vault and Azure key packages ship such providers).");
+    }
+}

--- a/src/Abblix.Oidc.Server/Common/Constants/ScopeDefinition.cs
+++ b/src/Abblix.Oidc.Server/Common/Constants/ScopeDefinition.cs
@@ -25,4 +25,52 @@ namespace Abblix.Oidc.Server.Common.Constants;
 /// <summary>
 /// Defines a structure for OAuth 2.0 scope definitions, specifying the scope and associated claim types.
 /// </summary>
-public record ScopeDefinition(string Scope, params string[] ClaimTypes);
+/// <remarks>
+/// The properties are settable and a parameterless constructor is available so that a definition can
+/// be read from configuration. A configuration binder builds a positional record through its
+/// constructor, and it drops an element outright when a constructor parameter of collection type is
+/// absent or empty from the source - which is exactly the shape of a resource scope that carries no
+/// claims. Building the instance and then assigning its properties has no such blind spot.
+/// </remarks>
+public record ScopeDefinition
+{
+    /// <summary>
+    /// Initializes an empty definition, to be completed through its properties.
+    /// </summary>
+    public ScopeDefinition()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a definition for the given scope and the claims it asks for.
+    /// </summary>
+    /// <param name="scope">The name of the scope as it appears on the wire.</param>
+    /// <param name="claimTypes">The claims this scope requests, if any.</param>
+    public ScopeDefinition(string scope, params string[] claimTypes)
+    {
+        Scope = scope;
+        ClaimTypes = claimTypes;
+    }
+
+    /// <summary>
+    /// The name of the scope as it appears on the wire.
+    /// </summary>
+    public string Scope { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The claims this scope requests. An empty set is meaningful: a scope that authorizes access to
+    /// a resource has nothing to say about the user.
+    /// </summary>
+    public string[] ClaimTypes { get; set; } = [];
+
+    /// <summary>
+    /// Deconstructs the definition into its scope and claim types.
+    /// </summary>
+    /// <param name="scope">Receives <see cref="Scope"/>.</param>
+    /// <param name="claimTypes">Receives <see cref="ClaimTypes"/>.</param>
+    public void Deconstruct(out string scope, out string[] claimTypes)
+    {
+        scope = Scope;
+        claimTypes = ClaimTypes;
+    }
+}

--- a/src/Abblix.Oidc.Server/Features/ScopeManagement/ScopeManager.cs
+++ b/src/Abblix.Oidc.Server/Features/ScopeManagement/ScopeManager.cs
@@ -33,7 +33,9 @@ namespace Abblix.Oidc.Server.Features.ScopeManagement;
 /// standard scopes (<c>openid</c>, <c>profile</c>, <c>email</c>, <c>address</c>, <c>phone</c>,
 /// <c>offline_access</c>) and merges any host-defined scopes from
 /// <see cref="OidcOptions.Scopes"/>. Lookups are case-sensitive (RFC 6749 §3.3 treats scope
-/// values as case-sensitive strings) and host-defined scopes do not override the standard ones.
+/// values as case-sensitive strings). A host-defined scope under a standard name extends that
+/// scope: the claims it lists are added to the standard ones, so the standard claim set cannot be
+/// narrowed by redefinition and the host's additions cannot be lost to it.
 /// </summary>
 /// <param name="options">The options containing OIDC configuration, including additional custom scopes.</param>
 public class ScopeManager(IOptions<OidcOptions> options) : IScopeManager
@@ -44,7 +46,15 @@ public class ScopeManager(IOptions<OidcOptions> options) : IScopeManager
     {
         var scopes = new Dictionary<string, ScopeDefinition>(StringComparer.Ordinal);
 
-        void Add(ScopeDefinition scope) => scopes.TryAdd(scope.Scope, scope);
+        void Add(ScopeDefinition scope)
+        {
+            // Merging rather than replacing keeps both parties whole: the host cannot strip a claim
+            // OIDC Core assigns to a standard scope, and the library cannot silently discard the
+            // claims the host attached to it - which is what a plain TryAdd used to do.
+            scopes[scope.Scope] = scopes.TryGetValue(scope.Scope, out var existing)
+                ? existing with { ClaimTypes = [.. existing.ClaimTypes.Union(scope.ClaimTypes, StringComparer.Ordinal)] }
+                : scope;
+        }
 
         Add(StandardScopes.OpenId);
         Add(StandardScopes.Profile);

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -395,6 +395,13 @@ public static class ServiceCollectionExtensions
         // reader (ISP), so read-only consumers never depend on persistence.
         services.TryAddSingleton<IAuthServiceKeysStore, ReadOnlyAuthServiceKeysStore>();
 
+        // Fail loud at startup when the resolved provider is the static one above and OidcOptions carries no
+        // signing key: that host can never sign a token, and without this check the first symptom is an empty
+        // JWKS cached by every relying party. A host-supplied provider is trusted, not probed - its store may
+        // be legitimately unreachable while the host boots.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, SigningKeysPresenceValidator>());
+
         services.TryAddSingleton<IAuthServiceJwtFormatter, AuthServiceJwtFormatter>();
         services.TryAddSingleton<IAuthServiceJwtValidator, AuthServiceJwtValidator>();
         return services;

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ScopeDefinitionBindingTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ScopeDefinitionBindingTests.cs
@@ -1,0 +1,93 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections.Generic;
+using Abblix.Oidc.Server.Common.Constants;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Pins the property that lets a host keep its scope registry in configuration: every entry binds,
+/// whatever its claim list looks like. The configuration binder constructs a positional record
+/// through its constructor and silently drops an element whose collection parameter is absent or
+/// empty from the source, so this only holds while <see cref="ScopeDefinition"/> exposes a
+/// parameterless constructor with settable properties.
+/// </summary>
+public class ScopeDefinitionBindingTests
+{
+    /// <summary>
+    /// A scope with claims, a scope with an explicitly empty claim list, and a scope that does not
+    /// mention claims at all must each survive binding. The last two are the common shape of an
+    /// API scope, which authorizes access to a resource and has nothing to say about the user.
+    /// </summary>
+    [Fact]
+    public void Bind_ScopeWithoutClaimTypes_IsNotDropped()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Scopes:0:Scope"] = "orders",
+                ["Scopes:0:ClaimTypes:0"] = "address_city",
+                ["Scopes:1:Scope"] = "basket",
+                // Scopes:1:ClaimTypes deliberately absent
+                ["Scopes:2:Scope"] = "webhooks",
+                ["Scopes:2:ClaimTypes"] = "",
+            })
+            .Build();
+
+        var scopes = configuration.GetSection("Scopes").Get<ScopeDefinition[]>();
+
+        Assert.NotNull(scopes);
+        Assert.Collection(
+            scopes,
+            orders =>
+            {
+                Assert.Equal("orders", orders.Scope);
+                Assert.Equal(["address_city"], orders.ClaimTypes);
+            },
+            basket =>
+            {
+                Assert.Equal("basket", basket.Scope);
+                Assert.Empty(basket.ClaimTypes);
+            },
+            webhooks =>
+            {
+                Assert.Equal("webhooks", webhooks.Scope);
+                Assert.Empty(webhooks.ClaimTypes);
+            });
+    }
+
+    /// <summary>
+    /// The positional constructor and deconstruction stay available: every existing call site
+    /// builds a definition as <c>new("scope", "claim")</c>, and the shape must keep compiling.
+    /// </summary>
+    [Fact]
+    public void PositionalConstruction_AndDeconstruction_KeepWorking()
+    {
+        var (scope, claimTypes) = new ScopeDefinition("orders", "address_city", "last_name");
+
+        Assert.Equal("orders", scope);
+        Assert.Equal(["address_city", "last_name"], claimTypes);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/SigningKeysPresenceValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/SigningKeysPresenceValidatorTests.cs
@@ -1,0 +1,124 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using Abblix.Jwt;
+using Abblix.Jwt.ExternalKeys;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Pins when the host is refused at startup for having no signing key. The refusal must fire on
+/// exactly one state - the library's own static provider serving an empty
+/// <see cref="OidcOptions.SigningKeys"/> - because that host can never sign a token and the fact is
+/// fully known before the first request. Every other arrangement must start: a host-supplied
+/// provider may read keys from a store that is legitimately unreachable while the host boots, and a
+/// half-wired custodian is refused elsewhere with a message naming the missing placement call.
+/// Each case goes through the real registration and the options pipeline, so the wiring is part of
+/// what is proven - a validator class with passing tests and no registration protects nobody.
+/// </summary>
+public class SigningKeysPresenceValidatorTests
+{
+    /// <summary>
+    /// The hopeless state: static provider, no custodian, no keys. Without the refusal this host
+    /// comes up healthy and publishes an empty JWKS for relying parties to cache.
+    /// </summary>
+    [Fact]
+    public void Value_StaticProviderWithoutKeys_IsRefused()
+    {
+        using var serviceProvider = BuildHost();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => serviceProvider.GetRequiredService<IOptions<OidcOptions>>().Value);
+
+        Assert.Contains(nameof(OidcOptions.SigningKeys), exception.Message);
+    }
+
+    /// <summary>
+    /// One configured key is enough: the static provider will serve it.
+    /// </summary>
+    [Fact]
+    public void Value_StaticProviderWithSigningKey_Starts()
+    {
+        using var serviceProvider = BuildHost(services => services.Configure<OidcOptions>(
+            options => options.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature)]));
+
+        var options = serviceProvider.GetRequiredService<IOptions<OidcOptions>>().Value;
+
+        Assert.NotEmpty(options.SigningKeys);
+    }
+
+    /// <summary>
+    /// A host-supplied provider is trusted, not probed: its store may be unreachable during boot,
+    /// and a startup probe would turn that into a refusal to start a working deployment.
+    /// </summary>
+    [Fact]
+    public void Value_HostSuppliedProvider_StartsWithoutProbing()
+    {
+        var provider = new Mock<IAuthServiceKeysProvider>(MockBehavior.Strict);
+
+        using var serviceProvider = BuildHost(
+            services => services.AddSingleton(provider.Object));
+
+        _ = serviceProvider.GetRequiredService<IOptions<OidcOptions>>().Value;
+
+        provider.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// A registered custodian means external keys are intended; the placement machinery owns that
+    /// path and refuses its misconfigurations with a more precise message than this check could.
+    /// </summary>
+    [Fact]
+    public void Value_WithCustodianRegistered_LeavesTheDecisionToPlacement()
+    {
+        using var serviceProvider = BuildHost(
+            services => services.AddSingleton(Mock.Of<IKeyCustodian>()));
+
+        var options = serviceProvider.GetRequiredService<IOptions<OidcOptions>>().Value;
+
+        // No signing key and yet no refusal: with a custodian present the placement machinery,
+        // not this validator, is the authority on whether the arrangement is complete.
+        Assert.Empty(options.SigningKeys);
+    }
+
+    /// <summary>
+    /// Builds the service graph the way a host does: the real registration method, plus whatever
+    /// the case under test adds. The host-supplied registration runs first, matching a host that
+    /// registers its provider before calling the library.
+    /// </summary>
+    private static ServiceProvider BuildHost(Action<IServiceCollection>? configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        configure?.Invoke(services);
+        services.AddAuthServiceJwt();
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/EnabledEndpointsRegistrationValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/EnabledEndpointsRegistrationValidatorTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Mvc;
@@ -70,6 +71,9 @@ public class EnabledEndpointsRegistrationValidatorTests
             .AddOidcServices(o =>
             {
                 o.Issuer = TestConstants.DefaultIssuer.OriginalString;
+                // A signing key, because a host with none is refused at startup by
+                // SigningKeysPresenceValidator and this test is about endpoint registration.
+                o.SigningKeys = [JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature)];
                 o.DeviceAuthorization = new DeviceAuthorizationOptions
                 {
                     VerificationUri = new Uri("https://provider.example/device"),

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ExternalKeys/ExternalKeysWiringTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ExternalKeys/ExternalKeysWiringTests.cs
@@ -151,9 +151,11 @@ public class ExternalKeysWiringTests
     [Fact]
     public async Task ConfiguredKeysAreServed_WhenNoCustodianIsRegisteredAtAll()
     {
+        var signingKey = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature);
+
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddOptions<OidcOptions>();
+        services.AddOptions<OidcOptions>().Configure(options => options.SigningKeys = [signingKey]);
         services.AddSingleton(TimeProvider.System);
         services.AddJsonWebTokens();
         services.AddAuthServiceJwt();
@@ -161,7 +163,9 @@ public class ExternalKeysWiringTests
         await using var provider = services.BuildServiceProvider();
         var keysProvider = provider.GetRequiredService<IAuthServiceKeysProvider>();
 
-        // The refusal is about a HALF-wired custodian, so a host that wired none must be unaffected by it.
-        Assert.Empty(await keysProvider.GetSigningKeys().ToListAsync(TestContext.Current.CancellationToken));
+        // The refusal is about a HALF-wired custodian, so a host that wired none must be unaffected
+        // by it and simply served the keys it configured.
+        var served = await keysProvider.GetSigningKeys().ToListAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(signingKey.KeyId, Assert.Single(served).KeyId);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ScopeManagement/ScopeManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ScopeManagement/ScopeManagerTests.cs
@@ -158,28 +158,51 @@ public class ScopeManagerTests
     }
 
     /// <summary>
-    /// Verifies custom scope with same name as standard scope doesn't override.
-    /// Standard scopes are added first, custom scopes use TryAdd (no override).
+    /// Verifies a host definition under a standard scope name extends that scope: the standard
+    /// claims survive and the host's additions join them. Redefinition can therefore neither
+    /// narrow what OIDC Core assigns to the scope nor be silently discarded.
     /// </summary>
     [Fact]
-    public void Constructor_CustomScopeSameAsStandard_ShouldNotOverride()
+    public void Constructor_CustomScopeSameAsStandard_ShouldExtendStandardClaims()
     {
         // Arrange
-        var customOpenId = new ScopeDefinition(Scopes.OpenId, "custom_claim");
+        var customProfile = new ScopeDefinition(Scopes.Profile, "custom_claim");
 
         var options = Options.Create(new OidcOptions
         {
-            Scopes = [customOpenId]
+            Scopes = [customProfile]
         });
 
         // Act
         var manager = new ScopeManager(options);
 
         // Assert
-        Assert.True(manager.TryGet(Scopes.OpenId, out var retrieved));
-        // Should be the standard scope, not the custom one
-        Assert.Equal(StandardScopes.OpenId.ClaimTypes, retrieved.ClaimTypes);
-        Assert.NotEqual(["custom_claim"], retrieved.ClaimTypes);
+        Assert.True(manager.TryGet(Scopes.Profile, out var retrieved));
+        foreach (var standardClaim in StandardScopes.Profile.ClaimTypes)
+            Assert.Contains(standardClaim, retrieved.ClaimTypes);
+        Assert.Contains("custom_claim", retrieved.ClaimTypes);
+    }
+
+    /// <summary>
+    /// Verifies extension never duplicates a claim the standard scope already carries: the merge
+    /// is a set union, so a host restating a standard claim adds nothing.
+    /// </summary>
+    [Fact]
+    public void Constructor_CustomScopeRestatingStandardClaim_ShouldNotDuplicateIt()
+    {
+        // Arrange
+        var restated = StandardScopes.Email.ClaimTypes[0];
+        var options = Options.Create(new OidcOptions
+        {
+            Scopes = [new ScopeDefinition(Scopes.Email, restated)]
+        });
+
+        // Act
+        var manager = new ScopeManager(options);
+
+        // Assert
+        Assert.True(manager.TryGet(Scopes.Email, out var retrieved));
+        Assert.Single(retrieved.ClaimTypes, claim => claim == restated);
     }
 
     /// <summary>
@@ -301,10 +324,11 @@ public class ScopeManagerTests
 
     /// <summary>
     /// Verifies duplicate custom scopes are handled (first wins).
-    /// TryAdd behavior ensures first scope is kept.
+    /// Duplicate definitions merge into one scope carrying the union of their claims, matching
+    /// how a redefined standard scope is treated.
     /// </summary>
     [Fact]
-    public void Constructor_WithDuplicateCustomScopes_ShouldKeepFirst()
+    public void Constructor_WithDuplicateCustomScopes_ShouldMergeClaims()
     {
         // Arrange
         var scopes = new[]
@@ -320,8 +344,7 @@ public class ScopeManagerTests
 
         // Assert
         Assert.True(manager.TryGet("duplicate", out var definition));
-        Assert.Single(definition.ClaimTypes);
-        Assert.Equal("claim1", definition.ClaimTypes[0]);
+        Assert.Equal(["claim1", "claim2"], definition.ClaimTypes);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #362, #363, #364, #365.

## A ScopeDefinition binds from configuration whatever its claim list looks like (#363)

The configuration binder builds a positional record through its constructor and drops an element outright when a constructor parameter of collection type is absent or empty from the source. A scope that carries no claims is the common case - it authorizes access to a resource and has nothing to say about the user - so a host keeping its scope registry in appsettings lost exactly those scopes, and the first symptom was `invalid_scope` for a scope plainly written in the file.

The record gains a parameterless constructor and settable properties, the one shape the binder handles without a blind spot; the positional constructor and deconstruction stay, so every existing call site compiles unchanged. A binding test pins all three shapes: claims present, claims empty, claims absent.

## A host definition under a standard scope name extends it instead of vanishing (#362)

`ScopeManager` seeded the standard scopes first and added the host's with `TryAdd`, so a definition named `profile` - the idiomatic way to attach application claims to the standard scope - was discarded with no exception and no log record, and the claims it carried were never requested from `IUserInfoProvider` at all. Duplicate definitions now merge into one scope carrying the union of the claim sets: the host cannot strip a claim OIDC Core assigns to a standard scope, and the library cannot silently discard the claims the host attached to it.

## A host that can never sign a token is refused at startup (#364)

The library deliberately never generates a signing key, but a host that supplied none started healthy, published an empty JWKS for relying parties to cache, and failed later somewhere else. A `ValidateOnStart` options validator now refuses the one state that is provably hopeless without touching any backend: the resolved provider is the library's own static one, no custodian is wired, and `OidcOptions.SigningKeys` is empty. A host-supplied provider is trusted rather than probed - its store may be legitimately unreachable while the host boots - and a half-wired custodian keeps its own, more precise refusal.

One subtlety worth a reviewer's minute: the validator resolves its dependency inside `Validate` rather than through the constructor. The options factory constructs every registered validator in its own constructor, and the default keys provider takes `IOptions<OidcOptions>`, so a constructor dependency closes a cycle the container cannot see through the provider's factory lambda - it overflows the stack instead of reporting a circular dependency.

## The UseCors requirement is stated where the integrator reads (#365)

The protocol controllers carry CORS metadata, and routing refuses to serve an endpoint whose CORS metadata no middleware honours, so a host that never calls `app.UseCors()` gets a 500 from every protocol endpoint. The middleware cannot be inserted from the library: the framework accepts it only when it runs after routing has selected an endpoint (`CorsMiddleware` sets its marker only on observing a non-null endpoint), a position only the host's own pipeline can provide. The remarks on `AddOidcServices` now state the requirement, which puts it in IntelliSense at the moment of integration; the getting-started guide's wording is hardened in the docs repository alongside.