### PR TITLE
Stop counting generated logging against the branch figure

### DIFF
--- a/.github/workflows/test-shards.yml
+++ b/.github/workflows/test-shards.yml
@@ -77,10 +77,15 @@ jobs:
         # The new dotnet test experience (Microsoft.Testing.Platform runner, opted in via global.json)
         # takes MTP options directly, without the VSTest separator. --results-directory resolves from
         # the working directory (repo root), so files land beside the projects that produced them.
+        #
+        # The settings file excludes generated sources from the MEASUREMENT: a LoggerMessage partial
+        # carries a branch no test can take both sides of, and counting them ranks the package that
+        # logs the most as the least tested one.
         run: |
           dotnet test "tests/$PROJECT/$PROJECT.csproj" --configuration Release --no-restore \
             --report-trx --report-trx-filename test-results.trx \
             --coverage --coverage-output-format cobertura \
+            --coverage-settings tests/code-coverage.settings.xml \
             --results-directory ./tests/results
         timeout-minutes: 5
       - name: Upload test results

--- a/tests/code-coverage.settings.xml
+++ b/tests/code-coverage.settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Coverage settings for the test shards.
+
+Generated sources are excluded from the MEASUREMENT, not from the build. A LoggerMessage partial
+carries one branch per log call - the compiler's "is this level enabled" test - and no test can
+take both sides of it, because the level is fixed by the run. Counted, those branches drag down
+whichever package logs the most, which then reads as the least tested one: before this file,
+34 of the 160 untaken branches in Abblix.Jwt.Vault were generated logging.
+
+Excluding by source path rather than by module keeps the hand-written half of every partial class
+measured: LoginClient.cs is counted, LoginClient's LoggerMessage.g.cs is not.
+-->
+<Configuration>
+  <CodeCoverage>
+    <Sources>
+      <Exclude>
+        <Source>.*\.g\.cs$</Source>
+      </Exclude>
+    </Sources>
+  </CodeCoverage>
+</Configuration>


### PR DESCRIPTION
A LoggerMessage partial carries one branch per log call - the compiler's test for whether the
level is enabled - and no test can take both sides of it, because the level is fixed for the run.
Counted, those branches land on whichever package logs the most, which then reads as the least
tested one.

Measured on the Vault suite, the worst affected: 17 of its 80 untaken branches were generated
logging. Excluding the generated sources moves that package from 74.2% to 77.7% on branches and
from 83.0% to 93.8% on lines, with the same 71 tests running and every hand-written branch still
counted.

The exclusion is by source path rather than by module, so the hand-written half of every partial
class stays measured: `LoginClient.cs` is counted, its `LoggerMessage.g.cs` is not. Verified by
running the same suite twice, with the settings file and without, and comparing what the report
attributes to each source file.

This PR exists rather than a push to develop because the workflow it edits runs on `pull_request`
only - a push would never execute the changed line, and a wrong option name or an unresolvable
path would surface on somebody else's PR instead of this one.

Toward #275, which names this as measurement noise.
