### PR TITLE
Leave one licence header per file, and detect a second one

### DIFF
--- a/.github/scripts/lint-license-headers.py
+++ b/.github/scripts/lint-license-headers.py
@@ -15,6 +15,14 @@ import sys
 
 SPDX = re.compile(r'^//\s*SPDX-License-Identifier:\s*(\S+)\s*$')
 OLD_NOTICE = 'LICENSE RESTRICTIONS'
+# One header per file. Checked by STRUCTURE rather than by the wording of any superseded notice,
+# because OLD_NOTICE only ever named the verbose form: 61 files carried a second, two-line header
+# ('Copyright (c) Abblix LLP. All rights reserved.') that the phrase never looked for, left behind
+# where the SPDX rewrite could not recognise what it was replacing and prepended instead.
+HEADER_MARKER = '// Abblix OIDC Server Library'
+# Every source file names the copyright holder. Required regardless of which licence the file is
+# under: the SPDX identifier says what you may do with it, the copyright line says whose it is.
+COPYRIGHT = 'Copyright (c) Abblix LLP'
 PROPRIETARY = 'LicenseRef-Abblix-EULA'
 APACHE = 'Apache-2.0'
 
@@ -74,6 +82,26 @@ def declared_in(path):
     return None
 
 
+def problem_with(path, relative):
+    """The one thing wrong with this file's header, or None. First failure wins: a file carrying a
+    superseded notice has nothing to say about which identifier it declares."""
+    text = io.open(path, encoding='utf-8-sig').read(4000)
+    if OLD_NOTICE in text:
+        return 'carries the superseded proprietary notice'
+    headers = text.count(HEADER_MARKER)
+    if headers > 1:
+        return 'the licence header appears %d times' % headers
+    if COPYRIGHT not in text:
+        return 'no copyright line naming Abblix LLP'
+    got = declared_in(path)
+    if got is None:
+        return 'no SPDX-License-Identifier in the first 30 lines'
+    want = expected_for(relative)
+    if got != want:
+        return 'declares %s, package expects %s' % (got, want)
+    return None
+
+
 def scan(root, problems):
     checked = 0
     for current, dirs, files in os.walk(root):
@@ -84,16 +112,9 @@ def scan(root, problems):
             path = os.path.join(current, name)
             relative = os.path.relpath(path).replace(os.sep, '/')
             checked += 1
-            text = io.open(path, encoding='utf-8-sig').read(4000)
-            if OLD_NOTICE in text:
-                problems.append((relative, 'carries the superseded proprietary notice'))
-                continue
-            want = expected_for(relative)
-            got = declared_in(path)
-            if got is None:
-                problems.append((relative, 'no SPDX-License-Identifier in the first 30 lines'))
-            elif got != want:
-                problems.append((relative, 'declares %s, package expects %s' % (got, want)))
+            why = problem_with(path, relative)
+            if why is not None:
+                problems.append((relative, why))
     return checked
 
 

--- a/src/Abblix.Oidc.Server/Common/Configuration/MtlsAliasesOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/MtlsAliasesOptions.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP.
-
 namespace Abblix.Oidc.Server.Common.Configuration;
 
 /// <summary>

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Common;
 

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/TlsMetadataClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/TlsMetadataClientAuthenticator.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP.
-
 using System.Formats.Asn1;
 using System.Net;
 using System.Security.Cryptography;

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/TlsClientAuthOptions.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/TlsClientAuthOptions.cs
@@ -6,11 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-//
-// See license notes in repository root.
-
 namespace Abblix.Oidc.Server.Features.ClientInformation;
 
 /// <summary>

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Features.ClientInformation;

--- a/tests/Abblix.DependencyInjection.UnitTests/DecorateKeyedWithHttpClientTests.cs
+++ b/tests/Abblix.DependencyInjection.UnitTests/DecorateKeyedWithHttpClientTests.cs
@@ -5,9 +5,6 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/AddOidcCorsTests.cs
+++ b/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/AddOidcCorsTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Common.Constants;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/Program.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/Program.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Security.Cryptography;
 using System.Text;
 using Abblix.Jwt;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestInfrastructure/TestConstants.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/AutoAuthSessionService.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/AutoAuthSessionService.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Features.UserAuthentication;
 
 namespace Abblix.Oidc.Server.E2E.TestHost.TestStubs;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/AutoConsentsProvider.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/AutoConsentsProvider.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/PaymentInitiationValidator.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/PaymentInitiationValidator.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/StaticUserClaimsProvider.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/StaticUserClaimsProvider.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.UserAuthentication;

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/TestConsentOverrideMiddleware.cs
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/TestStubs/TestConsentOverrideMiddleware.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 
 namespace Abblix.Oidc.Server.E2E.TestHost.TestStubs;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/AssemblyFixtures.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/AssemblyFixtures.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.E2E.Tests;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Xunit;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Model/DiscoveryDocument.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Serialization;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Model;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/CorsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/CorsPolicyTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/EncryptedIdTokenTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/EncryptedIdTokenTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/IntrospectionCallerTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/IntrospectionCallerTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Jwt;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JarRichAuthorizationRequestsTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwksCacheTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwksCacheTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Xunit;
 
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtIntrospectionResponseTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtIntrospectionResponseTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net.Http.Headers;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtSecuredAuthorizationResponseTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/JwtSecuredAuthorizationResponseTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ModelValidationResponseTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ModelValidationResponseTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/NoneResponseTypeTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/NoneResponseTypeTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/OAuthMetadataEndpointTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/OAuthMetadataEndpointTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Model;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/OidcEndpointResolverTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/OidcEndpointResolverTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarConsentTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarConsentTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarMetadataTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarMetadataTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarTestBase.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RarTestBase.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 
 /// <summary>

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RequirePushedAuthorizationRequestsTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RequirePushedAuthorizationRequestsTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResourceIndicatorTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResponseModeRestrictionTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ResponseModeRestrictionTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RichAuthorizationRequestsTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.Model;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenEndpointClientAuthTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenEndpointClientAuthTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenExchangeTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TokenExchangeTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.Model;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TransportSecurityTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/TransportSecurityTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/TestBase.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Cryptography;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/TestFactory.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/TestFactory.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Microsoft.AspNetCore.Hosting;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/HttpClientConsentOverrideExtensions.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/HttpClientConsentOverrideExtensions.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.E2E.TestHost.TestStubs;
 

--- a/tests/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/PairwiseStaticUserClaimsProvider.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/PairwiseStaticUserClaimsProvider.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;

--- a/tests/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/TestServerAddress.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/TestInfrastructure/TestServerAddress.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Program.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Program.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Security.Cryptography;
 using System.Text;
 using Abblix.Jwt;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/TestInfrastructure/MinimalApiTestConstants.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/TestInfrastructure/MinimalApiTestConstants.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Abblix.Oidc.Server.MinimalApi.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BindingTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/BindingTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/FormEncodedAdapterTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/FormEncodedAdapterTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common.Constants;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/FormatterTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/FormatterTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/JwksCacheTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/JwksCacheTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/OidcEndpointResolverTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/OidcEndpointResolverTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.MinimalApi.E2E.TestHost.TestInfrastructure;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/OidcFlows.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/OidcFlows.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RoutingTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Json;

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/TestFactory.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/TestFactory.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 using Abblix.Oidc.Server.Common.Configuration;
 using Microsoft.AspNetCore.Hosting;

--- a/tests/Abblix.Oidc.Server.MinimalApi.UnitTests/OidcEndpointResolverTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.UnitTests/OidcEndpointResolverTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Diagnostics.CodeAnalysis;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.MinimalApi.Features.EndpointResolving;

--- a/tests/Abblix.Oidc.Server.Mvc.UnitTests/OidcEndpointResolverTests.cs
+++ b/tests/Abblix.Oidc.Server.Mvc.UnitTests/OidcEndpointResolverTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Mvc.Features.ConfigurableRoutes;
 using Abblix.Oidc.Server.Mvc.Features.EndpointResolving;

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Implementation/JsonSerializationBinderRarTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Implementation/JsonSerializationBinderRarTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Implementation;

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/PushModeValidatorRegistrationTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System;
 using System.Linq;
 using System.Reflection;

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenAuthorizationContextEvaluatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenAuthorizationContextEvaluatorTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System;
 using System.Buffers.Text;
 using System.Globalization;

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/Validation/MtlsUserInfoValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/UserInfo/Validation/MtlsUserInfoValidatorTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using System;
 using System.Buffers.Text;
 using System.Globalization;

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/JwtBearer/AddSecureHttpFetchIntegrationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/JwtBearer/AddSecureHttpFetchIntegrationTests.cs
@@ -6,9 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-
 using Abblix.Oidc.Server.Endpoints;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.JwtBearer;


### PR DESCRIPTION
61 files carried the licence header twice: the SPDX block, and under it a two-line remnant of the
notice it replaced. The SPDX sweep rewrote a header where it could recognise one and **prepended**
where it could not, and prepending is what left the pair.

**Why the linter missed it.** `OLD_NOTICE` names the verbose form, `LICENSE RESTRICTIONS`. The
remnant here is the short form, `Copyright (c) Abblix LLP. All rights reserved.`, which that phrase
never mentioned. A pattern taken from the instances in front of you is narrower than the class by
construction, and it fails silently in the direction that reads as success - the linter reported OK
over all 1693 files while 61 of them were wrong.

The check added here is structural instead: the header line may appear once. That follows from the
grammar of the thing rather than from any wording, so a third form of stale notice cannot slip past
it the way this one did.

**Also enforced here: every source file names the copyright holder.** That was already true of all
1693 files - removing the duplicate block left the `SPDX-FileCopyrightText: Copyright (c) Abblix LLP`
line of the surviving header untouched - but nothing checked it. The linter asked which licence a
file declares and never asked whose the file is; now it asks both, so the requirement holds by rule
rather than by luck.

**Verified on the result, not on intent:**

| check | result |
| --- | --- |
| lines the diff adds | 0 |
| removed lines that are not a comment or blank | 0 |
| removed lines total | 124 comments + 1 blank per file = 185 |
| solution build | clean, 0 warnings |
| licence linter over `src` and `tests` | OK, 1693 files |
| new check, on a planted duplicate | named the file, exit 1; silent once removed |
| `Abblix.DependencyInjection.UnitTests` | 128 pass |
| `Abblix.Oidc.Server.MinimalApi.E2E.Tests` | 74 pass |

Found while measuring something else, which is the usual way: the duplicate sat at the top of a test
file I opened for an unrelated reason.
