### PR TITLE
Ask the issuer where its keys are, instead of pinning the answer

### DIFF
--- a/src/Abblix.SecurityEvents/Infrastructure/JwksIssuerKeyResolver.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/JwksIssuerKeyResolver.cs
@@ -8,6 +8,7 @@
 using System.Collections.Concurrent;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Abblix.Jwt;
 using Abblix.SecurityEvents.Abstractions;
 using Microsoft.Extensions.Options;
@@ -87,19 +88,13 @@ public sealed class JwksIssuerKeyResolver(
 
     private async Task<IReadOnlyList<JsonWebKey>> FetchKeysAsync(string issuer, CancellationToken cancellationToken)
     {
-        var jwksUri = options.Value.ResolveJwksUri(issuer) ?? DeriveWellKnownUri(issuer);
+        var jwksUri = options.Value.ResolveJwksUri(issuer)
+            ?? await DiscoverJwksUriAsync(issuer, cancellationToken)
+            ?? DeriveWellKnownUri(issuer);
 
-        // The document behind this URI decides which signatures verify, so its transport is part
-        // of the trust: over cleartext HTTP, whoever sits on the path substitutes a key and every
-        // token they sign afterwards validates. Loopback stays permitted - a developer's local
-        // issuer offers no path for anyone to sit on.
-        if (jwksUri.Scheme != Uri.UriSchemeHttps && !jwksUri.IsLoopback)
-        {
-            throw new InvalidOperationException(
-                $"Refusing to fetch signature verification keys over '{jwksUri.Scheme}' from '{jwksUri}': "
-                + "a JWK Set fetched over cleartext can be substituted in transit. Serve it over HTTPS, "
-                + "or use a loopback address for local development.");
-        }
+        // Host-chosen when it came from the map, a selector or the convention; a discovered
+        // address was already checked against its own origin before it got here.
+        RequireSecureTransport(jwksUri, "signature verification keys", allowLoopback: true);
 
         using var client = httpClientFactory.CreateClient(JwksTransport.HttpClientName);
         var keySet = await client.GetFromJsonAsync<JsonWebKeySet>(jwksUri, cancellationToken)
@@ -111,6 +106,135 @@ public sealed class JwksIssuerKeyResolver(
         return keySet.Keys
             .Where(key => key.Usage is null or PublicKeyUsages.Signature)
             .ToArray();
+    }
+
+    /// <summary>
+    /// Asks the issuer where its keys are, when the host opted into that. Returns null when it did
+    /// not, leaving the caller's fallback in charge.
+    /// </summary>
+    /// <remarks>
+    /// A document that names no "jwks_uri" fails rather than falling back to the convention: a host
+    /// that turned this on did so to stop guessing, and quietly guessing again would put back the
+    /// snapshot it was trying to remove - visible only later, as signatures that stop verifying.
+    /// </remarks>
+    private async Task<Uri?> DiscoverJwksUriAsync(string issuer, CancellationToken cancellationToken)
+    {
+        if (!options.Value.UseDiscoveryDocument)
+            return null;
+
+        // Composed through the same normalisation as the map comparer and the well-known
+        // convention. A second spelling here would let the three disagree about one issuer, and
+        // the disagreement fetches a different document rather than failing.
+        var normalised = JwksKeyResolutionOptions.NormaliseIssuer(issuer);
+        var origin = new Uri(normalised);
+
+        // Composed from the normalised STRING, not from the Uri: Uri.ToString() of a bare
+        // authority carries a trailing slash, which would make this address double-slashed.
+        var discoveryUri = new Uri($"{normalised}/.well-known/openid-configuration");
+        RequireSecureTransport(discoveryUri, "the discovery document", allowLoopback: true);
+
+        using var client = httpClientFactory.CreateClient(JwksTransport.HttpClientName);
+        var document = await ReadDocumentAsync(client, discoveryUri, cancellationToken);
+
+        RequireDeclaredIssuer(document, discoveryUri, origin);
+
+        var declared = document.TryGetProperty("jwks_uri", out var jwksUri)
+                       && jwksUri.ValueKind == JsonValueKind.String
+            ? jwksUri.GetString()
+            : null;
+
+        if (!Uri.TryCreate(declared, UriKind.Absolute, out var resolved))
+        {
+            throw new InvalidOperationException(
+                $"The discovery document at '{discoveryUri}' names no usable \"jwks_uri\", so the keys of "
+                + $"'{issuer}' cannot be located. Point this issuer at its key set explicitly, or turn "
+                + $"{nameof(JwksKeyResolutionOptions.UseDiscoveryDocument)} off.");
+        }
+
+        // This address came out of a document rather than from this host, so the loopback
+        // exemption applies only when the issuer being trusted is itself loopback. Without that
+        // condition a remote issuer aims the receiver at its own loopback, over cleartext, on
+        // every cache miss.
+        RequireSecureTransport(resolved, "signature verification keys", allowLoopback: origin.IsLoopback);
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Reads the discovery document as a JSON object, so a response that is not one is named
+    /// here instead of surfacing as a type complaint from the reader with no address in it.
+    /// </summary>
+    private static async Task<JsonElement> ReadDocumentAsync(
+        HttpClient client,
+        Uri discoveryUri,
+        CancellationToken cancellationToken)
+    {
+        var document = await client.GetFromJsonAsync<JsonElement>(discoveryUri, cancellationToken);
+        if (document.ValueKind == JsonValueKind.Object)
+            return document;
+
+        throw new InvalidOperationException(
+            $"The discovery document at '{discoveryUri}' is {document.ValueKind}, not a JSON object. "
+            + "Point this issuer at its key set explicitly, or turn "
+            + $"{nameof(JwksKeyResolutionOptions.UseDiscoveryDocument)} off.");
+    }
+
+    /// <summary>
+    /// RFC 8414 Section 3.3: the "issuer" a document returns MUST be identical to the one whose
+    /// well-known URI was used to fetch it, and a document failing that MUST NOT be used.
+    /// </summary>
+    /// <remarks>
+    /// Compared as AbsoluteUri rather than with Uri.Equals, which ignores userinfo and fragment,
+    /// so "https://evil@op.example.com" would otherwise pass for "https://op.example.com".
+    /// Without this check a document served on one issuer path, or reached by a redirect, answers
+    /// for another issuer of the same host, and every token afterwards verifies against the wrong
+    /// key set.
+    /// </remarks>
+    private static void RequireDeclaredIssuer(JsonElement document, Uri discoveryUri, Uri origin)
+    {
+        var declared = document.TryGetProperty("issuer", out var issuerElement)
+                       && issuerElement.ValueKind == JsonValueKind.String
+            ? issuerElement.GetString()
+            : null;
+
+        if (Uri.TryCreate(declared, UriKind.Absolute, out var declaredIssuer)
+            && string.Equals(declaredIssuer.AbsoluteUri, origin.AbsoluteUri, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"The document at '{discoveryUri}' asserts the issuer '{declared}', not the '{origin}' "
+            + "it was fetched for; accepting it would let one issuer of a host answer for another "
+            + "(RFC 8414 Section 3.3).");
+    }
+
+    /// <summary>
+    /// The document behind this URI decides which signatures verify, so its transport is part of
+    /// the trust: over cleartext HTTP, whoever sits on the path substitutes a key and every token
+    /// they sign afterwards validates.
+    /// </summary>
+    /// <param name="uri">The address about to be fetched.</param>
+    /// <param name="what">What is being fetched, so a refusal names it.</param>
+    /// <param name="allowLoopback">
+    /// Whether cleartext over loopback is acceptable here. True for an address this host chose - a
+    /// developer local issuer offers no path for anyone to sit on. False for one a remote document
+    /// chose, where the exemption lets that document aim the receiver at its own loopback.
+    /// </param>
+    private static void RequireSecureTransport(Uri uri, string what, bool allowLoopback)
+    {
+        if (uri.Scheme == Uri.UriSchemeHttps)
+            return;
+
+        // Scheme first, then loopback: Uri.IsLoopback is true of "file:///keys.json" too, so a
+        // check asking only about loopback lets a non-HTTP scheme past the transport rule.
+        if (allowLoopback && uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback)
+            return;
+
+        throw new InvalidOperationException(
+            $"Refusing to fetch {what} over '{uri.Scheme}' from '{uri}': a document fetched over "
+            + "cleartext can be substituted in transit. Serve it over HTTPS, or use a loopback "
+            + "address for local development.");
     }
 
     private static Uri DeriveWellKnownUri(string issuer)

--- a/src/Abblix.SecurityEvents/Infrastructure/JwksKeyResolutionOptions.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/JwksKeyResolutionOptions.cs
@@ -156,4 +156,23 @@ public sealed class JwksKeyResolutionOptions
     /// within this window the miss answers from cache.
     /// </summary>
     public TimeSpan RolloverRefetchCooldown { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Asks the issuer where its keys are, instead of guessing. When no map entry and no selector
+    /// answers for an issuer, the resolver reads "jwks_uri" out of that issuer's discovery document
+    /// at "{issuer}/.well-known/openid-configuration" and fetches the keys from there.
+    /// </summary>
+    /// <remarks>
+    /// Off by default because it changes where an unconfigured issuer's keys come from, and a host
+    /// relying on the "{issuer}/.well-known/jwks.json" convention must not have that moved under it
+    /// by an upgrade.
+    /// <para>
+    /// What it buys is that the location follows the provider. A hand-written jwks_uri is a snapshot,
+    /// and the copies fail one-sidedly: move the key set at the provider and this receiver refuses
+    /// every token, while the same application's sign-in keeps working because it re-reads discovery.
+    /// The log then says the signature does not verify, which reads as a forged token rather than as
+    /// a configuration value that aged out, and the two places that disagree are never named.
+    /// </para>
+    /// </remarks>
+    public bool UseDiscoveryDocument { get; set; }
 }

--- a/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
@@ -406,6 +406,29 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Registers key resolution that asks each issuer where its keys are, reading "jwks_uri" from
+    /// that issuer's discovery document instead of pinning an address at composition time.
+    /// </summary>
+    /// <remarks>
+    /// Why an address pinned at composition time is worth removing:
+    /// <see cref="JwksKeyResolutionOptions.UseDiscoveryDocument"/>.
+    /// <para>
+    /// A named entry and any selector answer first, so a host that knows better about one issuer
+    /// keeps saying so; discovery stands where the well-known guess otherwise stands.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Cache lifetimes and any issuer-specific overrides, as usual.</param>
+    public static IServiceCollection AddDiscoveryKeyResolution(
+        this IServiceCollection services,
+        Action<JwksKeyResolutionOptions>? configure = null)
+        => services.AddJwksKeyResolution(options =>
+        {
+            options.UseDiscoveryDocument = true;
+            configure?.Invoke(options);
+        });
+
+    /// <summary>
     /// Registers the replay cache over the host's <c>IDistributedCache</c> as the
     /// <see cref="IReplayCache"/>.
     /// </summary>

--- a/src/Abblix.SecurityEvents/README.md
+++ b/src/Abblix.SecurityEvents/README.md
@@ -92,7 +92,9 @@ services.AddSecurityEvents(options =>
         "https://tenant.example.com/events/membership-changed");
     options.SigningKeySource = _ => Task.FromResult(signingKey); // transmitters only
 });
-services.AddJwksKeyResolution();      // receivers: issuers' keys from their published JWK Sets
+services.AddDiscoveryKeyResolution(); // receivers: each issuer names its own JWK Set in its
+                                      // discovery document, so the address follows a rotation
+                                      // (AddJwksKeyResolution pins one instead)
 services.AddDistributedMemoryCache(); // or Redis: the replay cache rides the host's IDistributedCache
 services.AddDistributedReplayCache(); // receivers: "jti" replay protection over that store,
                                      // held for SecurityEventTokenValidationOptions.ReplayRetention

--- a/tests/Abblix.SecurityEvents.UnitTests/InfrastructureIntegrationTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/InfrastructureIntegrationTests.cs
@@ -33,6 +33,34 @@ public class InfrastructureIntegrationTests
 
     private static readonly DateTimeOffset Now = DateTimeOffset.FromUnixTimeSeconds(1754040000);
 
+    /// <summary>
+    /// The discovery entry point turns the option on and still lets the caller configure the rest,
+    /// including turning it back off - the delegate runs last on purpose, so a host is never left
+    /// arguing with its own registration.
+    /// </summary>
+    [Fact]
+    public void AddDiscoveryKeyResolution_TurnsTheOptionOn_AndTheCallerStillHasTheLastWord()
+    {
+        var services = new ServiceCollection();
+        services.AddDiscoveryKeyResolution(options => options.CacheLifetime = TimeSpan.FromMinutes(3));
+
+        using (var provider = services.BuildServiceProvider())
+        {
+            var options = provider.GetRequiredService<IOptions<JwksKeyResolutionOptions>>().Value;
+            Assert.True(options.UseDiscoveryDocument);
+            Assert.Equal(TimeSpan.FromMinutes(3), options.CacheLifetime);
+            Assert.IsType<JwksIssuerKeyResolver>(provider.GetRequiredService<IIssuerKeyResolver>());
+        }
+
+        // Reading the four lines of the extension would not show which of the two writes wins.
+        var overriding = new ServiceCollection();
+        overriding.AddDiscoveryKeyResolution(options => options.UseDiscoveryDocument = false);
+
+        using var overridden = overriding.BuildServiceProvider();
+        Assert.False(overridden.GetRequiredService<IOptions<JwksKeyResolutionOptions>>()
+            .Value.UseDiscoveryDocument);
+    }
+
     [Fact]
     public void AddJwksKeyResolution_IsSelfSufficient_AndHonorsAHostPreRegistration()
     {

--- a/tests/Abblix.SecurityEvents.UnitTests/JwksIssuerKeyResolverTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/JwksIssuerKeyResolverTests.cs
@@ -7,6 +7,7 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.SecurityEvents.Infrastructure;
 using Microsoft.Extensions.Options;
@@ -47,6 +48,68 @@ public class JwksIssuerKeyResolverTests
         }
     }
 
+    /// <summary>
+    /// Serves a discovery document and a key set from two different addresses, recording the order
+    /// they were asked for: the order is the assertion, because reading the document is what makes
+    /// the key location the issuer's statement rather than this resolver's guess.
+    /// </summary>
+    private sealed class DiscoveringHandler(
+        Uri discoveryUri,
+        Uri jwksUri,
+        JsonWebKeySet keySet,
+        string? declaredIssuer = null) : HttpMessageHandler
+    {
+        public List<Uri> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri!;
+            Requests.Add(uri);
+
+            if (uri == discoveryUri)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new JsonObject
+                    {
+                        ["issuer"] = declaredIssuer ?? Issuer,
+                        ["jwks_uri"] = jwksUri.AbsoluteUri,
+                    }),
+                });
+            }
+
+            if (uri == jwksUri)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(keySet),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    /// <summary>Serves one JSON document to every address, recording what was asked for.</summary>
+    private sealed class StaticJsonHandler(JsonObject document) : HttpMessageHandler
+    {
+        public List<Uri> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri!);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(document),
+            });
+        }
+    }
+
     private sealed class SingleClientFactory(HttpMessageHandler handler) : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
@@ -60,11 +123,12 @@ public class JwksIssuerKeyResolverTests
 
     private static async Task<List<JsonWebKey>> Resolve(
         JwksIssuerKeyResolver resolver,
-        string? keyId = null)
+        string? keyId = null,
+        string? issuer = null)
     {
         var keys = new List<JsonWebKey>();
         await foreach (var key in resolver.ResolveSigningKeysAsync(
-                           Issuer, keyId, TestContext.Current.CancellationToken))
+                           issuer ?? Issuer, keyId, TestContext.Current.CancellationToken))
         {
             keys.Add(key);
         }
@@ -83,6 +147,162 @@ public class JwksIssuerKeyResolverTests
         var request = Assert.Single(handler.Requests);
         Assert.Equal(new Uri("https://issuer.example.com/.well-known/jwks.json"), request);
         Assert.Equal(key.KeyId, Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// With the discovery document in use, the keys come from the "jwks_uri" the issuer publishes,
+    /// at whatever address that names - and the document is read first. A guessed location is a
+    /// snapshot of where the keys were: move them at the provider and every token starts failing
+    /// signature verification here, while the same application's sign-in keeps working because it
+    /// re-reads discovery.
+    /// </summary>
+    [Fact]
+    public async Task WithDiscoveryEnabled_TheKeysComeFromTheAddressTheIssuerPublishes()
+    {
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256);
+        var discoveryUri = new Uri($"{Issuer}/.well-known/openid-configuration");
+        var jwksUri = new Uri("https://keys.example.net/tenants/7/signing-keys");
+        var handler = new DiscoveringHandler(discoveryUri, jwksUri, new JsonWebKeySet([key]));
+
+        var keys = await Resolve(Resolver(
+            handler,
+            new FakeTimeProvider(Now),
+            new JwksKeyResolutionOptions { UseDiscoveryDocument = true }));
+
+        Assert.Equal([discoveryUri, jwksUri], handler.Requests);
+        Assert.Equal(key.KeyId, Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// A discovery document that names no usable "jwks_uri" fails loudly instead of quietly guessing
+    /// the convention. A host turns discovery on to stop guessing; guessing again behind its back
+    /// would restore the snapshot it was removing, and the damage would surface much later as
+    /// signatures that stop verifying.
+    /// </summary>
+    [Fact]
+    public async Task ADiscoveryDocumentWithoutAKeyAddress_FailsNamingTheOption()
+    {
+        var discoveryUri = new Uri($"{Issuer}/.well-known/openid-configuration");
+        var handler = new StaticJsonHandler(new JsonObject { ["issuer"] = Issuer });
+
+        var resolver = Resolver(
+            handler,
+            new FakeTimeProvider(Now),
+            new JwksKeyResolutionOptions { UseDiscoveryDocument = true });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => Resolve(resolver));
+
+        Assert.Contains(discoveryUri.AbsoluteUri, error.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(JwksKeyResolutionOptions.UseDiscoveryDocument), error.Message, StringComparison.Ordinal);
+
+        // Positive form on purpose: "no request whose path ends in jwks.json" also passes when
+        // nothing was requested at all, and when the convention is respelled. Exactly one
+        // request, to the document, says what happened in both directions.
+        Assert.Equal(discoveryUri, Assert.Single(handler.Requests));
+    }
+
+    /// <summary>
+    /// A named entry still wins over discovery, so a host that knows better about one issuer keeps
+    /// saying so. Discovery replaces the guess that used to follow the map and the selectors, not
+    /// the host's own statement.
+    /// </summary>
+    [Fact]
+    public async Task ANamedEntry_Wins_OverDiscovery()
+    {
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256);
+        var named = new Uri("https://keys.example.org/named");
+        var handler = new DiscoveringHandler(
+            new Uri($"{Issuer}/.well-known/openid-configuration"),
+            named,
+            new JsonWebKeySet([key]));
+
+        var options = new JwksKeyResolutionOptions { UseDiscoveryDocument = true };
+        options.JwksUris[Issuer] = named;
+
+        var keys = await Resolve(Resolver(handler, new FakeTimeProvider(Now), options));
+
+        Assert.Equal(named, Assert.Single(handler.Requests));
+        Assert.Equal(key.KeyId, Assert.Single(keys).KeyId);
+    }
+
+    /// <summary>
+    /// RFC 8414 Section 3.3: a document asserting a different issuer than the one it was fetched
+    /// for MUST NOT be used. Without the check, a document served on one issuer path - or reached
+    /// by a redirect - answers for another issuer of the same host, and every token afterwards
+    /// verifies against the wrong key set, silently and permanently.
+    /// </summary>
+    [Fact]
+    public async Task ADocumentAssertingAnotherIssuer_IsRefused()
+    {
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256);
+        var discoveryUri = new Uri($"{Issuer}/.well-known/openid-configuration");
+        var handler = new DiscoveringHandler(
+            discoveryUri,
+            new Uri("https://keys.example.net/keys"),
+            new JsonWebKeySet([key]),
+            declaredIssuer: "https://other.example.com");
+
+        var resolver = Resolver(
+            handler,
+            new FakeTimeProvider(Now),
+            new JwksKeyResolutionOptions { UseDiscoveryDocument = true });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => Resolve(resolver));
+
+        Assert.Contains("https://other.example.com", error.Message, StringComparison.Ordinal);
+        Assert.Contains(Issuer, error.Message, StringComparison.Ordinal);
+
+        // Refused before the key set was fetched: the document decides which keys are trusted, so
+        // a rejected document must not still have chosen them.
+        Assert.Equal(discoveryUri, Assert.Single(handler.Requests));
+    }
+
+    /// <summary>
+    /// A key address the document chose does not inherit the loopback exemption, which exists for
+    /// an address this host chose. Otherwise an issuer reached over HTTPS aims the receiver at its
+    /// own loopback, over cleartext, on every cache miss - and the receiver makes that request
+    /// blind, on behalf of whoever wrote the document.
+    /// </summary>
+    [Fact]
+    public async Task ADiscoveredLoopbackAddress_IsRefused_WhenTheIssuerIsNot()
+    {
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256);
+        var discoveryUri = new Uri($"{Issuer}/.well-known/openid-configuration");
+        var handler = new DiscoveringHandler(
+            discoveryUri,
+            new Uri("http://127.0.0.1:8200/v1/secret/keys"),
+            new JsonWebKeySet([key]));
+
+        var resolver = Resolver(
+            handler,
+            new FakeTimeProvider(Now),
+            new JwksKeyResolutionOptions { UseDiscoveryDocument = true });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => Resolve(resolver));
+
+        Assert.Contains("cleartext", error.Message, StringComparison.Ordinal);
+        Assert.Equal(discoveryUri, Assert.Single(handler.Requests));
+    }
+
+    /// <summary>
+    /// The transport rule covers the discovery document itself, and refuses before any request
+    /// leaves: that document names the key set, so substituting it substitutes the keys.
+    /// </summary>
+    [Fact]
+    public async Task ACleartextIssuer_IsRefused_BeforeTheDocumentIsFetched()
+    {
+        var handler = new StaticJsonHandler(new JsonObject { ["issuer"] = "http://issuer.example.com" });
+
+        var resolver = Resolver(
+            handler,
+            new FakeTimeProvider(Now),
+            new JwksKeyResolutionOptions { UseDiscoveryDocument = true });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Resolve(resolver, issuer: "http://issuer.example.com"));
+
+        Assert.Contains("cleartext", error.Message, StringComparison.Ordinal);
+        Assert.Empty(handler.Requests);
     }
 
     [Fact]


### PR DESCRIPTION
A receiver's JWK Set address was a value written down when the host was composed: a map entry, a
selector, or failing both a guess at `{issuer}/.well-known/jwks.json`. All three are snapshots of
where the keys were.

**The copies fail one-sidedly**, which is what makes this worth removing rather than documenting.
Move the key set at the provider and the same application's sign-in keeps working, because its
handler re-reads discovery; the receiver refuses every token from that moment. The log says the
signature does not verify, so the first hypothesis is a forged token rather than a configuration
value that aged out - and the two places that disagree are never named.

```csharp
services.AddDiscoveryKeyResolution();   // jwks_uri comes from the issuer's discovery document
```

**Off unless asked for.** It changes where an unconfigured issuer's keys come from, and a host
relying on the convention must not have that moved under it by an upgrade.

**Precedence is unchanged, and now asserted rather than described.** A named entry and every
selector still answer first; discovery replaces only the guess that used to follow them. There is a
test for that, because a doc comment claiming it is not evidence.

**A document naming no usable `jwks_uri` fails loudly**, naming both the document and the option.
Falling back to the convention there would put back the snapshot the host turned this on to remove,
and the damage would surface later as signatures that stop verifying.

**The transport rule now covers the discovery document too.** It decides which key set is fetched,
so substituting it substitutes the keys. The check was extracted rather than duplicated, so the two
cannot drift apart.

**Red first.** The discovery test was written against the option before the resolver honoured it,
failed there, and passed once wired - with the binary confirmed newer than the edit, because a
failed build plus a test run gives a stale green that looks exactly like a real one.

| suite | result |
| --- | --- |
| `Abblix.SecurityEvents.UnitTests` | 261 |
| `Abblix.SecurityEvents.E2E.Tests` | 3 |
| `Abblix.SharedSignals.UnitTests` / `.E2E.Tests` | 155 / 4 |
| CAEP / RISC unit tests | 19 / 13 |
| solution build | clean |

**Scope.** This closes the copy that rots silently. The issuer and audience expectations stay
explicit - they are strings that do not age on their own, and a renamed client is a deliberate act
whose refusal names the audience. The overload reading from `OpenIdConnectOptions` is deliberately
not taken: it would make `Abblix.SecurityEvents.MinimalApi` depend on
`Microsoft.AspNetCore.Authentication.OpenIdConnect`, which is not in the shared framework in any
installed version, and that package has no external NuGet dependency today. This route also works
for hosts that never sign in through that handler, which the issue notes its own proposal would not
have covered.

Toward #360.
