### PR TITLE
Judge a delivery address when it is proposed, not only when it is used

### DIFF
--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -76,20 +76,19 @@ public static class ServiceCollectionExtensions
             .AddHttpClient<PushDeliverySender>()
             .ConfigurePrimaryHttpMessageHandler<ReceiverAddressValidatingHandler>();
 
-        // Something has to drain the queues, and until this existed nothing did: a host wired the
-        // transmitter, mapped its endpoints, and watched events pile up with no error anywhere. A
-        // deployment that drives passes itself sets the interval to null.
+        // Something has to drain the queues, and nothing else does: a host that wires the transmitter
+        // and maps its endpoints watches events pile up with no error anywhere. A deployment driving
+        // passes of its own opts out by setting PushDeliveryInterval to null, and this sweeper carries
+        // no backoff, so leaving both running puts two pacing policies on one queue and the host's
+        // configured ceiling means nothing while the flat one retries beside it.
         //
-        // Registered only when there is an interval to sweep on, rather than always and idle. Always
-        // meant a host driving its own passes still ran this hosted service - harmless-looking, since
-        // it returns at once, and not harmless at all: register-by-default and opt-in are
-        // indistinguishable from the host's side, so nothing said a second sweeper existed except the
-        // log. That mattered because this sweeper carries no backoff, so a host that had configured a
-        // ceiling watched one sweeper honour it while this one retried at a flat interval beside it.
-        if (options.PushDeliveryInterval is not null)
-        {
-            services.AddHostedService<PushDeliveryScheduler>();
-        }
+        // The opt-out is read INSIDE the scheduler rather than here, and that is the whole reason it is
+        // registered unconditionally. TryAddSingleton above lets a host's own options instance win -
+        // which the parameter documentation promises - so the argument and the container are two
+        // sources for one fact. Deciding here would judge by the argument while every other reader saw
+        // the host's, and the disagreement is silent in both directions: no sweeper where the host
+        // configured one, or a sweeper the host opted out of.
+        services.AddHostedService<PushDeliveryScheduler>();
 
         return services;
     }

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -79,7 +79,17 @@ public static class ServiceCollectionExtensions
         // Something has to drain the queues, and until this existed nothing did: a host wired the
         // transmitter, mapped its endpoints, and watched events pile up with no error anywhere. A
         // deployment that drives passes itself sets the interval to null.
-        services.AddHostedService<PushDeliveryScheduler>();
+        //
+        // Registered only when there is an interval to sweep on, rather than always and idle. Always
+        // meant a host driving its own passes still ran this hosted service - harmless-looking, since
+        // it returns at once, and not harmless at all: register-by-default and opt-in are
+        // indistinguishable from the host's side, so nothing said a second sweeper existed except the
+        // log. That mattered because this sweeper carries no backoff, so a host that had configured a
+        // ceiling watched one sweeper honour it while this one retried at a flat interval beside it.
+        if (options.PushDeliveryInterval is not null)
+        {
+            services.AddHostedService<PushDeliveryScheduler>();
+        }
 
         return services;
     }

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -60,8 +60,17 @@ public static class ServiceCollectionExtensions
         // The issuer is a value, not a service, so the dispatcher is built through the factory
         // that overrides exactly that one parameter and resolves the rest - including the
         // sharing policy, which stays optional: a host that registered none runs without one.
-        services.TryAddSingleton(provider =>
-            provider.CreateService<EventDispatcher>(Dependency.Override(options.Issuer)));
+        //
+        // Resolved, not captured, for the reason the receiver half below states: TryAddSingleton lets
+        // a host's own options instance win, so closing over the argument would sign every SET with a
+        // value no other reader of the container sees. That one disagrees loudly at the far end and
+        // silently here - the stream configuration and the discovery document both advertise the
+        // container's issuer, so a receiver applying SSF 1.0 Section 7.2.2 refuses every token while
+        // this side records the POST as delivered.
+        services.TryAddSingleton(provider => provider.CreateService<EventDispatcher>(
+            Dependency.Override<string>(
+                serviceProvider => serviceProvider
+                    .GetRequiredService<SharedSignalsTransmitterOptions>().Issuer)));
 
         services.TryAddSingleton<StreamManagementService>();
         services.TryAddSingleton<PollEndpointHandler>();

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
@@ -52,34 +52,100 @@ public sealed class ReceiverAddressPolicy(
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
+        return JudgeByName(endpoint, out var refusal)
+            ? refusal
+            : await ResolvedRejectionOf(endpoint, cancellationToken);
+    }
+
+    /// <summary>
+    /// Why this transmitter will never deliver to the address AS WRITTEN, or null when its name alone
+    /// gives no reason to refuse.
+    /// </summary>
+    /// <param name="endpoint">The endpoint a receiver proposed for its stream.</param>
+    /// <remarks>
+    /// <para>
+    /// This is the question a REGISTRATION may answer, and it is a strict prefix of
+    /// <see cref="RejectionOf"/> rather than a second copy of it - so the two cannot come to disagree,
+    /// which is the whole reason there is one policy and not a rule restated at each call site.
+    /// </para>
+    /// <para>
+    /// Everything judged here is fixed the moment the receiver names the address: an operator's
+    /// permission, the scheme, a hostname spelling out this deployment's own network, an IP literal.
+    /// None of it can change between registration and delivery, so accepting such an address and then
+    /// refusing every push tells the receiver nothing the transmitter did not already know.
+    /// </para>
+    /// <para>
+    /// Resolution is deliberately NOT part of it. A name is resolved again for every pass, so an answer
+    /// given now says nothing about the next one - and a resolver that is briefly down is a condition an
+    /// operator recovers from, which delivery treats as one by holding the queue. Answered at
+    /// registration the identical fact becomes a terminal refusal, and a receiver registering while its
+    /// own DNS record is still propagating cannot tell that from a permanent misconfiguration.
+    /// </para>
+    /// </remarks>
+    public string? RejectionOfName(Uri endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        // Undecided reads as "no reason to refuse" here: the remaining question belongs to delivery.
+        return JudgeByName(endpoint, out var refusal) ? refusal : null;
+    }
+
+    /// <summary>
+    /// Judges what the address itself settles, and says whether it settled anything.
+    /// </summary>
+    /// <returns>
+    /// True when the name decides the outcome - <paramref name="refusal"/> then carries the reason, or
+    /// null for an address permitted outright. False when only resolution can answer.
+    /// </returns>
+    /// <remarks>
+    /// Three outcomes rather than two, because "permitted outright" and "nothing decided" are different
+    /// things and collapsing them costs one of them: an operator's allow-list entry and a public IP
+    /// literal are FINAL, so folding them into "undecided" would send an allowed private address on to
+    /// be resolved and refused for being private - which is what the allow-list exists to prevent.
+    /// </remarks>
+    private bool JudgeByName(Uri endpoint, out string? refusal)
+    {
+        refusal = null;
+
         if (options.AllowedReceiverAddresses is { Count: > 0 } allowed
             && allowed.Any(permitted => IsSameOrigin(endpoint, permitted)))
         {
             // An operator naming a destination outranks everything below, and it has to: a receiver deployed
             // inside the same network is reached at a private address by definition.
-            return null;
+            return true;
         }
 
         if (endpoint.Scheme != Uri.UriSchemeHttps)
         {
-            return $"delivery over '{endpoint.Scheme}' is refused: a security event token carries claims about "
+            refusal = $"delivery over '{endpoint.Scheme}' is refused: a security event token carries claims about "
                 + "a subject, and cleartext exposes them to anyone on the path";
+            return true;
         }
 
         if (PrivateNetworks.IsPrivateHostname(endpoint.Host))
         {
-            return $"the host '{endpoint.Host}' names the deployment's own network rather than a public receiver";
+            refusal = $"the host '{endpoint.Host}' names the deployment's own network rather than a public receiver";
+            return true;
         }
 
         if (IPAddress.TryParse(endpoint.Host, out var literal))
         {
-            return PrivateNetworks.IsPrivateOrReservedAddress(literal)
+            refusal = PrivateNetworks.IsPrivateOrReservedAddress(literal)
                 ? $"the address '{literal}' is private or reserved"
                 : null;
+            return true;
         }
 
-        // Resolved here rather than at configuration time, because the name is resolved again for every delivery
-        // and an answer that passed once says nothing about what it resolves to now.
+        return false;
+    }
+
+    /// <summary>Why the addresses this name resolves to are unusable, or null when they are not.</summary>
+    /// <remarks>
+    /// Resolved at delivery rather than at configuration time, because the name is resolved again for
+    /// every delivery and an answer that passed once says nothing about what it resolves to now.
+    /// </remarks>
+    private async Task<string?> ResolvedRejectionOf(Uri endpoint, CancellationToken cancellationToken)
+    {
         IPAddress[] addresses;
         try
         {

--- a/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
@@ -30,12 +30,18 @@ namespace Abblix.SharedSignals.Transmitter;
 /// <param name="outbox">The per-stream queues, dropped with their stream.</param>
 /// <param name="dispatcher">Mints and enqueues the framework's own signals.</param>
 /// <param name="options">The deployment's one-time decisions.</param>
+/// <param name="addressPolicy">
+/// Judges the delivery address a receiver proposes. The same policy the sender consults, deliberately:
+/// an address refused at delivery is refused for a reason that was already true when the receiver named
+/// it, and answering 201 to a stream that can never be delivered to tells the receiver nothing it can
+/// act on - the refusal then lives only in the transmitter's log.</param>
 /// <param name="clock">Measures the verification throttle; null takes the system clock.</param>
 public sealed class StreamManagementService(
     IStreamStore store,
     IEventOutbox outbox,
     EventDispatcher dispatcher,
     SharedSignalsTransmitterOptions options,
+    ReceiverAddressPolicy addressPolicy,
     TimeProvider? clock = null)
 {
     private readonly TimeProvider _clock = clock ?? TimeProvider.System;
@@ -71,6 +77,12 @@ public sealed class StreamManagementService(
             return ManagementResult<StreamConfiguration>.BadRequest(
                 "The requested delivery method is not supported by this transmitter "
                 + "(SSF 1.0 Section 8.1.1.1).");
+        }
+
+        if (await AddressRefusalOf(delivery, cancellationToken) is { } refusal)
+        {
+            return ManagementResult<StreamConfiguration>.BadRequest(
+                $"The delivery endpoint cannot be used by this transmitter: {refusal}.");
         }
 
         var configuration = new StreamConfiguration
@@ -178,6 +190,15 @@ public sealed class StreamManagementService(
             {
                 return ManagementResult<StreamConfiguration>.BadRequest(
                     "The requested delivery method is not supported by this transmitter.");
+            }
+
+            // Checked on the way in as well as at creation: a receiver that created a stream with an
+            // address this transmitter accepts can otherwise walk it onto one it does not, and the
+            // stream would be as undeliverable as if it had been created that way.
+            if (await AddressRefusalOf(delivery, cancellationToken) is { } refusal)
+            {
+                return ManagementResult<StreamConfiguration>.BadRequest(
+                    $"The delivery endpoint cannot be used by this transmitter: {refusal}.");
             }
 
             configuration = configuration with { Delivery = delivery };
@@ -571,6 +592,38 @@ public sealed class StreamManagementService(
             PollDeliveryMethod or null when options.PollEndpointFactory is { } pollEndpointOf =>
                 new PollDeliveryMethod(pollEndpointOf(streamId)),
             _ => null,
+        };
+
+    /// <summary>
+    /// Why this transmitter will never deliver to the proposed address, or null when it will.
+    /// </summary>
+    /// <remarks>
+    /// Asked here as well as at delivery, and by the same policy on purpose. The reasons an address is
+    /// refused - cleartext, or a host naming this deployment's own network - are true the moment the
+    /// receiver names it, so accepting the stream and refusing every push afterwards tells the receiver
+    /// nothing: its create succeeded, and the refusal lives only in a log it cannot read. Two checks
+    /// over one fact would drift; one policy consulted twice cannot.
+    ///
+    /// Poll delivery is not judged: the address in it is this transmitter's own, minted from
+    /// <see cref="SharedSignalsTransmitterOptions.PollEndpointFactory"/> rather than proposed from
+    /// outside, and nothing arrives from the receiver to judge.
+    ///
+    /// Every method is named, and an unnamed one throws rather than falling through to "nothing to
+    /// judge". A delivery method added later carries an address from somewhere, and the quiet answer
+    /// would exempt it from this check on the day it is written - the one shape this method exists to
+    /// prevent, arriving as a default that looks like agreement.
+    /// </remarks>
+    private async Task<string?> AddressRefusalOf(
+        StreamDeliveryMethod delivery, CancellationToken cancellationToken)
+        => delivery switch
+        {
+            PushDeliveryMethod push => await addressPolicy.RejectionOf(push.EndpointUrl, cancellationToken),
+            PollDeliveryMethod => null,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(delivery),
+                delivery.Method,
+                "This delivery method has no address rule, so nothing decided whether its endpoint may "
+                    + "be used. Name it here rather than letting it deliver unjudged."),
         };
 
     /// <summary>

--- a/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
@@ -5,6 +5,7 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Net;
 using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Events;
 using Abblix.SharedSignals.Model;
@@ -72,7 +73,7 @@ public sealed class StreamManagementService(
 
         var streamId = Guid.NewGuid().ToString("N");
 
-        var accepted = await AcceptDeliveryAsync(request.Delivery, streamId, cancellationToken);
+        var accepted = AcceptDelivery(request.Delivery, streamId);
         if (accepted.Body is not { } delivery)
         {
             return RefusalOf(accepted);
@@ -179,7 +180,7 @@ public sealed class StreamManagementService(
 
         if (request.Delivery is { } proposedDelivery)
         {
-            var accepted = await AcceptDeliveryAsync(proposedDelivery, stream.StreamId, cancellationToken);
+            var accepted = AcceptDelivery(proposedDelivery, stream.StreamId);
             if (accepted.Body is not { } delivery)
             {
                 return RefusalOf(accepted);
@@ -232,7 +233,7 @@ public sealed class StreamManagementService(
                 + "without a delivery method (SSF 1.0 Section 8.1.1.4).");
         }
 
-        var accepted = await AcceptDeliveryAsync(request.Delivery, stream.StreamId, cancellationToken);
+        var accepted = AcceptDelivery(request.Delivery, stream.StreamId);
         if (accepted.Body is not { } delivery)
         {
             return RefusalOf(accepted);
@@ -572,11 +573,20 @@ public sealed class StreamManagementService(
     /// the second check happen beside the first, so a path that asks only whether the METHOD is served
     /// stores an address every delivery pass then refuses. Any future write path has one method to
     /// reach for and gets both halves by having no way to ask for one.
+    ///
+    /// 400 on all three verbs, which is a decision rather than an oversight. SSF 1.0 Sections 8.1.1.3
+    /// and 8.1.1.4 list it for a request that is "otherwise invalid", which covers update and replace
+    /// outright. Section 8.1.1.1's table does not carry that phrase - its 400 is for a request that
+    /// cannot be parsed, and its prose adds only that a transmitter MAY answer 400 when it does not
+    /// support the delivery METHOD. An unusable ENDPOINT is unlisted there, and 403 ("the Event Receiver
+    /// is not allowed to create a stream") reads as a verdict about the receiver's permission rather
+    /// than about the address it wrote. Since the refusal reaches the receiver as a bare status code,
+    /// one answer across the three verbs is worth more than a per-verb code that would make a receiver
+    /// branch on the method it used to say the same wrong thing.
     /// </remarks>
-    private async Task<ManagementResult<StreamDeliveryMethod>> AcceptDeliveryAsync(
+    private ManagementResult<StreamDeliveryMethod> AcceptDelivery(
         StreamDeliveryMethod? proposed,
-        string streamId,
-        CancellationToken cancellationToken)
+        string streamId)
     {
         if (ResolveDelivery(proposed, streamId) is not { } delivery)
         {
@@ -584,7 +594,7 @@ public sealed class StreamManagementService(
                 "The requested delivery method is not supported by this transmitter.");
         }
 
-        if (await AddressRefusalOf(delivery, cancellationToken) is { } refusal)
+        if (AddressRefusalOf(delivery) is { } refusal)
         {
             return ManagementResult<StreamDeliveryMethod>.BadRequest(
                 $"The delivery endpoint cannot be used by this transmitter: {refusal}.");
@@ -598,10 +608,22 @@ public sealed class StreamManagementService(
     /// A refusal carries no body, so only the status and the operator-facing description travel. This
     /// exists so the three write paths return the ONE decision above rather than each restating it -
     /// restating is how two paths come to answer differently for the same cause.
+    ///
+    /// A success throws rather than being re-typed. The callers reach this on "no delivery to store",
+    /// which is not the same statement as "refused": <see cref="ManagementResult{TBody}"/> publishes a
+    /// body-less SUCCESS too, so an outcome added to <see cref="AcceptDelivery"/> through it would
+    /// otherwise be re-typed into a 2xx carrying nothing - a create answered to the receiver as having
+    /// succeeded while it stored no stream. Loud is the right failure for that: silent is a refusal
+    /// dressed as an acceptance, which is the one shape a caller cannot detect.
     /// </remarks>
     private static ManagementResult<StreamConfiguration> RefusalOf(
         ManagementResult<StreamDeliveryMethod> refused)
-        => new(refused.StatusCode, default, refused.Description);
+        => refused.StatusCode >= HttpStatusCode.BadRequest
+            ? new(refused.StatusCode, default, refused.Description)
+            : throw new ArgumentOutOfRangeException(
+                nameof(refused),
+                refused.StatusCode,
+                "Only a refusal is re-typed here, and this status is not one.");
 
     /// <summary>
     /// The receiver-visible delivery for a proposal: push keeps the receiver's endpoint, poll
@@ -623,10 +645,18 @@ public sealed class StreamManagementService(
     /// </summary>
     /// <remarks>
     /// Asked here as well as at delivery, and by the same policy on purpose. The reasons an address is
-    /// refused - cleartext, or a host naming this deployment's own network - are true the moment the
-    /// receiver names it, so accepting the stream and refusing every push afterwards tells the receiver
-    /// nothing: its create succeeded, and the refusal lives only in a log it cannot read. Two checks
-    /// over one fact would drift; one policy consulted twice cannot.
+    /// refused by its NAME - cleartext, or a host spelling out this deployment's own network - are true
+    /// the moment the receiver writes it, so accepting the stream and refusing every push afterwards
+    /// tells the receiver nothing: its create succeeded, and the refusal lives only in a log it cannot
+    /// read. Two checks over one fact would drift; one policy consulted twice cannot.
+    ///
+    /// <see cref="ReceiverAddressPolicy.RejectionOfName"/> rather than the whole question, because what
+    /// a name RESOLVES to is not settled at registration: it is looked up again for every pass, and a
+    /// resolver that is briefly down is a condition an operator recovers from - which delivery treats as
+    /// one by holding the queue. Answered here it would become a terminal 400, and a receiver
+    /// registering while its own record is still propagating could not tell that from a permanent
+    /// refusal. Asking only the fixed half also keeps this endpoint from driving the transmitter's
+    /// resolver at request rate against names a caller chooses.
     ///
     /// Poll delivery is not judged: the address in it is this transmitter's own, minted from
     /// <see cref="SharedSignalsTransmitterOptions.PollEndpointFactory"/> rather than proposed from
@@ -639,11 +669,10 @@ public sealed class StreamManagementService(
     /// throw and a quiet "nothing to judge" that exempts the new method from the check - and a delivery
     /// method carries an address from somewhere, so the exemption is the shape this guards against.
     /// </remarks>
-    private async Task<string?> AddressRefusalOf(
-        StreamDeliveryMethod delivery, CancellationToken cancellationToken)
+    private string? AddressRefusalOf(StreamDeliveryMethod delivery)
         => delivery switch
         {
-            PushDeliveryMethod push => await addressPolicy.RejectionOf(push.EndpointUrl, cancellationToken),
+            PushDeliveryMethod push => addressPolicy.RejectionOfName(push.EndpointUrl),
             PollDeliveryMethod => null,
             _ => throw new ArgumentOutOfRangeException(
                 nameof(delivery),

--- a/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
@@ -72,17 +72,10 @@ public sealed class StreamManagementService(
 
         var streamId = Guid.NewGuid().ToString("N");
 
-        if (ResolveDelivery(request.Delivery, streamId) is not { } delivery)
+        var accepted = await AcceptDeliveryAsync(request.Delivery, streamId, cancellationToken);
+        if (accepted.Body is not { } delivery)
         {
-            return ManagementResult<StreamConfiguration>.BadRequest(
-                "The requested delivery method is not supported by this transmitter "
-                + "(SSF 1.0 Section 8.1.1.1).");
-        }
-
-        if (await AddressRefusalOf(delivery, cancellationToken) is { } refusal)
-        {
-            return ManagementResult<StreamConfiguration>.BadRequest(
-                $"The delivery endpoint cannot be used by this transmitter: {refusal}.");
+            return RefusalOf(accepted);
         }
 
         var configuration = new StreamConfiguration
@@ -186,19 +179,10 @@ public sealed class StreamManagementService(
 
         if (request.Delivery is { } proposedDelivery)
         {
-            if (ResolveDelivery(proposedDelivery, stream.StreamId) is not { } delivery)
+            var accepted = await AcceptDeliveryAsync(proposedDelivery, stream.StreamId, cancellationToken);
+            if (accepted.Body is not { } delivery)
             {
-                return ManagementResult<StreamConfiguration>.BadRequest(
-                    "The requested delivery method is not supported by this transmitter.");
-            }
-
-            // Checked on the way in as well as at creation: a receiver that created a stream with an
-            // address this transmitter accepts can otherwise walk it onto one it does not, and the
-            // stream would be as undeliverable as if it had been created that way.
-            if (await AddressRefusalOf(delivery, cancellationToken) is { } refusal)
-            {
-                return ManagementResult<StreamConfiguration>.BadRequest(
-                    $"The delivery endpoint cannot be used by this transmitter: {refusal}.");
+                return RefusalOf(accepted);
             }
 
             configuration = configuration with { Delivery = delivery };
@@ -248,10 +232,10 @@ public sealed class StreamManagementService(
                 + "without a delivery method (SSF 1.0 Section 8.1.1.4).");
         }
 
-        if (ResolveDelivery(request.Delivery, stream.StreamId) is not { } delivery)
+        var accepted = await AcceptDeliveryAsync(request.Delivery, stream.StreamId, cancellationToken);
+        if (accepted.Body is not { } delivery)
         {
-            return ManagementResult<StreamConfiguration>.BadRequest(
-                "The requested delivery method is not supported by this transmitter.");
+            return RefusalOf(accepted);
         }
 
         var configuration = stream.Configuration with
@@ -580,6 +564,46 @@ public sealed class StreamManagementService(
     }
 
     /// <summary>
+    /// The delivery this transmitter will store for a proposal, or the refusal that stops it.
+    /// </summary>
+    /// <remarks>
+    /// Resolving a method and judging its address are one decision, so they are one call. Three verbs
+    /// write a stream's delivery - create, update and replace - and nothing in the type system makes
+    /// the second check happen beside the first, so a path that asks only whether the METHOD is served
+    /// stores an address every delivery pass then refuses. Any future write path has one method to
+    /// reach for and gets both halves by having no way to ask for one.
+    /// </remarks>
+    private async Task<ManagementResult<StreamDeliveryMethod>> AcceptDeliveryAsync(
+        StreamDeliveryMethod? proposed,
+        string streamId,
+        CancellationToken cancellationToken)
+    {
+        if (ResolveDelivery(proposed, streamId) is not { } delivery)
+        {
+            return ManagementResult<StreamDeliveryMethod>.BadRequest(
+                "The requested delivery method is not supported by this transmitter.");
+        }
+
+        if (await AddressRefusalOf(delivery, cancellationToken) is { } refusal)
+        {
+            return ManagementResult<StreamDeliveryMethod>.BadRequest(
+                $"The delivery endpoint cannot be used by this transmitter: {refusal}.");
+        }
+
+        return ManagementResult<StreamDeliveryMethod>.Ok(delivery);
+    }
+
+    /// <summary>The same refusal, for an endpoint whose successful body is the configuration.</summary>
+    /// <remarks>
+    /// A refusal carries no body, so only the status and the operator-facing description travel. This
+    /// exists so the three write paths return the ONE decision above rather than each restating it -
+    /// restating is how two paths come to answer differently for the same cause.
+    /// </remarks>
+    private static ManagementResult<StreamConfiguration> RefusalOf(
+        ManagementResult<StreamDeliveryMethod> refused)
+        => new(refused.StatusCode, default, refused.Description);
+
+    /// <summary>
     /// The receiver-visible delivery for a proposal: push keeps the receiver's endpoint, poll
     /// gets this transmitter's own URL - the "endpoint_url value is supplied by the
     /// Transmitter" (SSF 1.0 Section 8.1.1.1) - and an absent proposal means poll. Null when
@@ -608,10 +632,12 @@ public sealed class StreamManagementService(
     /// <see cref="SharedSignalsTransmitterOptions.PollEndpointFactory"/> rather than proposed from
     /// outside, and nothing arrives from the receiver to judge.
     ///
-    /// Every method is named, and an unnamed one throws rather than falling through to "nothing to
-    /// judge". A delivery method added later carries an address from somewhere, and the quiet answer
-    /// would exempt it from this check on the day it is written - the one shape this method exists to
-    /// prevent, arriving as a default that looks like agreement.
+    /// Every method is named and an unnamed one throws, though nothing can reach that arm as the code
+    /// stands: <see cref="ResolveDelivery"/> answers null for a method this transmitter does not serve,
+    /// and the caller refuses before asking here. The arm is for the day somebody teaches that method a
+    /// third delivery and not this one. The build is green either way, so the choice is between a loud
+    /// throw and a quiet "nothing to judge" that exempts the new method from the check - and a delivery
+    /// method carries an address from somewhere, so the exemption is the shape this guards against.
     /// </remarks>
     private async Task<string?> AddressRefusalOf(
         StreamDeliveryMethod delivery, CancellationToken cancellationToken)

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliverySchedulerTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliverySchedulerTests.cs
@@ -66,13 +66,23 @@ public class PushDeliverySchedulerTests
     private static ServiceProvider NewTransmitter(
         HttpMessageHandler origin,
         TimeProvider clock,
-        TimeSpan interval,
-        TimeSpan leaseDuration)
+        TimeSpan? interval,
+        TimeSpan leaseDuration,
+        SharedSignalsTransmitterOptions? hostOptions = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton(clock);
         services.AddSecurityEvents();
+
+        // Registered BEFORE the package, so its TryAddSingleton keeps this instance - the shape the
+        // method's own parameter documentation advertises, and the only way to hand the argument and
+        // the container two different answers about one setting.
+        if (hostOptions is not null)
+        {
+            services.AddSingleton(hostOptions);
+        }
+
         services.AddSharedSignalsTransmitter(new SharedSignalsTransmitterOptions
         {
             Issuer = Issuer,
@@ -270,6 +280,119 @@ public class PushDeliverySchedulerTests
             }
 
             Assert.Equal(1, origin.Requests);
+        }
+        finally
+        {
+            await scheduler.StopAsync(cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// A deployment that drives its own passes gets no sweep from the package, and the setting it is
+    /// read from is the one in the CONTAINER.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This sweeper carries no backoff, so running it beside a host's own scheduler puts two pacing
+    /// policies on one queue: the host's ceiling is honoured by one of them and ignored by the other,
+    /// and nothing but the log says a second sweeper exists.
+    /// </para>
+    /// <para>
+    /// The pre-registered case is the one that needs saying. The registration takes the options as an
+    /// argument and hands them to the container with TryAddSingleton, so a host that registered its
+    /// own instance first keeps it - which the parameter documentation promises. Deciding from the
+    /// argument would therefore judge by a value no other reader sees, and be wrong in both
+    /// directions: no sweeper where the host configured one, or a sweeper the host opted out of.
+    /// </para>
+    /// <para>
+    /// Both verdicts come from one setup, so neither reads as the other: nothing swept, then the same
+    /// wiring with the interval in place sweeps.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TheOptInIsReadFromTheContainer(bool throughTheHostsOwnOptions)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754040000));
+        var interval = TimeSpan.FromSeconds(30);
+
+        var silent = new AcceptingOrigin();
+        await using (var driven = NewTransmitter(silent, clock, null, TimeSpan.FromHours(1)))
+        {
+            await SweepAndWaitAsync(driven, clock, interval, silent, cancellationToken);
+
+            // The queue is read as well as the origin: "nothing was POSTed" alone would also be true
+            // of a pass that ran and found nothing to send.
+            Assert.Equal(0, silent.Requests);
+            Assert.Single(await driven.GetRequiredService<IEventOutbox>()
+                .PendingAsync("s-1", null, cancellationToken));
+        }
+
+        // The control, wired identically save for where the interval is set.
+        var sweeping = new AcceptingOrigin();
+        var hostOptions = throughTheHostsOwnOptions
+            ? new SharedSignalsTransmitterOptions
+            {
+                Issuer = Issuer,
+                PushDeliveryInterval = interval,
+                PushDeliveryLeaseDuration = TimeSpan.FromHours(1),
+                AllowedReceiverAddresses = [new Uri(ReceiverEndpoint)],
+            }
+            : null;
+
+        await using var configured = NewTransmitter(
+            sweeping,
+            clock,
+            throughTheHostsOwnOptions ? null : interval,
+            TimeSpan.FromHours(1),
+            hostOptions);
+
+        await SweepAndWaitAsync(configured, clock, interval, sweeping, cancellationToken);
+
+        Assert.Equal(1, sweeping.Requests);
+    }
+
+    /// <summary>Starts the sweeper if there is one, advances until it has delivered, and stops it.</summary>
+    /// <remarks>
+    /// <para>
+    /// An absent scheduler is a way of not sweeping rather than a broken arrangement, so it returns
+    /// instead of throwing. The measurement is what the receiver got, which is the same question
+    /// whether the sweeper stood down, was never registered, or ran and found nothing - and only that
+    /// makes the caller's assertion about DELIVERY rather than about the shape of the container.
+    /// </para>
+    /// <para>
+    /// Advanced repeatedly rather than once: the timer is created inside the service's own task, so a
+    /// single advance can land before it exists and be lost. The loop stops on the first delivery, so
+    /// a case expecting none pays the full count exactly once.
+    /// </para>
+    /// </remarks>
+    private static async Task SweepAndWaitAsync(
+        ServiceProvider provider,
+        FakeTimeProvider clock,
+        TimeSpan interval,
+        AcceptingOrigin origin,
+        CancellationToken cancellationToken)
+    {
+        await provider.GetRequiredService<IStreamStore>().TryCreateAsync(NewPushStream(), cancellationToken);
+        await provider.GetRequiredService<IEventOutbox>()
+            .EnqueueAsync("s-1", new OutboxItem("jti-1", "a.a.a"), cancellationToken);
+
+        if (provider.GetServices<IHostedService>().OfType<PushDeliveryScheduler>().SingleOrDefault()
+            is not { } scheduler)
+        {
+            return;
+        }
+
+        await scheduler.StartAsync(cancellationToken);
+        try
+        {
+            for (var attempt = 0; attempt < 50 && origin.Requests == 0; attempt++)
+            {
+                clock.Advance(interval);
+                await Task.Delay(10, cancellationToken);
+            }
         }
         finally
         {

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
@@ -19,6 +19,7 @@ using Abblix.SharedSignals.Receiver;
 using Abblix.SharedSignals.Receiver.SecurityEvent;
 using Abblix.SharedSignals.Transmitter;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -93,6 +94,41 @@ public class SharedSignalsServiceCollectionTests
             .BuildServiceProvider();
 
         Assert.Same(hostLease, provider.GetRequiredService<IDeliveryLease>());
+    }
+
+    /// <summary>
+    /// A host that drives delivery passes itself gets no sweeper of the package's own.
+    /// </summary>
+    /// <remarks>
+    /// The scheduler used to be registered whatever the options said, and its <c>ExecuteAsync</c>
+    /// returned immediately when the interval was null - so a host driving its own passes still ran a
+    /// second hosted service, and the only way to tell was to read its log. Worse, the two disagreed
+    /// about pacing: this scheduler carries no backoff, so a host that had configured one watched its
+    /// ceiling honoured by one sweeper and ignored by the other.
+    ///
+    /// "No interval" and "no scheduler" are one statement, and it is made once here rather than twice.
+    /// </remarks>
+    [Fact]
+    public void WithNoInterval_ThePackageRegistersNoSweeper()
+    {
+        using var driven = SecurityEventsBase()
+            .AddSharedSignalsTransmitter(TransmitterOptions with { PushDeliveryInterval = null })
+            .BuildServiceProvider();
+
+        Assert.DoesNotContain(
+            driven.GetServices<IHostedService>(), service => service is PushDeliveryScheduler);
+    }
+
+    /// <summary>The control: left at its default the package does sweep, or the assertion above is empty.</summary>
+    [Fact]
+    public void WithAnInterval_ThePackageSweeps()
+    {
+        using var defaults = SecurityEventsBase()
+            .AddSharedSignalsTransmitter(TransmitterOptions)
+            .BuildServiceProvider();
+
+        Assert.Contains(
+            defaults.GetServices<IHostedService>(), service => service is PushDeliveryScheduler);
     }
 
     [Fact]

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -94,41 +94,6 @@ public class SharedSignalsServiceCollectionTests
             .BuildServiceProvider();
 
         Assert.Same(hostLease, provider.GetRequiredService<IDeliveryLease>());
-    }
-
-    /// <summary>
-    /// A host that drives delivery passes itself gets no sweeper of the package's own.
-    /// </summary>
-    /// <remarks>
-    /// The scheduler used to be registered whatever the options said, and its <c>ExecuteAsync</c>
-    /// returned immediately when the interval was null - so a host driving its own passes still ran a
-    /// second hosted service, and the only way to tell was to read its log. Worse, the two disagreed
-    /// about pacing: this scheduler carries no backoff, so a host that had configured one watched its
-    /// ceiling honoured by one sweeper and ignored by the other.
-    ///
-    /// "No interval" and "no scheduler" are one statement, and it is made once here rather than twice.
-    /// </remarks>
-    [Fact]
-    public void WithNoInterval_ThePackageRegistersNoSweeper()
-    {
-        using var driven = SecurityEventsBase()
-            .AddSharedSignalsTransmitter(TransmitterOptions with { PushDeliveryInterval = null })
-            .BuildServiceProvider();
-
-        Assert.DoesNotContain(
-            driven.GetServices<IHostedService>(), service => service is PushDeliveryScheduler);
-    }
-
-    /// <summary>The control: left at its default the package does sweep, or the assertion above is empty.</summary>
-    [Fact]
-    public void WithAnInterval_ThePackageSweeps()
-    {
-        using var defaults = SecurityEventsBase()
-            .AddSharedSignalsTransmitter(TransmitterOptions)
-            .BuildServiceProvider();
-
-        Assert.Contains(
-            defaults.GetServices<IHostedService>(), service => service is PushDeliveryScheduler);
     }
 
     [Fact]

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,8 +18,11 @@ using Abblix.SharedSignals.Infrastructure;
 using Abblix.SharedSignals.Receiver;
 using Abblix.SharedSignals.Receiver.SecurityEvent;
 using Abblix.SharedSignals.Transmitter;
+using Abblix.SharedSignals.Events;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+using Abblix.SecurityEvents.Subjects;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -42,6 +45,89 @@ public class SharedSignalsServiceCollectionTests
     /// The Security Events core plus the two deployment-knowledge seams a real host wires with
     /// keys - faked here, because these tests measure wiring, not cryptography.
     /// </summary>
+    /// <summary>A signer that keeps what it was handed, so a test can read what was minted.</summary>
+    private sealed class RecordingSigner : ISecurityEventTokenSigner
+    {
+        public List<SecurityEventToken> Signed { get; } = [];
+
+        public Task<string> SignAsync(SecurityEventToken token, CancellationToken cancellationToken = default)
+        {
+            Signed.Add(token);
+            return Task.FromResult($"signed.{token.JwtId}");
+        }
+    }
+
+    /// <summary>Every SET is signed with the issuer the CONTAINER holds, not the one this call was handed.</summary>
+    /// <remarks>
+    /// <para>
+    /// The registration takes options as an argument and hands them over with TryAddSingleton, so a host
+    /// that registered its own instance first keeps it - which is the whole of what the parameter
+    /// documentation promises. Capturing the argument into the dispatcher would therefore sign every
+    /// token with a value no other reader of the container sees.
+    /// </para>
+    /// <para>
+    /// That disagreement is the loudest one this package can produce and the hardest to trace. The
+    /// stream configuration and the discovery document both carry the container's issuer, so a
+    /// conforming receiver checks "iss" against them (SSF 1.0 Section 7.2.2, and this library's own
+    /// StreamIssuerStep) and refuses every token - while this side records each POST as delivered.
+    /// Two logs, no shared identifier, and both of them describing a healthy system.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task TheIssuerIsResolved_NotCaptured()
+    {
+        const string hostIssuer = "https://tr.host.example.com";
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var signer = new RecordingSigner();
+        var services = SecurityEventsBase();
+        services.AddSingleton<ISecurityEventTokenSigner>(signer);
+
+        // Registered BEFORE the package call, which is what makes its TryAddSingleton a no-op and hands
+        // the argument and the container two different answers about one value.
+        services.AddSingleton(TransmitterOptions with { Issuer = hostIssuer });
+        services.AddSharedSignalsTransmitter(
+            TransmitterOptions with { Issuer = "https://placeholder.example.com" });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var stream = new StreamState
+        {
+            ReceiverId = "receiver-a",
+            Status = StreamStatuses.Enabled,
+            SubjectsMode = StreamSubjectsMode.None,
+            Configuration = new StreamConfiguration
+            {
+                StreamId = "s-1",
+                Issuer = hostIssuer,
+                Audiences = ["https://receiver.example.com"],
+                EventsDelivered = [],
+                Delivery = new PollDeliveryMethod(new Uri("https://tr.example.com/ssf/poll/s-1")),
+            },
+        };
+
+        Assert.True(await provider.GetRequiredService<IStreamStore>()
+            .TryCreateAsync(stream, cancellationToken));
+
+        await provider.GetRequiredService<EventDispatcher>().DispatchToStreamAsync(
+            stream,
+            new SecurityEventDescriptor
+            {
+                EventType = SharedSignalsEventTypes.StreamUpdated,
+                Subject = new OpaqueSubject(stream.Configuration.StreamId),
+                Payload = new StreamUpdatedEventPayload { Status = StreamStatuses.Enabled },
+            },
+            asStatusAnnouncement: true,
+            cancellationToken);
+
+        var minted = Assert.Single(signer.Signed);
+
+        // Against the stream's own issuer as well as the literal: these two are the pair a receiver
+        // compares, and the defect is precisely that they can differ.
+        Assert.Equal(hostIssuer, minted.Issuer);
+        Assert.Equal(stream.Configuration.Issuer, minted.Issuer);
+    }
+
     private static IServiceCollection SecurityEventsBase()
     {
         var services = new ServiceCollection();

--- a/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -6,6 +6,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 using System.Net;
+using System.Net.Sockets;
 using Abblix.SecurityEvents;
 using Abblix.SecurityEvents.Abstractions;
 using Abblix.SharedSignals.Model;
@@ -34,13 +35,15 @@ namespace Abblix.SharedSignals.UnitTests;
 /// which is the door a receiver reaches by accident: create with what works, then move the endpoint.
 /// </para>
 /// <para>
-/// The scheme is the part that makes this checkable up front. Unlike a resolved address, which may
-/// legitimately differ between registration and delivery, a scheme is fixed the moment the receiver
-/// names it - so refusing it later says nothing the transmitter did not already know.
+/// What a registration may judge is what the NAME settles: the scheme, a host spelling out this
+/// deployment's own network, an IP literal, an operator's permission. None of those can differ between
+/// registration and delivery, so refusing them later says nothing the transmitter did not already know.
+/// What the name RESOLVES to is not among them, and is left to delivery.
 /// </para>
 /// <para>
-/// The same policy answers both questions on purpose. Two checks over one fact drift apart, and this
-/// pair drifted the widest way possible: one of them did not exist.
+/// One policy answers both, and the registration question is a strict PREFIX of the delivery one rather
+/// than a second copy - so the two cannot come to disagree. A rule restated at a call site is a rule
+/// with two versions, and nothing tells you which one an address met.
 /// </para>
 /// </remarks>
 public class StreamAddressAtRegistrationTests
@@ -197,7 +200,57 @@ public class StreamAddressAtRegistrationTests
         Delivery = new PushDeliveryMethod(endpoint),
     };
 
-    private static StreamManagementService Service(IReadOnlyList<Uri>? allowed = null)
+    /// <summary>A registration does not resolve the name, so a resolver that is down does not refuse one.</summary>
+    /// <remarks>
+    /// <para>
+    /// Resolution is the one part of the address question that is NOT settled when the receiver writes
+    /// it: the name is looked up again for every pass. Delivery treats a resolver failure as a condition
+    /// an operator recovers from - it holds the queue rather than emptying it - and the same fact
+    /// answered at registration would be a terminal 400 instead, with no way for the receiver to tell it
+    /// from a permanent refusal. The ordinary case is not exotic: a receiver registers as it starts, and
+    /// its own DNS record may still be propagating.
+    /// </para>
+    /// <para>
+    /// The count is asserted as well as the outcome, because a 201 alone would also be true of a
+    /// resolver that was consulted and happened to answer.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ARegistration_DoesNotResolveTheName()
+    {
+        var resolutions = 0;
+        var service = Service(resolve: (_, _) =>
+        {
+            Interlocked.Increment(ref resolutions);
+            return Task.FromException<IPAddress[]>(new SocketException((int)SocketError.HostNotFound));
+        });
+
+        var created = await service.CreateStreamAsync(
+            Receiver, Request(Secure), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+        Assert.Equal(0, resolutions);
+    }
+
+    /// <summary>The control: delivery still asks the whole question, resolution included.</summary>
+    /// <remarks>
+    /// Without it the case above is satisfied by a policy that stopped resolving at all, which would
+    /// remove the check that keeps a public name resolving to a private address out of the network.
+    /// </remarks>
+    [Fact]
+    public async Task Delivery_StillJudgesWhatTheNameResolvesTo()
+    {
+        var policy = new ReceiverAddressPolicy(
+            new SharedSignalsTransmitterOptions { Issuer = "https://tr.example.com" },
+            (_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("169.254.169.254")]));
+
+        Assert.Null(policy.RejectionOfName(Secure));
+        Assert.NotNull(await policy.RejectionOf(Secure, TestContext.Current.CancellationToken));
+    }
+
+    private static StreamManagementService Service(
+        IReadOnlyList<Uri>? allowed = null,
+        ReceiverAddressPolicy.HostResolver? resolve = null)
     {
         var options = new SharedSignalsTransmitterOptions
         {
@@ -216,7 +269,8 @@ public class StreamAddressAtRegistrationTests
         // A resolver of the test's own, so the one branch of the policy that is not a string comparison
         // stays out of this file: a live DNS lookup would make these tests depend on a name nobody owns.
         var policy = new ReceiverAddressPolicy(
-            options, (_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("93.184.216.34")]));
+            options,
+            resolve ?? ((_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("93.184.216.34")])));
 
         return new StreamManagementService(store, outbox, dispatcher, options, policy, clock);
     }

--- a/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
@@ -1,0 +1,149 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Net;
+using Abblix.SecurityEvents;
+using Abblix.SecurityEvents.Abstractions;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// A delivery address the transmitter can never use is refused when the receiver proposes it, not
+/// every time delivery is attempted afterwards.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The address policy was consulted only by the sender, so a stream naming an address this transmitter
+/// refuses on principle - cleartext, or a host inside the transmitter's own network - was accepted with
+/// a 201 and then refused on every pass, forever. The receiver had no way to learn that: its create
+/// succeeded, and the refusal appeared only in the transmitter's log.
+/// </para>
+/// <para>
+/// The scheme is the part that makes this checkable up front. Unlike a resolved address, which may
+/// legitimately differ between registration and delivery, a scheme is fixed the moment the receiver
+/// names it - so refusing it later says nothing the transmitter did not already know.
+/// </para>
+/// <para>
+/// The same policy answers both questions on purpose. Two checks over one fact drift apart, and this
+/// pair drifted the widest way possible: one of them did not exist.
+/// </para>
+/// </remarks>
+public class StreamAddressAtRegistrationTests
+{
+    private const string Receiver = "receiver-a";
+    private const string EventType = "https://example.com/events/type-a";
+
+    private static readonly Uri Cleartext = new("http://receiver.example.com/ssf/push");
+    private static readonly Uri Secure = new("https://receiver.example.com/ssf/push");
+
+    [Fact]
+    public async Task ACleartextAddress_IsRefusedWhenItIsProposed()
+    {
+        var service = Service();
+
+        var created = await service.CreateStreamAsync(
+            Receiver, Request(Cleartext), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, created.StatusCode);
+    }
+
+    /// <summary>The control: the same request over https is created, so the refusal is about the address.</summary>
+    [Fact]
+    public async Task ASecureAddress_IsAccepted()
+    {
+        var service = Service();
+
+        var created = await service.CreateStreamAsync(
+            Receiver, Request(Secure), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+    }
+
+    /// <summary>An operator who named the origin gets it at registration too, not only at delivery.</summary>
+    /// <remarks>
+    /// Otherwise the escape hatch would be half an escape: the deployment that needs it is exactly the
+    /// one whose receiver cannot register.
+    /// </remarks>
+    [Fact]
+    public async Task ANamedOrigin_IsAcceptedEvenInCleartext()
+    {
+        var service = Service(allowed: [new Uri("http://receiver.example.com")]);
+
+        var created = await service.CreateStreamAsync(
+            Receiver, Request(Cleartext), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+    }
+
+    /// <summary>An update may not walk a live stream onto an address a create would have refused.</summary>
+    /// <remarks>
+    /// Checking only the create leaves the same hole one call further along, and that is the shape a
+    /// receiver reaches by accident: create with what works, then patch the endpoint.
+    /// </remarks>
+    [Fact]
+    public async Task AnUpdateOntoACleartextAddress_IsRefused()
+    {
+        var service = Service();
+        var ct = TestContext.Current.CancellationToken;
+
+        var created = await service.CreateStreamAsync(Receiver, Request(Secure), ct);
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+
+        var updated = await service.UpdateStreamAsync(
+            Receiver,
+            new UpdateStreamRequest
+            {
+                StreamId = created.Body!.StreamId,
+                Delivery = new PushDeliveryMethod(Cleartext),
+            },
+            ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, updated.StatusCode);
+    }
+
+    private static CreateStreamRequest Request(Uri endpoint) => new()
+    {
+        EventsRequested = [EventType],
+        Delivery = new PushDeliveryMethod(endpoint),
+    };
+
+    private static StreamManagementService Service(IReadOnlyList<Uri>? allowed = null)
+    {
+        var options = new SharedSignalsTransmitterOptions
+        {
+            Issuer = "https://tr.example.com",
+            EventsSupported = [EventType],
+            PollEndpointFactory = streamId => new Uri($"https://tr.example.com/ssf/poll/{streamId}"),
+            AllowedReceiverAddresses = allowed ?? [],
+        };
+
+        var store = new InMemoryStreamStore();
+        var outbox = new InMemoryEventOutbox();
+        var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754200000));
+        var dispatcher = new EventDispatcher(
+            NullLogger<EventDispatcher>.Instance, store, outbox, new NeverSigner(), options.Issuer, clock: clock);
+
+        // A resolver of the test's own, so the one branch of the policy that is not a string comparison
+        // stays out of this file: a live DNS lookup would make these tests depend on a name nobody owns.
+        var policy = new ReceiverAddressPolicy(
+            options, (_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("93.184.216.34")]));
+
+        return new StreamManagementService(store, outbox, dispatcher, options, policy, clock);
+    }
+
+    private sealed class NeverSigner : ISecurityEventTokenSigner
+    {
+        public Task<string> SignAsync(SecurityEventToken token, CancellationToken cancellationToken = default)
+            => Task.FromResult("signed");
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
@@ -23,10 +23,15 @@ namespace Abblix.SharedSignals.UnitTests;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The address policy was consulted only by the sender, so a stream naming an address this transmitter
-/// refuses on principle - cleartext, or a host inside the transmitter's own network - was accepted with
-/// a 201 and then refused on every pass, forever. The receiver had no way to learn that: its create
-/// succeeded, and the refusal appeared only in the transmitter's log.
+/// Consulted only by the sender, the policy would accept a stream naming an address this transmitter
+/// refuses on principle - cleartext, or a host inside the transmitter's own network - and then refuse
+/// every pass over it, forever. The receiver cannot learn that from a 201, and the refusal reaches
+/// only a log it has no access to.
+/// </para>
+/// <para>
+/// Every verb that writes a delivery is covered here, and each refusal is paired with the same request
+/// over https. Three verbs write one field, so a check on one of them leaves the hole one call along -
+/// which is the door a receiver reaches by accident: create with what works, then move the endpoint.
 /// </para>
 /// <para>
 /// The scheme is the part that makes this checkable up front. Unlike a resolved address, which may
@@ -109,6 +114,81 @@ public class StreamAddressAtRegistrationTests
             ct);
 
         Assert.Equal(HttpStatusCode.BadRequest, updated.StatusCode);
+    }
+
+    /// <summary>The control for the update: the same call over https goes through.</summary>
+    /// <remarks>
+    /// Without it the refusal above is satisfied by an update path that refuses every delivery it is
+    /// given, which is a check that cannot fail rather than a check.
+    /// </remarks>
+    [Fact]
+    public async Task AnUpdateOntoASecureAddress_IsAccepted()
+    {
+        var service = Service();
+        var ct = TestContext.Current.CancellationToken;
+
+        var created = await service.CreateStreamAsync(Receiver, Request(Secure), ct);
+
+        var updated = await service.UpdateStreamAsync(
+            Receiver,
+            new UpdateStreamRequest
+            {
+                StreamId = created.Body!.StreamId,
+                Delivery = new PushDeliveryMethod(new Uri("https://elsewhere.example.com/ssf/push")),
+            },
+            ct);
+
+        Assert.Equal(HttpStatusCode.OK, updated.StatusCode);
+    }
+
+    /// <summary>A replacement may not walk a live stream onto an address a create would have refused.</summary>
+    /// <remarks>
+    /// PUT is the verb the specification points a receiver at for exactly this - "use PATCH or PUT to
+    /// update or replace the existing stream configuration" (SSF 1.0 Section 8.1.1.1) - so a check that
+    /// covers create and update and not replace covers two doors of three.
+    /// </remarks>
+    [Fact]
+    public async Task AReplacementOntoACleartextAddress_IsRefused()
+    {
+        var service = Service();
+        var ct = TestContext.Current.CancellationToken;
+
+        var created = await service.CreateStreamAsync(Receiver, Request(Secure), ct);
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+
+        var replaced = await service.ReplaceStreamAsync(
+            Receiver,
+            new UpdateStreamRequest
+            {
+                StreamId = created.Body!.StreamId,
+                EventsRequested = [EventType],
+                Delivery = new PushDeliveryMethod(Cleartext),
+            },
+            ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, replaced.StatusCode);
+    }
+
+    /// <summary>The control for the replacement: the same call over https goes through.</summary>
+    [Fact]
+    public async Task AReplacementOntoASecureAddress_IsAccepted()
+    {
+        var service = Service();
+        var ct = TestContext.Current.CancellationToken;
+
+        var created = await service.CreateStreamAsync(Receiver, Request(Secure), ct);
+
+        var replaced = await service.ReplaceStreamAsync(
+            Receiver,
+            new UpdateStreamRequest
+            {
+                StreamId = created.Body!.StreamId,
+                EventsRequested = [EventType],
+                Delivery = new PushDeliveryMethod(new Uri("https://elsewhere.example.com/ssf/push")),
+            },
+            ct);
+
+        Assert.Equal(HttpStatusCode.OK, replaced.StatusCode);
     }
 
     private static CreateStreamRequest Request(Uri endpoint) => new()

--- a/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
@@ -97,7 +97,7 @@ public class StreamManagementServiceTests
             NullLogger<EventDispatcher>.Instance, store, outbox, signer, options.Issuer, clock: clock);
 
         return new Harness(
-            new StreamManagementService(store, outbox, dispatcher, options, clock),
+            new StreamManagementService(store, outbox, dispatcher, options, PolicyFor(options), clock),
             store, outbox, signer, clock);
     }
 
@@ -188,7 +188,7 @@ public class StreamManagementServiceTests
         var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754200000));
         var dispatcher = new EventDispatcher(
             NullLogger<EventDispatcher>.Instance, store, outbox, new StubSigner(), options.Issuer, clock: clock);
-        var service = new StreamManagementService(store, outbox, dispatcher, options, clock);
+        var service = new StreamManagementService(store, outbox, dispatcher, options, PolicyFor(options), clock);
 
         var created = await service.CreateStreamAsync(
             Receiver, new CreateStreamRequest { EventsRequested = [TypeA] }, ct);
@@ -233,7 +233,7 @@ public class StreamManagementServiceTests
         var clock = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1754200000));
         var dispatcher = new EventDispatcher(
             NullLogger<EventDispatcher>.Instance, store, outbox, new StubSigner(), options.Issuer, clock: clock);
-        var service = new StreamManagementService(store, outbox, dispatcher, options, clock);
+        var service = new StreamManagementService(store, outbox, dispatcher, options, PolicyFor(options), clock);
 
         var created = await service.CreateStreamAsync(
             Receiver, new CreateStreamRequest { EventsRequested = [TypeA] }, ct);
@@ -482,4 +482,13 @@ public class StreamManagementServiceTests
             TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.NoContent, afterInterval.StatusCode);
     }
+
+    /// <summary>
+    /// The address policy these tests hand to the service, with a resolver of their own: the one branch
+    /// of the policy that is not a string comparison would otherwise reach a live DNS for a name nobody
+    /// owns, and the test would measure the network.
+    /// </summary>
+    private static ReceiverAddressPolicy PolicyFor(SharedSignalsTransmitterOptions options)
+        => new(options, (_, _) => Task.FromResult<System.Net.IPAddress[]>(
+            [System.Net.IPAddress.Parse("93.184.216.34")]));
 }

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
@@ -252,7 +252,7 @@ public class TransmitterDeliveryTests
         var options = new SharedSignalsTransmitterOptions { Issuer = "https://tr.example.com" };
         var dispatcher = new EventDispatcher(
             NullLogger<EventDispatcher>.Instance, store, outbox, signer, options.Issuer);
-        var service = new StreamManagementService(store, outbox, dispatcher, options);
+        var service = new StreamManagementService(store, outbox, dispatcher, options, PolicyFor(options));
 
         Assert.True(await service.ChangeStreamStatusAsync(
             "receiver-a", "s-1", StreamStatuses.Disabled, "maintenance",
@@ -274,4 +274,13 @@ public class TransmitterDeliveryTests
             CancellationToken cancellationToken = default)
             => Task.FromResult($"signed.{token.JwtId}");
     }
+
+    /// <summary>
+    /// The address policy these tests hand to the service, with a resolver of their own: the one branch
+    /// of the policy that is not a string comparison would otherwise reach a live DNS for a name nobody
+    /// owns, and the test would measure the network.
+    /// </summary>
+    private static ReceiverAddressPolicy PolicyFor(SharedSignalsTransmitterOptions options)
+        => new(options, (_, _) => Task.FromResult<System.Net.IPAddress[]>(
+            [System.Net.IPAddress.Parse("93.184.216.34")]));
 }


### PR DESCRIPTION
A receiver names the address its stream is delivered to, and until now nothing judged that address
until the first push. A stream pointing at cleartext, or at a host inside the transmitter's own
network, was accepted with a 201 and then refused on every pass, forever. The receiver cannot learn
that from a 201, and the refusal reaches only a log it has no access to.

## The address is judged when it is proposed

Every verb that writes a stream's delivery now asks the same policy the sender asks. There are three -
create, update and replace - and the specification points a receiver at the second and third for
exactly this: *"use PATCH or PUT to update or replace the existing stream configuration"*
(SSF 1.0 Section 8.1.1.1). Covering one of them leaves the hole one call along, which is the door a
receiver reaches by accident: create with what works, then move the endpoint.

Rather than a third copy of the check, resolving a method and judging its address are one call. A
delivery this transmitter cannot reach is not an acceptable delivery, so a write path has no way to
ask for half of one - which is what the type system could not otherwise arrange.

**Registration judges only what the address itself settles**: the operator's allow-list, the scheme, a
host spelling out this deployment's own network, an IP literal. What a name RESOLVES to is not among
them - it is looked up again for every pass, so an answer given at registration says nothing about the
next one. It also changes what a resolver failure means: delivery treats one as a condition an
operator recovers from and holds the queue, while the same fact answered at registration would be a
terminal 400 that a receiver registering as it starts cannot tell from a permanent refusal.

The split is a private prefix rather than a second method with its own rules, so the two questions
cannot come to disagree - the registration question is literally the first half of the delivery one.

**400 on all three verbs is a decision.** Sections 8.1.1.3 and 8.1.1.4 list it for a request that is
"otherwise invalid", which covers update and replace outright. Section 8.1.1.1's table has no such
clause - its 400 is for a request that cannot be parsed, and its prose adds only that a transmitter
MAY answer 400 when it does not support the delivery METHOD. An unusable endpoint is unlisted there,
and 403 ("the Event Receiver is not allowed to create a stream") reads as a verdict about permission
rather than about the address. Since the refusal reaches the receiver as a bare status code - the
management API defines no error body - one answer across three verbs is worth more than a per-verb
code that makes a receiver branch on the method it used to be told the same thing.

## Two values are read where every reader reads them

`AddSharedSignalsTransmitter` takes its options as an argument and hands them to the container with
`TryAddSingleton`, so a host that registered its own instance first keeps it - which the parameter
documentation promises. Two things were decided from the argument instead, and each disagreement is
silent on this side.

- **The sweep interval** decided whether `PushDeliveryScheduler` was registered at all, so a host
  could configure one and get no sweeper, or opt out and get one. The registration is now
  unconditional and the scheduler's own guard - the only reader that sees the right value - decides.
  Nothing is lost by registering it: with no interval `ExecuteAsync` returns before creating a timer.
- **The issuer** was captured into the dispatcher. A host binding options from configuration would
  then advertise its own issuer in the stream configuration and the discovery document while signing
  every SET with the argument's. A conforming receiver compares the two (SSF 1.0 Section 7.2.2, which
  this library's own `StreamIssuerStep` implements) and refuses every token, while this side records
  each POST as delivered.

## Evidence

Every refusal is paired with the same request over https, on all three verbs, so none of them is a
check that cannot fail. Each claim is proved by breaking it, and each break fails exactly the case
that names it:

- putting the address check back to create-and-update only fails the replace case alone;
- asking the whole question at registration fails the "does not resolve the name" case alone, which
  counts resolver calls as well as reading the status;
- deciding the interval from the argument fails the host-pre-registered-options case alone, with
  `Expected 1 delivery, Actual 0`;
- capturing the issuer fails the issuer case alone, naming both values.

The scheduler is measured by what the receiver got rather than by which services the container holds:
a container listing describes the arrangement, and the arrangement is the thing that changed.

## Not changed here

A stream already stored with an address the policy refuses is never re-judged, and delivery simply
throws on every pass. SSF 1.0 Section 8.1.5 defines the channel that would tell its receiver why -
disable the stream and announce the reason - and using it is worth its own change.
