### PR TITLE
Bind a client registry from configuration without silently widening it

### DIFF
--- a/src/Abblix.Oidc.Server/Common/Configuration/ClientSecretsOptionsValidator.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/ClientSecretsOptionsValidator.cs
@@ -1,0 +1,109 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Fails loudly at startup when a configured client cannot authenticate with the secret it appears
+/// to carry, instead of answering <c>invalid_client</c> to every request it ever makes.
+/// </summary>
+/// <remarks>
+/// A registry kept in configuration makes a mistyped hash easy and its consequences invisible. The
+/// .NET configuration binder discards an element whose binding threw, so a hash the file spells
+/// wrongly leaves the client with no secret at all rather than with a bad one, and nothing downstream
+/// distinguishes that from a client deliberately registered without secrets: the token endpoint
+/// simply refuses it, logging at debug level. A hash of the wrong length is the same mistake caught
+/// one step later - a digest pasted into the wrong notation decodes without error and compares
+/// against nothing.
+/// </remarks>
+public class ClientSecretsOptionsValidator : IValidateOptions<OidcOptions>
+{
+    /// <summary>Length in bytes of a SHA-256 digest.</summary>
+    private const int Sha256HashLength = 256 / 8;
+
+    /// <summary>Length in bytes of a SHA-512 digest.</summary>
+    private const int Sha512HashLength = 512 / 8;
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OidcOptions options)
+    {
+        if (options.Clients == null)
+            return ValidateOptionsResult.Success;
+
+        var failures = new List<string>();
+
+        foreach (var client in options.Clients)
+        {
+            CheckSecretsArePresent(failures, client);
+
+            foreach (var secret in client.ClientSecrets ?? [])
+            {
+                CheckHashLength(failures, client, secret.Sha256Hash, Sha256HashLength, nameof(secret.Sha256Hash));
+                CheckHashLength(failures, client, secret.Sha512Hash, Sha512HashLength, nameof(secret.Sha512Hash));
+            }
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    /// <summary>
+    /// A client authenticating by shared secret needs one. The check exists for the client that was
+    /// given a secret the binder could not read, so the message names that cause first.
+    /// </summary>
+    private static void CheckSecretsArePresent(List<string> failures, ClientInfo client)
+    {
+        var authenticatesBySecret =
+            client.TokenEndpointAuthMethod == ClientAuthenticationMethods.ClientSecretBasic ||
+            client.TokenEndpointAuthMethod == ClientAuthenticationMethods.ClientSecretPost ||
+            client.TokenEndpointAuthMethod == ClientAuthenticationMethods.ClientSecretJwt;
+
+        if (!authenticatesBySecret || client.ClientSecrets is { Length: > 0 })
+            return;
+
+        failures.Add(
+            $"Client '{client.ClientId}' authenticates with '{client.TokenEndpointAuthMethod}' and has no usable " +
+            $"secret. When the registry comes from configuration, this is what a hash the binder could not read " +
+            $"looks like: check that every hash is a valid Base64 or hexadecimal string.");
+    }
+
+    private static void CheckHashLength(
+        List<string> failures,
+        ClientInfo client,
+        byte[]? hash,
+        int expectedLength,
+        string propertyName)
+    {
+        if (hash is null || hash.Length == expectedLength)
+            return;
+
+        failures.Add(
+            $"Client '{client.ClientId}' has a {propertyName} of {hash.Length} bytes, where {expectedLength} are " +
+            $"expected. A digest written in the other notation decodes to the wrong length rather than failing, " +
+            $"so this usually means Base64 and hexadecimal were swapped.");
+    }
+}

--- a/src/Abblix.Oidc.Server/Common/Configuration/ClientSecretsOptionsValidator.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/ClientSecretsOptionsValidator.cs
@@ -72,23 +72,57 @@ public class ClientSecretsOptionsValidator : IValidateOptions<OidcOptions>
     }
 
     /// <summary>
-    /// A client authenticating by shared secret needs one. The check exists for the client that was
-    /// given a secret the binder could not read, so the message names that cause first.
+    /// A client authenticating by shared secret needs one in the form its method actually reads.
+    /// The check exists for the client that was given a secret the binder could not read, so the
+    /// no-secrets message names that cause first.
     /// </summary>
+    /// <remarks>
+    /// Presence alone proves nothing, because each method reads one form of the secret and silently
+    /// skips the other: client_secret_basic and client_secret_post compare the presented secret
+    /// against a stored hash and never read <see cref="ClientSecret.Value"/>, while
+    /// client_secret_jwt signs with the raw value as the HMAC key and cannot use a hash, which is
+    /// one-way. A secret in the wrong form passes a presence check and is then skipped on every
+    /// request, with nothing said above debug level - the same quiet refusal this validator exists
+    /// to catch.
+    /// </remarks>
     private static void CheckSecretsArePresent(List<string> failures, ClientInfo client)
     {
-        var authenticatesBySecret =
-            client.TokenEndpointAuthMethod == ClientAuthenticationMethods.ClientSecretBasic ||
-            client.TokenEndpointAuthMethod == ClientAuthenticationMethods.ClientSecretPost ||
-            client.TokenEndpointAuthMethod == ClientAuthenticationMethods.ClientSecretJwt;
+        var authenticatesBySecret = client.TokenEndpointAuthMethod is
+            ClientAuthenticationMethods.ClientSecretBasic or
+            ClientAuthenticationMethods.ClientSecretPost or
+            ClientAuthenticationMethods.ClientSecretJwt;
 
-        if (!authenticatesBySecret || client.ClientSecrets is { Length: > 0 })
+        if (!authenticatesBySecret)
             return;
 
-        failures.Add(
-            $"Client '{client.ClientId}' authenticates with '{client.TokenEndpointAuthMethod}' and has no usable " +
-            $"secret. When the registry comes from configuration, this is what a hash the binder could not read " +
-            $"looks like: check that every hash is a valid Base64 or hexadecimal string.");
+        if (client.ClientSecrets is not { Length: > 0 })
+        {
+            failures.Add(
+                $"Client '{client.ClientId}' authenticates with '{client.TokenEndpointAuthMethod}' and has no " +
+                $"usable secret. When the registry comes from configuration, this is what a hash the binder could " +
+                $"not read looks like: check that every hash is a valid Base64 or hexadecimal string.");
+            return;
+        }
+
+        if (client.TokenEndpointAuthMethod is ClientAuthenticationMethods.ClientSecretJwt)
+        {
+            if (!Array.Exists(client.ClientSecrets, secret => !string.IsNullOrEmpty(secret.Value)))
+            {
+                failures.Add(
+                    $"Client '{client.ClientId}' authenticates with '{client.TokenEndpointAuthMethod}', which uses " +
+                    $"the raw secret value as the HMAC key, and no secret carries " +
+                    $"{nameof(ClientSecret.Value)}. A hash cannot serve this method: it is one-way, and the key " +
+                    $"the client signs with cannot be recovered from it.");
+            }
+        }
+        else if (!Array.Exists(client.ClientSecrets, secret => secret.Sha256Hash != null || secret.Sha512Hash != null))
+        {
+            failures.Add(
+                $"Client '{client.ClientId}' authenticates with '{client.TokenEndpointAuthMethod}', which compares " +
+                $"the presented secret against a stored hash, and no secret carries one. A secret holding only the " +
+                $"raw value never matches: store the hash, for example via {nameof(ClientSecret.Sha256HashBase64)} " +
+                $"or {nameof(ClientSecret.Sha256HashHex)}.");
+        }
     }
 
     private static void CheckHashLength(

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/FlowTypeValidator.cs
@@ -159,7 +159,7 @@ public partial class FlowTypeValidator(
 
         // Check if any of the allowed response types matches the requested response type
         return Array.Exists(
-            context.ClientInfo.AllowedResponseTypes,
+            context.ClientInfo.EffectiveResponseTypes,
             allowedResponseType => responseTypeSet.Count == allowedResponseType.Length &&
                                    Array.TrueForAll(allowedResponseType, responseTypeSet.Contains));
     }

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/ClientValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/ClientValidator.cs
@@ -54,7 +54,7 @@ public class ClientValidator(IClientAuthenticator clientAuthenticator) : IBackCh
                 ErrorCodes.UnauthorizedClient, "The client is not authorized");
         }
 
-        if (!clientInfo.AllowedGrantTypes.Contains(GrantTypes.Ciba))
+        if (!clientInfo.EffectiveGrantTypes.Contains(GrantTypes.Ciba))
         {
             return new OidcError(
                 ErrorCodes.UnauthorizedClient, "The Client is not authorized to use this authentication flow");

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/ClientValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/ClientValidator.cs
@@ -43,7 +43,7 @@ public class ClientValidator(IClientAuthenticator clientAuthenticator) : IDevice
                 "The client is not authorized");
         }
 
-        if (!clientInfo.AllowedGrantTypes.Contains(GrantTypes.DeviceAuthorization))
+        if (!clientInfo.EffectiveGrantTypes.Contains(GrantTypes.DeviceAuthorization))
         {
             return new OidcError(
                 ErrorCodes.UnauthorizedClient,

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ReadClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/ReadClientRequestProcessor.cs
@@ -67,8 +67,8 @@ public class ReadClientRequestProcessor(
             RedirectUris = client.RedirectUris,
             // RFC 7592 §3: the read response carries the full registered metadata, including the
             // grant/response types the server assigned by default when registration omitted them.
-            GrantTypes = client.AllowedGrantTypes,
-            ResponseTypes = client.AllowedResponseTypes,
+            GrantTypes = client.EffectiveGrantTypes,
+            ResponseTypes = client.EffectiveResponseTypes,
             Scope = client.AllowedScopes,
             RequirePushedAuthorizationRequests = client.RequirePushedAuthorizationRequests,
             RequireSignedRequestObject = client.RequireSignedRequestObject,

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -93,8 +93,8 @@ public class RegisterClientRequestProcessor(
             // RFC 7591 §3.2.1: grant_types/response_types/scope are read back from the stored
             // ClientInfo, not from the request - this is what makes server-assigned defaults
             // (authorization_code / code when omitted) visible to the client.
-            GrantTypes = clientInfo.AllowedGrantTypes,
-            ResponseTypes = clientInfo.AllowedResponseTypes,
+            GrantTypes = clientInfo.EffectiveGrantTypes,
+            ResponseTypes = clientInfo.EffectiveResponseTypes,
             Scope = clientInfo.AllowedScopes,
             ClientName = clientInfo.ClientName,
             LogoUri = clientInfo.LogoUri,

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -207,8 +207,8 @@ public class UpdateClientRequestProcessor(
             RedirectUris = updatedClient.RedirectUris,
             // RFC 7592 §3: echo the post-update registered state so the client can verify the
             // full replacement took effect (grant/response types and scope included).
-            GrantTypes = updatedClient.AllowedGrantTypes,
-            ResponseTypes = updatedClient.AllowedResponseTypes,
+            GrantTypes = updatedClient.EffectiveGrantTypes,
+            ResponseTypes = updatedClient.EffectiveResponseTypes,
             Scope = updatedClient.AllowedScopes,
             RequirePushedAuthorizationRequests = updatedClient.RequirePushedAuthorizationRequests,
             RequireSignedRequestObject = updatedClient.RequireSignedRequestObject,

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Validation/AuthorizationGrantValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Validation/AuthorizationGrantValidator.cs
@@ -53,7 +53,7 @@ public class AuthorizationGrantValidator(IAuthorizationGrantHandler grantHandler
     public async Task<OidcError?> ValidateAsync(TokenValidationContext context, CancellationToken cancellationToken)
     {
         // Ensure the client is authorized to use the requested grant type
-        if (!context.ClientInfo.AllowedGrantTypes.Contains(context.Request.GrantType))
+        if (!context.ClientInfo.EffectiveGrantTypes.Contains(context.Request.GrantType))
         {
             return new OidcError(
                 ErrorCodes.UnauthorizedClient,

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -137,7 +137,7 @@ public record ClientInfo(string ClientId)
     /// The response types this client may actually use: what it states, or the authorization code
     /// response when it states nothing.
     /// </summary>
-    public string[][] EffectiveResponseTypes => AllowedResponseTypes ?? DefaultResponseTypes;
+    public string[][] EffectiveResponseTypes => AllowedResponseTypes ?? [[ResponseTypes.Code]];
 
     /// <summary>
     /// Specifies the grant types the client is authorized to use when obtaining tokens from the token
@@ -151,11 +151,7 @@ public record ClientInfo(string ClientId)
     /// The grant types this client may actually use: what it states, or the authorization code grant
     /// when it states nothing.
     /// </summary>
-    public string[] EffectiveGrantTypes => AllowedGrantTypes ?? DefaultGrantTypes;
-
-    private static readonly string[][] DefaultResponseTypes = [[ResponseTypes.Code]];
-
-    private static readonly string[] DefaultGrantTypes = [GrantTypes.AuthorizationCode];
+    public string[] EffectiveGrantTypes => AllowedGrantTypes ?? [GrantTypes.AuthorizationCode];
 
     /// <summary>
     /// Optionally restricts the <c>response_mode</c> values this client may use, pinning the channel through
@@ -240,9 +236,9 @@ public record ClientInfo(string ClientId)
 
     /// <summary>
     /// RFC 8693 §2.1 per-client allowlist of <c>subject_token_type</c> URIs this client may submit
-    /// to the Token Exchange grant. Independent of <see cref="AllowedGrantTypes"/> -- a client must
+    /// to the Token Exchange grant. Independent of <see cref="EffectiveGrantTypes"/> -- a client must
     /// have <c>urn:ietf:params:oauth:grant-type:token-exchange</c> in
-    /// <see cref="AllowedGrantTypes"/> to invoke the grant, and the requested
+    /// <see cref="EffectiveGrantTypes"/> to invoke the grant, and the requested
     /// <c>subject_token_type</c> must additionally satisfy this allowlist.
     /// <list type="bullet">
     /// <item><description><c>null</c>: no constraint (any of <see cref="TokenExchangeTokenTypes"/> the

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -120,15 +120,42 @@ public record ClientInfo(string ClientId)
     public BackChannelLogoutOptions? BackChannelLogout { get; set; }
 
     /// <summary>
-    /// Defines the response types that the client is permitted to use.
+    /// Defines the response types that the client is permitted to use, or null when the client does not
+    /// state them and the default in <see cref="EffectiveResponseTypes"/> applies.
     /// This controls how tokens are issued in response to an authorization request.
     /// </summary>
-    public string[][] AllowedResponseTypes { get; set; } = [[ResponseTypes.Code]];
+    /// <remarks>
+    /// Null rather than a defaulted value on purpose, so that a registry kept in configuration says what
+    /// the client may do and nothing else. The .NET configuration binder adds to a collection a property
+    /// already holds instead of replacing it, so a default stored here would arrive on every bound client
+    /// on top of what the file lists, silently and in the direction of more permission.
+    /// Read <see cref="EffectiveResponseTypes"/> to decide anything.
+    /// </remarks>
+    public string[][]? AllowedResponseTypes { get; set; }
 
     /// <summary>
-    /// Specifies the grant types the client is authorized to use when obtaining tokens from the token endpoint.
+    /// The response types this client may actually use: what it states, or the authorization code
+    /// response when it states nothing.
     /// </summary>
-    public string[] AllowedGrantTypes { get; set; } = [GrantTypes.AuthorizationCode];
+    public string[][] EffectiveResponseTypes => AllowedResponseTypes ?? DefaultResponseTypes;
+
+    /// <summary>
+    /// Specifies the grant types the client is authorized to use when obtaining tokens from the token
+    /// endpoint, or null when the client does not state them and the default in
+    /// <see cref="EffectiveGrantTypes"/> applies.
+    /// </summary>
+    /// <inheritdoc cref="AllowedResponseTypes" path="/remarks"/>
+    public string[]? AllowedGrantTypes { get; set; }
+
+    /// <summary>
+    /// The grant types this client may actually use: what it states, or the authorization code grant
+    /// when it states nothing.
+    /// </summary>
+    public string[] EffectiveGrantTypes => AllowedGrantTypes ?? DefaultGrantTypes;
+
+    private static readonly string[][] DefaultResponseTypes = [[ResponseTypes.Code]];
+
+    private static readonly string[] DefaultGrantTypes = [GrantTypes.AuthorizationCode];
 
     /// <summary>
     /// Optionally restricts the <c>response_mode</c> values this client may use, pinning the channel through

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -125,6 +125,10 @@ public record ClientInfo(string ClientId)
     /// This controls how tokens are issued in response to an authorization request.
     /// </summary>
     /// <remarks>
+    /// Null and empty mean different things. Null is "not stated", and the default applies. An empty
+    /// list is stated: it allows nothing, and it is how a client is switched off without being removed
+    /// from the registry.
+    ///
     /// Null rather than a defaulted value on purpose, so that a registry kept in configuration says what
     /// the client may do and nothing else. The .NET configuration binder adds to a collection a property
     /// already holds instead of replacing it, so a default stored here would arrive on every bound client
@@ -135,7 +139,8 @@ public record ClientInfo(string ClientId)
 
     /// <summary>
     /// The response types this client may actually use: what it states, or the authorization code
-    /// response when it states nothing.
+    /// response when it states nothing. A client that states an empty list gets an empty list, which
+    /// permits no authorization request at all.
     /// </summary>
     public string[][] EffectiveResponseTypes => AllowedResponseTypes ?? [[ResponseTypes.Code]];
 
@@ -149,7 +154,8 @@ public record ClientInfo(string ClientId)
 
     /// <summary>
     /// The grant types this client may actually use: what it states, or the authorization code grant
-    /// when it states nothing.
+    /// when it states nothing. A client that states an empty list gets an empty list, which permits no
+    /// grant at all.
     /// </summary>
     public string[] EffectiveGrantTypes => AllowedGrantTypes ?? [GrantTypes.AuthorizationCode];
 

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientSecret.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientSecret.cs
@@ -20,6 +20,8 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text;
+
 namespace Abblix.Oidc.Server.Features.ClientInformation;
 
 /// <summary>
@@ -127,4 +129,19 @@ public record ClientSecret
 	/// to maintain the security integrity of client applications.
 	/// </remarks>
 	public DateTimeOffset? ExpiresAt { get; init; }
+
+	/// <summary>
+	/// Keeps secret material out of the generated <see cref="object.ToString"/>, which structured
+	/// logging and debugger displays reach for. A record prints every property it declares, so adding
+	/// the string aliases above would otherwise have put a hash into logs in a form an attacker can
+	/// take offline. Only whether a hash is present is printed, never its value.
+	/// </summary>
+	protected virtual bool PrintMembers(StringBuilder builder)
+	{
+		builder.Append("Sha256Hash = ").Append(Sha256Hash is null ? "none" : "set");
+		builder.Append(", Sha512Hash = ").Append(Sha512Hash is null ? "none" : "set");
+		builder.Append(", Value = ").Append(Value is null ? "none" : "set");
+		builder.Append(", ExpiresAt = ").Append(ExpiresAt);
+		return true;
+	}
 }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientSecret.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientSecret.cs
@@ -55,6 +55,58 @@ public record ClientSecret
 	public byte[]? Sha512Hash { get; init; }
 
 	/// <summary>
+	/// <see cref="Sha256Hash"/> written as a single Base64 string, for a registry that lives in
+	/// configuration.
+	/// </summary>
+	/// <remarks>
+	/// The .NET configuration binder treats a byte array as a collection to fill element by element,
+	/// so a hash has no scalar form to bind to without this alias: a settings file would have to spell
+	/// the value out one byte per key. Setting either member sets the hash; reading returns whatever
+	/// <see cref="Sha256Hash"/> holds, so the two can never disagree.
+	/// </remarks>
+	public string? Sha256HashBase64
+	{
+		get => Sha256Hash is { } hash ? Convert.ToBase64String(hash) : null;
+		init => Sha256Hash = value is null ? null : Convert.FromBase64String(value);
+	}
+
+	/// <summary>
+	/// <see cref="Sha512Hash"/> written as a single Base64 string, for a registry that lives in
+	/// configuration.
+	/// </summary>
+	/// <inheritdoc cref="Sha256HashBase64" path="/remarks"/>
+	public string? Sha512HashBase64
+	{
+		get => Sha512Hash is { } hash ? Convert.ToBase64String(hash) : null;
+		init => Sha512Hash = value is null ? null : Convert.FromBase64String(value);
+	}
+
+	/// <summary>
+	/// <see cref="Sha256Hash"/> written as a single hexadecimal string, which is the form command-line
+	/// digest tools print and the form most people paste.
+	/// </summary>
+	/// <remarks>
+	/// The same alias as <see cref="Sha256HashBase64"/> in the other common notation. Reading returns
+	/// upper case; either case is accepted when writing.
+	/// </remarks>
+	public string? Sha256HashHex
+	{
+		get => Sha256Hash is { } hash ? Convert.ToHexString(hash) : null;
+		init => Sha256Hash = value is null ? null : Convert.FromHexString(value);
+	}
+
+	/// <summary>
+	/// <see cref="Sha512Hash"/> written as a single hexadecimal string, which is the form command-line
+	/// digest tools print and the form most people paste.
+	/// </summary>
+	/// <inheritdoc cref="Sha256HashHex" path="/remarks"/>
+	public string? Sha512HashHex
+	{
+		get => Sha512Hash is { } hash ? Convert.ToHexString(hash) : null;
+		init => Sha512Hash = value is null ? null : Convert.FromHexString(value);
+	}
+
+	/// <summary>
 	/// The plain-text value of the client secret. This property is required for authentication methods
 	/// that need the raw secret value, such as client_secret_jwt (which uses HMAC signatures).
 	/// </summary>

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
@@ -46,7 +46,7 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
                 options.DefaultSecurityProfile);
 
             foreach (var violation in
-                     SecurityProfileConsistency.FindViolations(client.AllowedResponseTypes, effectiveProfile))
+                     SecurityProfileConsistency.FindViolations(client.EffectiveResponseTypes, effectiveProfile))
             {
                 failures.Add($"Client '{client.ClientId}': {violation}.");
             }

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -141,6 +141,11 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, SecretLengthOptionsValidator>());
 
+        // Fail loud at startup when a client that authenticates by shared secret has none, or carries a
+        // hash of the wrong length, instead of refusing that client on every request it ever makes.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, ClientSecretsOptionsValidator>());
+
         // Fail loud at startup when EnabledEndpoints advertises an opt-in endpoint whose feature services were
         // never registered by the matching AddX() call, instead of 500-ing on every request to it.
         services.TryAddEnumerable(

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientInfoBindingTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientInfoBindingTests.cs
@@ -132,6 +132,46 @@ public class ClientInfoBindingTests
     }
 
     /// <summary>
+    /// An empty list is a statement, not an omission: it allows nothing, and it is how a client is
+    /// switched off without being removed from the registry. Reading it as "nothing stated, use the
+    /// default" would hand that client the authorization code grant it was denied, which is the same
+    /// silent widening this whole change exists to remove.
+    /// </summary>
+    [Fact]
+    public void Bind_ExplicitlyEmptyGrantTypes_AllowNothing()
+    {
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["Clients:0:ClientId"] = "retired",
+            ["Clients:0:AllowedGrantTypes"] = "",
+            ["Clients:0:AllowedResponseTypes"] = "",
+        });
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+        Assert.NotNull(client.AllowedGrantTypes);
+        Assert.Empty(client.AllowedGrantTypes);
+        Assert.Empty(client.EffectiveGrantTypes);
+        Assert.NotNull(client.AllowedResponseTypes);
+        Assert.Empty(client.AllowedResponseTypes);
+        Assert.Empty(client.EffectiveResponseTypes);
+    }
+
+    /// <summary>
+    /// The same statement made in code rather than in a file, because a host that builds its clients
+    /// in C# needs the identical guarantee.
+    /// </summary>
+    [Fact]
+    public void EmptyGrantTypes_SetInCode_AllowNothing()
+    {
+        var client = new ClientInfo("retired") { AllowedGrantTypes = [] };
+
+        Assert.Empty(client.EffectiveGrantTypes);
+    }
+
+    /// <summary>
     /// The hexadecimal notation binds the same way, because that is what a command-line digest tool
     /// prints and therefore what most registries hold. Lower case is accepted as well as upper.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientInfoBindingTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientInfoBindingTests.cs
@@ -1,0 +1,188 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System;
+using System.Collections.Generic;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Pins what a host needs in order to keep its client registry in configuration: what the file says
+/// is what the client gets. The configuration binder adds to a collection that already holds
+/// something instead of replacing it, so a permission stored in a property initializer arrives on
+/// every client whether or not the file names it - and it arrives silently, which is the part that
+/// makes it worth a test.
+/// </summary>
+public class ClientInfoBindingTests
+{
+    private static IConfiguration Configuration(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    /// <summary>
+    /// A client that names one grant type gets that one grant type. With the default held in the
+    /// property, the bound client also carries the authorization code grant nobody asked for.
+    /// </summary>
+    [Fact]
+    public void Bind_GrantTypes_ReplacesRatherThanExtends()
+    {
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["Clients:0:ClientId"] = "batch",
+            ["Clients:0:AllowedGrantTypes:0"] = GrantTypes.RefreshToken,
+        });
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+        Assert.NotNull(client.AllowedGrantTypes);
+        Assert.Equal([GrantTypes.RefreshToken], client.AllowedGrantTypes);
+    }
+
+    /// <summary>
+    /// The same for response types, where the default is a nested collection and the appended member
+    /// is a whole response type combination.
+    /// </summary>
+    [Fact]
+    public void Bind_ResponseTypes_ReplacesRatherThanExtends()
+    {
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["Clients:0:ClientId"] = "hybrid",
+            ["Clients:0:AllowedResponseTypes:0:0"] = ResponseTypes.Code,
+            ["Clients:0:AllowedResponseTypes:0:1"] = ResponseTypes.IdToken,
+        });
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+        Assert.NotNull(client.AllowedResponseTypes);
+        var responseTypes = Assert.Single(client.AllowedResponseTypes);
+        Assert.Equal([ResponseTypes.Code, ResponseTypes.IdToken], responseTypes);
+    }
+
+    /// <summary>
+    /// A file that says nothing about grant or response types leaves the client on the library's
+    /// defaults, which is what every host relied on before the registry could be bound at all.
+    /// </summary>
+    [Fact]
+    public void Bind_WithoutGrantOrResponseTypes_KeepsLibraryDefaults()
+    {
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["Clients:0:ClientId"] = "storefront",
+        });
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+        Assert.Equal([GrantTypes.AuthorizationCode], client.EffectiveGrantTypes);
+        var responseTypes = Assert.Single(client.EffectiveResponseTypes);
+        Assert.Equal([ResponseTypes.Code], responseTypes);
+    }
+
+    /// <summary>
+    /// A secret is registered as a hash, and a settings file can hold one only as a single Base64
+    /// string: the binder treats a byte array as a collection to fill by index, so the natural
+    /// scalar has nowhere to bind without an alias for it.
+    /// </summary>
+    [Fact]
+    public void Bind_ClientSecretHash_AcceptsBase64Scalar()
+    {
+        var hash = new byte[] { 0x2b, 0xb8, 0x0d, 0x53, 0x7b, 0x1d, 0xa3, 0xe3 };
+
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["Clients:0:ClientId"] = "storefront",
+            ["Clients:0:ClientSecrets:0:Sha256HashBase64"] = Convert.ToBase64String(hash),
+        });
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+        Assert.NotNull(client.ClientSecrets);
+        var secret = Assert.Single(client.ClientSecrets);
+        Assert.Equal(hash, secret.Sha256Hash);
+    }
+
+    /// <summary>
+    /// The hexadecimal notation binds the same way, because that is what a command-line digest tool
+    /// prints and therefore what most registries hold. Lower case is accepted as well as upper.
+    /// </summary>
+    [Fact]
+    public void Bind_ClientSecretHash_AcceptsHexScalar()
+    {
+        var hash = new byte[] { 0x2b, 0xb8, 0x0d, 0x53, 0x7b, 0x1d, 0xa3, 0xe3 };
+
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["Clients:0:ClientId"] = "storefront",
+            ["Clients:0:ClientSecrets:0:Sha256HashHex"] = Convert.ToHexString(hash).ToLowerInvariant(),
+            ["Clients:0:ClientSecrets:1:Sha512HashHex"] = Convert.ToHexString(hash),
+        });
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+        Assert.NotNull(client.ClientSecrets);
+        Assert.Collection(
+            client.ClientSecrets,
+            fromLowerCase => Assert.Equal(hash, fromLowerCase.Sha256Hash),
+            fromUpperCase => Assert.Equal(hash, fromUpperCase.Sha512Hash));
+    }
+
+    /// <summary>
+    /// Both notations describe the same bytes, so a hash set through one member reads back through
+    /// the other and neither can drift from <see cref="ClientSecret.Sha256Hash"/> itself.
+    /// </summary>
+    [Fact]
+    public void SecretHashNotations_AgreeWithEachOther()
+    {
+        var hash = new byte[] { 0x2b, 0xb8, 0x0d, 0x53 };
+
+        var secret = new ClientSecret { Sha256HashBase64 = Convert.ToBase64String(hash) };
+
+        Assert.Equal(hash, secret.Sha256Hash);
+        Assert.Equal(Convert.ToHexString(hash), secret.Sha256HashHex);
+    }
+
+    /// <summary>
+    /// Hosts that build clients in code keep the shape they had: an unset grant list still behaves
+    /// as the authorization code grant, and nothing about the positional identifier changes.
+    /// </summary>
+    [Fact]
+    public void ConstructedInCode_KeepsTheDefaultsItAlwaysHad()
+    {
+        var client = new ClientInfo("storefront");
+
+        Assert.Equal("storefront", client.ClientId);
+        Assert.Equal([GrantTypes.AuthorizationCode], client.EffectiveGrantTypes);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientSecretsOptionsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientSecretsOptionsValidatorTests.cs
@@ -166,4 +166,81 @@ public class ClientSecretsOptionsValidatorTests
         Assert.False(result.Succeeded);
         Assert.Contains(result.Failures!, failure => failure.Contains("Base64 or hexadecimal"));
     }
+
+    /// <summary>
+    /// client_secret_jwt signs with the raw secret as the HMAC key, and a hash cannot recover it, so
+    /// a client whose secrets are all hashes can never authenticate. Hashing the secret is exactly
+    /// what a careful operator does for the other secret methods, which is what makes this mistake
+    /// likely, and the authenticator skips such a secret with a debug log nobody reads.
+    /// </summary>
+    [Fact]
+    public void Validate_ClientSecretJwtWithHashOnlySecrets_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("storefront")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretJwt,
+                    ClientSecrets = [new ClientSecret { Sha256Hash = Sha256Sized() }],
+                },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("HMAC"));
+    }
+
+    /// <summary>
+    /// The same client with the raw value present is fine, which keeps the check above about the
+    /// form of the secret rather than its presence.
+    /// </summary>
+    [Fact]
+    public void Validate_ClientSecretJwtWithRawValue_Succeeds()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("storefront")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretJwt,
+                    ClientSecrets = [new ClientSecret { Value = new string('s', 32) }],
+                },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// The mirror image: client_secret_basic and client_secret_post compare the presented secret
+    /// against a stored hash and never read the raw value, so a client whose only secret is a raw
+    /// value can never authenticate either.
+    /// </summary>
+    [Fact]
+    public void Validate_HashComparedMethodWithRawValueOnlySecret_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("storefront")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+                    ClientSecrets = [new ClientSecret { Value = new string('s', 32) }],
+                },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains(nameof(ClientSecret.Sha256HashBase64)));
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientSecretsOptionsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/ClientSecretsOptionsValidatorTests.cs
@@ -1,0 +1,169 @@
+// Abblix OIDC Server Library
+// Copyright (c) Abblix LLP. All rights reserved.
+//
+// DISCLAIMER: This software is provided 'as-is', without any express or implied
+// warranty. Use at your own risk. Abblix LLP is not liable for any damages
+// arising from the use of this software.
+//
+// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
+// in any form outside of the official GitHub repository at:
+// https://github.com/Abblix/OIDC.Server. All development and modifications
+// must occur within the official repository and are managed solely by Abblix LLP.
+//
+// Unauthorized use, modification, or distribution of this software is strictly
+// prohibited and may be subject to legal action.
+//
+// For full licensing terms, please visit:
+//
+// https://oidc.abblix.com/license
+//
+// CONTACT: For license inquiries or permissions, contact Abblix LLP at
+// info@abblix.com
+
+using System.Collections.Generic;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// Verifies that <see cref="ClientSecretsOptionsValidator"/> refuses a client that cannot
+/// authenticate with the secret it appears to carry. The case worth the test is the quiet one: the
+/// configuration binder discards an element whose binding threw, so a hash a settings file spells
+/// wrongly leaves the client with no secret rather than a bad one, and every request that client
+/// ever makes is refused with nothing said about why.
+/// </summary>
+public class ClientSecretsOptionsValidatorTests
+{
+    private readonly ClientSecretsOptionsValidator _validator = new();
+
+    private static byte[] Sha256Sized() => new byte[256 / 8];
+
+    /// <summary>
+    /// A client that authenticates by shared secret and has none cannot ever succeed, so the host
+    /// hears about it while it is still starting.
+    /// </summary>
+    [Fact]
+    public void Validate_SecretAuthenticationWithoutSecrets_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("storefront")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+                },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("storefront"));
+    }
+
+    /// <summary>
+    /// A public client has no secret by definition, so the same shape must pass.
+    /// </summary>
+    [Fact]
+    public void Validate_PublicClientWithoutSecrets_Succeeds()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("mobile") { TokenEndpointAuthMethod = ClientAuthenticationMethods.None },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// A digest pasted in the wrong notation decodes without complaint and to the wrong length, which
+    /// is the only trace it leaves before the client starts failing to authenticate.
+    /// </summary>
+    [Fact]
+    public void Validate_HashOfWrongLength_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("storefront")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+                    ClientSecrets = [new ClientSecret { Sha256Hash = new byte[20] }],
+                },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("20 bytes"));
+    }
+
+    /// <summary>
+    /// A correctly sized hash on a client that uses it passes, which is the control that keeps the
+    /// two checks above meaningful.
+    /// </summary>
+    [Fact]
+    public void Validate_WellFormedSecret_Succeeds()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("storefront")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+                    ClientSecrets = [new ClientSecret { Sha256Hash = Sha256Sized() }],
+                },
+            ],
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures ?? []));
+    }
+
+    /// <summary>
+    /// The whole chain, from the settings file to the startup refusal: a hash the binder cannot read
+    /// leaves the client with no secrets at all, and that is what the validator is here to notice.
+    /// </summary>
+    [Fact]
+    public void Validate_ClientWhoseHashTheBinderCouldNotRead_Fails()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Clients:0:ClientId"] = "storefront",
+                ["Clients:0:TokenEndpointAuthMethod"] = ClientAuthenticationMethods.ClientSecretPost,
+                // A digest copied with the spaces a spreadsheet adds and a digest tool does not print.
+                ["Clients:0:ClientSecrets:0:Sha256HashHex"] = "5e88 4898 da28 0471",
+            })
+            .Build();
+
+        var clients = configuration.GetSection("Clients").Get<ClientInfo[]>();
+
+        Assert.NotNull(clients);
+        var client = Assert.Single(clients);
+
+        // The binder builds the collection and then drops the element whose binding threw, so the
+        // client arrives with an empty secret list rather than with a bad secret or an error.
+        Assert.NotNull(client.ClientSecrets);
+        Assert.Empty(client.ClientSecrets);
+
+        var result = _validator.Validate(null, new OidcOptions { Clients = clients });
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("Base64 or hexadecimal"));
+    }
+}


### PR DESCRIPTION
Closes #367.

A host that keeps its client registry in `appsettings.json` got more than the file listed. The .NET configuration binder adds to a collection a property already holds instead of replacing it, so the grant and response types stored as property defaults arrived on top of whatever the file named, silently and in the direction of more permission.

`AllowedGrantTypes` and `AllowedResponseTypes` are now null when a client does not state them, and the default lives in `EffectiveGrantTypes` and `EffectiveResponseTypes`. Making them nullable is what enumerated the work: the compiler named every place that decides on them, and each was moved to the effective value, including the dynamic registration responses that RFC 7591 §3.2.1 requires to report server-assigned defaults.

Null and empty stay different statements, which the code already did and nothing said. Null is "not stated", so the default applies; an empty list allows nothing, and it is how a client is switched off without leaving the registry. Reading empty as "nothing stated" is the tempting simplification and would hand a switched-off client the authorization code grant, so two tests fail if anybody makes it.

A secret hash had no scalar form to bind to either, because a byte array is a collection the binder fills by index. `ClientSecret` gains `Sha256HashBase64`, `Sha512HashBase64`, `Sha256HashHex` and `Sha512HashHex` over the same bytes. They are exact inverses on purpose: the binder reads every bindable property and writes it back even when the file never mentions it, so an alias that is not a faithful projection would overwrite a hash set through another member.

The second commit answers what happens when the file gets a hash wrong. The binder discards the element whose binding threw, so the client arrived with an empty secret list rather than a bad secret, and nothing downstream could tell that apart from a client registered without secrets on purpose. Startup now refuses a client that authenticates by shared secret and carries none, and refuses a hash whose length does not match its algorithm, which is what a digest pasted into the wrong notation looks like.

The third commit closes the same gap from the other side: a secret that is present but in the wrong form. Each method reads one form and silently skips the other - `client_secret_basic` and `client_secret_post` compare the presented secret against a stored hash and never read the raw value, while `client_secret_jwt` signs with the raw value as the HMAC key and cannot use a hash. A client whose only secret is in the form its method does not read passed the presence check and was refused on every request, which is the same quiet refusal one check short. Startup now requires the form the authenticator will actually use, and each refusal names what to store instead.

### Breaking change

`AllowedGrantTypes` and `AllowedResponseTypes` change type to nullable. Setting them is unaffected. Code that reads them gets `null` where it previously got the default, and should read `EffectiveGrantTypes` / `EffectiveResponseTypes` instead. Inside this repository the compiler found every such site; a host with nullable reference types disabled gets no warning at all, so this belongs in the release notes for 2.4. The one known consumer is tracked in Abblix/Account#11.

### Verification

The two binder defects were reproduced as failing tests before any fix: response types bound as `[["code"], ["code", "id_token"]]` where the file named one combination, and a Base64 hash bound as null. Each accessor was then mutated to confirm the tests fail without it, including a mutation on one notation that the other notation's test catches, which is what proves the write-back behaviour described above, and a mutation that reads an empty list as the default.

Full unit suite: 2635 passing.

Out of scope, filed separately as #368: `SecureHttpFetchOptions.AllowedSchemes` has the same shape, and fixing it means deciding what `null` means on an SSRF allowlist. The change was attempted here and reverted when two existing tests showed it inverting a sentinel.

