### PR TITLE
fix(token-exchange): a subject_token of undeterminable origin no longer skips the guard

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/TokenExchangeGrantHandler.cs
@@ -393,13 +393,28 @@ public class TokenExchangeGrantHandler(
         string? requestedTypeUri,
         ClientInfo clientInfo)
     {
-        if (token.OriginalClientId is { Length: > 0 } originalClient
-            && !string.Equals(originalClient, clientInfo.ClientId, StringComparison.Ordinal)
-            && !clientInfo.AllowCrossClientSubjectTokenExchange)
+        // The confused-deputy check needs an origin to compare against, and an absent one is the case
+        // it cannot decide: a token whose issuing client is undeterminable may or may not belong to the
+        // presenting client, and the guard exists precisely because the difference matters. Refusing is
+        // the only reading that keeps the check meaningful - skipping on absence would let a subject_token
+        // shaped to hide its origin pass the guard that a token naming another client fails.
+        // AllowCrossClientSubjectTokenExchange remains the single opt-out: a client trusted to present
+        // tokens it was not issued is equally trusted to present one whose issuer cannot be read.
+        if (!clientInfo.AllowCrossClientSubjectTokenExchange)
         {
-            return new OidcError(
-                ErrorCodes.InvalidRequest,
-                "subject_token was issued to a different client than the one presenting it.");
+            if (token.OriginalClientId is not { Length: > 0 } originalClient)
+            {
+                return new OidcError(
+                    ErrorCodes.InvalidRequest,
+                    "The client the subject_token was issued to could not be determined.");
+            }
+
+            if (!string.Equals(originalClient, clientInfo.ClientId, StringComparison.Ordinal))
+            {
+                return new OidcError(
+                    ErrorCodes.InvalidRequest,
+                    "subject_token was issued to a different client than the one presenting it.");
+            }
         }
 
         // typ header expected per URI (JWT-based subject types only):

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -279,8 +279,9 @@ public record ClientInfo(string ClientId)
     /// <c>subject_token</c> was originally issued to a different client than the one presenting
     /// it -- the "confused deputy" anti-pattern. When this client is intended to operate as an
     /// audit broker / proxy that legitimately receives tokens issued to other clients, set this
-    /// to <c>true</c> to opt out of the default check. Has no effect when no subject_token
-    /// origin can be determined.
+    /// to <c>true</c> to opt out of the default check. The opt-out also covers a subject_token whose
+    /// origin cannot be determined at all, which is otherwise refused: a client trusted to present
+    /// tokens issued to others is equally trusted to present one whose issuer cannot be read.
     /// </summary>
     public bool AllowCrossClientSubjectTokenExchange { get; set; } = false;
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenExchangeGrantHandlerTests.cs
@@ -90,7 +90,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task ValidSubjectToken_DispatchedToTypedResolver_ReturnsAuthorizedGrant()
     {
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: "https://issuer", Scope: ["openid"], AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: "https://issuer", Scope: ["openid"], AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
@@ -108,7 +109,8 @@ public class TokenExchangeGrantHandlerTests
         const string adWire = """[{"type":"payment_initiation","actions":["initiate"]}]""";
         var adNode = (JsonArray)JsonNode.Parse(adWire)!;
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: null, AuthorizationDetails: adNode);
+            Subject: TestSubject, Issuer: null, Scope: null, AuthorizationDetails: adNode)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
@@ -169,8 +171,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task DelegationFlow_BuildsActClaimWithActorSubject()
     {
         // Single-hop delegation: subject_token has no prior act chain. Result: act = { sub: <actor> }.
-        var subject = new SubjectTokenContext("alice", null, ["openid"], null);
-        var actor = new SubjectTokenContext("svc-worker-7", null, null, null);
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null) { OriginalClientId = ClientId };
+        var actor = new SubjectTokenContext("svc-worker-7", null, null, null) { OriginalClientId = ClientId };
         const string actorWire = "actor.jwt";
         var (handler, resolverMock) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         resolverMock
@@ -198,8 +200,8 @@ public class TokenExchangeGrantHandlerTests
         // Subject_token already carries an act chain: { sub: prev-actor }. New actor wraps it:
         // result act = { sub: new-actor, act: { sub: prev-actor } }.
         var existingChain = new JsonObject { ["sub"] = "prev-actor" };
-        var subject = new SubjectTokenContext("alice", null, ["openid"], null) { Act = existingChain };
-        var actor = new SubjectTokenContext("svc-worker-7", null, null, null);
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null) { Act = existingChain, OriginalClientId = ClientId };
+        var actor = new SubjectTokenContext("svc-worker-7", null, null, null) { OriginalClientId = ClientId };
         const string actorWire = "actor.jwt";
         var (handler, resolverMock) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         resolverMock
@@ -260,7 +262,7 @@ public class TokenExchangeGrantHandlerTests
     {
         // actor_token resolution failure is wrapped so the wire client can distinguish actor
         // problems from subject problems even though both map to invalid_request.
-        var subject = new SubjectTokenContext("alice", null, ["openid"], null);
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null) { OriginalClientId = ClientId };
         const string actorWire = "actor.jwt";
         var (handler, resolverMock) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
         resolverMock
@@ -307,7 +309,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task ClientWithNullAllowlist_AcceptsAnyResolvedTokenType()
     {
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: null, AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: null, Scope: null, AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.IdToken, ctx);
         var clientInfo = ClientWithAllowlist(null);  // tri-state: no constraint
         var request = ExchangeRequest(TokenExchangeTokenTypes.IdToken);
@@ -324,7 +327,8 @@ public class TokenExchangeGrantHandlerTests
         var subjectScope = new[] { "openid", "profile", "email" };
         var requestScope = new[] { "openid" };  // narrow to one
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: subjectScope, AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: null, Scope: subjectScope, AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = requestScope };
@@ -345,7 +349,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task InheritedSubjectScope_FilteredToRequestingClientAllowedScopes()
     {
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: ["openid", "profile", "admin"], AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: null, Scope: ["openid", "profile", "admin"], AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = new ClientInfo(ClientId)
         {
@@ -371,7 +376,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task InheritedSubjectScope_WithNullAllowedScopes_PassesThroughUnfiltered()
     {
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: ["openid", "admin"], AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: null, Scope: ["openid", "admin"], AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = new ClientInfo(ClientId)
         {
@@ -395,7 +401,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task RequestScope_IntersectedWithSubjectScope_WhenSubjectCarriesScope()
     {
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: ["read"], AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: null, Scope: ["read"], AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = ["read", "admin"] };
@@ -416,7 +423,8 @@ public class TokenExchangeGrantHandlerTests
     public async Task RequestScope_PreservedWhenSubjectTokenHasNoScope()
     {
         var ctx = new SubjectTokenContext(
-            Subject: TestSubject, Issuer: null, Scope: null, AuthorizationDetails: null);
+            Subject: TestSubject, Issuer: null, Scope: null, AuthorizationDetails: null)
+            { OriginalClientId = ClientId };
         var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, ctx);
         var clientInfo = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
         var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken) with { Scope = ["api:read"] };
@@ -456,6 +464,52 @@ public class TokenExchangeGrantHandlerTests
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
         Assert.Contains("issued to a different client", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task S1_SubjectToken_with_undeterminable_origin_rejected_by_default()
+    {
+        // A subject_token whose issuing client cannot be read is the case the confused-deputy check
+        // cannot decide, so it must refuse rather than skip: a token shaped to hide its origin would
+        // otherwise clear the guard that a token naming another client fails.
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null)
+        {
+            OriginalClientId = null,
+            JwtTokenType = JsonWebTokenTypes.AccessToken,
+        };
+        var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
+        var requestingClient = ClientWithAllowlist(TokenExchangeTokenTypes.AccessToken);
+        var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
+
+        var result = await handler.AuthorizeAsync(request, requestingClient, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+        Assert.Contains("could not be determined", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task S1_SubjectToken_with_undeterminable_origin_allowed_when_client_opted_in()
+    {
+        // The opt-out covers both shapes the guard refuses: a token issued to another client, and one
+        // whose issuer cannot be read at all. A broker trusted with the first is trusted with the second.
+        var subject = new SubjectTokenContext("alice", null, ["openid"], null)
+        {
+            OriginalClientId = null,
+            JwtTokenType = JsonWebTokenTypes.AccessToken,
+        };
+        var (handler, _) = CreateHandlerWith(TokenExchangeTokenTypes.AccessToken, subject);
+        var brokerClient = new ClientInfo(ClientId)
+        {
+            TokenExchangeAllowedSubjectTokenTypes = [TokenExchangeTokenTypes.AccessToken],
+            AllowCrossClientSubjectTokenExchange = true,
+        };
+        var request = ExchangeRequest(TokenExchangeTokenTypes.AccessToken);
+
+        var result = await handler.AuthorizeAsync(request, brokerClient, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetSuccess(out var grant));
+        Assert.Equal("alice", grant.AuthSession.Subject);
     }
 
     [Fact]


### PR DESCRIPTION
The confused-deputy check in `TokenExchangeGrantHandler` compared the client a `subject_token` was issued to against the client presenting it, and entered only when that origin was known:

```csharp
if (token.OriginalClientId is { Length: > 0 } originalClient
    && !string.Equals(originalClient, clientInfo.ClientId, StringComparison.Ordinal)
    && !clientInfo.AllowCrossClientSubjectTokenExchange)
```

So the one case the check cannot decide was the one it let through. A token naming another client was refused; a token whose issuing client could not be read passed. The second shape is the cheaper one to produce, which makes the skip the wrong way round: the guard held against the honest case and opened on the ambiguous one. The behaviour was even documented as a property on `AllowCrossClientSubjectTokenExchange` ("Has no effect when no subject_token origin can be determined").

## Change

The guard refuses both shapes, and `AllowCrossClientSubjectTokenExchange` remains the single opt-out for both. A client trusted to present tokens issued to others is equally trusted to present one whose issuer cannot be read, so no new configuration surface is introduced.

## Reach

Every token this server issues names its client: an access token through `client_id` per RFC 9068 section 2.2, a refresh token through its own grant. `JwtSubjectTokenResolver` reads `client_id`, then `azp`, then a sole audience. The refused case is therefore a foreign or opaque `subject_token`, which is where an explicit opt-in belongs.

## Compatibility

A deployment exchanging tokens whose origin cannot be determined - a custom `ISubjectTokenResolver` for an opaque format, or a JWT with several audiences and neither `client_id` nor `azp` - now needs `AllowCrossClientSubjectTokenExchange` on the presenting client.

## Fixtures

Thirteen fixtures in the handler suite built a subject token with no origin. That modelled the foreign shape while the tests were about scope filtering, act chains and authorization details, so the ordinary same-client exchange those tests describe was never the input they ran. They now carry the presenting client.
