### PR TITLE
fix(dcr): registration without pkce_required no longer weakens the client

### DIFF
--- a/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -459,10 +459,17 @@ public record ClientRegistrationRequest
 
     /// <summary>
     /// When <c>true</c>, this client must present a PKCE <c>code_challenge</c> on every authorization request
-    /// per RFC 7636. Server extension to RFC 7591 metadata; defaults to <c>false</c>.
+    /// per RFC 7636. Server extension to RFC 7591 metadata.
     /// </summary>
+    /// <remarks>
+    /// Null when the registration request does not state it, so that the default lives in one place -
+    /// <see cref="Features.ClientInformation.ClientInfo.PkceRequired"/>, which requires PKCE. A non-null default here
+    /// would be copied onto the registered client and win over that one, leaving a dynamically registered
+    /// client without the protection a statically configured client gets, which is the opposite of what
+    /// RFC 9700 section 2.1.1 asks of an authorization server.
+    /// </remarks>
     [JsonPropertyName(Parameters.PkceRequired)]
-    public bool? PkceRequired { get; init; } = false;
+    public bool? PkceRequired { get; init; }
 
     /// <summary>
     /// When <c>true</c>, the client is permitted to request the <c>offline_access</c> scope and receive

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/RegisterClientHandlerIntegrationTests.cs
@@ -270,6 +270,54 @@ public class RegisterClientHandlerIntegrationTests
     }
 
     /// <summary>
+    /// RFC 9700 §2.1.1 requires an authorization server to enforce PKCE for public clients, and this server
+    /// requires it of every client that can receive a code. A registration request that says nothing about
+    /// <c>pkce_required</c> must therefore leave the stored client on the server's own default rather than
+    /// carrying a weaker one in from the request model: the flag is nullable precisely so that "not stated"
+    /// stays distinguishable from "stated false", and a non-null default on the request would be copied onto
+    /// the client and silently win.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_PkceRequiredOmitted_StoredClientStillRequiresPkce()
+    {
+        var provider = BuildProvider();
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+        var clientInfoProvider = provider.GetRequiredService<Abblix.Oidc.Server.Features.ClientInformation.IClientInfoProvider>();
+
+        var result = await handler.HandleAsync(CreateRequest());
+
+        Assert.True(result.TryGetSuccess(out var success));
+
+        var stored = await clientInfoProvider.TryFindClientAsync(success.ClientId);
+        Assert.NotNull(stored);
+        Assert.NotEqual(false, stored.PkceRequired);
+    }
+
+    /// <summary>
+    /// The counterpart of the case above: a registration request that explicitly opts out still opts out,
+    /// so the nullable default restores the server's own value without taking the choice away from a client
+    /// that states one.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_PkceRequiredFalse_StoredClientOptsOut()
+    {
+        var provider = BuildProvider();
+        var handler = provider.GetRequiredService<IRegisterClientHandler>();
+        var clientInfoProvider = provider.GetRequiredService<Abblix.Oidc.Server.Features.ClientInformation.IClientInfoProvider>();
+
+        var request = CreateRequest();
+        request = request with { PkceRequired = false };
+
+        var result = await handler.HandleAsync(request);
+
+        Assert.True(result.TryGetSuccess(out var success));
+
+        var stored = await clientInfoProvider.TryFindClientAsync(success.ClientId);
+        Assert.NotNull(stored);
+        Assert.Equal(false, stored.PkceRequired);
+    }
+
+    /// <summary>
     /// RFC 7591 §3.2.1: the registration response echoes registered client metadata so the
     /// client can confirm what was stored without a follow-up read. Locks that the
     /// extended echo (added alongside DPoP) actually surfaces a representative subset of


### PR DESCRIPTION
`ClientRegistrationRequest.PkceRequired` was initialised to `false` rather than left null, and `RegisterClientRequestProcessor` copies the value through as it stands. A non-null `false` therefore reached `ClientInfo` and won over its own default of `true`, so the `?? true` fallback in `PkceValidator` never fired for a client created through dynamic registration.

That left two opposite defaults for one flag. A statically configured client required PKCE; a dynamically registered one did not, unless the registration request said so explicitly or the deployment pinned a security profile. Each half reads correctly on its own, which is why it survived review: `ClientInfo.PkceRequired = true` looks strict, and a request model that does not impose a server extension on clients that never asked for it looks conservative.

RFC 9700 section 2.1.1 asks an authorization server to enforce PKCE for public clients. The static path did; the dynamic path silently did not.

## Change

The flag stays nullable so that "not stated" remains distinguishable from "stated false", and the default now lives in `ClientInfo` alone. A registration request that states `false` still opts out, so a deployment that deliberately registers a client without PKCE keeps that ability.

## Compatibility

A client registered through the registration endpoint without `pkce_required` now requires a `code_challenge` on authorization requests that yield a code. A deployment relying on the previous behaviour sets `"pkce_required": false` at registration.

Dynamic client registration is not part of the default endpoint set, so this reaches only deployments that enabled it.
