### PR TITLE
A contended configuration or status update answers 202

### DIFF
--- a/src/Abblix.SharedSignals/Transmitter/ManagementResult.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ManagementResult.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // Copyright (c) Abblix LLP. All rights reserved.
 //
 // DISCLAIMER: This software is provided 'as-is', without any express or implied
@@ -56,10 +56,30 @@ public sealed record ManagementResult<TBody>(
     public static ManagementResult<TBody> NotFound(string description)
         => new(HttpStatusCode.NotFound, default, description);
 
-    /// <summary>The stream already exists and the transmitter allows one per receiver:
-    /// "409 Conflict" (SSF 1.0 Section 8.1.1.1).</summary>
+    /// <summary>
+    /// The stream already exists and the transmitter allows one per receiver: "409 Conflict".
+    /// </summary>
+    /// <remarks>
+    /// Creation only. SSF 1.0 gives this code exactly one meaning, in the Create Stream error table
+    /// of Section 8.1.1.1, and the update tables of Sections 8.1.1.3 and 8.1.2.2 do not list it at
+    /// all - so answering an update with it says "you already have a stream" to a receiver reading
+    /// the specification, which is the opposite of what a failed update means.
+    /// </remarks>
     public static ManagementResult<TBody> Conflict(string description)
         => new(HttpStatusCode.Conflict, default, description);
+
+    /// <summary>
+    /// The update was taken and not carried out: "202 Accepted".
+    /// </summary>
+    /// <remarks>
+    /// The code SSF 1.0 assigns to exactly this outcome in both update tables - "accepted, but not
+    /// processed. Receiver MAY try the same request later to get processing result" - and Section
+    /// 8.1.2.2 states it as a MUST for a transmitter that cannot decide whether to complete the
+    /// request. It tells the receiver the one thing that matters here and that no other code does:
+    /// nothing changed, and repeating the call is the way forward rather than a mistake.
+    /// </remarks>
+    public static ManagementResult<TBody> Accepted(string description)
+        => new(HttpStatusCode.Accepted, default, description);
 
     /// <summary>The request is invalid: "400 Bad Request".</summary>
     public static ManagementResult<TBody> BadRequest(string description)

--- a/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
@@ -325,7 +325,7 @@ public sealed class StreamManagementService(
             return NoSuchStream<StreamStatus>(request.StreamId);
 
         if (updated is null)
-            return Contended<StreamStatus>(request.StreamId);
+            return AcceptedNotProcessed<StreamStatus>(request.StreamId);
 
         if (request.Status == StreamStatuses.Disabled)
         {
@@ -612,7 +612,7 @@ public sealed class StreamManagementService(
             return NoSuchStream<StreamConfiguration>(stream.StreamId);
 
         return written is null
-            ? Contended<StreamConfiguration>(stream.StreamId)
+            ? AcceptedNotProcessed<StreamConfiguration>(stream.StreamId)
             : ManagementResult<StreamConfiguration>.Ok(configuration);
     }
 
@@ -629,7 +629,7 @@ public sealed class StreamManagementService(
     /// <remarks>
     /// Small on purpose. Each attempt is a fresh read, so the loop converges as soon as writers
     /// stop arriving; a stream contended past this is not slow, it is being written by something
-    /// that will not stop, and answering 409 tells the receiver that rather than blocking on it.
+    /// that will not stop, and answering at all tells the receiver that rather than blocking on it.
     /// </remarks>
     private const int MutationAttempts = 4;
 
@@ -666,12 +666,37 @@ public sealed class StreamManagementService(
     }
 
     /// <summary>
-    /// The answer to a stream that stayed contended: the receiver may repeat the call.
+    /// The answer to a contended CONFIGURATION or STATUS update: the receiver may repeat the call.
     /// </summary>
+    /// <remarks>
+    /// "202 Accepted", the code SSF 1.0 lists for exactly this outcome in the update tables of
+    /// Sections 8.1.1.3, 8.1.1.4 and 8.1.2.2. Not "409 Conflict", however much a lost race sounds
+    /// like one: the specification spends that code on the neighbouring create endpoint for "you
+    /// already have a stream", so a receiver reading it here is told the opposite of what happened -
+    /// its change did not land, and it hears that everything is in order. That is not an ambiguity a
+    /// discriminator in the body would fix, because the code is what a receiver branches on.
+    /// </remarks>
+    private static ManagementResult<TBody> AcceptedNotProcessed<TBody>(string streamId)
+        => ManagementResult<TBody>.Accepted(
+            $"The stream '{streamId}' is being changed by someone else; nothing was written. Read "
+            + "it again and repeat the call.");
+
+    /// <summary>
+    /// The answer to a contended SUBJECT or VERIFICATION request, where 202 is not available.
+    /// </summary>
+    /// <remarks>
+    /// The error tables for these endpoints - Sections 8.1.3.2, 8.1.3.3 and 8.1.4.2 - list no 202,
+    /// and lending them one would be worse than imprecise. Every 2xx is a success to
+    /// <c>StreamManagementClient</c>, which answers these three calls with a plain bool: a 202 there
+    /// is reported to the receiver as a subject it is now subscribed to, or a verification event on
+    /// its way, when the write was in fact discarded. A signal nobody will ever deliver, announced
+    /// as delivered, is a worse failure than a refusal in a code the table does not name - so these
+    /// keep answering loudly, and the receiver keeps finding out.
+    /// </remarks>
     private static ManagementResult<TBody> Contended<TBody>(string streamId)
         => ManagementResult<TBody>.Conflict(
-            $"The stream '{streamId}' is being changed by someone else; read it again and repeat "
-            + "the call.");
+            $"The stream '{streamId}' is being changed by someone else; nothing was written. Read "
+            + "it again and repeat the call.");
 
     private static ManagementResult<TBody> NoSuchStream<TBody>(string streamId)
         => ManagementResult<TBody>.NotFound(

--- a/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
@@ -55,6 +55,36 @@ public class StreamManagementServiceTests
         }
     }
 
+    /// <summary>
+    /// A store that takes every call except the conditional write, so an update reaches the end of
+    /// the retry loop with nothing written.
+    /// </summary>
+    private sealed class RefusingUpdates(IStreamStore inner) : IStreamStore
+    {
+        public bool Refuse { get; set; }
+
+        public Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
+            => inner.TryCreateAsync(stream, cancellationToken);
+
+        public Task<StreamState?> FindAsync(
+            string receiverId, string streamId, CancellationToken cancellationToken = default)
+            => inner.FindAsync(receiverId, streamId, cancellationToken);
+
+        public Task<IReadOnlyList<StreamState>> ListAsync(
+            string receiverId, CancellationToken cancellationToken = default)
+            => inner.ListAsync(receiverId, cancellationToken);
+
+        public Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
+            => inner.ListAllAsync(cancellationToken);
+
+        public Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
+            => Refuse ? Task.FromResult(false) : inner.UpdateAsync(stream, cancellationToken);
+
+        public Task<bool> DeleteAsync(
+            string receiverId, string streamId, CancellationToken cancellationToken = default)
+            => inner.DeleteAsync(receiverId, streamId, cancellationToken);
+    }
+
     private sealed record Harness(
         StreamManagementService Service,
         InMemoryStreamStore Store,
@@ -62,13 +92,15 @@ public class StreamManagementServiceTests
         StubSigner Signer,
         FakeTimeProvider Clock);
 
-    private static Harness CreateHarness() => CreateHarness(new SharedSignalsTransmitterOptions
+    private static SharedSignalsTransmitterOptions DefaultOptions() => new()
     {
         Issuer = "https://tr.example.com",
         EventsSupported = [TypeA, TypeB],
         PollEndpointFactory = streamId => new Uri($"https://tr.example.com/ssf/poll/{streamId}"),
         MinVerificationInterval = TimeSpan.FromMinutes(5),
-    });
+    };
+
+    private static Harness CreateHarness() => CreateHarness(DefaultOptions());
 
     private static Harness CreateHarness(SharedSignalsTransmitterOptions options)
     {
@@ -148,6 +180,99 @@ public class StreamManagementServiceTests
             Receiver, new CreateStreamRequest(), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+    }
+
+    /// <summary>
+    /// An update the store would not take answers "202 Accepted", and never "409 Conflict".
+    /// </summary>
+    /// <remarks>
+    /// SSF 1.0 lists 202 in both update tables - Sections 8.1.1.3 and 8.1.2.2 - for a request
+    /// accepted and not processed, and 8.1.2.2 makes it a MUST for a transmitter that cannot decide
+    /// whether to complete one. 409 belongs to the create endpoint of Section 8.1.1.1 and means "you
+    /// already have a stream", which is what a receiver branching on the code would be told here:
+    /// that everything is in order, while its change is gone. A discriminator in the body does not
+    /// repair that, because the code is what gets branched on.
+    /// </remarks>
+    [Fact]
+    public async Task AnUpdateTheStoreRefuses_Answers202_NeverConflict()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var options = DefaultOptions();
+        var store = new RefusingUpdates(new InMemoryStreamStore());
+        var outbox = new InMemoryEventOutbox();
+        var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754200000));
+        var dispatcher = new EventDispatcher(
+            NullLogger<EventDispatcher>.Instance, store, outbox, new StubSigner(), options.Issuer, clock: clock);
+        var service = new StreamManagementService(store, outbox, dispatcher, options, clock);
+
+        var created = await service.CreateStreamAsync(
+            Receiver, new CreateStreamRequest { EventsRequested = [TypeA] }, ct);
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+
+        store.Refuse = true;
+
+        var updated = await service.UpdateStreamAsync(
+            Receiver,
+            new UpdateStreamRequest { StreamId = created.Body!.StreamId, EventsRequested = [TypeB] },
+            ct);
+
+        // The create endpoint's "you already have a stream" is what this used to say, and it is the
+        // whole reason the code changed.
+        Assert.Equal(HttpStatusCode.Accepted, updated.StatusCode);
+
+        // And nothing was written, whatever the code says: 202 promises the receiver that repeating
+        // the call is the way forward, which is only true while the change really is absent.
+        store.Refuse = false;
+        var read = await service.GetStreamAsync(Receiver, created.Body.StreamId, ct);
+        Assert.Equal([TypeA], read.Body!.EventsDelivered);
+    }
+
+    /// <summary>
+    /// A contended subject or verification request must NOT answer any 2xx, 202 included.
+    /// </summary>
+    /// <remarks>
+    /// The error tables for these endpoints - Sections 8.1.3.2, 8.1.3.3 and 8.1.4.2 - list no 202,
+    /// and the reason to care is one layer further on: <c>StreamManagementClient</c> answers all
+    /// three of these calls with a bool, false only on 429, so every other 2xx becomes "done". A
+    /// contended add-subject reported as done leaves the receiver believing it is subscribed to a
+    /// subject nothing was ever written for, and no event about that subject will ever arrive -
+    /// a security signal announced as delivered and silently dropped.
+    /// </remarks>
+    [Fact]
+    public async Task AContendedSubjectOrVerificationRequest_IsNeverAnswered2xx()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var options = DefaultOptions();
+        var store = new RefusingUpdates(new InMemoryStreamStore());
+        var outbox = new InMemoryEventOutbox();
+        var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754200000));
+        var dispatcher = new EventDispatcher(
+            NullLogger<EventDispatcher>.Instance, store, outbox, new StubSigner(), options.Issuer, clock: clock);
+        var service = new StreamManagementService(store, outbox, dispatcher, options, clock);
+
+        var created = await service.CreateStreamAsync(
+            Receiver, new CreateStreamRequest { EventsRequested = [TypeA] }, ct);
+        var streamId = created.Body!.StreamId;
+
+        store.Refuse = true;
+
+        var added = await service.AddSubjectAsync(
+            Receiver,
+            new AddSubjectRequest { StreamId = streamId, Subject = new OpaqueSubject("subject-1") },
+            ct);
+        var removed = await service.RemoveSubjectAsync(
+            Receiver,
+            new RemoveSubjectRequest { StreamId = streamId, Subject = new OpaqueSubject("subject-1") },
+            ct);
+        var verified = await service.RequestVerificationAsync(
+            Receiver, new VerificationRequest { StreamId = streamId }, ct);
+
+        foreach (var refused in new[] { added.StatusCode, removed.StatusCode, verified.StatusCode })
+        {
+            Assert.False(
+                (int)refused is >= 200 and <= 299,
+                $"A discarded write answered {(int)refused}, which the receiver reads as success.");
+        }
     }
 
     [Fact]


### PR DESCRIPTION
An update that reached the end of `MutateAsync`'s retry loop with nothing written was answered `409 Conflict`. SSF 1.0 spends that code on the neighbouring create endpoint - Section 8.1.1.1, Table 1, "if the Transmitter does not support multiple streams per Receiver" - and lists it in neither update table.

So one code carried two opposite meanings on one API. A receiver branches on the code, so a failed update told it what a successful re-registration tells it: all is in order. Its change was gone.

## What the specification assigns, and where

Table 3 (Update Stream Configuration Errors, 8.1.1.3), Table 4 (Replace, 8.1.1.4) and Table 7 (Update Stream Status Errors, 8.1.2.2) list:

> 202 - if the update request has been accepted, but not processed. Receiver MAY try the same request later to get processing result.

Section 8.1.2.2 also states it as a MUST, though under a condition worth quoting exactly rather than paraphrasing:

> If a Receiver makes a request to update a stream status, and the Transmitter is unable to decide whether or not to complete the request, then the Transmitter MUST respond with a 202 status code.

This transmitter did decide - it refused after four attempts - so that MUST does not compel this case. 202 is chosen because it is the only listed code that says "not processed, repeat it", which is the one thing the receiver has to know; the alternative is a code the endpoint's own table does not name.

## The split, which is the point rather than an omission

`Contended` was one helper behind five call sites, and the tables do not agree about them:

| Call site | Endpoint | Table | 202 listed |
|---|---|---|---|
| `SaveConfigurationAsync` | update / replace configuration | 3, 4 | yes |
| `UpdateStreamStatusAsync` | update status | 7 | yes |
| `AddSubjectAsync` | add subject | 8 | no |
| `RemoveSubjectAsync` | remove subject | 9 | no |
| `RequestVerificationAsync` | verification | 10 | no |

Only the first two move to 202. The other three keep 409, and lending them a 202 would be worse than imprecise. `StreamManagementClient` answers all three of those calls with a bool through `PostForOutcomeAsync`, which is false only on 429 and otherwise calls `EnsureSuccessStatusCode()` and returns true - so any other 2xx becomes "done". A contended add-subject reported as done leaves the receiver believing it is subscribed to a subject nothing was ever written for, and no event about that subject will ever arrive. A security signal announced as delivered and silently dropped is a worse failure than a refusal in a code the table does not name.

On the two paths that do move, the receiver in this package already reads 202: `UpdateAsync`, `ReplaceAsync` and `UpdateStatusAsync` return null on it and document it as taken-but-not-processed.

## Scope

`ManagementResult.Conflict` keeps its three create-path call sites, where the specification puts it; its documentation now says so, because the next person to reach for it will be looking at an update.

The two outcomes stop sharing a code without a discriminator in a body - which the management API does not define anyway.

## Tests

- `AnUpdateTheStoreRefuses_Answers202_NeverConflict` drives a configuration update through a store that refuses the conditional write, and asserts the code and that nothing was in fact written, because 202 promises the receiver that repeating the call is the way forward, which holds only while the change really is absent.
- `AContendedSubjectOrVerificationRequest_IsNeverAnswered2xx` covers the three endpoints on the other side of the split, where a 2xx would be read as success by the client above.

Each fails under its own inversion: reverting the update path to `Conflict` fails the first, and pointing any subject or verification path at the 202 helper fails the second with the code it answered.

155 unit, 4 end-to-end and 28 Redis store tests pass; the solution builds clean.

Found in the field: the same code arrived ten times in a row for a write that could never land, and read as the ordinary "you already have a stream".
