### PR TITLE
A stream stored before versions existed can be changed again

### DIFF
--- a/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
@@ -86,10 +86,24 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection, SharedSi
     /// Compared as a substring of the stored document rather than by parsing it, so the script
     /// needs no JSON library and works on every server that speaks Lua. The property name and the
     /// quoting are what make the match exact: a version is a 32-character hex string, so the
-    /// needle cannot occur anywhere else in the document.
+    /// needle cannot occur anywhere else in the document. Nor can either needle be forged by
+    /// anything a receiver supplies - a quote inside a JSON string value is escaped, so the raw
+    /// sequence only ever appears where the serializer put it.
     /// </remarks>
     /// <param name="version">The version a caller believes is on record.</param>
-    private static string VersionMarkerOf(string? version) => $"\"version\":\"{version}\"";
+    private static string VersionMarkerOf(string version) => $"{AnyVersionMarker}{version}\"";
+
+    /// <summary>
+    /// The text a stored stream carries when it has any version at all.
+    /// </summary>
+    /// <remarks>
+    /// Its ABSENCE is what a caller holding no version is judged against. Versions arrived after this
+    /// store had been shipping, so registrations written by the earlier build carry no such member,
+    /// and a caller reading one is handed null - matching it against a version marker would refuse
+    /// every write to that stream for as long as it exists, while telling the receiver it lost a race
+    /// that never happened.
+    /// </remarks>
+    private const string AnyVersionMarker = "\"version\":\"";
 
     private static RedisValue FieldOf(string receiverId, string streamId)
         => $"{Uri.EscapeDataString(receiverId)}|{Uri.EscapeDataString(streamId)}";
@@ -170,13 +184,26 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection, SharedSi
         // The version is compared server-side, in the same script that writes: a caller may only
         // replace the copy it read. Reading it here and comparing in C# would be the very
         // read-modify-write this is meant to close.
+        // A caller whose copy carried no version replaces one that still carries none, and gains a
+        // version by doing so - the migration for registrations written before versions existed, and
+        // one that happens per stream on its first change rather than as a pass over the store. The
+        // condition runs in the same place and the same direction for both: any version on record
+        // means somebody has written since that read, which is the lost update this exists to refuse.
+        // Which needle, and which way it has to come out: one decision, because the two are one
+        // fact. Derived separately they disagree the day either is edited, and disagreeing means
+        // looking for a version marker while requiring it to be missing, which refuses every write.
+        var (needle, mustBeFound) = stream.Version is { } version
+            ? (VersionMarkerOf(version), "1")
+            : (AnyVersionMarker, "0");
+
         var replaced = await _database.ScriptEvaluateAsync(
             """
             local stored = redis.call('HGET', KEYS[1], ARGV[1])
             if not stored then
                 return 0
             end
-            if string.find(stored, ARGV[3], 1, true) == nil then
+            local present = string.find(stored, ARGV[3], 1, true) ~= nil
+            if present ~= (ARGV[4] == '1') then
                 return 0
             end
             redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
@@ -186,7 +213,8 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection, SharedSi
             [FieldOf(stream.ReceiverId, stream.StreamId),
              (RedisValue)JsonSerializer.SerializeToUtf8Bytes(
                  stream with { Version = Guid.NewGuid().ToString("N") }, SerializerOptions),
-             (RedisValue)VersionMarkerOf(stream.Version)]);
+             (RedisValue)needle,
+             (RedisValue)mustBeFound]);
 
         return (long)replaced == 1;
     }

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
@@ -20,6 +20,9 @@
 // CONTACT: For license inquiries or permissions, contact Abblix LLP at
 // info@abblix.com
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
@@ -118,6 +121,70 @@ public sealed class RedisStreamStoreTests(GarnetFixture garnet) : IClassFixture<
         // exactly the shape that used to overwrite whatever landed in between.
         Assert.False(await store.UpdateAsync(read with { Status = StreamStatuses.Disabled }, ct));
         Assert.Equal(StreamStatuses.Paused, (await store.FindAsync(_receiver, streamId, ct))!.Status);
+    }
+
+    /// <summary>
+    /// A registration written before versions existed can still be changed, once, after which it
+    /// carries a version like any other.
+    /// </summary>
+    /// <remarks>
+    /// The version arrived after this store had been shipping, so registrations the earlier build
+    /// wrote carry no version member at all. A caller reads one, is handed a null version, and its
+    /// write is then judged against a marker the stored document cannot contain - so every change to
+    /// that stream is refused for as long as the stream exists, and the refusal reaches the receiver
+    /// as a lost race that never happened. Nothing about it improves with the retry that refusal
+    /// advises.
+    /// </remarks>
+    [Fact]
+    public async Task AStreamStoredBeforeVersionsExisted_CanStillBeUpdated()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = NewStore();
+        var streamId = Guid.NewGuid().ToString("N");
+
+        await garnet.Connection.GetDatabase().HashSetAsync(
+            HashKey,
+            $"{Uri.EscapeDataString(_receiver)}|{Uri.EscapeDataString(streamId)}",
+            WithoutVersion(NewState(streamId)));
+
+        try
+        {
+            var read = await store.FindAsync(_receiver, streamId, ct);
+            Assert.NotNull(read);
+            Assert.Null(read.Version);
+
+            Assert.True(await store.UpdateAsync(read with { Status = StreamStatuses.Paused }, ct));
+
+            var updated = await store.FindAsync(_receiver, streamId, ct);
+            Assert.Equal(StreamStatuses.Paused, updated!.Status);
+            Assert.NotNull(updated.Version);
+
+            // Ordinary from here on: the versionless copy no longer replaces anything, or admitting
+            // it would leave the stream permanently unguarded instead of migrating it once.
+            Assert.False(await store.UpdateAsync(read with { Status = StreamStatuses.Disabled }, ct));
+            Assert.Equal(
+                StreamStatuses.Paused, (await store.FindAsync(_receiver, streamId, ct))!.Status);
+        }
+        finally
+        {
+            await store.DeleteAsync(_receiver, streamId, ct);
+        }
+    }
+
+    /// <summary>
+    /// The same state as the build before versions wrote it: the member absent, not present and
+    /// empty. Only absence is what those registrations carry, and the two are different shapes to
+    /// anything comparing text.
+    /// </summary>
+    private static string WithoutVersion(StreamState state)
+    {
+        var document = JsonSerializer.SerializeToNode(
+                state,
+                new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } })!
+            .AsObject();
+
+        document.Remove("version");
+        return document.ToJsonString();
     }
 
     /// <summary>


### PR DESCRIPTION
The Redis stream store shipped in `f3109c40` (8 August) with an update that replaced whatever it found. Optimistic concurrency arrived in `4cfba398` (15 August), together with a `version` member on `StreamState` and a script that requires the caller's version marker to appear in the stored document.

Registrations written between those two commits carry no `version` member at all - `git show f3109c40:src/Abblix.SharedSignals/Transmitter/StreamState.cs | grep -c version` returns zero. A caller reads one, is handed a null version, and its write is then judged against a needle the stored document cannot contain. Every change to such a stream is refused for as long as the stream exists: the delivery endpoint, enable and disable, adding and removing subjects, all of it.

## Why it does not look like what it is

`StreamManagementService` re-reads and retries four times, then answers `409` with "the stream is being changed by someone else; read it again and repeat the call". That is the wording of a lost race, and here there is no second writer at all - the only writer of stream state in the package is `MutateAsync`. The receiver retries forever on advice that cannot work.

Seen in the field on a staging receiver rewriting its delivery endpoint: ten attempts, fifteen seconds apart, ten identical `409`s. A deterministic refusal wearing a transient answer.

## The change

A caller holding no version is judged by the marker's ABSENCE instead of by a marker of its own. It replaces a registration that still carries none, and stamps a version by doing so - so the migration happens per stream on its first change, rather than as a pass over the store.

Both directions matter and the condition runs in one place for both: a version on record means somebody wrote after that read, and admitting the write would be exactly the lost update the version exists to refuse. Which needle to look for and whether it must be found are derived from one decision, because they are one fact - computed apart, they disagree the day either is edited, and disagreeing means hunting a version marker while requiring it to be missing.

The script keeps to string operations, so it still needs no JSON library on the server.

## Tests

`AStreamStoredBeforeVersionsExisted_CanStillBeUpdated` plants a document in the pre-version shape - the member absent, not present and empty, which is a different thing to anything comparing text - and requires both halves: the first change lands and the document gains a version, and the same stale copy is refused afterwards, so migrating a stream does not leave it unguarded.

The test fails on `develop`. Each half was confirmed to bite by inverting it separately: dropping the absence branch loses the second assertion, and requiring the marker unconditionally loses the first.

28 tests in `Abblix.SharedSignals.Redis.UnitTests`, 153 in `Abblix.SharedSignals.UnitTests` and 4 end-to-end pass; the solution builds clean.
