### PR TITLE
Keep the registration members this server does not model

### DIFF
--- a/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -207,7 +207,12 @@ public static class EndpointRouteBuilderExtensions
                 .MapGet(routes.RegisterClient, ReadClientAsync)
                 .WithName(EndpointNames.RegisterClient);
 
-            oidcGroup.MapPut(routes.RegisterClient, UpdateClientAsync);
+            // The update endpoint (RFC 7592 Section 2.2) binds the same model as registration, ahead of the
+            // registration access token check, so it carries the same bound.
+            oidcGroup
+                .MapPut(routes.RegisterClient, UpdateClientAsync)
+                .WithMetadata(new RegistrationRequestSizeLimit(options.MaxRegistrationRequestSize));
+
             oidcGroup.MapDelete(routes.RegisterClient, RemoveClientAsync);
         }
 

--- a/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -201,7 +201,7 @@ public static class EndpointRouteBuilderExtensions
             oidcGroup
                 .MapPost(routes.Register, RegisterClientAsync)
                 .WithName(EndpointNames.Register)
-                .WithMetadata(new RegistrationRequestSizeLimit(options.MaxRegistrationRequestSize));
+                .BoundBy(options.MaxRegistrationRequestSize);
 
             oidcGroup
                 .MapGet(routes.RegisterClient, ReadClientAsync)
@@ -211,7 +211,7 @@ public static class EndpointRouteBuilderExtensions
             // registration access token check, so it carries the same bound.
             oidcGroup
                 .MapPut(routes.RegisterClient, UpdateClientAsync)
-                .WithMetadata(new RegistrationRequestSizeLimit(options.MaxRegistrationRequestSize));
+                .BoundBy(options.MaxRegistrationRequestSize);
 
             oidcGroup.MapDelete(routes.RegisterClient, RemoveClientAsync);
         }

--- a/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/EndpointRouteBuilderExtensions.cs
@@ -200,7 +200,8 @@ public static class EndpointRouteBuilderExtensions
         {
             oidcGroup
                 .MapPost(routes.Register, RegisterClientAsync)
-                .WithName(EndpointNames.Register);
+                .WithName(EndpointNames.Register)
+                .WithMetadata(new RegistrationRequestSizeLimit(options.MaxRegistrationRequestSize));
 
             oidcGroup
                 .MapGet(routes.RegisterClient, ReadClientAsync)

--- a/src/Abblix.Oidc.Server.MinimalApi/RegistrationRequestSizeLimit.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/RegistrationRequestSizeLimit.cs
@@ -1,0 +1,26 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Abblix.Oidc.Server.MinimalApi;
+
+/// <summary>
+/// Bounds the registration body at <see cref="OidcOptions.MaxRegistrationRequestSize"/>, as endpoint metadata
+/// the server reads before it reads the body.
+/// </summary>
+/// <remarks>
+/// The registration endpoint parses a foreign document and keeps the members it does not model, which costs
+/// several times the body's own size in memory. Model binding runs ahead of every validator, including the
+/// initial access token check, so nothing inside the pipeline is early enough to bound it - and an endpoint
+/// filter, which runs after binding, would refuse a request whose cost has already been paid. Metadata is the
+/// one hook the server consults first.
+/// </remarks>
+/// <param name="MaxRequestBodySize">The largest body the server will read, in bytes.</param>
+internal sealed record RegistrationRequestSizeLimit(long? MaxRequestBodySize) : IRequestSizeLimitMetadata;

--- a/src/Abblix.Oidc.Server.MinimalApi/RegistrationRequestSizeLimit.cs
+++ b/src/Abblix.Oidc.Server.MinimalApi/RegistrationRequestSizeLimit.cs
@@ -7,20 +7,49 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Oidc.Server.Common.Configuration;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 
 namespace Abblix.Oidc.Server.MinimalApi;
 
 /// <summary>
-/// Bounds the registration body at <see cref="OidcOptions.MaxRegistrationRequestSize"/>, as endpoint metadata
-/// the server reads before it reads the body.
+/// Bounds a request body at <see cref="OidcOptions.MaxRegistrationRequestSize"/>, as endpoint metadata the
+/// server reads before it reads the body.
 /// </summary>
 /// <remarks>
-/// The registration endpoint parses a foreign document and keeps the members it does not model, which costs
-/// several times the body's own size in memory. Model binding runs ahead of every validator, including the
-/// initial access token check, so nothing inside the pipeline is early enough to bound it - and an endpoint
-/// filter, which runs after binding, would refuse a request whose cost has already been paid. Metadata is the
-/// one hook the server consults first.
+/// The registration and update endpoints parse a foreign document and keep the members they do not model,
+/// which costs several times the body's own size in memory. Model binding runs ahead of every validator,
+/// including the initial access token check and the registration access token check, so nothing inside the
+/// pipeline is early enough to bound it - and an endpoint filter, which runs after binding, would refuse a
+/// request whose cost has already been paid. Metadata is the one hook the server consults first.
 /// </remarks>
 /// <param name="MaxRequestBodySize">The largest body the server will read, in bytes.</param>
 internal sealed record RegistrationRequestSizeLimit(long? MaxRequestBodySize) : IRequestSizeLimitMetadata;
+
+/// <summary>
+/// Attaches a body bound to an endpoint, or leaves it to whatever already bounds it.
+/// </summary>
+internal static class RequestSizeLimitExtensions
+{
+    /// <summary>
+    /// Declares <paramref name="maxRequestBodySize"/> as this endpoint's body bound; a cleared value attaches
+    /// nothing.
+    /// </summary>
+    /// <remarks>
+    /// The absence matters and is the whole reason this method exists. A null carried IN the metadata is not
+    /// "no bound of ours" - it is the value <c>DisableRequestSizeLimitAttribute</c> uses to switch the bound
+    /// off, because the routing middleware writes whatever the metadata says onto
+    /// <c>IHttpMaxRequestBodySizeFeature</c>, and a null there means unlimited. Attaching it would therefore
+    /// remove the server's own default (Kestrel's is 30,000,000 bytes) on exactly the endpoint that most
+    /// needs one, while reading in configuration as the safest possible setting. Measured on Kestrel: an
+    /// endpoint with no metadata refuses a 40 MB body with 413, the same endpoint carrying null-valued
+    /// metadata accepts it and reads all of it.
+    /// </remarks>
+    /// <param name="builder">The endpoint being mapped.</param>
+    /// <param name="maxRequestBodySize">The bound in bytes, or <c>null</c> to attach none.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static RouteHandlerBuilder BoundBy(this RouteHandlerBuilder builder, long? maxRequestBodySize)
+        => maxRequestBodySize is { } bytes
+            ? builder.WithMetadata(new RegistrationRequestSizeLimit(bytes))
+            : builder;
+}

--- a/src/Abblix.Oidc.Server.Mvc/Controllers/ClientManagementController.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Controllers/ClientManagementController.cs
@@ -58,6 +58,7 @@ public class ClientManagementController : ControllerBase
     [HttpPost(Path.Register)]
     [Produces(MediaTypeNames.Application.Json)]
     [Consumes(MediaTypeNames.Application.Json)]
+    [LimitsRegistrationRequestSize]
     public async Task<ActionResult> RegisterClientAsync(
         [FromServices] IRegisterClientHandler handler,
         [FromServices] IRegisterClientResponseFormatter formatter,

--- a/src/Abblix.Oidc.Server.Mvc/Controllers/ClientManagementController.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Controllers/ClientManagementController.cs
@@ -116,6 +116,7 @@ public class ClientManagementController : ControllerBase
     [HttpPut(Path.RegisterClient)]
     [Produces(MediaTypeNames.Application.Json)]
     [Consumes(MediaTypeNames.Application.Json)]
+    [LimitsRegistrationRequestSize]
     public async Task<ActionResult> UpdateClientAsync(
         [FromServices] IUpdateClientHandler handler,
         [FromServices] IUpdateClientResponseFormatter formatter,

--- a/src/Abblix.Oidc.Server.Mvc/Filters/LimitsRegistrationRequestSizeAttribute.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Filters/LimitsRegistrationRequestSizeAttribute.cs
@@ -1,0 +1,77 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Mvc.Filters;
+
+/// <summary>
+/// Refuses a registration body larger than <see cref="OidcOptions.MaxRegistrationRequestSize"/>.
+/// </summary>
+/// <remarks>
+/// A resource filter because it is the last stage that still runs ahead of model binding. The registration
+/// endpoint parses a foreign document and keeps the members it does not model, which costs several times the
+/// body's own size in memory, and binding runs before every validator - including the initial access token
+/// check. Expressed anywhere later, the bound would be paid for after the allocation it exists to prevent,
+/// and an anonymous caller would be the one spending it.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class LimitsRegistrationRequestSizeAttribute : Attribute, IAsyncResourceFilter
+{
+	/// <inheritdoc />
+	public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+	{
+		var limit = context.HttpContext.RequestServices
+			.GetRequiredService<IOptions<OidcOptions>>().Value.MaxRegistrationRequestSize;
+
+		var request = context.HttpContext.Request;
+
+		// Reading one byte past the limit is what distinguishes "exactly at the limit" from "over it", and
+		// reading is the only way to ask: a client that declares no length still sends a body, and a
+		// declared length is the client's claim about it rather than a measurement.
+		var buffer = new MemoryStream();
+		var copied = await CopyAtMostAsync(request.Body, buffer, limit + 1, context.HttpContext.RequestAborted);
+		if (copied > limit)
+		{
+			context.Result = new StatusCodeResult(StatusCodes.Status413PayloadTooLarge);
+			return;
+		}
+
+		// Binding reads the body next, and this one has already been drained.
+		buffer.Position = 0;
+		request.Body = buffer;
+		request.ContentLength = copied;
+
+		await next();
+	}
+
+	private static async Task<long> CopyAtMostAsync(
+		Stream source, Stream destination, long maxBytes, CancellationToken cancellationToken)
+	{
+		var buffer = new byte[8192];
+		var total = 0L;
+
+		while (total < maxBytes)
+		{
+			var wanted = (int)Math.Min(buffer.Length, maxBytes - total);
+			var read = await source.ReadAsync(buffer.AsMemory(0, wanted), cancellationToken);
+			if (read == 0)
+				break;
+
+			await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+			total += read;
+		}
+
+		return total;
+	}
+}

--- a/src/Abblix.Oidc.Server.Mvc/Filters/LimitsRegistrationRequestSizeAttribute.cs
+++ b/src/Abblix.Oidc.Server.Mvc/Filters/LimitsRegistrationRequestSizeAttribute.cs
@@ -16,32 +16,70 @@ using Microsoft.Extensions.Options;
 namespace Abblix.Oidc.Server.Mvc.Filters;
 
 /// <summary>
-/// Refuses a registration body larger than <see cref="OidcOptions.MaxRegistrationRequestSize"/>.
+/// Refuses a request body larger than <see cref="OidcOptions.MaxRegistrationRequestSize"/>.
 /// </summary>
 /// <remarks>
-/// A resource filter because it is the last stage that still runs ahead of model binding. The registration
-/// endpoint parses a foreign document and keeps the members it does not model, which costs several times the
-/// body's own size in memory, and binding runs before every validator - including the initial access token
-/// check. Expressed anywhere later, the bound would be paid for after the allocation it exists to prevent,
-/// and an anonymous caller would be the one spending it.
+/// A resource filter because it is the last stage that still runs ahead of model binding. The registration and
+/// update endpoints parse a foreign document and keep the members they do not model, which costs several times
+/// the body's own size in memory, and binding runs before every validator - including the initial access token
+/// check and the registration access token check. Expressed anywhere later, the bound would be paid for after
+/// the allocation it exists to prevent, and an anonymous caller would be the one spending it.
+/// <para>
+/// The bound is enforced here rather than handed to the server, unlike the minimal API adapter, which
+/// publishes it as endpoint metadata. The trade is deliberate and runs both ways: this holds on any server,
+/// including one that does not implement <c>IHttpMaxRequestBodySizeFeature</c>, and it produces a normal 413
+/// result instead of an exception thrown mid-action - but it buffers the body in managed memory to do so,
+/// where the metadata route costs nothing. A declared length over the limit is refused without reading
+/// anything, so only a body that hides its length behind chunked encoding is ever buffered.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
-internal sealed class LimitsRegistrationRequestSizeAttribute : Attribute, IAsyncResourceFilter
+internal sealed class LimitsRegistrationRequestSizeAttribute : Attribute, IAsyncResourceFilter, IOrderedFilter
 {
+	/// <summary>
+	/// Runs after <see cref="ConsumesAttribute"/>, which is also a resource filter of the same scope.
+	/// </summary>
+	/// <remarks>
+	/// Stated rather than left to the default, because both would otherwise sit at order 0 in the same scope
+	/// and their relative position would fall through to the order reflection happens to return attributes in,
+	/// which is not guaranteed. The order matters to what a caller is told: a body of the wrong content type
+	/// should be answered 415 without reading a byte, not buffered to the limit and answered 413.
+	/// </remarks>
+	public int Order => 1;
+
 	/// <inheritdoc />
 	public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
 	{
 		var limit = context.HttpContext.RequestServices
 			.GetRequiredService<IOptions<OidcOptions>>().Value.MaxRegistrationRequestSize;
 
+		// A cleared option means the deployment bounds the body elsewhere - at the server, or at a reverse
+		// proxy in front of it - and asked us not to add one of our own.
+		if (limit is not { } maxBytes)
+		{
+			await next();
+			return;
+		}
+
 		var request = context.HttpContext.Request;
 
+		// A declared length over the limit settles it without reading anything. It is the client's claim
+		// rather than a measurement, so it can only be trusted in this direction: a claim of being too large
+		// is not one anybody makes to get further in.
+		if (request.ContentLength > maxBytes)
+		{
+			context.Result = new StatusCodeResult(StatusCodes.Status413PayloadTooLarge);
+			return;
+		}
+
 		// Reading one byte past the limit is what distinguishes "exactly at the limit" from "over it", and
-		// reading is the only way to ask: a client that declares no length still sends a body, and a
-		// declared length is the client's claim about it rather than a measurement.
+		// reading is the only way to ask when no length was declared: a chunked body still arrives, and its
+		// size is knowable only by taking it.
 		var buffer = new MemoryStream();
-		var copied = await CopyAtMostAsync(request.Body, buffer, limit + 1, context.HttpContext.RequestAborted);
-		if (copied > limit)
+		context.HttpContext.Response.RegisterForDispose(buffer);
+
+		var copied = await CopyAtMostAsync(request.Body, buffer, maxBytes + 1, context.HttpContext.RequestAborted);
+		if (copied > maxBytes)
 		{
 			context.Result = new StatusCodeResult(StatusCodes.Status413PayloadTooLarge);
 			return;

--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -333,6 +333,30 @@ public record OidcOptions
 	/// names in return is interoperability, since client software cannot register itself unattended.
 	/// </remarks>
 	public bool RequireInitialAccessToken { get; set; } = true;
+
+	/// <summary>
+	/// The largest registration request body this server will read, in bytes. A body over the limit is
+	/// refused by the transport with 413 before any of it is parsed.
+	/// </summary>
+	/// <remarks>
+	/// The bound exists because the registration endpoint parses a foreign document and keeps the members
+	/// it does not model (<see cref="Model.ClientRegistrationRequest.AdditionalMembers"/>), which costs
+	/// several times the body's own size in memory. Model binding runs ahead of every validator, including
+	/// the initial access token check, so a bound expressed as a validator would be paid for after the
+	/// allocation it is meant to prevent; only a limit the transport enforces runs early enough.
+	/// <para>
+	/// The refusal is deliberately a transport one. RFC 7591 Section 2 requires the server to ignore
+	/// metadata it does not understand, so refusing a registration for carrying unknown members would
+	/// contradict it - whereas declining to read an oversized body is not a statement about metadata at all.
+	/// </para>
+	/// <para>
+	/// The default is generous next to a real registration: an inline JWKS with several keys, a software
+	/// statement and a long list of redirect URIs together stay well under a tenth of it. Raise it for a
+	/// deployment that genuinely needs more, and note that a host or reverse proxy may impose a lower
+	/// limit of its own, which wins.
+	/// </para>
+	/// </remarks>
+	public long MaxRegistrationRequestSize { get; set; } = 128 * 1024;
 
 	/// <summary>
 	/// The set of revoked initial access token identifiers (JWT subject claims).

--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -335,28 +335,39 @@ public record OidcOptions
 	public bool RequireInitialAccessToken { get; set; } = true;
 
 	/// <summary>
-	/// The largest registration request body this server will read, in bytes. A body over the limit is
-	/// refused by the transport with 413 before any of it is parsed.
+	/// The largest body the registration and update endpoints will read, in bytes, or <c>null</c> to leave
+	/// the bound entirely to the host. A body over the limit is answered 413 before it is bound.
 	/// </summary>
 	/// <remarks>
-	/// The bound exists because the registration endpoint parses a foreign document and keeps the members
-	/// it does not model (<see cref="Model.ClientRegistrationRequest.AdditionalMembers"/>), which costs
-	/// several times the body's own size in memory. Model binding runs ahead of every validator, including
-	/// the initial access token check, so a bound expressed as a validator would be paid for after the
-	/// allocation it is meant to prevent; only a limit the transport enforces runs early enough.
+	/// The bound exists because these endpoints parse a foreign document and keep the members they do not
+	/// model (<see cref="Model.ClientRegistrationRequest.AdditionalMembers"/>), which costs several times
+	/// the body's own size in memory. Model binding runs ahead of every validator, including the initial
+	/// access token check and the registration access token check, so a bound expressed as a validator
+	/// would be paid for after the allocation it is meant to prevent.
 	/// <para>
-	/// The refusal is deliberately a transport one. RFC 7591 Section 2 requires the server to ignore
-	/// metadata it does not understand, so refusing a registration for carrying unknown members would
-	/// contradict it - whereas declining to read an oversized body is not a statement about metadata at all.
+	/// The refusal is about length and never about content. RFC 7591 Section 2 requires the server to
+	/// ignore metadata it does not understand, so refusing a registration for carrying unknown members
+	/// would contradict it - whereas declining to read an oversized body is not a statement about metadata
+	/// at all, and a bound that counted unrecognised members would be.
+	/// </para>
+	/// <para>
+	/// How it is enforced differs by host, and the difference is worth knowing when sizing capacity.
+	/// A minimal API host publishes the value as endpoint metadata the server reads before the body, so
+	/// the refusal costs no managed memory - but a server that does not implement
+	/// <c>IHttpMaxRequestBodySizeFeature</c>, including the in-memory test server, ignores it. An MVC host
+	/// enforces it in a resource filter that buffers the body itself, which holds regardless of server and
+	/// costs up to this many bytes per concurrent request while the request is refused.
 	/// </para>
 	/// <para>
 	/// The default is generous next to a real registration: an inline JWKS with several keys, a software
 	/// statement and a long list of redirect URIs together stay well under a tenth of it. Raise it for a
-	/// deployment that genuinely needs more, and note that a host or reverse proxy may impose a lower
-	/// limit of its own, which wins.
+	/// deployment that genuinely needs more. A host or reverse proxy may impose a lower limit of its own,
+	/// which wins - and a deployment that would rather bound the body there alone sets this to <c>null</c>,
+	/// which is the one way to express "no limit of ours": every numeric value is a limit, so a very large
+	/// number asks an MVC host to buffer a very large body rather than removing the bound.
 	/// </para>
 	/// </remarks>
-	public long MaxRegistrationRequestSize { get; set; } = 128 * 1024;
+	public long? MaxRegistrationRequestSize { get; set; } = 128 * 1024;
 
 	/// <summary>
 	/// The set of revoked initial access token identifiers (JWT subject claims).

--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -361,10 +361,14 @@ public record OidcOptions
 	/// <para>
 	/// The default is generous next to a real registration: an inline JWKS with several keys, a software
 	/// statement and a long list of redirect URIs together stay well under a tenth of it. Raise it for a
-	/// deployment that genuinely needs more. A host or reverse proxy may impose a lower limit of its own,
-	/// which wins - and a deployment that would rather bound the body there alone sets this to <c>null</c>,
-	/// which is the one way to express "no limit of ours": every numeric value is a limit, so a very large
-	/// number asks an MVC host to buffer a very large body rather than removing the bound.
+	/// deployment that genuinely needs more.
+	/// </para>
+	/// <para>
+	/// Clearing it adds no bound of ours and removes none of anybody else's: the server's own limit still
+	/// applies (Kestrel defaults to 30,000,000 bytes) and so does whatever a reverse proxy in front of it
+	/// enforces, which is the point of clearing it. That is why it is expressed as an absent value rather
+	/// than as a very large number - a number is still a bound, and a very large one asks an MVC host to
+	/// buffer a very large body.
 	/// </para>
 	/// </remarks>
 	public long? MaxRegistrationRequestSize { get; set; } = 128 * 1024;

--- a/src/Abblix.Oidc.Server/Common/Configuration/RegistrationRequestSizeValidator.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/RegistrationRequestSizeValidator.cs
@@ -1,0 +1,45 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Common.Configuration;
+
+/// <summary>
+/// Refuses at startup a <see cref="OidcOptions.MaxRegistrationRequestSize"/> that no request could satisfy.
+/// </summary>
+/// <remarks>
+/// A non-positive limit takes the endpoints down rather than bounding them, and it does so differently on each
+/// host: an MVC host answers 413 to every registration, including a valid one of a few hundred bytes, while a
+/// minimal API host hands the value to a server that rejects it and answers 500. Neither reads as a
+/// configuration error at the point it surfaces, and both look to an operator like the endpoint being broken.
+/// <para>
+/// Zero is refused alongside a negative value because it means the same thing here: a request body always
+/// carries at least the two braces of an empty JSON object. A deployment that wants no bound of ours clears
+/// the option instead, which this validator lets through.
+/// </para>
+/// </remarks>
+public sealed class RegistrationRequestSizeValidator : IValidateOptions<OidcOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OidcOptions options)
+    {
+        if (options.MaxRegistrationRequestSize is not { } limit)
+            return ValidateOptionsResult.Success;
+
+        if (limit <= 0)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(OidcOptions.MaxRegistrationRequestSize)} is {limit}, which refuses every " +
+                $"registration and update request instead of bounding them. Set a positive number of bytes, " +
+                $"or clear it to leave the bound to the host.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -147,6 +147,11 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, DefaultResourceIndicatorValidator>());
 
+        // Refuse a registration body limit that would answer every request with a refusal, which surfaces as
+        // a broken endpoint rather than as the misconfiguration it is.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OidcOptions>, RegistrationRequestSizeValidator>());
+
         // TryAddAlias: a host that pre-registers its own client store must win over the
         // OidcOptions-backed default (issue #226) - same host-first contract as TryAdd* seams.
         return services

--- a/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -649,18 +649,30 @@ public record ClientRegistrationRequest
     /// unmapped half at parse time leaves no seam that could recover it - by the time any extension
     /// point runs, the information is gone.
     /// <para>
-    /// Keeping a member is not understanding it. RFC 7591 section 2 and OpenID Connect Dynamic Client
-    /// Registration 1.0 section 2 both require that the server ignore metadata it does not understand,
-    /// so nothing here may cause a registration to be refused and nothing here reaches the stored
-    /// client record. A host that wants to act on one of these members supplies the understanding, by
-    /// adding its own <see cref="Endpoints.DynamicClientManagement.Validation.IClientRegistrationContextValidator"/>
+    /// Keeping a member is not understanding it. RFC 7591 Section 2: "The authorization server MUST
+    /// ignore any client metadata sent by the client that it does not understand". OpenID Connect
+    /// Dynamic Client Registration 1.0 states the same rule in Section 3.2, about the response: "An
+    /// Authorization Server MAY ignore values provided by the client and MUST ignore any fields sent by
+    /// the Client that it does not understand". So nothing here may cause a registration to be refused
+    /// and nothing here reaches the stored client record. A host that wants to act on one of these
+    /// members supplies the understanding, by adding its own
+    /// <see cref="Endpoints.DynamicClientManagement.Validation.IClientRegistrationContextValidator"/>
     /// through the family API rather than by registering the contract directly.
+    /// </para>
+    /// <para>
+    /// These are body members and nothing else. A claim carried in a trusted <c>software_statement</c>
+    /// never appears here, so a host reading one of these values is reading the client's own assertion
+    /// even when the software statement contradicts it - and RFC 7591 Section 2 gives the software
+    /// statement precedence: "If the same client metadata name is present in both locations and the
+    /// software statement is trusted by the authorization server, the value of a claim in the software
+    /// statement MUST take precedence". A host acting on a member that its software statements can also
+    /// carry has to resolve that itself.
     /// </para>
     /// <para>
     /// What arrives here is attacker-controlled, unlike the provider metadata a client keeps the same
     /// way, and it is bounded only by the size of the request body - see
     /// <see cref="Common.Configuration.OidcOptions.MaxRegistrationRequestSize"/>, which refuses an
-    /// oversized body before it is parsed. This type must not be serialized outward: the extension
+    /// oversized body before it is bound. This type must not be serialized outward: the extension
     /// data is written back verbatim, so anything that serializes a request emits client-supplied JSON.
     /// The registration response is built from a separate type for that reason.
     /// </para>

--- a/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
+++ b/src/Abblix.Oidc.Server/Model/ClientRegistrationRequest.cs
@@ -7,6 +7,7 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Constants;
@@ -638,6 +639,34 @@ public record ClientRegistrationRequest
     /// </summary>
     [JsonPropertyName(Parameters.SoftwareStatement)]
     public string? SoftwareStatement { get; set; }
+
+    /// <summary>
+    /// The members of the registration this server does not model, kept as raw JSON rather than
+    /// discarded, so an extension can read metadata the core knows nothing about.
+    /// </summary>
+    /// <remarks>
+    /// This is a foreign document: a registering client sends its own metadata, and dropping the
+    /// unmapped half at parse time leaves no seam that could recover it - by the time any extension
+    /// point runs, the information is gone.
+    /// <para>
+    /// Keeping a member is not understanding it. RFC 7591 section 2 and OpenID Connect Dynamic Client
+    /// Registration 1.0 section 2 both require that the server ignore metadata it does not understand,
+    /// so nothing here may cause a registration to be refused and nothing here reaches the stored
+    /// client record. A host that wants to act on one of these members supplies the understanding, by
+    /// adding its own <see cref="Endpoints.DynamicClientManagement.Validation.IClientRegistrationContextValidator"/>
+    /// through the family API rather than by registering the contract directly.
+    /// </para>
+    /// <para>
+    /// What arrives here is attacker-controlled, unlike the provider metadata a client keeps the same
+    /// way, and it is bounded only by the size of the request body - see
+    /// <see cref="Common.Configuration.OidcOptions.MaxRegistrationRequestSize"/>, which refuses an
+    /// oversized body before it is parsed. This type must not be serialized outward: the extension
+    /// data is written back verbatim, so anything that serializes a request emits client-supplied JSON.
+    /// The registration response is built from a separate type for that reason.
+    /// </para>
+    /// </remarks>
+    [JsonExtensionData]
+    public IDictionary<string, JsonElement>? AdditionalMembers { get; init; }
 
     /// <summary>
     /// Wire-level parameter names for the dynamic client registration request (RFC 7591 and OpenID Connect

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
@@ -9,9 +9,17 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using Abblix.DependencyInjection;
+using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.Tests.Model;
+using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
+using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using RequestMembers = Abblix.Oidc.Server.Model.ClientRegistrationRequest.Parameters;
 using ResponseMembers = Abblix.Oidc.Server.Model.ClientRegistrationResponse.Parameters;
 using Xunit;
@@ -101,6 +109,136 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
         var error = body["error"];
         Assert.NotNull(error);
         Assert.Equal(ErrorCodes.InvalidRedirectUri, error.GetValue<string>());
+    }
+
+    /// <summary>
+    /// The registration response carries only what this server knows. A member the core does not model is
+    /// kept for an extension to read, and keeping it must not turn the endpoint into a mirror for whatever
+    /// JSON a stranger posts at it.
+    /// </summary>
+    [Fact]
+    public async Task An_unmodelled_member_is_not_echoed_in_the_response()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var metadata = NewClientMetadata("keeps-its-own-metadata");
+        metadata["x_vendor_tier"] = "gold";
+
+        var registered = await RegisterClientAsync(client, discovery, metadata);
+
+        Assert.NotNull(registered[ResponseMembers.ClientId]);
+
+        // The response is built from a separate type, so nothing the caller sent comes back by accident.
+        // Asserted rather than assumed: the day someone builds the response from the request, this says so.
+        Assert.Null(registered["x_vendor_tier"]);
+    }
+
+    /// <summary>
+    /// Records what an extension sees of a registration, which is the only vantage point from which "the
+    /// member survived" can be asserted: the response deliberately does not carry it, so a test reading the
+    /// response alone cannot tell a kept member from a discarded one.
+    /// </summary>
+    private sealed class CapturingValidator : IClientRegistrationContextValidator
+    {
+        public IDictionary<string, JsonElement>? Seen { get; private set; }
+
+        public Task<OidcError?> ValidateAsync(ClientRegistrationValidationContext context)
+        {
+            Seen = context.Request.AdditionalMembers;
+            return Task.FromResult<OidcError?>(null);
+        }
+    }
+
+    /// <summary>
+    /// A member the core does not model reaches an extension point intact, name and value. Remove the
+    /// extension data from the request model and the information is gone before anything a host registered
+    /// can run.
+    /// </summary>
+    /// <remarks>
+    /// The capturing validator joins the family through <c>Decompose().AddLast</c>, which is also half of
+    /// what this test proves. Registering the contract directly would replace the composed pipeline instead
+    /// of extending it, and the test would then pass over a host with no registration validation at all -
+    /// which is why it also asserts, in the same host, that an invalid registration is still refused.
+    /// </remarks>
+    [Fact]
+    public async Task An_unmodelled_member_reaches_an_extension_point()
+    {
+        var capturing = new CapturingValidator();
+        await using var host = Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.Decompose<IClientRegistrationContextValidator>()
+                    .AddLast(ServiceDescriptor.Singleton<IClientRegistrationContextValidator>(capturing))));
+
+        var client = host.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = TestServerAddress.BaseAddress,
+        });
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var metadata = NewClientMetadata("seen-by-an-extension");
+        metadata["x_vendor_tier"] = "gold";
+
+        await RegisterClientAsync(client, discovery, metadata);
+
+        Assert.NotNull(capturing.Seen);
+        Assert.True(capturing.Seen.TryGetValue("x_vendor_tier", out var tier));
+        Assert.Equal("gold", tier.GetString());
+
+        // Only the unmodelled member is here: everything the core models was parsed into its own property,
+        // and finding one of those here would mean the mapping had stopped working.
+        Assert.Equal(["x_vendor_tier"], capturing.Seen.Keys);
+
+        // The pipeline this validator joined is still whole. Without this the test would stay green over a
+        // host that validates nothing, and the added validator is exactly what could have caused that.
+        var invalid = NewClientMetadata("no-redirect-uri");
+        invalid.Remove(RequestMembers.RedirectUris);
+        var refusal = await client.PostAsJsonAsync(
+            discovery.RegistrationEndpoint, invalid, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, refusal.StatusCode);
+    }
+
+    /// <summary>
+    /// Members the core does not model never cause a refusal, however many of them arrive. RFC 7591
+    /// Section 2 and OpenID Connect Dynamic Client Registration 1.0 Section 2 both require the server to
+    /// ignore metadata it does not understand, and a count-based refusal would be a refusal for exactly
+    /// that reason.
+    /// </summary>
+    [Fact]
+    public async Task Many_unmodelled_members_are_ignored_rather_than_refused()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var metadata = NewClientMetadata("brings-a-lot");
+        for (var i = 0; i < 256; i++)
+            metadata[$"x_vendor_member_{i}"] = "value";
+
+        var registered = await RegisterClientAsync(client, discovery, metadata);
+
+        Assert.NotNull(registered[ResponseMembers.ClientId]);
+    }
+
+    /// <summary>
+    /// An oversized body is refused by the transport before it is parsed. This is the only bound that can
+    /// work: model binding materializes the unmodelled members ahead of every validator, so a bound
+    /// expressed as a validator would be paid for after the allocation it exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task An_oversized_registration_body_is_refused_before_it_is_parsed()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var metadata = NewClientMetadata("brings-too-much");
+        metadata["x_vendor_blob"] = new string('a', 256 * 1024);
+
+        var response = await client.PostAsJsonAsync(
+            discovery.RegistrationEndpoint, metadata, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
@@ -42,6 +42,10 @@ namespace Abblix.Oidc.Server.E2E.Tests.Scenarios;
 /// </remarks>
 public class ClientManagementTests(TestFactory factory) : TestBase(factory)
 {
+    // Named once: the same member is written into a request and looked for in a response and in an
+    // extension's view, and those three have to agree.
+    private const string VendorTier = "x_vendor_tier";
+
     private static JsonObject NewClientMetadata(string clientName) => new()
     {
         [RequestMembers.ClientName] = clientName,
@@ -123,7 +127,7 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
         var discovery = await FetchDiscoveryAsync(client);
 
         var metadata = NewClientMetadata("keeps-its-own-metadata");
-        metadata["x_vendor_tier"] = "gold";
+        metadata[VendorTier] = "gold";
 
         var registered = await RegisterClientAsync(client, discovery, metadata);
 
@@ -131,7 +135,7 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
 
         // The response is built from a separate type, so nothing the caller sent comes back by accident.
         // Asserted rather than assumed: the day someone builds the response from the request, this says so.
-        Assert.Null(registered["x_vendor_tier"]);
+        Assert.Null(registered[VendorTier]);
     }
 
     /// <summary>
@@ -178,17 +182,17 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
         var discovery = await FetchDiscoveryAsync(client);
 
         var metadata = NewClientMetadata("seen-by-an-extension");
-        metadata["x_vendor_tier"] = "gold";
+        metadata[VendorTier] = "gold";
 
         await RegisterClientAsync(client, discovery, metadata);
 
         Assert.NotNull(capturing.Seen);
-        Assert.True(capturing.Seen.TryGetValue("x_vendor_tier", out var tier));
+        Assert.True(capturing.Seen.TryGetValue(VendorTier, out var tier));
         Assert.Equal("gold", tier.GetString());
 
         // Only the unmodelled member is here: everything the core models was parsed into its own property,
         // and finding one of those here would mean the mapping had stopped working.
-        Assert.Equal(["x_vendor_tier"], capturing.Seen.Keys);
+        Assert.Equal([VendorTier], capturing.Seen.Keys);
 
         // The pipeline this validator joined is still whole. Without this the test would stay green over a
         // host that validates nothing, and the added validator is exactly what could have caused that.

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/ClientManagementTests.cs
@@ -9,10 +9,13 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Net.Mime;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.DependencyInjection;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.Tests.Model;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
@@ -20,6 +23,7 @@ using Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using RequestMembers = Abblix.Oidc.Server.Model.ClientRegistrationRequest.Parameters;
 using ResponseMembers = Abblix.Oidc.Server.Model.ClientRegistrationResponse.Parameters;
 using Xunit;
@@ -45,6 +49,10 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
     // Named once: the same member is written into a request and looked for in a response and in an
     // extension's view, and those three have to agree.
     private const string VendorTier = "x_vendor_tier";
+
+    // The member every size test pads with: named once so the boundary cases and the oversized cases
+    // measure the same document rather than two that happen to look alike.
+    private const string VendorPad = "x_vendor_blob";
 
     private static JsonObject NewClientMetadata(string clientName) => new()
     {
@@ -206,9 +214,9 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
 
     /// <summary>
     /// Members the core does not model never cause a refusal, however many of them arrive. RFC 7591
-    /// Section 2 and OpenID Connect Dynamic Client Registration 1.0 Section 2 both require the server to
-    /// ignore metadata it does not understand, and a count-based refusal would be a refusal for exactly
-    /// that reason.
+    /// Section 2 requires the server to ignore metadata it does not understand, and OpenID Connect Dynamic
+    /// Client Registration 1.0 Section 3.2 states the same rule, so a count-based refusal would be a
+    /// refusal for exactly that reason.
     /// </summary>
     [Fact]
     public async Task Many_unmodelled_members_are_ignored_rather_than_refused()
@@ -226,8 +234,8 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
     }
 
     /// <summary>
-    /// An oversized body is refused by the transport before it is parsed. This is the only bound that can
-    /// work: model binding materializes the unmodelled members ahead of every validator, so a bound
+    /// An oversized body is refused before it is bound. This is the only place a bound can work: model
+    /// binding materializes the unmodelled members ahead of every validator, so a bound
     /// expressed as a validator would be paid for after the allocation it exists to prevent.
     /// </summary>
     [Fact]
@@ -237,10 +245,83 @@ public class ClientManagementTests(TestFactory factory) : TestBase(factory)
         var discovery = await FetchDiscoveryAsync(client);
 
         var metadata = NewClientMetadata("brings-too-much");
-        metadata["x_vendor_blob"] = new string('a', 256 * 1024);
+        metadata[VendorPad] = new string('a', 256 * 1024);
 
         var response = await client.PostAsJsonAsync(
             discovery.RegistrationEndpoint, metadata, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The boundary itself, from both sides, over a body that declares no length - which is the case that
+    /// forces the server to measure rather than believe what it was told.
+    /// </summary>
+    /// <remarks>
+    /// Written as one theory over an overshoot of zero and one because the two cases are the same document
+    /// differing by a single byte: anything wider leaves the comparison free to drift by one in either
+    /// direction with every test still green, and the accepted side is the half that would drift silently.
+    /// </remarks>
+    [Theory]
+    [InlineData(0, HttpStatusCode.Created)]
+    [InlineData(1, HttpStatusCode.RequestEntityTooLarge)]
+    public async Task A_body_at_the_boundary_is_decided_by_one_byte(int overshoot, HttpStatusCode expected)
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+
+        var limit = Factory.Services.GetRequiredService<IOptions<OidcOptions>>()
+            .Value.MaxRegistrationRequestSize;
+        Assert.NotNull(limit);
+
+        var clientName = $"at-the-boundary-{overshoot}";
+
+        // Everything the document costs apart from the padding, measured rather than counted by hand: the
+        // point of the test is a single byte, so an assumption about the framing would decide the outcome.
+        var probe = NewClientMetadata(clientName);
+        probe[VendorPad] = string.Empty;
+        var framing = Encoding.UTF8.GetByteCount(probe.ToJsonString());
+
+        var metadata = NewClientMetadata(clientName);
+        metadata[VendorPad] = new string('a', (int)(limit.Value - framing) + overshoot);
+
+        var body = metadata.ToJsonString();
+        Assert.Equal(limit.Value + overshoot, Encoding.UTF8.GetByteCount(body));
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, discovery.RegistrationEndpoint)
+        {
+            Content = new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json),
+        };
+
+        // Chunked on purpose: a declared length is settled without reading, so it would exercise a
+        // different comparison than the one this test is about.
+        request.Content.Headers.ContentLength = null;
+        request.Headers.TransferEncodingChunked = true;
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The update endpoint carries the same bound. It binds the same model, and it does so ahead of the
+    /// registration access token check, so an unbounded one would leave the hole next door to the fix.
+    /// </summary>
+    [Fact]
+    public async Task An_oversized_update_body_is_refused_before_it_is_bound()
+    {
+        var client = CreateClient();
+        var discovery = await FetchDiscoveryAsync(client);
+        var registration = await RegisterAsync(client, discovery, "updates-too-much");
+
+        var metadata = NewClientMetadata("updates-too-much");
+        metadata[RequestMembers.ClientId] = registration.ClientId;
+        metadata[VendorPad] = new string('a', 256 * 1024);
+
+        using var request = Request(HttpMethod.Put, registration.ConfigurationUri, registration.AccessToken);
+        request.Content = JsonContent.Create(metadata);
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
     }

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RegistrationRequestSizeTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RegistrationRequestSizeTests.cs
@@ -14,6 +14,7 @@ using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.Model;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -73,6 +74,40 @@ public sealed class RegistrationRequestSizeTests(TestFactory factory) : IClassFi
 
         Assert.NotNull(limit);
         Assert.Equal(configured, limit.MaxRequestBodySize);
+    }
+
+    /// <summary>
+    /// A cleared limit attaches no metadata at all, rather than metadata carrying a cleared value.
+    /// </summary>
+    /// <remarks>
+    /// The distinction is the whole of it, and it runs the opposite way to how it reads. The routing
+    /// middleware writes whatever the metadata says onto <c>IHttpMaxRequestBodySizeFeature</c>, where a
+    /// cleared value means unlimited - it is the value <c>DisableRequestSizeLimitAttribute</c> is built on.
+    /// So attaching it would remove the server's own default on the one endpoint that most needs a bound,
+    /// while reading in configuration as the most cautious setting available. Measured on Kestrel while
+    /// writing this: an endpoint with no metadata refuses a 40 MB body with 413, and the same endpoint
+    /// carrying null-valued metadata accepts it and reads every byte.
+    /// </remarks>
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    public async Task A_cleared_limit_attaches_no_metadata(string method)
+    {
+        await using var host = factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.Configure<OidcOptions>(options => options.MaxRegistrationRequestSize = null)));
+
+        var services = host.Services;
+        var routes = services.GetRequiredService<IOptions<OidcRouteOptions>>().Value;
+        var route = method is "POST" ? routes.Register : routes.RegisterClient;
+
+        var endpoint = services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Single(candidate =>
+                candidate.RoutePattern.RawText == route
+                && candidate.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains(method));
+
+        Assert.Null(endpoint.Metadata.GetMetadata<IRequestSizeLimitMetadata>());
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RegistrationRequestSizeTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RegistrationRequestSizeTests.cs
@@ -1,0 +1,88 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
+using Abblix.Oidc.Server.Model;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Abblix.Oidc.Server.MinimalApi.E2E.Tests;
+
+/// <summary>
+/// The bound on the registration body, which is the only bound that runs early enough to matter: model binding
+/// materializes the members this server does not model ahead of every validator, so an oversized body is paid
+/// for before anything in the pipeline has an opinion about it.
+/// </summary>
+public sealed class RegistrationRequestSizeTests(TestFactory factory) : IClassFixture<TestFactory>
+{
+    private HttpClient CreateClient() => factory.CreateClient(new WebApplicationFactoryClientOptions
+    {
+        AllowAutoRedirect = false,
+        BaseAddress = TestFactory.BaseAddress,
+    });
+
+    /// <summary>
+    /// The endpoint carries the configured limit as metadata, which is where the server reads it - before the
+    /// endpoint's own delegate runs, and therefore before the body is bound.
+    /// </summary>
+    /// <remarks>
+    /// Asserted as metadata rather than as a refused request because enforcement belongs to the server, and the
+    /// in-memory test server does not enforce it. What can go wrong here is the wiring: an endpoint mapped
+    /// without the metadata is unbounded, and looks exactly like a bounded one from the outside.
+    /// </remarks>
+    [Fact]
+    public void The_registration_endpoint_carries_the_configured_body_limit()
+    {
+        var services = factory.Services;
+        var configured = services.GetRequiredService<IOptions<OidcOptions>>().Value.MaxRegistrationRequestSize;
+
+        var registration = services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Single(endpoint =>
+                endpoint.RoutePattern.RawText is "/connect/register"
+                && endpoint.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains(HttpMethods.Post));
+
+        var limit = registration.Metadata.GetMetadata<IRequestSizeLimitMetadata>();
+
+        Assert.NotNull(limit);
+        Assert.Equal(configured, limit.MaxRequestBodySize);
+    }
+
+    /// <summary>
+    /// A registration within the limit still goes through. The bound is generous next to a real registration,
+    /// and a limit that refuses ordinary traffic would be found by hosts rather than by this suite.
+    /// </summary>
+    [Fact]
+    public async Task A_registration_within_the_limit_is_accepted()
+    {
+        var client = CreateClient();
+        var discovery = await client.FetchDiscoveryAsync();
+
+        var response = await client.PostAsync(
+            OidcFlows.Endpoint(discovery, ConfigurationResponse.Parameters.RegistrationEndpoint),
+            JsonContent.Create(new JsonObject
+            {
+                [ClientRegistrationRequest.Parameters.ClientName] = $"within-the-limit-{Guid.NewGuid():N}",
+                [ClientRegistrationRequest.Parameters.RedirectUris] =
+                    new JsonArray { "https://client.example.com/callback" },
+                ["x_vendor_note"] = new string('a', 1024),
+            }),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+}

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RegistrationRequestSizeTests.cs
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/RegistrationRequestSizeTests.cs
@@ -36,27 +36,40 @@ public sealed class RegistrationRequestSizeTests(TestFactory factory) : IClassFi
     });
 
     /// <summary>
-    /// The endpoint carries the configured limit as metadata, which is where the server reads it - before the
-    /// endpoint's own delegate runs, and therefore before the body is bound.
+    /// Both endpoints that bind a registration document carry the configured limit as metadata, which is
+    /// where the server reads it - before the endpoint's own delegate runs, and therefore before the body
+    /// is bound.
     /// </summary>
     /// <remarks>
-    /// Asserted as metadata rather than as a refused request because enforcement belongs to the server, and the
-    /// in-memory test server does not enforce it. What can go wrong here is the wiring: an endpoint mapped
-    /// without the metadata is unbounded, and looks exactly like a bounded one from the outside.
+    /// Asserted as metadata rather than as a refused request because enforcement belongs to the server, and
+    /// the in-memory test server does not implement <c>IHttpMaxRequestBodySizeFeature</c> at all - a request
+    /// over the limit sails through it, so a test asserting a 413 here would be a check that cannot fail.
+    /// What can go wrong is the wiring: an endpoint mapped without the metadata is unbounded and looks
+    /// exactly like a bounded one from the outside, which is how the update endpoint was left open while
+    /// registration beside it was closed.
+    /// <para>
+    /// The routes are read from <see cref="OidcRouteOptions"/> rather than written out, because a host may
+    /// move them and this suite would then look for an endpoint nobody mapped - which surfaces as an
+    /// unrelated-looking crash rather than as an unbounded endpoint.
+    /// </para>
     /// </remarks>
-    [Fact]
-    public void The_registration_endpoint_carries_the_configured_body_limit()
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    public void Every_endpoint_binding_a_registration_carries_the_configured_body_limit(string method)
     {
         var services = factory.Services;
         var configured = services.GetRequiredService<IOptions<OidcOptions>>().Value.MaxRegistrationRequestSize;
+        var routes = services.GetRequiredService<IOptions<OidcRouteOptions>>().Value;
+        var route = method is "POST" ? routes.Register : routes.RegisterClient;
 
-        var registration = services.GetRequiredService<EndpointDataSource>().Endpoints
+        var endpoint = services.GetRequiredService<EndpointDataSource>().Endpoints
             .OfType<RouteEndpoint>()
-            .Single(endpoint =>
-                endpoint.RoutePattern.RawText is "/connect/register"
-                && endpoint.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains(HttpMethods.Post));
+            .Single(candidate =>
+                candidate.RoutePattern.RawText == route
+                && candidate.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains(method));
 
-        var limit = registration.Metadata.GetMetadata<IRequestSizeLimitMetadata>();
+        var limit = endpoint.Metadata.GetMetadata<IRequestSizeLimitMetadata>();
 
         Assert.NotNull(limit);
         Assert.Equal(configured, limit.MaxRequestBodySize);

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/RegistrationRequestSizeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/Configuration/RegistrationRequestSizeValidatorTests.cs
@@ -1,0 +1,72 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Common.Configuration;
+
+/// <summary>
+/// The startup refusal of a registration body limit no request could satisfy.
+/// </summary>
+/// <remarks>
+/// The value is worth refusing here because neither host reports it as a configuration fault: an MVC host
+/// answers 413 to every registration and a minimal API host answers 500, and both read to an operator as the
+/// endpoint being broken rather than as a number somebody set wrong.
+/// </remarks>
+public class RegistrationRequestSizeValidatorTests
+{
+    private static readonly RegistrationRequestSizeValidator Validator = new();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(long.MinValue)]
+    public void A_non_positive_limit_is_refused(long limit)
+    {
+        var result = Validator.Validate(null, new OidcOptions { MaxRegistrationRequestSize = limit });
+
+        Assert.True(result.Failed);
+        Assert.Contains(nameof(OidcOptions.MaxRegistrationRequestSize), result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(128 * 1024)]
+    [InlineData(long.MaxValue)]
+    public void A_positive_limit_is_accepted(long limit)
+    {
+        var result = Validator.Validate(null, new OidcOptions { MaxRegistrationRequestSize = limit });
+
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
+    /// A cleared limit is the one way to say the deployment bounds the body elsewhere, so it must pass -
+    /// otherwise the only escape from our bound would be a number, and every number is a bound.
+    /// </summary>
+    [Fact]
+    public void A_cleared_limit_is_accepted()
+    {
+        var result = Validator.Validate(null, new OidcOptions { MaxRegistrationRequestSize = null });
+
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
+    /// The default this server ships with survives its own validator. Stated because the two are written in
+    /// different files and nothing else makes them agree.
+    /// </summary>
+    [Fact]
+    public void The_shipped_default_is_accepted()
+    {
+        var result = Validator.Validate(null, new OidcOptions());
+
+        Assert.True(result.Succeeded);
+    }
+}


### PR DESCRIPTION
Closes #272.

## What a registration keeps

A registering client sends its own metadata. The core maps the members it knows and used to discard the rest while the JSON was being read, so no extension point could ever see them - by the time a host's own validator ran, the information was gone. The request model now keeps the unmapped members as raw JSON.

## Where the issue's bound went, and why

The issue asks for a bound "rejected loudly when exceeded". Implemented as a metadata refusal, that bound contradicts a normative MUST, and it would not work anyway.

**The specification.** RFC 7591 section 2: *"The authorization server MUST ignore any client metadata sent by the client that it does not understand (for instance, by silently removing unknown metadata from the client's registration record during processing)."* OpenID Connect Dynamic Client Registration 1.0 states the same rule in section 3.2, about the response: *"MUST ignore any fields sent by the Client that it does not understand."* Refusing a registration because it carries too many unknown members is a refusal for exactly the reason the clause forbids. The sentence following the RFC's MUST permits rejecting metadata *values*, which is a different question. Both documents were retrieved and read rather than recalled.

**The mechanics.** Model binding runs ahead of every validator, including the initial access token check, so a member count consulted afterwards is consulted after the allocation it exists to prevent - and an anonymous caller is the one who spent it. A count is also the wrong unit: sixty-four members of arbitrary size are still arbitrary.

So the bound is on the request body, refused before anything is bound. That is not a statement about metadata, so it does not collide with the clause above, and it is early enough to matter. It is configurable, and the two hosts enforce it differently, which is worth knowing when sizing capacity. Minimal API publishes it as endpoint metadata the server reads before the body, so the refusal costs no managed memory - but a server that does not implement `IHttpMaxRequestBodySizeFeature` ignores it, and the in-memory test server is one. MVC enforces it in a resource filter, the last stage before binding, which holds on any server and produces an ordinary 413 rather than an exception thrown mid-action, at the cost of buffering the body to measure it. A declared length over the limit is refused without reading anything, so only a body hiding its size behind chunked encoding is buffered at all.

## Kept out of scope

The kept members reach a registration validator and stop there - nothing copies them onto the stored client record. That is deliberate: the RFC's own example of ignoring unknown metadata is removing it from the registration record. Persisting them is a separate decision about the stored client model.

## Evidence

- Full suites green: 167 end-to-end, 83 Minimal API end-to-end, 2663 unit.
- Each guard proved by mutation, each failing only its own test: removing the extension data attribute; detaching the size filter from the MVC action; dropping the size metadata from the Minimal API endpoint.
- The extension-point test registers through the family API and then asserts, in the same host, that an invalid registration is still refused. Registering the contract directly instead replaces the composed pipeline rather than extending it, and that mutation produces 201 for a registration with no redirect URI - so without the second assertion the test would pass over a host that validates nothing.

## Corrected after review

An adversarial review of this branch found four things worth changing.

**The bound was missing on the endpoint next door.** `PUT /connect/register/{id}` (RFC 7592 section 2.2)
binds the same model, ahead of the registration access token check, and carried no bound on either host. The
hole this PR exists to close stayed open one route away. Both adapters bound it now, and the minimal API test
enumerates the methods rather than naming one.

**The OpenID Connect citation named a section that carries no such clause.** The MUST-ignore sentence is in
section 3.2, not section 2. The document was retrieved and swept for the word before the correction, and the
quotation above is now verbatim from it. Its neighbour from RFC 7591 section 2 came along: kept members are
body members only, so a host acting on one is reading the client's own assertion even where a trusted
software statement contradicts it, and the specification gives the software statement precedence.

**The option could not express "no bound of ours".** Every number is a bound, so a deployment preferring to
bound the body at its reverse proxy had no way to say so - a very large value asks an MVC host to buffer a
very large body. It is nullable now, and a non-positive value is refused at startup rather than answering 413
to every registration on MVC and 500 on minimal API.

**And the first version of that got it backwards.** A cleared value was published as metadata carrying null,
which is not "no bound of ours" - it is the value `DisableRequestSizeLimitAttribute` is built on, because the
routing middleware writes whatever the metadata says onto `IHttpMaxRequestBodySizeFeature` and a cleared
value there means unlimited. So the safest-looking setting in configuration removed the server's own default
on the endpoint that most needs a bound. Measured on Kestrel rather than reasoned about: an endpoint with no
metadata refuses a 40 MB body with 413, and the same endpoint carrying null-valued metadata answers 200 and
reads all 41,943,040 bytes. The bound is attached only when there is one, both endpoints go through the one
method that decides it, and a test asserts the absence on each.

**The boundary was tested nowhere.** Both surrounding tests sat far from it, so changing the comparison to
`>=` left the suite green. It is pinned from both sides now over a chunked body, one byte apart; the mutation
fails the accepting case and only that case.
