### PR TITLE
Pin every mTLS alias shape a deployment can configure

### DIFF
--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/DiscoveryMetadataTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/DiscoveryMetadataTests.cs
@@ -36,6 +36,11 @@ public sealed class DiscoveryMetadataTests(TestFactory factory) : IClassFixture<
 {
     private static readonly Uri MtlsBaseUri = new("https://mtls.example.com");
 
+    // Both derived from the one host above, so a deployment shape is described by its PATH here
+    // rather than by repeating an address the file already names.
+    private static readonly Uri MtlsGatewayBase = new(MtlsBaseUri, "/gateway");
+    private static readonly Uri DedicatedTokenAlias = new(MtlsBaseUri, "/dedicated/token");
+
     private HttpClient CreateClientFor(WebApplicationFactory<Program> host)
         => host.CreateClient(new WebApplicationFactoryClientOptions
         {
@@ -69,6 +74,138 @@ public sealed class DiscoveryMetadataTests(TestFactory factory) : IClassFixture<
 
         Assert.Equal(MtlsBaseUri.GetLeftPart(UriPartial.Authority), aliasedToken.GetLeftPart(UriPartial.Authority));
         Assert.Equal(token.AbsolutePath, aliasedToken.AbsolutePath);
+    }
+
+    /// <summary>
+    /// An explicitly named alias wins over the one the base URI would compute. A deployment that sets both is
+    /// saying the mutual-TLS endpoint is not simply the same path on another host, and rebasing over that would
+    /// publish an address the operator deliberately did not choose.
+    /// </summary>
+    [Fact]
+    public async Task An_explicit_alias_wins_over_the_one_the_base_uri_would_compute()
+    {
+        var chosen = DedicatedTokenAlias;
+        await using var host = HostWith(options =>
+        {
+            options.Discovery.MtlsBaseUri = MtlsBaseUri;
+            options.Discovery.MtlsEndpointAliases = new MtlsAliasesOptions { TokenEndpoint = chosen };
+        });
+        var client = CreateClientFor(host);
+
+        var discovery = await client.FetchDiscoveryAsync();
+
+        var aliases = discovery[ConfigurationResponse.Parameters.MtlsEndpointAliases]?.AsObject();
+        Assert.NotNull(aliases);
+        Assert.Equal(
+            chosen.AbsoluteUri,
+            aliases[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>());
+
+        // The endpoints left unnamed still follow the base, so setting one alias does not silently drop the rest.
+        var revocation = new Uri(aliases[ConfigurationResponse.Parameters.RevocationEndpoint]!.GetValue<string>());
+        Assert.Equal(MtlsBaseUri.GetLeftPart(UriPartial.Authority), revocation.GetLeftPart(UriPartial.Authority));
+    }
+
+    /// <summary>
+    /// A base URI carrying a path prefix keeps that prefix and the endpoint path, joined by exactly one
+    /// separator. Deployments put the mutual-TLS listener behind a gateway path rather than on its own host, and
+    /// a doubled or dropped slash there is a 404 for every certificate-bound client - the kind of mistake a test
+    /// asserting only the host would not see.
+    /// </summary>
+    [Fact]
+    public async Task An_mtls_base_with_a_path_keeps_the_prefix_and_the_endpoint_path()
+    {
+        var gateway = MtlsGatewayBase;
+        await using var host = HostWith(options => options.Discovery.MtlsBaseUri = gateway);
+        var client = CreateClientFor(host);
+
+        var discovery = await client.FetchDiscoveryAsync();
+
+        var aliases = discovery[ConfigurationResponse.Parameters.MtlsEndpointAliases]?.AsObject();
+        Assert.NotNull(aliases);
+
+        var token = new Uri(OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.TokenEndpoint));
+        var aliased = new Uri(aliases[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>());
+
+        Assert.Equal($"/gateway{token.AbsolutePath}", aliased.AbsolutePath);
+        Assert.DoesNotContain("//", aliased.AbsolutePath, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Named aliases with no base at all: the endpoints nobody named keep their ordinary addresses rather than
+    /// vanishing or being invented. A deployment that exposes one endpoint over mutual TLS is not thereby
+    /// claiming the others moved, and dropping them from the block would tell a client the opposite.
+    /// </summary>
+    [Fact]
+    public async Task Named_aliases_without_a_base_leave_the_other_endpoints_where_they_are()
+    {
+        await using var host = HostWith(options =>
+            options.Discovery.MtlsEndpointAliases = new MtlsAliasesOptions { TokenEndpoint = DedicatedTokenAlias });
+        var client = CreateClientFor(host);
+
+        var discovery = await client.FetchDiscoveryAsync();
+
+        var aliases = discovery[ConfigurationResponse.Parameters.MtlsEndpointAliases]?.AsObject();
+        Assert.NotNull(aliases);
+        Assert.Equal(
+            DedicatedTokenAlias.AbsoluteUri,
+            aliases[ConfigurationResponse.Parameters.TokenEndpoint]!.GetValue<string>());
+
+        // With nothing to rebase onto, an unnamed alias is the ordinary endpoint itself.
+        Assert.Equal(
+            OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.UserInfoEndpoint),
+            aliases[ConfigurationResponse.Parameters.UserInfoEndpoint]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// An endpoint switched off is absent from the alias block as well as from the document. Advertising a
+    /// mutual-TLS address for an endpoint this deployment does not serve sends certificate-bound clients at a
+    /// path that answers 404, and they would have no way to tell that from a misconfigured certificate.
+    /// </summary>
+    [Fact]
+    public async Task A_disabled_endpoint_is_missing_from_the_alias_block_too()
+    {
+        await using var host = HostWith(options =>
+        {
+            options.Discovery.MtlsBaseUri = MtlsBaseUri;
+            options.EnabledEndpoints &= ~OidcEndpoints.Revocation;
+        });
+        var client = CreateClientFor(host);
+
+        var discovery = await client.FetchDiscoveryAsync();
+
+        Assert.Null(discovery[ConfigurationResponse.Parameters.RevocationEndpoint]);
+
+        var aliases = discovery[ConfigurationResponse.Parameters.MtlsEndpointAliases]?.AsObject();
+        Assert.NotNull(aliases);
+        Assert.Null(aliases[ConfigurationResponse.Parameters.RevocationEndpoint]);
+
+        // The endpoints still served keep their aliases, so switching one off does not empty the block.
+        Assert.NotNull(aliases[ConfigurationResponse.Parameters.TokenEndpoint]);
+    }
+
+    /// <summary>
+    /// With endpoint path discovery switched off the document names no endpoint addresses at all - not the
+    /// ordinary ones and not the mutual-TLS aliases. The option exists for deployments that hand their clients
+    /// addresses out of band, and publishing them anyway would defeat the only reason to set it.
+    /// </summary>
+    [Fact]
+    public async Task With_path_discovery_off_the_document_names_no_endpoint_addresses()
+    {
+        await using var host = HostWith(options =>
+        {
+            options.Discovery.AllowEndpointPathsDiscovery = false;
+            options.Discovery.MtlsBaseUri = MtlsBaseUri;
+        });
+        var client = CreateClientFor(host);
+
+        var discovery = await client.FetchDiscoveryAsync();
+
+        Assert.Null(discovery[ConfigurationResponse.Parameters.TokenEndpoint]);
+        Assert.Null(discovery[ConfigurationResponse.Parameters.UserInfoEndpoint]);
+
+        // The issuer stays: it identifies the provider rather than locating an endpoint, and a client that
+        // cannot read it cannot validate a token from this server at all.
+        Assert.NotNull(discovery[ConfigurationResponse.Parameters.Issuer]);
     }
 
     /// <summary>


### PR DESCRIPTION
The discovery document had one alias test - a mutual-TLS base on its own host. Four other shapes an
operator can configure had none, and each is RFC 8705 section 5 behaviour a certificate-bound client
depends on.

| shape | what the test pins |
| --- | --- |
| explicit alias plus a base | the named alias wins; endpoints left unnamed still follow the base |
| base carrying a path prefix | prefix and endpoint path joined by exactly one separator |
| named aliases, no base | unnamed endpoints keep their ordinary addresses rather than vanishing |
| an endpoint switched off | absent from the alias block as well as from the document |
| path discovery off | no addresses at all, ordinary or aliased; the issuer stays |

Each of those is a wrong-address failure rather than a refusal: the client goes somewhere that
answers 404 or nowhere at all, and the server never learns of it.

**Proved to bite, twice.** Swapping the arms of the path-joining ternary fails the prefix test and
only that one. Inverting the enabled-endpoint check fails six, the disabled-endpoint test among
them. Both were checked against a binary confirmed newer than the edit - worth stating because the
first attempt at each mutation did not compile, the suite then ran the previous binary, and the
tests reported green. A stale pass looks exactly like a real one.

| | before | after |
| --- | --- | --- |
| untaken conditions in `ConfigurationResponseFormatter` | 12 | 1 |
| package branches | 76.9% | 79.9% |
| package lines | - | 95.5% |
| tests in the suite | 74 | 81, all green |

**What is deliberately not covered, with reasons** - the issue asks for this to be recorded:

- `ConfigurationResponseFormatter` line 152, a null URL from `LinkGenerator`. No configuration
  produces it.
- `IntrospectionResponseFormatter` lines 89, 90 and 94: `HttpContext` being null and an `Accept`
  entry with no media type. A real HTTP request cannot take either; the first is also defensive
  programming the code style asks to avoid.
- `OidcResults` - the 404 fallback of the client-read formatter and the DPoP overload's 400 arm.
  Both unreachable: the read endpoint can only fail with `invalid_token`, and the DPoP overload has
  one caller which always passes 401.
- `AuthorizationResponseFormatter` `MapSuccess`, 11 conditions on one line. Those are field-presence
  combinations in an object initialiser, not response shapes - the case this issue's own comment
  argues against chasing.

Item 4 needed nothing: `UserInfoResponseFormatter` is already at 2/2, covered by `SignedUserInfoTests`.

Closes items 3 and 4 of #305, and the reachable half of item 2.
