### PR TITLE
Align the licensing artefacts with the published terms

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-﻿# License Agreement
+# License Agreement
 
 **Effective Date:** November 18, 2025
 
@@ -80,7 +80,7 @@ Commercial production use is permitted free of charge under this Section: passin
    
    (c) **No limit on functionality**: every protocol, profile and feature of the Software is available, and none is withheld from use free of charge;
    
-   (d) **Enforcement**: The limit in Subsection (a) is enforced according to the License Limit Enforcement Framework specified in Section 2.7. Violations must be remedied by either:
+   (d) **Enforcement**: The limit in Subsection (a) is enforced by technical means as described in Section 2.7. Violations must be remedied by either:
    
    (i) reducing the number of production issuers to a compliant level, or
    

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# License Agreement
+﻿# License Agreement
 
 **Effective Date:** November 18, 2025
 
@@ -52,37 +52,45 @@ This License Agreement ("Agreement") is a legal agreement between you (as a pers
    
    (c) Distribute, sublicense, sell, rent, lease, or lend the Software;
    
-   (d) Remove, obscure, or circumvent copyright, proprietary notices, or access controls.
+   (d) Remove, obscure, or circumvent copyright, proprietary notices, or access controls;
+   
+   (e) Offer the Software, or a wrapper around it, to third parties as a hosted authentication service;
+   
+   (f) Use the source code of the Software, in whole or in part, to develop a product competing with the Software.
 
 2.2.1. **Security Research Exception.** Subsections 2.2(a) and 2.2(b) do not apply to good-faith security research conducted in accordance with the Security Policy published in the Software's official repository (SECURITY.md), which is incorporated into this Agreement by reference under Section 11.4(c). For that purpose You may modify, instrument, decompile and analyse the Software on installations You control, and the Copyright Holder will not treat such work as a breach of this Agreement. This exception does not permit distribution of the Software or of any derivative work, and Section 2.2(c) and 2.2(d) continue to apply in full.
 
-2.3. You may not use the Software in commercial projects, except as provided in Section 2.5. If you wish to use the Software for non-commercial purposes, you may download and access the Software free of charge, subject to all license terms and technical limits specified in Section 2.3.1. Examples of non-commercial projects include:
+2.3. **Free of Charge Use.** You may download and use the Software free of charge, subject to all license terms and the technical limits specified in Section 2.3.1, in each of the following cases:
 
-   (a) Free educational projects;
+   (a) Your company had less than USD 1,000,000 in annual revenue in its last completed financial year and has raised less than USD 1,000,000 in outside funding, counting investment, grants and the sale of a stake in aggregate. Both conditions must hold; exceeding either one moves commercial production use to Section 2.5;
    
-   (b) Games without monetization;
+   (b) You are a non-profit organization, an educational institution, or an individual using the Software in a personal project, whatever your size;
    
-   (c) Internal testing or evaluation of the Software before purchasing a commercial license, provided such use does not occur in production environments and does not generate revenue.
+   (c) You use the Software in an open-source project that is itself non-commercial;
+   
+   (d) You deploy the Software in a development, testing or staging environment, whatever your size. Such environments are free of charge for everyone, including companies above the thresholds in Section 2.3(a). An environment accessible to external end users, or serving production traffic, is a production environment and is not covered by this subsection.
 
-If your product generates revenue through advertising, paid subscriptions, or any commercial means, you may not use the Software under the free non-commercial license.
+Commercial production use is permitted free of charge under this Section: passing the thresholds in Section 2.3(a), not the presence of revenue, is what makes a paid license necessary.
 
-2.3.1. **Non-Commercial License Technical Limits.** Non-commercial licenses granted at no charge are subject to the following technical restrictions:
+2.3.1. **Technical Limits of Free of Charge Use.** Use free of charge under Section 2.3 is subject to the following technical restrictions:
 
-   (a) **Client Limit**: Maximum **2 (two)** unique client applications may be used;
+   (a) **Issuer Limit**: Maximum 1 (one) production issuer may be used;
    
-   (b) **Issuer Limit**: Maximum **1 (one)** issuer may be used;
+   (b) **No limit on client applications, users or nodes**: the number of unique client applications, of end users, and of servers running one issuer is unrestricted;
    
-   (c) **Enforcement**: These limits are enforced according to the License Limit Enforcement Framework specified in Section 2.7. Violations must be remedied by either:
+   (c) **No limit on functionality**: every protocol, profile and feature of the Software is available, and none is withheld from use free of charge;
    
-   (i) reducing the number of clients or issuers to compliant levels, or
+   (d) **Enforcement**: The limit in Subsection (a) is enforced according to the License Limit Enforcement Framework specified in Section 2.7. Violations must be remedied by either:
+   
+   (i) reducing the number of production issuers to a compliant level, or
    
    (ii) upgrading to a commercial license under Section 2.5 or Section 2.6.
 
 2.4. If the laws of your country prohibit you from using the Software, you are not authorized to use it, and you agree to comply with all applicable laws and regulations concerning your use of the Software.
 
-2.5. If you wish to use the Software in commercial projects, or if your projects have a commercial component in any way, you may download and use the Software during the term upon payment of the applicable license fee, in accordance with the terms of this Agreement.
+2.5. If you use the Software in commercial production and none of the cases in Section 2.3 applies to you, you may download and use the Software during the term upon payment of the applicable license fee, in accordance with the terms of this Agreement.
 
-2.6. **Commercial Licenses.** Commercial license types (Standard, Redistribution) are available for commercial use. Current pricing, terms, and license comparisons are available at [abblix.com/abblix-oidc-server-pricing](https://www.abblix.com/abblix-oidc-server-pricing). The specific terms of your license are governed by your purchase agreement. In the event of conflict between this License Agreement and your purchase agreement, the purchase agreement shall control.
+2.6. **Commercial Licenses.** Two commercial license types cover internal use: Pro, which permits 1 (one) production issuer, and Enterprise, which permits an unrestricted number of independent production issuers. Neither restricts the number of client applications, end users, nodes or features, and each carries the support terms stated at the address below. Redistribution is a separate license type, required when the Software reaches third parties inside a product You sell or deploy at customer sites; internal use is not redistribution, however many of Your own applications a single deployment serves. Current pricing, terms, and license comparisons are available at [abblix.com/en/oidc-server/pricing](https://www.abblix.com/en/oidc-server/pricing). The specific terms of your license are governed by your purchase agreement. In the event of conflict between this License Agreement and your purchase agreement, the purchase agreement shall control.
 
 2.7. **License Enforcement.** You are solely responsible for monitoring your usage and ensuring compliance with license limits. The Software may enforce limits through technical means, including warnings, feature restrictions, or denial of service. Failure to comply may result in termination under Section 3.5.
 
@@ -113,7 +121,7 @@ If your product generates revenue through advertising, paid subscriptions, or an
 
 3.6. **License Keys.** All license keys are generated exclusively by the Copyright Holder and cannot be self-generated, transferred, or modified. You are responsible for maintaining the confidentiality of your license keys. License keys expire on the date specified; renewal requires explicit request to the Copyright Holder.
 
-3.7. **Software Updates.** Updates and maintenance terms for commercial licenses are specified in your purchase agreement. Free License users receive the Software "as is" without any commitment to updates, support, or maintenance.
+3.7. **Software Updates.** Updates and maintenance terms for commercial licenses are specified in your purchase agreement. Users of the Software free of charge under Section 2.3 receive it "as is", with no guaranteed response time and no commitment to updates or maintenance; community channels remain open to them.
 
 ## 4. Data Processing
 
@@ -150,7 +158,7 @@ If your product generates revenue through advertising, paid subscriptions, or an
 
 For commercial licenses, the aggregate liability of the Copyright Holder under any provision of this License Agreement shall not exceed the license fees paid by You for the most recent license term.
 
-For non-commercial licenses granted at no charge, the Copyright Holder shall have no liability whatsoever.
+For licenses granted at no charge under Section 2.3, the Copyright Holder shall have no liability whatsoever.
 
 9.2. **Enforceability.** The limitations set forth in this Section 9 shall apply to the fullest extent permitted by applicable law. Some jurisdictions do not allow the limitation or exclusion of liability for incidental or consequential damages; in such jurisdictions, the above limitation may not apply to You, and the Copyright Holder's liability shall be limited to the maximum extent permitted by applicable law.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/Abblix/Oidc.Server)](#)
 [![getting started](https://img.shields.io/badge/getting_started-guide-1D76DB)](https://docs.abblix.com/docs/getting-started-guide)
 [![License](https://img.shields.io/badge/license-Source_Available-blue)](LICENSE.md)
-[![Free](https://img.shields.io/badge/free_for_non_commercial_use-brightgreen)](#-license)
+[![Free](https://img.shields.io/badge/free_under_%241M_revenue-brightgreen)](#-license)
 
 ⭐ Star us on GitHub: your support motivates us a lot! 🙏😊
 
@@ -46,7 +46,7 @@
 
 **Abblix OIDC Server** turns your ASP.NET Core application into a fully certified OpenID Connect provider. Rather than deploying and operating a separate identity server, you embed the protocol directly into your app, so your users, your data, and your UI stay inside your product.
 
-- **Certified to the letter:** every OpenID profile, 634 conformance tests passed, zero skipped and zero warnings.
+- **Certified:** all seven OpenID Provider profiles and all four logout profiles, 634 conformance tests passed with none skipped and no warnings. FAPI is not among them.
 - **A library you own, not a server you run:** the OpenID Connect endpoints live inside your app, so users, data, and UI never leave it.
 - **Current with the modern security stack:** DPoP, PAR, JARM, RAR, token exchange, and certificate-bound tokens, alongside the OAuth 2.0 and OpenID Connect core.
 - **Engineering you can audit:** 2000+ passing tests, top SonarCloud security, reliability, and maintainability ratings, and CodeQL scanning on every change.
@@ -228,7 +228,8 @@ This product is distributed under a source-available proprietary license. See �
 It is free of charge for companies under $1M in annual revenue and under $1M raised in outside funding, for
 non-profits, educational institutions, personal projects and non-commercial open source, and for development,
 test and staging environments at any size. Every protocol is included at every tier, with no limit on client
-applications or users. See the [pricing page](https://www.abblix.com/en/oidc-server/pricing).
+applications or users, and one production issuer per free deployment. See the
+[pricing page](https://www.abblix.com/en/oidc-server/pricing).
 
 ## 🗨️ Contacts
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,10 @@ We appreciate your support and look forward to making our product even better wi
 
 This product is distributed under a source-available proprietary license. See 📋[License Agreement](LICENSE.md) for details.
 
-For non-commercial use, this product is available for free.
+It is free of charge for companies under $1M in annual revenue and under $1M raised in outside funding, for
+non-profits, educational institutions, personal projects and non-commercial open source, and for development,
+test and staging environments at any size. Every protocol is included at every tier, with no limit on client
+applications or users. See the [pricing page](https://www.abblix.com/en/oidc-server/pricing).
 
 ## 🗨️ Contacts
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,7 +82,7 @@ Whichever route you take, tell us:
 These timings cover the handling of vulnerability reports, from anyone, licence or no licence: a defect in
 this library is our problem before it is yours. They are not technical support. Support and maintenance are
 governed by your licence and purchase agreement, and Section 3.7 of the [licence](LICENSE.md) is explicit that
-free non-commercial use carries no commitment to either.
+use free of charge under Section 2.3, commercial or not, carries no commitment to either.
 
 We do not run a paid bug bounty.
 
@@ -93,8 +93,8 @@ binds Abblix LLP. Within its scope we will not bring or support legal action aga
 treat your research as a breach of the licence.
 
 For good-faith security research under this policy, and notwithstanding Sections 2.2(a) and 2.2(b) of the
-[licence](LICENSE.md), you may modify, instrument, decompile and fuzz the Software on an installation you
-control. Nothing else in those sections is waived. What we ask in return:
+[licence](LICENSE.md), you may modify, instrument, decompile and analyse the Software, fuzzing included, on
+an installation you control. Nothing else in those sections is waived. What we ask in return:
 
 - **Test against an installation you control.** Providers built on this library are deployed and operated by
   their owners, and their end users' accounts, tokens and data are not yours to reach. Probing a live provider

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Full platform and end-of-support dates are on the
 [version support lifecycle](https://docs.abblix.com/docs/version-support-lifecycle) page.
 
 A fix is made in the latest release and reaches you by upgrading the package. The fixed package is published
-on NuGet and available to everyone, including users of the free non-commercial licence: a security fix is
+on NuGet and available to everyone, including those using the library free of charge: a security fix is
 never gated behind a purchase.
 
 Know what upgrading can cost, though. Minor releases in this library do carry breaking changes. In 2.4, for

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseChecker.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseChecker.cs
@@ -39,7 +39,16 @@ public static partial class LicenseChecker
 {
     private const double ClientLimitOverExceedingFactor = 1.3;
 
-    private static readonly License FreeLicense = new() { ClientLimit = 2, IssuerLimit = 1 };
+    /// <summary>
+    /// What an installation gets with no license supplied: one issuer, and no ceiling on client applications.
+    /// </summary>
+    /// <remarks>
+    /// The published terms meter the size of the company and the number of production issuers, never the number
+    /// of client applications or users, so a client count here would refuse registrations the terms allow. The
+    /// issuer limit stays because a second independent issuer is exactly what the terms do meter.
+    /// The client-limit machinery below is kept for a license that carries the claim: absent it, nothing counts.
+    /// </remarks>
+    private static readonly License FreeLicense = new() { IssuerLimit = 1 };
     private static readonly LicenseManager LicenseManager = new();
 
     private static ConcurrentDictionary<string, object>? _knownClientIds;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -9,8 +9,8 @@ namespace Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 /// Shared constants for the E2E test suite. Centralising client IDs and the issuer
 /// here keeps the static <c>LicenseChecker._knownIssuers</c> /
 /// <c>_knownClientIds</c> dictionaries small - the same ID across tests collapses
-/// to a single entry. <see cref="LicenseFixture"/> separately removes the
-/// FreeLicense numeric ceiling, but the constants reduce noise and keep tests
+/// to a single entry. The suite runs inside the licence, on the same terms a
+/// deployment gets, and the constants reduce noise and keep tests
 /// readable when they need to refer to the same client repeatedly.
 /// </summary>
 public static class TestConstants

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -9,9 +9,8 @@ namespace Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 /// Shared constants for the E2E test suite. Centralising client IDs and the issuer
 /// here keeps the static <c>LicenseChecker._knownIssuers</c> /
 /// <c>_knownClientIds</c> dictionaries small - the same ID across tests collapses
-/// to a single entry. The suite runs inside the licence, on the same terms a
-/// deployment gets, and the constants reduce noise and keep tests
-/// readable when they need to refer to the same client repeatedly.
+/// to a single entry, which also keeps tests readable when they refer to the
+/// same client repeatedly.
 /// </summary>
 public static class TestConstants
 {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseCheckerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseCheckerTests.cs
@@ -78,10 +78,10 @@ public class LicenseCheckerTests
     }
 
     /// <summary>
-    /// Verifies that CheckClientLicense allows clients within the free license limit (2 clients).
+    /// Verifies that CheckClientLicense serves distinct clients under a licence that sets no client limit.
     /// </summary>
     [Fact]
-    public void CheckClientLicense_WithinFreeLicense_AllowsClients()
+    public void CheckClientLicense_WithoutClientLimit_AllowsClients()
     {
         // Static state in LicenseChecker accumulates across tests; under default capacity
         // pressure, prior pollution can make new clients return null. Register a permissive

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
@@ -89,16 +89,7 @@ public sealed class LicenseEnforcementTests : IDisposable
         // which the count is ever consulted: a licence that names its issuers refuses an unknown one on the
         // name, before anything is counted. Written this way after the first attempt, which reused the
         // assembly's licence, turned out to exercise the whitelist while claiming to test the count.
-        //
-        // The period is stated as fixed instants rather than read from the clock. The checker reads the clock
-        // itself and cannot be driven from here, so the licence is simply made wide enough to cover any run.
-        TestLicense.ClearChecker();
-        LicenseChecker.AddLicense(new License
-        {
-            IssuerLimit = 1,
-            NotBefore = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            ExpiresAt = new DateTimeOffset(2100, 1, 1, 0, 0, 0, TimeSpan.Zero),
-        });
+        ArrangeLicenceThatCountsIssuers();
 
         Assert.Equal(TestLicense.Issuer, LicenseChecker.CheckIssuer(TestLicense.Issuer));
 
@@ -129,7 +120,7 @@ public sealed class LicenseEnforcementTests : IDisposable
         // assembly licence, and so is refused on the whitelist before anything is counted, or supplies a
         // licence of its own carrying the limit. None of them asks the fallback what it allows, so the
         // constant could be deleted outright with the whole suite still green - measured, not assumed.
-        TestLicense.ClearChecker();
+        ArrangeInstallationWithNoLicence();
 
         Assert.Equal(TestLicense.Issuer, LicenseChecker.CheckIssuer(TestLicense.Issuer));
 
@@ -143,11 +134,15 @@ public sealed class LicenseEnforcementTests : IDisposable
     [Fact]
     public void The_refusal_past_the_issuer_limit_is_recorded()
     {
-        // The refusal is covered above; this covers the record of it, which an operator's alerting is built
-        // on. It went untested for a mechanical reason worth stating: the throttle window is process-wide and
-        // fifteen minutes long, so whichever test reached the limit first consumed the only record any test
-        // could observe, and every later one found the decision taken in silence.
-        TestLicense.ClearChecker();
+        // The refusal is covered by the test above; this covers the record of it, which an operator's
+        // alerting is built on. It went untested for a mechanical reason worth stating: the throttle window
+        // is process-wide and fifteen minutes long, so whichever test reached the limit first consumed the
+        // only record any test could observe, and every later one found the decision taken in silence.
+        //
+        // On a licence of its own rather than on the unlicensed fallback, so that this test and the fallback
+        // test fail for different reasons: removing the fallback's limit must not be able to take this one
+        // down with it, or the two stop measuring two things.
+        ArrangeLicenceThatCountsIssuers();
         TestLicense.ClearLogThrottle();
 
         var records = new RecordingLoggerFactory();
@@ -171,6 +166,41 @@ public sealed class LicenseEnforcementTests : IDisposable
         Assert.Contains(TestLicense.Issuer, record.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Puts the checker where an installation is before any licence has been supplied.
+    /// </summary>
+    /// <remarks>
+    /// The assembly installs its licence before the first test runs, so reaching the state a deployment
+    /// starts in means removing it. That state is the subject of the two tests below rather than a
+    /// convenience for them: it is the only state in which the fallback is ever consulted.
+    /// </remarks>
+    private static void ArrangeInstallationWithNoLicence() => TestLicense.ClearChecker();
+
+    /// <summary>
+    /// Puts the checker on a licence that caps the number of issuers and names none of them, which is the
+    /// only arrangement under which that count is ever consulted.
+    /// </summary>
+    /// <remarks>
+    /// A licence that names its issuers refuses an unknown one on the name, before anything is counted, and
+    /// licences accumulate rather than replace one another - so the assembly's licence and its whitelist have
+    /// to go before this one is added. That is the whole reason a test of the count reaches into the
+    /// checker's state at all, and saying it once here keeps it out of the test bodies, which then read as
+    /// what they need rather than as how the statics are arranged.
+    ///
+    /// The period is stated as fixed instants rather than read from the clock: the checker reads the clock
+    /// itself and cannot be driven from here, so the licence is simply made wide enough to cover any run.
+    /// </remarks>
+    private static void ArrangeLicenceThatCountsIssuers()
+    {
+        TestLicense.ClearChecker();
+        LicenseChecker.AddLicense(new License
+        {
+            IssuerLimit = 1,
+            NotBefore = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2100, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        });
+    }
+
     [Fact]
     public void An_installation_running_before_a_licence_is_supplied_still_serves_every_client()
     {
@@ -178,7 +208,7 @@ public sealed class LicenseEnforcementTests : IDisposable
         // installation runs on before any licence is supplied must not count clients either. Written against
         // the fallback itself - no licence is added after the clear - because that is the only state in which
         // it is ever consulted, and a licence carrying no client limit would pass whatever the fallback said.
-        TestLicense.ClearChecker();
+        ArrangeInstallationWithNoLicence();
 
         for (var index = 0; index < 20; index++)
         {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
@@ -21,6 +21,7 @@
 // info@abblix.com
 
 using System;
+using System.Collections.Generic;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
@@ -121,6 +122,56 @@ public sealed class LicenseEnforcementTests : IDisposable
     }
 
     [Fact]
+    public void An_installation_running_before_a_licence_is_supplied_serves_one_issuer_and_refuses_the_second()
+    {
+        // The one limit the free tier has. Its sibling below pins the client half of the same fallback, and
+        // that asymmetry is how this went missing: every other test reaching CheckIssuer either runs under the
+        // assembly licence, and so is refused on the whitelist before anything is counted, or supplies a
+        // licence of its own carrying the limit. None of them asks the fallback what it allows, so the
+        // constant could be deleted outright with the whole suite still green - measured, not assumed.
+        TestLicense.ClearChecker();
+
+        Assert.Equal(TestLicense.Issuer, LicenseChecker.CheckIssuer(TestLicense.Issuer));
+
+        // Every time, not only the first: a limit that stops applying once reported is not a limit.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            Assert.Throws<InvalidOperationException>(() => LicenseChecker.CheckIssuer(UnlicensedIssuer));
+        }
+    }
+
+    [Fact]
+    public void The_refusal_past_the_issuer_limit_is_recorded()
+    {
+        // The refusal is covered above; this covers the record of it, which an operator's alerting is built
+        // on. It went untested for a mechanical reason worth stating: the throttle window is process-wide and
+        // fifteen minutes long, so whichever test reached the limit first consumed the only record any test
+        // could observe, and every later one found the decision taken in silence.
+        TestLicense.ClearChecker();
+        TestLicense.ClearLogThrottle();
+
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.Equal(TestLicense.Issuer, LicenseChecker.CheckIssuer(TestLicense.Issuer));
+            Assert.Throws<InvalidOperationException>(() => LicenseChecker.CheckIssuer(UnlicensedIssuer));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        var record = Assert.Single(records.Entries);
+        Assert.Equal(LogEvents.Licensing.LicenseChecker.IssuerLimitExceeded, record.EventId.Id);
+        Assert.Equal(LogLevel.Error, record.Level);
+
+        // The message carries what an operator needs to act: which issuers were counted against the limit.
+        Assert.Contains(UnlicensedIssuer, record.Message, StringComparison.Ordinal);
+        Assert.Contains(TestLicense.Issuer, record.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void An_installation_running_before_a_licence_is_supplied_still_serves_every_client()
     {
         // The terms meter company size and production issuers, never client applications, so the fallback an
@@ -205,6 +256,40 @@ public sealed class LicenseEnforcementTests : IDisposable
         finally
         {
             LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+    }
+
+    /// <summary>What a single log write carried.</summary>
+    private sealed record LogRecord(LogLevel Level, EventId EventId, string Message);
+
+    /// <summary>A factory whose loggers keep what was written, so a test can assert on the record itself.</summary>
+    private sealed class RecordingLoggerFactory : ILoggerFactory
+    {
+        public List<LogRecord> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class RecordingLogger(List<LogRecord> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => entries.Add(new LogRecord(logLevel, eventId, formatter(state, exception)));
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
@@ -121,6 +121,22 @@ public sealed class LicenseEnforcementTests : IDisposable
     }
 
     [Fact]
+    public void An_installation_running_before_a_licence_is_supplied_still_serves_every_client()
+    {
+        // The terms meter company size and production issuers, never client applications, so the fallback an
+        // installation runs on before any licence is supplied must not count clients either. Written against
+        // the fallback itself - no licence is added after the clear - because that is the only state in which
+        // it is ever consulted, and a licence carrying no client limit would pass whatever the fallback said.
+        TestLicense.ClearChecker();
+
+        for (var index = 0; index < 20; index++)
+        {
+            var client = new ClientInfo($"unlicensed-client-{index}");
+            Assert.Same(client, client.CheckClientLicense());
+        }
+    }
+
+    [Fact]
     public void A_client_far_beyond_the_licensed_count_is_turned_away()
     {
         // The client limit is not refused at the limit but at a margin above it, so an operator who has grown

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoggerTests.cs
@@ -21,8 +21,10 @@
 // info@abblix.com
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using Abblix.Oidc.Server.Features.Licensing;
@@ -544,4 +546,35 @@ public class LicenseLoggerTests
     }
 
     #endregion
+
+    /// <summary>
+    /// The timer callback that keeps the throttle dictionary from growing without bound drops the entries whose
+    /// window has closed and keeps the rest.
+    /// </summary>
+    /// <remarks>
+    /// Nothing else in the suite reaches this method: it runs on a one-minute timer inside a singleton that
+    /// lives for the process, so no test waits for it and the whole body was unexecuted. It is the only thing
+    /// standing between a server that refuses a misconfigured issuer on every request and a dictionary that
+    /// grows for as long as the process runs.
+    ///
+    /// Driven with a dictionary of the test's own rather than the singleton's, because the callback takes the
+    /// dictionary as its state parameter: the product method runs on real input, and no shared state moves.
+    /// The windows are stated as fixed instants rather than read from a clock - the callback reads the clock
+    /// itself and cannot be driven from here, so one instant is placed far behind any run and one far ahead.
+    /// </remarks>
+    [Fact]
+    public void CleanupExpiredEntries_RemovesOnlyEntriesWhosePeriodHasClosed()
+    {
+        var entries = new ConcurrentDictionary<object, DateTimeOffset>();
+        entries["closed"] = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        entries["still-open"] = new DateTimeOffset(2100, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var cleanup = typeof(LicenseLogger).GetMethod(
+            "CleanupExpiredEntries", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(cleanup);
+
+        cleanup.Invoke(null, [entries]);
+
+        Assert.Equal(["still-open"], entries.Keys.Cast<string>());
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/TestLicense.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/TestLicense.cs
@@ -107,6 +107,31 @@ internal static class TestLicense
         managerType.GetField("_currentLicense", Instances)!.SetValue(manager, null);
     }
 
+    /// <summary>
+    /// Empties the throttle window <see cref="LicenseLogger"/> keeps, so a test can observe a record that the
+    /// logger would otherwise suppress.
+    /// </summary>
+    /// <remarks>
+    /// The logger is a process-wide singleton and its window is fifteen minutes per key, so whichever test
+    /// reaches a limit first consumes the only record anybody can see, and every later test finds the decision
+    /// taken in silence. That silence looks exactly like a decision that was never reported at all, which is
+    /// why the record went untested while the refusal beside it did not.
+    ///
+    /// Like <see cref="ClearChecker"/> this reaches into the product rather than asking it for a reset: a
+    /// method existing only so a test can call it does not belong in a shipped assembly. It removes nothing
+    /// and relaxes nothing - the throttle behaves exactly as it does in a deployment, from an empty start.
+    /// </remarks>
+    internal static void ClearLogThrottle()
+    {
+        const BindingFlags Instances = BindingFlags.NonPublic | BindingFlags.Instance;
+
+        var logger = LicenseLogger.Instance;
+        var times = logger.GetType().GetField("_nextAllowedTimes", Instances)!.GetValue(logger);
+
+        // A ConcurrentDictionary of an internal key type, so it is emptied through the non-generic interface.
+        ((IDictionary)times!).Clear();
+    }
+
     [ModuleInitializer]
     internal static void Install()
     {


### PR DESCRIPTION
The pricing page is the reference. Everything in this repository that described the licensing model described the previous one, and the two were reachable from each other.

What the published terms say: pricing meters the size of the company and the number of production issuers. Client applications, users and nodes are unlimited on every tier, including the free one. No feature is gated at any tier. Free of charge covers commercial production under $1M annual revenue and $1M raised in outside funding, plus non-profits, education, personal projects and non-commercial open source, plus development, test and staging environments at any size.

Code. The fallback an installation runs on with no licence supplied carried a ceiling of two client applications, logged a violation from the third and refused a new client from the fourth. A deployment entitled to unlimited clients lost registrations. It now carries the issuer limit alone. The client-limit path stays in place for a licence that carries the claim.

Agreement. Section 2.3 stated that the software could not be used in commercial projects at all, and 2.3.1 capped free use at two clients and one issuer. Both now follow the published terms. Section 2.6 named licence types that no longer exist and pointed at an address that redirects. Section 2.2 gained the two prohibitions the licence page states and the text did not carry: offering the library as a hosted authentication service, and using its source to build a competing product.

The rewritten sections are 2.2, 2.3, 2.3.1, 2.5, 2.6, and the wording in 3.7 and 9.1 that named the old free tier. They need a lawyer's reading before being treated as final.

Verification: the whole solution is green, 4670 tests. The new test drives the unlicensed fallback and fails against the previous value, checked by planting it.
