### PR TITLE
Point the opened packages at the site, and correct their licence statements

### DIFF
--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix DependencyInjection</Title>
     <Description>Dependency-injection helpers for .NET: service aliasing, composition, decorators, and keyed registration that lets host registrations win. The DI layer behind Abblix OIDC Server, usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/en/docs/advanced-dependency-injection</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.DependencyInjection</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Dependency-Injection DI IoC Inversion-of-Control Service-Lifetime Scoped Singleton Transient Composite Decorator Keyed-Services Service-Alias Microsoft-Extensions-DependencyInjection dotnet OpenID Identity TryAddEnumerable Composition-Root</PackageTags>

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix DependencyInjection</Title>
     <Description>Dependency-injection helpers for .NET: service aliasing, composition, decorators, and keyed registration that lets host registrations win. The DI layer behind Abblix OIDC Server, usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.DependencyInjection</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/en/docs/advanced-dependency-injection</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Dependency-Injection DI IoC Inversion-of-Control Service-Lifetime Scoped Singleton Transient Composite Decorator Keyed-Services Service-Alias Microsoft-Extensions-DependencyInjection dotnet</PackageTags>
+    <PackageTags>Abblix Dependency-Injection DI IoC Inversion-of-Control Service-Lifetime Scoped Singleton Transient Composite Decorator Keyed-Services Service-Alias Microsoft-Extensions-DependencyInjection dotnet OpenID Identity TryAddEnumerable Composition-Root</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.DependencyInjection/README.md
+++ b/src/Abblix.DependencyInjection/README.md
@@ -66,13 +66,13 @@ Overloads accept a type mapping, an instance, or a factory, and the same overrid
 
 `Find`, `FindRequired`, `FindAll`, `RemoveAll` and `ChangeLifetime` operate on the registration list itself - the tools for the rare but real cases where a host must inspect or reshape what a library registered.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 The composition and decoration machinery here is what lets [Abblix.OIDC.Server](https://www.nuget.org/packages/Abblix.OIDC.Server) ship assembled pipelines a host can still edit; the full family lives in the [repository](https://github.com/Abblix/Oidc.Server).
 
 ## License
 
-Abblix.DependencyInjection is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.DependencyInjection is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.DependencyInjection/README.md
+++ b/src/Abblix.DependencyInjection/README.md
@@ -72,8 +72,7 @@ The composition and decoration machinery here is what lets [Abblix.OIDC.Server](
 
 ## License
 
-Abblix.DependencyInjection is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.DependencyInjection is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.DependencyInjection/README.md
+++ b/src/Abblix.DependencyInjection/README.md
@@ -2,6 +2,8 @@
 
 Extensions over `Microsoft.Extensions.DependencyInjection` for the patterns a modular library actually needs: aliasing one registration under several contracts, composing many implementations into one pipeline and editing that pipeline afterwards, decorating registered services, and constructing services with per-call overrides. This is the DI layer behind Abblix OIDC Server, usable on its own in any .NET application.
 
+[Advanced DI in .NET](https://www.abblix.com/en/docs/advanced-dependency-injection) is the long form: the same ladder from aliases to an editable pipeline, with the reasoning behind each rung and what it costs.
+
 ## Install
 
 ```bash

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix JWT</Title>
     <Description>A JWT and JOSE toolkit for .NET: token signing, encryption, validation, custom claims, and JSON Web Key handling. The token layer behind Abblix OIDC Server, usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Jwt</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix JWT JSON-Web-Token JOSE JWS JWE JWK JWKS Signing Encryption Validation Authentication Security Token API-Security OAuth OAuth2 Access-Token Identity Web-Security JWK-Thumbprint DPoP dotnet</PackageTags>
+    <PackageTags>Abblix JWT JSON-Web-Token JOSE JWS JWE JWK JWKS Signing Encryption Validation Authentication Security Token API-Security OAuth OAuth2 Access-Token Identity Web-Security JWK-Thumbprint DPoP dotnet RFC7515 RFC7516 RFC7517 RFC7518 RFC7519</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix JWT</Title>
     <Description>A JWT and JOSE toolkit for .NET: token signing, encryption, validation, custom claims, and JSON Web Key handling. The token layer behind Abblix OIDC Server, usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Jwt</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix JWT JSON-Web-Token JOSE JWS JWE JWK JWKS Signing Encryption Validation Authentication Security Token API-Security OAuth OAuth2 Access-Token Identity Web-Security JWK-Thumbprint DPoP dotnet RFC7515 RFC7516 RFC7517 RFC7518 RFC7519</PackageTags>

--- a/src/Abblix.Jwt/README.md
+++ b/src/Abblix.Jwt/README.md
@@ -96,13 +96,13 @@ services
 - JSON Web Token (JWT): [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519)
 - AES Key Wrap: [RFC 3394](https://datatracker.ietf.org/doc/html/rfc3394)
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 Abblix.JWT is the token layer under [Abblix.OIDC.Server](https://www.nuget.org/packages/Abblix.OIDC.Server) and [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents); the full family lives in the [repository](https://github.com/Abblix/Oidc.Server).
 
 ## License
 
-Abblix.JWT is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.JWT is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.Jwt/README.md
+++ b/src/Abblix.Jwt/README.md
@@ -102,8 +102,7 @@ Abblix.JWT is the token layer under [Abblix.OIDC.Server](https://www.nuget.org/p
 
 ## License
 
-Abblix.JWT is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.JWT is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -11,7 +11,7 @@
 
         <!-- Embed the shared Abblix.Oidc.Server.AspNetCore assembly into this package (see the target below). -->
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAspNetCoreSharedInPackage</TargetsForTfmSpecificBuildOutput>
-        <PackageId>Abblix.OIDC.Server.MinimalApi</PackageId>
+        <PackageId>Abblix.OIDC.Server.MinimalAPI</PackageId>
         <Title>Abblix OIDC Server Minimal API</Title>
         <Description>ASP.NET Core Minimal API integration for Abblix OIDC Server, the certified OpenID Connect and OAuth 2.0 provider. Maps its protocol endpoints as Minimal API route handlers, with no MVC dependency.</Description>
         <Authors>Abblix LLP</Authors>

--- a/src/Abblix.Oidc.Server.MinimalApi/README.md
+++ b/src/Abblix.Oidc.Server.MinimalApi/README.md
@@ -1,6 +1,6 @@
 # Abblix OIDC Server Minimal API
 
-**Abblix.OIDC.Server.MinimalApi** integrates the Abblix OIDC Server with ASP.NET Core **Minimal APIs**, mapping the OpenID Connect and OAuth 2.0 endpoints as route handlers. It offers the same protocol coverage as `Abblix.OIDC.Server.MVC` without taking a dependency on the MVC framework. Both packages sit on top of the framework-neutral core (`Abblix.OIDC.Server`) and differ only in the transport layer.
+**Abblix.OIDC.Server.MinimalAPI** integrates the Abblix OIDC Server with ASP.NET Core **Minimal APIs**, mapping the OpenID Connect and OAuth 2.0 endpoints as route handlers. It offers the same protocol coverage as `Abblix.OIDC.Server.MVC` without taking a dependency on the MVC framework. Both packages sit on top of the framework-neutral core (`Abblix.OIDC.Server`) and differ only in the transport layer.
 
 ## What's New in Version 2.4
 
@@ -21,7 +21,7 @@
 ## Install
 
 ```bash
-dotnet add package Abblix.OIDC.Server.MinimalApi
+dotnet add package Abblix.OIDC.Server.MinimalAPI
 ```
 
 This package includes **Abblix.OIDC.Server**, **Abblix.JWT**, **Abblix.DependencyInjection**, and **Abblix.Utils** as transitive dependencies.
@@ -96,7 +96,7 @@ For the complete standards list, see the [Abblix.OIDC.Server](https://www.nuget.
 | **[Abblix.JWT](https://www.nuget.org/packages/Abblix.JWT)** | JWT signing, encryption, and validation using .NET crypto primitives |
 | **[Abblix.OIDC.Server](https://www.nuget.org/packages/Abblix.OIDC.Server)** | Core OpenID Connect server implementation |
 | **[Abblix.OIDC.Server.MVC](https://www.nuget.org/packages/Abblix.OIDC.Server.MVC)** | ASP.NET Core MVC integration |
-| **Abblix.OIDC.Server.MinimalApi** | ASP.NET Core Minimal API integration *(this package)* |
+| **Abblix.OIDC.Server.MinimalAPI** | ASP.NET Core Minimal API integration *(this package)* |
 | **[Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents)** | Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493): building, validation, and the delivery data types |
 | **[Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals)** | OpenID Shared Signals Framework 1.0 transmitter and receiver |
 
@@ -106,7 +106,7 @@ To learn more about the Abblix OIDC Server product, visit our [Documentation](ht
 
 ## License
 
-Abblix.OIDC.Server.MinimalApi is licensed under the Abblix license agreement. See
+Abblix.OIDC.Server.MinimalAPI is licensed under the Abblix license agreement. See
 [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
 
 ## Contacts

--- a/src/Abblix.Oidc.Server.Mvc/README.md
+++ b/src/Abblix.Oidc.Server.Mvc/README.md
@@ -1,6 +1,6 @@
 # Abblix OIDC Server MVC
 
-**Abblix.OIDC.Server.MVC** integrates the Abblix OIDC Server with ASP.NET Core MVC, providing controller classes, model binding, and routing for the OpenID Connect endpoints. This is the recommended package for controller-based ASP.NET Core applications; hosts without MVC take [Abblix.OIDC.Server.MinimalApi](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalApi) instead.
+**Abblix.OIDC.Server.MVC** integrates the Abblix OIDC Server with ASP.NET Core MVC, providing controller classes, model binding, and routing for the OpenID Connect endpoints. This is the recommended package for controller-based ASP.NET Core applications; hosts without MVC take [Abblix.OIDC.Server.MinimalAPI](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalAPI) instead.
 
 ## What's New in Version 2.4
 
@@ -81,7 +81,7 @@ For the complete standards list, see the [Abblix.OIDC.Server](https://www.nuget.
 | **[Abblix.JWT](https://www.nuget.org/packages/Abblix.JWT)** | JWT signing, encryption, and validation using .NET crypto primitives |
 | **[Abblix.OIDC.Server](https://www.nuget.org/packages/Abblix.OIDC.Server)** | Core OpenID Connect server implementation |
 | **Abblix.OIDC.Server.MVC** | ASP.NET Core MVC integration *(this package)* |
-| **[Abblix.OIDC.Server.MinimalApi](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalApi)** | ASP.NET Core Minimal API integration |
+| **[Abblix.OIDC.Server.MinimalAPI](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalAPI)** | ASP.NET Core Minimal API integration |
 | **[Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents)** | Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493): building, validation, and the delivery data types |
 | **[Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals)** | OpenID Shared Signals Framework 1.0 transmitter and receiver |
 

--- a/src/Abblix.Oidc.Server.SourceGenerators.MinimalApi/Abblix.Oidc.Server.SourceGenerators.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.SourceGenerators.MinimalApi/Abblix.Oidc.Server.SourceGenerators.MinimalApi.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
+        <PackageId>Abblix.OIDC.Server.SourceGenerators.MinimalAPI</PackageId>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/src/Abblix.Oidc.Server.SourceGenerators.Mvc/Abblix.Oidc.Server.SourceGenerators.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.SourceGenerators.Mvc/Abblix.Oidc.Server.SourceGenerators.Mvc.csproj
@@ -8,7 +8,7 @@
         <IsPackable>false</IsPackable>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageId>Abblix.Oidc.Server.SourceGenerators.MVC</PackageId>
+        <PackageId>Abblix.OIDC.Server.SourceGenerators.MVC</PackageId>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Abblix.Oidc.Server/README.md
+++ b/src/Abblix.Oidc.Server/README.md
@@ -5,7 +5,7 @@
 ## What's New in Version 2.4
 
 🚀 **Features**
-- **Minimal API integration**: every OIDC endpoint as ASP.NET Core route handlers via the new [Abblix.OIDC.Server.MinimalApi](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalApi) package, with full protocol parity with the MVC integration
+- **Minimal API integration**: every OIDC endpoint as ASP.NET Core route handlers via the new [Abblix.OIDC.Server.MinimalAPI](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalAPI) package, with full protocol parity with the MVC integration
 - **External signing keys**: private keys held in HashiCorp Vault / OpenBao Transit ([Abblix.JWT.Vault](https://www.nuget.org/packages/Abblix.JWT.Vault)) or Azure Key Vault ([Abblix.JWT.Azure](https://www.nuget.org/packages/Abblix.JWT.Azure)) - the private halves never enter the process, the public halves publish to the JWKS endpoint
 - **Security events and Shared Signals**: a new package family implementing Security Event Tokens ([RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417)) with Subject Identifiers ([RFC 9493](https://datatracker.ietf.org/doc/html/rfc9493)), push and poll SET delivery ([RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935), [RFC 8936](https://datatracker.ietf.org/doc/html/rfc8936)), the OpenID Shared Signals Framework 1.0 in both transmitter and receiver roles, and the CAEP 1.0 and RISC 1.0 event dictionaries
 
@@ -70,7 +70,7 @@ Abblix OIDC Server implements the following standards for authorization and secu
 dotnet add package Abblix.OIDC.Server
 ```
 
-> **Note**: Most applications should use [Abblix.OIDC.Server.MVC](https://www.nuget.org/packages/Abblix.OIDC.Server.MVC) or [Abblix.OIDC.Server.MinimalApi](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalApi), which include this package plus the ASP.NET Core endpoint wiring.
+> **Note**: Most applications should use [Abblix.OIDC.Server.MVC](https://www.nuget.org/packages/Abblix.OIDC.Server.MVC) or [Abblix.OIDC.Server.MinimalAPI](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalAPI), which include this package plus the ASP.NET Core endpoint wiring.
 
 ## Related Packages
 
@@ -83,12 +83,12 @@ dotnet add package Abblix.OIDC.Server
 | **[Abblix.JWT.Azure](https://www.nuget.org/packages/Abblix.JWT.Azure)** | Signing and decryption keys held in Azure Key Vault |
 | **Abblix.OIDC.Server** | Core OpenID Connect server implementation *(this package)* |
 | **[Abblix.OIDC.Server.MVC](https://www.nuget.org/packages/Abblix.OIDC.Server.MVC)** | ASP.NET Core MVC integration |
-| **[Abblix.OIDC.Server.MinimalApi](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalApi)** | ASP.NET Core Minimal API integration |
+| **[Abblix.OIDC.Server.MinimalAPI](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalAPI)** | ASP.NET Core Minimal API integration |
 | **[Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents)** | Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493): building, validation, and the delivery data types |
 | **[Abblix.SecurityEvents.CAEP](https://www.nuget.org/packages/Abblix.SecurityEvents.CAEP)** | The CAEP 1.0 event dictionary: session and access lifecycle |
 | **[Abblix.SecurityEvents.RISC](https://www.nuget.org/packages/Abblix.SecurityEvents.RISC)** | The RISC 1.0 event dictionary: account risk incidents |
 | **[Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals)** | OpenID Shared Signals Framework 1.0 transmitter and receiver |
-| **[Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi)** | SSF endpoints as ASP.NET Core Minimal API route handlers |
+| **[Abblix.SharedSignals.MinimalAPI](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalAPI)** | SSF endpoints as ASP.NET Core Minimal API route handlers |
 | **[Abblix.SharedSignals.Redis](https://www.nuget.org/packages/Abblix.SharedSignals.Redis)** | Redis-native event outbox for multi-replica transmitters |
 
 ## Getting Started

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Security Events CAEP</Title>
     <Description>The OpenID Continuous Access Evaluation Profile (CAEP) 1.0 event dictionary for Abblix Security Events: typed payload models and event type identifiers for session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, session-established, session-presented and risk-level-change, registered over the Security Events core in one call.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.CAEP</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix CAEP Continuous-Access-Evaluation OpenID Security-Event-Token SET Shared-Signals SSF Session-Revocation Credential-Change Risk-Level Zero-Trust Security Identity dotnet</PackageTags>
+    <PackageTags>Abblix CAEP Continuous-Access-Evaluation OpenID Security-Event-Token SET Shared-Signals SSF Session-Revocation Credential-Change Risk-Level Zero-Trust Security Identity dotnet CAEP-1.0 Session-Revoked Token-Claims-Change Assurance-Level Device-Compliance OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Security Events CAEP</Title>
     <Description>The OpenID Continuous Access Evaluation Profile (CAEP) 1.0 event dictionary for Abblix Security Events: typed payload models and event type identifiers for session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, session-established, session-presented and risk-level-change, registered over the Security Events core in one call.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.CAEP</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix CAEP Continuous-Access-Evaluation OpenID Security-Event-Token SET Shared-Signals SSF Session-Revocation Credential-Change Risk-Level Zero-Trust Security Identity dotnet CAEP-1.0 Session-Revoked Token-Claims-Change Assurance-Level Device-Compliance OIDC</PackageTags>

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -54,13 +54,13 @@ await dispatcher.DispatchAsync(new SecurityEventDescriptor
 });
 ```
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 The events themselves travel over the [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals) transmitter and receiver; the sibling dictionary for account risk incidents is [Abblix.SecurityEvents.RISC](https://www.nuget.org/packages/Abblix.SecurityEvents.RISC), and both compose on one registry.
 
 ## License
 
-Abblix.SecurityEvents.CAEP is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SecurityEvents.CAEP is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -60,8 +60,7 @@ The events themselves travel over the [Abblix.SharedSignals](https://www.nuget.o
 
 ## License
 
-Abblix.SecurityEvents.CAEP is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SecurityEvents.CAEP is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -2,6 +2,8 @@
 
 The OpenID Continuous Access Evaluation Profile (CAEP) 1.0 event dictionary for [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents): typed payload models and event type identifiers for the eight CAEP events, registered over the Security Events core in one call. CAEP is how cooperating services keep reacting to each other AFTER login - one provider revokes a session or sees a risk level shift, and every subscribed service learns of it without waiting for the next authentication.
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) places this vocabulary in the stack: the envelope underneath it, the streams that carry it, and what a receiver does with a session event once it arrives.
+
 ## Install
 
 ```bash

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Security Events Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Security Events: maps the OpenID Connect Back-Channel Logout intake as a route handler, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.MinimalApi</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Security-Event-Token SET Back-Channel-Logout OpenID OIDC Logout Session Security Identity AspNetCore Minimal-API dotnet</PackageTags>
+    <PackageTags>Abblix Security-Event-Token SET Back-Channel-Logout OpenID OIDC Logout Session Security Identity AspNetCore Minimal-API dotnet RFC8417 RFC8935 Back-Channel-Logout-Uri Relying-Party Webhook</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>Abblix.SecurityEvents.MinimalApi</PackageId>
+    <PackageId>Abblix.SecurityEvents.MinimalAPI</PackageId>
     <Title>Abblix Security Events Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Security Events: maps the OpenID Connect Back-Channel Logout intake as a route handler, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Security Events Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Security Events: maps the OpenID Connect Back-Channel Logout intake as a route handler, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.MinimalApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Security-Event-Token SET Back-Channel-Logout OpenID OIDC Logout Session Security Identity AspNetCore Minimal-API dotnet RFC8417 RFC8935 Back-Channel-Logout-Uri Relying-Party Webhook</PackageTags>

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>Abblix.SecurityEvents.MinimalAPI</PackageId>
+    <PackageId>Abblix.SecurityEvents.MinimalApi</PackageId>
     <Title>Abblix Security Events Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Security Events: maps the OpenID Connect Back-Channel Logout intake as a route handler, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>

--- a/src/Abblix.SecurityEvents.MinimalApi/README.md
+++ b/src/Abblix.SecurityEvents.MinimalApi/README.md
@@ -62,13 +62,13 @@ The route is whatever the client registered with its provider as `backchannel_lo
   than guessing.
 - **Resilience and timeouts** of anything fetched outward, through `IHttpClientFactory` as usual.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 Abblix.SecurityEvents.MinimalAPI is the ASP.NET Core adapter of [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents), which owns the token and the wire. Event streams and their management layer live in [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), and the identity provider that emits these events is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 ## License
 
-Abblix.SecurityEvents.MinimalAPI is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SecurityEvents.MinimalAPI is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SecurityEvents.MinimalApi/README.md
+++ b/src/Abblix.SecurityEvents.MinimalApi/README.md
@@ -1,4 +1,4 @@
-# Abblix.SecurityEvents.MinimalApi
+# Abblix.SecurityEvents.MinimalAPI
 
 ASP.NET Core Minimal API integration for `Abblix.SecurityEvents`. It maps the two endpoints that
 receive a token and nothing more: `MapBackChannelLogoutEndpoint` for OpenID Connect Back-Channel
@@ -23,7 +23,7 @@ stream**:
 - **Stream management, status, subjects, verification, the `ssf-configuration` document and the
   transmitter's poll endpoint** - each is meaningless without a stream, and the poll address is
   addressed *by stream identifier*. Those live in
-  [Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi).
+  [Abblix.SharedSignals.MinimalAPI](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalAPI).
 
 Push and poll are the pair worth understanding, because both are core delivery specifications
 (RFC 8935 and RFC 8936) and yet they land in different packages. What separates them is not which

--- a/src/Abblix.SecurityEvents.MinimalApi/README.md
+++ b/src/Abblix.SecurityEvents.MinimalApi/README.md
@@ -5,6 +5,8 @@ receive a token and nothing more: `MapBackChannelLogoutEndpoint` for OpenID Conn
 Logout 1.0, and `MapPushDeliveryEndpoint` for RFC 8935 push delivery. The request and response rules
 live in the core, so this package is the transport and the route pattern.
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) walks the smallest path through the whole stack: a relying party that wants logout notifications, installs this adapter and its core, and never meets a stream.
+
 ## Which adapter maps which endpoint
 
 There are two Minimal API packages in this family, and the line between them is not the one that

--- a/src/Abblix.SecurityEvents.MinimalApi/README.md
+++ b/src/Abblix.SecurityEvents.MinimalApi/README.md
@@ -62,6 +62,16 @@ The route is whatever the client registered with its provider as `backchannel_lo
   than guessing.
 - **Resilience and timeouts** of anything fetched outward, through `IHttpClientFactory` as usual.
 
-## Licence
+## Part of the Abblix family
 
-See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SecurityEvents.MinimalAPI is the ASP.NET Core adapter of [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents), which owns the token and the wire. Event streams and their management layer live in [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), and the identity provider that emits these events is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
+
+## License
+
+Abblix.SecurityEvents.MinimalAPI is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+
+## Contacts
+
+- General inquiries: [info@abblix.com](mailto:info@abblix.com)
+- Support and security reports: [support@abblix.com](mailto:support@abblix.com)
+- Website: [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server)

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Security Events RISC</Title>
     <Description>The OpenID RISC Profile 1.0 (Risk Incident Sharing and Coordination) event dictionary for Abblix Security Events: typed payload models and event type identifiers for credential compromise, account disabling and deletion, identifier change and recycling, opt-out and recovery events, registered over the Security Events core in one call.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.RISC</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix RISC Risk-Incident-Sharing OpenID Security-Event-Token SET Shared-Signals SSF Credential-Compromise Account-Takeover Account-Disabled Identifier-Changed Security Identity dotnet</PackageTags>
+    <PackageTags>Abblix RISC Risk-Incident-Sharing OpenID Security-Event-Token SET Shared-Signals SSF Credential-Compromise Account-Takeover Account-Disabled Identifier-Changed Security Identity dotnet RISC-1.0 Account-Recovery Opt-Out RFC8417 OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Security Events RISC</Title>
     <Description>The OpenID RISC Profile 1.0 (Risk Incident Sharing and Coordination) event dictionary for Abblix Security Events: typed payload models and event type identifiers for credential compromise, account disabling and deletion, identifier change and recycling, opt-out and recovery events, registered over the Security Events core in one call.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.RISC</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix RISC Risk-Incident-Sharing OpenID Security-Event-Token SET Shared-Signals SSF Credential-Compromise Account-Takeover Account-Disabled Identifier-Changed Security Identity dotnet RISC-1.0 Account-Recovery Opt-Out RFC8417 OIDC</PackageTags>

--- a/src/Abblix.SecurityEvents.RISC/README.md
+++ b/src/Abblix.SecurityEvents.RISC/README.md
@@ -70,8 +70,7 @@ The events themselves travel over the [Abblix.SharedSignals](https://www.nuget.o
 
 ## License
 
-Abblix.SecurityEvents.RISC is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SecurityEvents.RISC is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.SecurityEvents.RISC/README.md
+++ b/src/Abblix.SecurityEvents.RISC/README.md
@@ -64,13 +64,13 @@ await dispatcher.DispatchAsync(new SecurityEventDescriptor
 });
 ```
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 The events themselves travel over the [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals) transmitter and receiver; the sibling dictionary for session and access lifecycle is [Abblix.SecurityEvents.CAEP](https://www.nuget.org/packages/Abblix.SecurityEvents.CAEP), and both compose on one registry.
 
 ## License
 
-Abblix.SecurityEvents.RISC is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SecurityEvents.RISC is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SecurityEvents.RISC/README.md
+++ b/src/Abblix.SecurityEvents.RISC/README.md
@@ -2,6 +2,8 @@
 
 The OpenID RISC Profile 1.0 (Risk Incident Sharing and Coordination) event dictionary for [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents): typed payload models and event type identifiers for the fourteen RISC events, registered over the Security Events core in one call. RISC is how providers protect a shared user together - a credential found in a breach or an account hijacked at one provider becomes a signal every other provider holding the same identifier can act on.
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) places this vocabulary in the stack, and explains why account-level incidents travel the same envelope and the same streams as session events.
+
 ## Install
 
 ```bash

--- a/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
+++ b/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Security Events</Title>
     <Description>Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493) for .NET: a typed model of every registered identifier format with polymorphic JSON handling, plus a typed token model, builder and composable validation profile over the Abblix JWT core, delivery models for push (RFC 8935) and poll (RFC 8936), JWKS-based key resolution and replay protection. The event layer of the Shared Signals stack, usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Security-Event-Token SET SecEvent RFC8417 RFC9493 Subject-Identifier Shared-Signals SSF CAEP RISC JWT Security Identity dotnet RFC8935 RFC8936 Back-Channel-Logout Replay-Protection Webhook OAuth2 OIDC</PackageTags>

--- a/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
+++ b/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Security Events</Title>
     <Description>Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493) for .NET: a typed model of every registered identifier format with polymorphic JSON handling, plus a typed token model, builder and composable validation profile over the Abblix JWT core, delivery models for push (RFC 8935) and poll (RFC 8936), JWKS-based key resolution and replay protection. The event layer of the Shared Signals stack, usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Security-Event-Token SET SecEvent RFC8417 RFC9493 Subject-Identifier Shared-Signals SSF CAEP RISC JWT Security Identity dotnet</PackageTags>
+    <PackageTags>Abblix Security-Event-Token SET SecEvent RFC8417 RFC9493 Subject-Identifier Shared-Signals SSF CAEP RISC JWT Security Identity dotnet RFC8935 RFC8936 Back-Channel-Logout Replay-Protection Webhook OAuth2 OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SecurityEvents/README.md
+++ b/src/Abblix.SecurityEvents/README.md
@@ -3,6 +3,8 @@
 Security Event Tokens ([RFC 8417](https://www.rfc-editor.org/rfc/rfc8417.html)) and Subject
 Identifiers ([RFC 9493](https://www.rfc-editor.org/rfc/rfc9493.html)) for .NET.
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) is the map this package sits on: why the envelope came before the streams, and why nothing here has a stream concept even though it carries both delivery methods.
+
 ## Install
 
 ```bash

--- a/src/Abblix.SecurityEvents/README.md
+++ b/src/Abblix.SecurityEvents/README.md
@@ -207,13 +207,13 @@ var options = new JsonSerializerOptions
 A name from the built-in vocabulary - RFC 9493 or Shared Signals - cannot be rebound, so a custom
 format can never change how a standard document is read.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 The event dictionaries [Abblix.SecurityEvents.CAEP](https://www.nuget.org/packages/Abblix.SecurityEvents.CAEP) and [Abblix.SecurityEvents.RISC](https://www.nuget.org/packages/Abblix.SecurityEvents.RISC) register their typed payloads over this package's event registry, and [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals) carries the tokens built here over managed event streams; the full family lives in the [repository](https://github.com/Abblix/Oidc.Server).
 
 ## License
 
-Abblix.SecurityEvents is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SecurityEvents is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SecurityEvents/README.md
+++ b/src/Abblix.SecurityEvents/README.md
@@ -213,8 +213,7 @@ The event dictionaries [Abblix.SecurityEvents.CAEP](https://www.nuget.org/packag
 
 ## License
 
-Abblix.SecurityEvents is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SecurityEvents is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Shared Signals Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Shared Signals: maps the SSF 1.0 transmitter endpoints - configuration discovery, stream management, subjects, verification and poll delivery - and the receiver's push intake as route handlers, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals.MinimalApi</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Security Identity AspNetCore Minimal-API dotnet</PackageTags>
+    <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Security Identity AspNetCore Minimal-API dotnet Continuous-Access-Evaluation Zero-Trust Stream-Management Webhook OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>Abblix.SharedSignals.MinimalApi</PackageId>
+    <PackageId>Abblix.SharedSignals.MinimalAPI</PackageId>
     <Title>Abblix Shared Signals Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Shared Signals: maps the SSF 1.0 transmitter endpoints - configuration discovery, stream management, subjects, verification and poll delivery - and the receiver's push intake as route handlers, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Shared Signals Minimal API</Title>
     <Description>ASP.NET Core Minimal API integration for Abblix Shared Signals: maps the SSF 1.0 transmitter endpoints - configuration discovery, stream management, subjects, verification and poll delivery - and the receiver's push intake as route handlers, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals.MinimalApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Security Identity AspNetCore Minimal-API dotnet Continuous-Access-Evaluation Zero-Trust Stream-Management Webhook OIDC</PackageTags>

--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -2,6 +2,8 @@
 
 ASP.NET Core Minimal API integration for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals): the OpenID Shared Signals Framework 1.0 endpoints as route handlers, with no MVC dependency.
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) explains which endpoints belong to the event layer and which to the stream layer, so the two adapters stop looking interchangeable.
+
 ## Which adapter maps which endpoint
 
 There are two Minimal API packages in this family, and the line between them is not the one that first suggests itself. It is **not** transmitter here and receiver there: this package holds receiver-role code of its own - the stream management client, the transmitter discovery client. The question that decides placement is whether the endpoint stops making sense **without a stream**:

--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -1,4 +1,4 @@
-# Abblix.SharedSignals.MinimalApi
+# Abblix.SharedSignals.MinimalAPI
 
 ASP.NET Core Minimal API integration for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals): the OpenID Shared Signals Framework 1.0 endpoints as route handlers, with no MVC dependency.
 
@@ -9,7 +9,7 @@ ASP.NET Core Minimal API integration for [Abblix.SharedSignals](https://www.nuge
 There are two Minimal API packages in this family, and the line between them is not the one that first suggests itself. It is **not** transmitter here and receiver there: this package holds receiver-role code of its own - the stream management client, the transmitter discovery client. The question that decides placement is whether the endpoint stops making sense **without a stream**:
 
 - **Stream management, status, subjects, verification, the `ssf-configuration` document, and the transmitter's poll endpoint** - every one is meaningless without a stream, and the poll address is addressed *by stream identifier*. Here.
-- **Push delivery intake** - "accept a SET at this address" (RFC 8935 Section 2.1). The URL is the receiver's own and carries no stream identity, so a receiver can be handed events by a counterparty known from anywhere. That endpoint is `MapPushDeliveryEndpoint` in [Abblix.SecurityEvents.MinimalApi](https://www.nuget.org/packages/Abblix.SecurityEvents.MinimalApi), which a push-based receiver installs alongside this one: the dependency chain here reaches the core library but not the core's adapter.
+- **Push delivery intake** - "accept a SET at this address" (RFC 8935 Section 2.1). The URL is the receiver's own and carries no stream identity, so a receiver can be handed events by a counterparty known from anywhere. That endpoint is `MapPushDeliveryEndpoint` in [Abblix.SecurityEvents.MinimalAPI](https://www.nuget.org/packages/Abblix.SecurityEvents.MinimalAPI), which a push-based receiver installs alongside this one: the dependency chain here reaches the core library but not the core's adapter.
 - **Back-Channel Logout** - one token, delivered once, from a provider the relying party already knows. Also there.
 
 Push and poll are the pair worth understanding, because both are core delivery specifications (RFC 8935 and RFC 8936) and yet they land in different packages. What separates them is not which document defines the protocol but whether a stream is part of the addressing: the push intake just accepts a token, while the poll endpoint below serves one stream's queue and its URL is built per stream from your `PollEndpointFactory`. The specification says how to carry an event; the stream says to whom - and that second half is what this package is.
@@ -19,8 +19,8 @@ The split is kept for what it buys the other side: a relying party that wants on
 ## Install
 
 ```bash
-dotnet add package Abblix.SharedSignals.MinimalApi
-dotnet add package Abblix.SecurityEvents.MinimalApi   # a push-based receiver also needs the intake endpoint
+dotnet add package Abblix.SharedSignals.MinimalAPI
+dotnet add package Abblix.SecurityEvents.MinimalAPI   # a push-based receiver also needs the intake endpoint
 ```
 
 ## Transmitter
@@ -81,17 +81,17 @@ app.MapPushDeliveryEndpoint("/events")
     .RequireAuthorization("ssf-transmitters");
 ```
 
-The intake endpoint itself comes from `Abblix.SecurityEvents.MinimalApi`, which this package already depends on - see the section above for why RFC 8935's intake belongs to the core while the poll endpoint above belongs here. It answers the empty 202 or the 400 whose body speaks the RFC 8935 registry vocabulary; where accepted events land is the host's `ISecurityEventSink`.
+The intake endpoint itself comes from `Abblix.SecurityEvents.MinimalAPI`, which this package already depends on - see the section above for why RFC 8935's intake belongs to the core while the poll endpoint above belongs here. It answers the empty 202 or the 400 whose body speaks the RFC 8935 registry vocabulary; where accepted events land is the host's `ISecurityEventSink`.
 
 Signature validation decides whether an event is genuine, but it is not what keeps the endpoint standing: an unauthenticated route spends a cryptographic verification on every body posted to it, which RFC 8935 Section 5.4 names as the recipient's denial-of-service exposure and answers with transmitter authentication and rate limiting. Attach both - the returned builder takes the host's conventions like any other route.
 
 ## Part of the Abblix product family
 
-Abblix.SharedSignals.MinimalApi maps the routes of [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), which in turn sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
+Abblix.SharedSignals.MinimalAPI maps the routes of [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), which in turn sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 ## License
 
-Abblix.SharedSignals.MinimalApi is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
+Abblix.SharedSignals.MinimalAPI is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -83,13 +83,13 @@ The intake endpoint itself comes from `Abblix.SecurityEvents.MinimalApi`, which 
 
 Signature validation decides whether an event is genuine, but it is not what keeps the endpoint standing: an unauthenticated route spends a cryptographic verification on every body posted to it, which RFC 8935 Section 5.4 names as the recipient's denial-of-service exposure and answers with transmitter authentication and rate limiting. Attach both - the returned builder takes the host's conventions like any other route.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 Abblix.SharedSignals.MinimalApi maps the routes of [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), which in turn sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 ## License
 
-Abblix.SharedSignals.MinimalApi is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SharedSignals.MinimalApi is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -83,10 +83,13 @@ The intake endpoint itself comes from `Abblix.SecurityEvents.MinimalApi`, which 
 
 Signature validation decides whether an event is genuine, but it is not what keeps the endpoint standing: an unauthenticated route spends a cryptographic verification on every body posted to it, which RFC 8935 Section 5.4 names as the recipient's denial-of-service exposure and answers with transmitter authentication and rate limiting. Attach both - the returned builder takes the host's conventions like any other route.
 
+## Part of the Abblix family
+
+Abblix.SharedSignals.MinimalApi maps the routes of [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), which in turn sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
+
 ## License
 
-Abblix.SharedSignals.MinimalApi is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SharedSignals.MinimalApi is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Shared Signals Redis</Title>
     <Description>Redis-native event outbox for Abblix Shared Signals: the transmitter's per-stream queues on Redis list and hash structures with atomic server-side operations, correct across transmitter replicas where a plain distributed-cache queue is not.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals.Redis</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET Redis Outbox Event-Stream Transmitter Security Identity dotnet</PackageTags>
+    <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET Redis Outbox Event-Stream Transmitter Security Identity dotnet Continuous-Access-Evaluation Zero-Trust Scale-Out Distributed Replica-Safe RFC8935 RFC8936 OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Shared Signals Redis</Title>
     <Description>Redis-native event outbox for Abblix Shared Signals: the transmitter's per-stream queues on Redis list and hash structures with atomic server-side operations, correct across transmitter replicas where a plain distributed-cache queue is not.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals.Redis</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET Redis Outbox Event-Stream Transmitter Security Identity dotnet Continuous-Access-Evaluation Zero-Trust Scale-Out Distributed Replica-Safe RFC8935 RFC8936 OIDC</PackageTags>

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -91,10 +91,13 @@ Two properties of the shape are worth knowing before adopting it. The whole regi
 
 Losing Redis loses registrations - deliberately a tier below a database. Stated plainly: the transmitter stops delivering to everybody until each receiver creates its stream again (SSF 1.0 Section 8.1.1.1), and whether a receiver ever does is a property of that receiver rather than of the protocol. A deployment that cannot accept that keeps its registrations in its own database, which is what `IStreamStore` is for.
 
+## Part of the Abblix family
+
+Abblix.SharedSignals.Redis is the outbox implementation for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), which in turn sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
+
 ## License
 
-Abblix.SharedSignals.Redis is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SharedSignals.Redis is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -2,6 +2,8 @@
 
 The Redis-native transmitter storage for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals): the event outbox and the stream registry: each stream's queue on Redis list and hash structures, every mutation a server-side transaction over keys that share one cluster hash tag. Take this package the day the transmitter scales past one replica.
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) covers what running a transmitter on more than one instance actually requires, and which of the shipped defaults are single-instance by design.
+
 ## Install
 
 ```bash

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -91,13 +91,13 @@ Two properties of the shape are worth knowing before adopting it. The whole regi
 
 Losing Redis loses registrations - deliberately a tier below a database. Stated plainly: the transmitter stops delivering to everybody until each receiver creates its stream again (SSF 1.0 Section 8.1.1.1), and whether a receiver ever does is a property of that receiver rather than of the protocol. A deployment that cannot accept that keeps its registrations in its own database, which is what `IStreamStore` is for.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 Abblix.SharedSignals.Redis is the outbox implementation for [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals), which in turn sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 ## License
 
-Abblix.SharedSignals.Redis is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SharedSignals.Redis is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Shared Signals</Title>
     <Description>OpenID Shared Signals Framework (SSF) 1.0 for .NET: transmitter and receiver in one package - transmitter configuration discovery, event stream management, subjects and verification, plus push (RFC 8935) and poll (RFC 8936) delivery over the Abblix Security Events core.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Push Poll Webhook Security Identity dotnet Continuous-Access-Evaluation Zero-Trust Session-Revocation Stream-Management OIDC OAuth2</PackageTags>

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Shared Signals</Title>
     <Description>OpenID Shared Signals Framework (SSF) 1.0 for .NET: transmitter and receiver in one package - transmitter configuration discovery, event stream management, subjects and verification, plus push (RFC 8935) and poll (RFC 8936) delivery over the Abblix Security Events core.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Push Poll Webhook Security Identity dotnet</PackageTags>
+    <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Push Poll Webhook Security Identity dotnet Continuous-Access-Evaluation Zero-Trust Session-Revocation Stream-Management OIDC OAuth2</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -91,10 +91,13 @@ Stream state and the outbox are deliberately separate tiers, and both default to
 
 The framework carries events; their vocabularies ship as separate dictionary packages registered in the same event registry: [Abblix.SecurityEvents.CAEP](https://www.nuget.org/packages/Abblix.SecurityEvents.CAEP) for session and access lifecycle, [Abblix.SecurityEvents.RISC](https://www.nuget.org/packages/Abblix.SecurityEvents.RISC) for account risk incidents, and any host-defined events via `options.Events.Register`.
 
+## Part of the Abblix family
+
+Abblix.SharedSignals sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents), which owns the token and the wire. Its ASP.NET Core routes come from [Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi) and its replica-safe outbox from [Abblix.SharedSignals.Redis](https://www.nuget.org/packages/Abblix.SharedSignals.Redis). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
+
 ## License
 
-Abblix.SharedSignals is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.SharedSignals is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -2,6 +2,8 @@
 
 The [OpenID Shared Signals Framework 1.0](https://openid.net/specs/openid-sharedsignals-framework-1_0.html) for .NET: transmitter and receiver in one package, built on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents). A transmitter tells its receivers that something security-relevant happened to a shared subject - a session revoked, a credential compromised - and this package carries both ends of that conversation: the event streams, their management API, and delivery over push (RFC 8935) and poll (RFC 8936).
 
+[Shared Signals in .NET: SSF, CAEP, RISC and Back-Channel Logout](https://www.abblix.com/en/docs/shared-signals-framework) explains what streams are for: the management questions OIDC client registration answered for Back-Channel Logout, and that nothing answers outside it.
+
 ## What is inside
 
 The transmitter side:

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -91,13 +91,13 @@ Stream state and the outbox are deliberately separate tiers, and both default to
 
 The framework carries events; their vocabularies ship as separate dictionary packages registered in the same event registry: [Abblix.SecurityEvents.CAEP](https://www.nuget.org/packages/Abblix.SecurityEvents.CAEP) for session and access lifecycle, [Abblix.SecurityEvents.RISC](https://www.nuget.org/packages/Abblix.SecurityEvents.RISC) for account risk incidents, and any host-defined events via `options.Events.Register`.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 Abblix.SharedSignals sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents), which owns the token and the wire. Its ASP.NET Core routes come from [Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi) and its replica-safe outbox from [Abblix.SharedSignals.Redis](https://www.nuget.org/packages/Abblix.SharedSignals.Redis). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 ## License
 
-Abblix.SharedSignals is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.SharedSignals is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -19,7 +19,7 @@ The receiver side:
 - `TransmitterConfigurationClient` discovers a transmitter at the address its issuer resolves to, with an explicit-address overload for transmitters that publish the document elsewhere - the issuer identity check binds either way. `StreamManagementClient` drives the management API, `PollClient` fetches and acknowledges events - transport only, so a poll-based receiver runs the validation profile and the sink itself.
 - A push intake that runs the full validation profile of Abblix.SecurityEvents - typ, `exp` absence, events, the REQUIRED `jti`, issuer, signature, audience, `iat` freshness - and hands each accepted event to the host's `ISecurityEventSink`. Duplicate suppression rides alongside the profile: the opt-in replay cache is consulted after the verdict, so a rejected token can never burn an identifier.
 
-The endpoints themselves are mapped by the ASP.NET Core adapter package, [Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi); this package is host-framework-neutral.
+The endpoints themselves are mapped by the ASP.NET Core adapter package, [Abblix.SharedSignals.MinimalAPI](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalAPI); this package is host-framework-neutral.
 
 ## Install
 
@@ -95,7 +95,7 @@ The framework carries events; their vocabularies ship as separate dictionary pac
 
 ## Part of the Abblix product family
 
-Abblix.SharedSignals sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents), which owns the token and the wire. Its ASP.NET Core routes come from [Abblix.SharedSignals.MinimalApi](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalApi) and its replica-safe outbox from [Abblix.SharedSignals.Redis](https://www.nuget.org/packages/Abblix.SharedSignals.Redis). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
+Abblix.SharedSignals sits on [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents), which owns the token and the wire. Its ASP.NET Core routes come from [Abblix.SharedSignals.MinimalAPI](https://www.nuget.org/packages/Abblix.SharedSignals.MinimalAPI) and its replica-safe outbox from [Abblix.SharedSignals.Redis](https://www.nuget.org/packages/Abblix.SharedSignals.Redis). The identity provider these signals originate from is [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server).
 
 ## License
 

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -11,7 +11,7 @@
     <Title>Abblix Utils</Title>
     <Description>Utility types shared across the Abblix OpenID Connect and OAuth 2.0 libraries: URI and string helpers, secure random generation, and custom JSON converters. Usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Utils</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Utilities String-Manipulation URI-Parsing JSON-Serialization Cryptography Data-Encoding Extensions Secure-Random Custom-JSON-Converters Base32-Encoding dotnet OpenID OAuth2 Identity Helpers</PackageTags>

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -11,10 +11,10 @@
     <Title>Abblix Utils</Title>
     <Description>Utility types shared across the Abblix OpenID Connect and OAuth 2.0 libraries: URI and string helpers, secure random generation, and custom JSON converters. Usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
-    <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Utils</PackageProjectUrl>
+    <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Abblix Utilities String-Manipulation URI-Parsing JSON-Serialization Cryptography Data-Encoding Extensions Secure-Random Custom-JSON-Converters Base32-Encoding dotnet</PackageTags>
+    <PackageTags>Abblix Utilities String-Manipulation URI-Parsing JSON-Serialization Cryptography Data-Encoding Extensions Secure-Random Custom-JSON-Converters Base32-Encoding dotnet OpenID OAuth2 Identity Helpers</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>

--- a/src/Abblix.Utils/README.md
+++ b/src/Abblix.Utils/README.md
@@ -49,13 +49,13 @@ Custom `System.Text.Json` converters for the shapes protocol messages actually u
 
 `ArrayExtensions`, `EnumerableExtensions`, `EnumFlagExtensions` and `ObjectExtensions` carry the small operations that otherwise get re-implemented per project.
 
-## Part of the Abblix family
+## Part of the Abblix product family
 
 Abblix.Utils sits under [Abblix.JWT](https://www.nuget.org/packages/Abblix.JWT), [Abblix.OIDC.Server](https://www.nuget.org/packages/Abblix.OIDC.Server), [Abblix.SecurityEvents](https://www.nuget.org/packages/Abblix.SecurityEvents) and the rest of the family; the full set lives in the [repository](https://github.com/Abblix/Oidc.Server).
 
 ## License
 
-Abblix.Utils is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
+Abblix.Utils is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
 
 ## Contacts
 

--- a/src/Abblix.Utils/README.md
+++ b/src/Abblix.Utils/README.md
@@ -55,8 +55,7 @@ Abblix.Utils sits under [Abblix.JWT](https://www.nuget.org/packages/Abblix.JWT),
 
 ## License
 
-Abblix.Utils is licensed under the Abblix license agreement. See
-[LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
+Abblix.Utils is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt). [Abblix OIDC Server](https://www.abblix.com/abblix-oidc-server) is a separate product under its own commercial agreement.
 
 ## Contacts
 


### PR DESCRIPTION
Discoverability work on the ten packages opened under Apache-2.0, so that a reader who finds one of them can reach the product.

### The readmes contradicted the licence

Each of the ten stated that the package is licensed under the Abblix agreement. That readme renders on the package page directly beneath metadata now declaring `Apache-2.0`, so an opened package disagreed with itself in the one place a screening reader looks. Each now names the Apache licence and states plainly that Abblix OIDC Server is a separate product under its own terms.

### The one outbound link was spent on the repository

`PackageProjectUrl` pointed at a GitHub folder listing, and the manifest already carries the repository in its own `repository` element. The prominent "Project website" link therefore led back to source, and the site received nothing from it. Nine packages now point at the product page; `Abblix.DependencyInjection` points at the article about its own subject, which is live.

### Four packages did not say what family they belong to

One of them had no link to the site anywhere in its readme. Each now names what it sits on, what adapts it, and which product emits the events it carries.

### Tags

Specification numbers, because people paste those into search, and role and outcome words, because people describe the problem before they know the name of the answer. Verified inside the built packages rather than in the project files: all ten carry the expression, the site URL and the corrected readme.

### Still open

Eight of these packages want a topical destination rather than the product page. The article written for exactly that purpose, covering SSF, CAEP, RISC and Back-Channel Logout and naming every one of these packages, exists in the site repository as a draft and is a 404 on the live site. Publishing it is the largest single lever here and is a separate decision.
