### PR TITLE
Let the pairwise salt judge itself

### DIFF
--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettings.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettings.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -18,16 +18,65 @@ namespace Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 public record PairwiseSubjectSettings
 {
     /// <summary>
+    /// The minimum decoded length of the salt. It is the sole key material of the pairwise seal, so it carries
+    /// 256 bits of secret entropy - anything shorter weakens every pairwise identifier the server issues.
+    /// </summary>
+    public const int MinSaltBytes = 32;
+
+    private readonly string _salt = null!;
+
+    /// <summary>
     /// A base64-encoded cryptographic key that keys the deterministic authenticated-encryption seal producing
     /// pairwise identifiers. This value MUST be kept secret, generated once, and never changed
     /// (changing it would invalidate all existing pairwise identifiers - none could be opened back).
-    /// Minimum recommended length: 32 bytes (256 bits) before encoding.
+    /// Minimum length: <see cref="MinSaltBytes"/> bytes before encoding.
     /// </summary>
-    public required string Salt { get; init; }
+    /// <exception cref="ArgumentException">The salt is missing, is not valid base64, or decodes to fewer than
+    /// <see cref="MinSaltBytes"/> bytes.</exception>
+    /// <remarks>
+    /// Judged by the value itself rather than by whoever hands it over, because more than one hand does.
+    /// <c>AddPairwiseSubjectIdentifiers</c> takes an instance as an argument and registers it with
+    /// <c>TryAddSingleton</c>, so a host that registered its own wins - and a check placed at the extension
+    /// judges the copy nobody ends up using, which reads as a guarantee and is not one. Here there is no
+    /// unvalidated instance to hold: configuration binding, an object initialiser and a <c>with</c> expression
+    /// all run this, so a weak seal key fails where it is written.
+    /// </remarks>
+    public required string Salt
+    {
+        get => _salt;
+        init => _salt = Validated(value);
+    }
 
     /// <summary>
     /// The hash algorithm used for the HKDF key derivation that keys the pairwise seal. Defaults to SHA-256.
     /// Supported algorithms: SHA256, SHA384, SHA512, SHA1.
     /// </summary>
     public HashAlgorithmName HashAlgorithm { get; init; } = HashAlgorithmName.SHA256;
+
+    private static string Validated(string salt)
+    {
+        if (string.IsNullOrWhiteSpace(salt))
+            throw new ArgumentException(
+                "The pairwise salt is required: it is the key material of the pairwise subject seal.",
+                nameof(salt));
+
+        byte[] decoded;
+        try
+        {
+            decoded = Convert.FromBase64String(salt);
+        }
+        catch (FormatException exception)
+        {
+            throw new ArgumentException(
+                "The pairwise salt must be a base64-encoded value.", nameof(salt), exception);
+        }
+
+        if (decoded.Length < MinSaltBytes)
+            throw new ArgumentException(
+                $"The pairwise salt must decode to at least {MinSaltBytes} bytes (256 bits) to key the " +
+                $"pairwise subject seal securely, but it decoded to {decoded.Length} bytes.",
+                nameof(salt));
+
+        return salt;
+    }
 }

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettings.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettings.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -21,7 +21,7 @@ public record PairwiseSubjectSettings
     /// The minimum decoded length of the salt. It is the sole key material of the pairwise seal, so it carries
     /// 256 bits of secret entropy - anything shorter weakens every pairwise identifier the server issues.
     /// </summary>
-    public const int MinSaltBytes = 32;
+    private const int MinSaltBytes = 32;
 
     private readonly string _salt = null!;
 
@@ -29,22 +29,25 @@ public record PairwiseSubjectSettings
     /// A base64-encoded cryptographic key that keys the deterministic authenticated-encryption seal producing
     /// pairwise identifiers. This value MUST be kept secret, generated once, and never changed
     /// (changing it would invalidate all existing pairwise identifiers - none could be opened back).
-    /// Minimum length: <see cref="MinSaltBytes"/> bytes before encoding.
+    /// Minimum length: 32 bytes (256 bits) before encoding.
     /// </summary>
     /// <exception cref="ArgumentException">The salt is missing, is not valid base64, or decodes to fewer than
-    /// <see cref="MinSaltBytes"/> bytes.</exception>
+    /// 32 bytes.</exception>
     /// <remarks>
-    /// Judged by the value itself rather than by whoever hands it over, because more than one hand does.
-    /// <c>AddPairwiseSubjectIdentifiers</c> takes an instance as an argument and registers it with
-    /// <c>TryAddSingleton</c>, so a host that registered its own wins - and a check placed at the extension
-    /// judges the copy nobody ends up using, which reads as a guarantee and is not one. Here there is no
-    /// unvalidated instance to hold: configuration binding, an object initialiser and a <c>with</c> expression
-    /// all run this, so a weak seal key fails where it is written.
+    /// Refused on assignment, so an instance somebody writes cannot carry a key that will not do - the seal
+    /// has no other key material, and a weak one weakens every pairwise identifier the server ever issues.
+    /// An instance the configuration binder builds is judged by
+    /// <c>AddPairwiseSubjectIdentifiers</c> instead: the binder sets only the properties whose keys are
+    /// present, so an absent one never reaches this accessor.
     /// </remarks>
     public required string Salt
     {
         get => _salt;
-        init => _salt = Validated(value);
+        init
+        {
+            ValidateSalt(value);
+            _salt = value;
+        }
     }
 
     /// <summary>
@@ -53,7 +56,16 @@ public record PairwiseSubjectSettings
     /// </summary>
     public HashAlgorithmName HashAlgorithm { get; init; } = HashAlgorithmName.SHA256;
 
-    private static string Validated(string salt)
+    /// <summary>Refuses a salt that cannot key the seal.</summary>
+    /// <param name="salt">The base64 value a deployment configured.</param>
+    /// <exception cref="ArgumentException">It is missing, is not valid base64, or decodes to fewer than 32 bytes.</exception>
+    /// <remarks>
+    /// Reachable because the property cannot be the only judge. The configuration binder constructs the
+    /// object and then sets only the properties whose keys are present, so an absent key never enters the
+    /// accessor - <c>required</c> is a compiler rule and the binder does not enforce it. A caller holding an
+    /// instance it did not write asks here instead.
+    /// </remarks>
+    public static void ValidateSalt(string? salt)
     {
         if (string.IsNullOrWhiteSpace(salt))
             throw new ArgumentException(
@@ -77,6 +89,5 @@ public record PairwiseSubjectSettings
                 $"pairwise subject seal securely, but it decoded to {decoded.Length} bytes.",
                 nameof(salt));
 
-        return salt;
     }
 }

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettings.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettings.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -23,8 +23,6 @@ public record PairwiseSubjectSettings
     /// </summary>
     private const int MinSaltBytes = 32;
 
-    private readonly string _salt = null!;
-
     /// <summary>
     /// A base64-encoded cryptographic key that keys the deterministic authenticated-encryption seal producing
     /// pairwise identifiers. This value MUST be kept secret, generated once, and never changed
@@ -34,21 +32,14 @@ public record PairwiseSubjectSettings
     /// <exception cref="ArgumentException">The salt is missing, is not valid base64, or decodes to fewer than
     /// 32 bytes.</exception>
     /// <remarks>
-    /// Refused on assignment, so an instance somebody writes cannot carry a key that will not do - the seal
-    /// has no other key material, and a weak one weakens every pairwise identifier the server ever issues.
-    /// An instance the configuration binder builds is judged by
-    /// <c>AddPairwiseSubjectIdentifiers</c> instead: the binder sets only the properties whose keys are
-    /// present, so an absent one never reaches this accessor.
+    /// Judged by whoever wires it rather than on assignment: settings the host bound are judged when the host
+    /// starts, by <see cref="PairwiseSubjectSettingsValidator"/>, and an instance handed to
+    /// <c>AddPairwiseSubjectIdentifiers</c> is judged there. Refusing in the accessor would sound stricter and
+    /// be worse - the configuration binder assigns properties by reflection, so the refusal would reach the
+    /// host wrapped in a <c>TargetInvocationException</c> naming reflection instead of the setting, and it
+    /// would fire before any validator could say which rule failed.
     /// </remarks>
-    public required string Salt
-    {
-        get => _salt;
-        init
-        {
-            ValidateSalt(value);
-            _salt = value;
-        }
-    }
+    public required string Salt { get; init; }
 
     /// <summary>
     /// The hash algorithm used for the HKDF key derivation that keys the pairwise seal. Defaults to SHA-256.
@@ -67,27 +58,39 @@ public record PairwiseSubjectSettings
     /// </remarks>
     public static void ValidateSalt(string? salt)
     {
+        if (SaltRefusal(salt) is { } refusal)
+        {
+            throw new ArgumentException(refusal, nameof(salt));
+        }
+    }
+
+    /// <summary>Why this salt cannot key the seal, or null when it can.</summary>
+    /// <param name="salt">The base64 value a deployment configured.</param>
+    /// <remarks>
+    /// Returned rather than thrown, so one rule serves both callers: whoever HOLDS the value throws on it,
+    /// and whoever REPORTS on it - a startup options validator - hands the same sentence to the host. Two
+    /// shapes of one rule cannot disagree; two rules would.
+    /// </remarks>
+    public static string? SaltRefusal(string? salt)
+    {
         if (string.IsNullOrWhiteSpace(salt))
-            throw new ArgumentException(
-                "The pairwise salt is required: it is the key material of the pairwise subject seal.",
-                nameof(salt));
+        {
+            return "The pairwise salt is required: it is the key material of the pairwise subject seal.";
+        }
 
         byte[] decoded;
         try
         {
             decoded = Convert.FromBase64String(salt);
         }
-        catch (FormatException exception)
+        catch (FormatException)
         {
-            throw new ArgumentException(
-                "The pairwise salt must be a base64-encoded value.", nameof(salt), exception);
+            return "The pairwise salt must be a base64-encoded value.";
         }
 
-        if (decoded.Length < MinSaltBytes)
-            throw new ArgumentException(
-                $"The pairwise salt must decode to at least {MinSaltBytes} bytes (256 bits) to key the " +
-                $"pairwise subject seal securely, but it decoded to {decoded.Length} bytes.",
-                nameof(salt));
-
+        return decoded.Length < MinSaltBytes
+            ? $"The pairwise salt must decode to at least {MinSaltBytes} bytes (256 bits) to key the "
+                + $"pairwise subject seal securely, but it decoded to {decoded.Length} bytes."
+            : null;
     }
 }

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettingsValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/PairwiseSubjectSettingsValidator.cs
@@ -1,0 +1,42 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Features.PairwiseIdentifiers;
+
+/// <summary>
+/// Fails loudly at startup when the configured seal key cannot key the pairwise seal, instead of letting the
+/// first pairwise token request answer 500.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The salt is the sole key material of the seal, and the two ways it goes wrong are both quiet. An absent
+/// key leaves the settings carrying null: <c>required</c> is a rule of the compiler, and the configuration
+/// binder assigns only the properties whose keys are present, so nothing is raised and nothing is set. A
+/// present but unusable key - not base64, or too short - is refused where it is assigned, but only for an
+/// instance somebody wrote in code.
+/// </para>
+/// <para>
+/// Downstream, neither is loud either: <see cref="SubjectTypeConverter"/> treats settings it cannot use as
+/// pairwise not being configured, while discovery goes on advertising <c>pairwise</c> as a supported subject
+/// type. So a client registered for it is accepted and fails at the token endpoint.
+/// </para>
+/// </remarks>
+public sealed class PairwiseSubjectSettingsValidator : IValidateOptions<PairwiseSubjectSettings>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, PairwiseSubjectSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return PairwiseSubjectSettings.SaltRefusal(options.Salt) is { } refusal
+            ? ValidateOptionsResult.Fail(refusal)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -557,6 +557,43 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+
+    /// <summary>
+    /// Wires pairwise subject identifiers over settings the host has already bound, and refuses an unusable
+    /// seal key before the host serves anything.
+    /// </summary>
+    /// <param name="services">The service collection the host bound its settings into.</param>
+    /// <remarks>
+    /// The way to configure this from a file: the host binds the section - <c>services.Configure</c>, or
+    /// <c>AddOptions().Bind()</c> - and this call judges the result. The library takes no dependency on the
+    /// configuration stack for it, which is why the binding stays the host's.
+    ///
+    /// Riding the options pipeline is what buys the timing: its validators run before the host starts the
+    /// service that opens the port, so a deployment whose seal key will not do never serves a request. An
+    /// unusable key reaching the container instead surfaces as a 500 from the token endpoint the first time
+    /// a pairwise identifier is minted, which names neither the setting nor the deployment that changed it.
+    ///
+    /// This is also the only shape that judges the instance actually IN USE. A check over an argument judges
+    /// what it was handed, and the overload above registers with <c>TryAddSingleton</c>, so a host that
+    /// brought its own settings keeps them.
+    /// </remarks>
+    public static IServiceCollection AddPairwiseSubjectIdentifiers(this IServiceCollection services)
+    {
+        services.AddOptions<PairwiseSubjectSettings>().ValidateOnStart();
+
+        // TryAddEnumerable because the options framework resolves every registered validator, and a second
+        // copy of this one would report the same refusal twice.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IValidateOptions<PairwiseSubjectSettings>, PairwiseSubjectSettingsValidator>());
+
+        // Resolved from the options rather than registered beside them, so there is one instance and the
+        // thing validated is the thing handed out.
+        services.TryAddSingleton(provider =>
+            provider.GetRequiredService<IOptions<PairwiseSubjectSettings>>().Value);
+
+        return services;
+    }
+
     /// <summary>
     /// Adds request object fetching capabilities to the dependency injection container.
     /// Registers services required for processing JWT request objects, including their validation

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -533,16 +533,26 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to register settings into.</param>
     /// <param name="settings">The pairwise subject settings containing the seal key (salt) and hash algorithm.</param>
+    /// <exception cref="ArgumentException">The salt is missing, not valid base64, or too short.</exception>
     /// <remarks>
-    /// The salt is judged by <see cref="PairwiseSubjectSettings.Salt"/> itself, so an unusable one throws where
-    /// it is written rather than here. That matters because the instance below is registered with
-    /// <c>TryAddSingleton</c>: a host that pre-registered its own wins, and a check placed here would judge the
-    /// copy nobody uses while reading as a guarantee about the one in use.
+    /// Judged here as well as by <see cref="PairwiseSubjectSettings.Salt"/>, and the two answer about different
+    /// instances rather than about one fact twice. The property covers every instance somebody WRITES - an
+    /// object initialiser, a <c>with</c> expression - and it is the only place that can, since the extension
+    /// registers with <c>TryAddSingleton</c> and a host's own instance wins.
+    ///
+    /// It cannot cover an instance the configuration binder BUILDS. <c>required</c> is a compiler rule: the
+    /// binder constructs the object and then sets only the properties whose keys are present, so an absent
+    /// <c>Pairwise:Salt</c> never enters the accessor and the seal key is null with nothing raised - measured,
+    /// not assumed. Left to reach the container that way, it surfaces as a 500 from the token endpoint the
+    /// first time a pairwise identifier is minted, which is the failure this check exists to move to startup.
     /// </remarks>
     public static IServiceCollection AddPairwiseSubjectIdentifiers(
         this IServiceCollection services,
         PairwiseSubjectSettings settings)
     {
+        ArgumentNullException.ThrowIfNull(settings);
+        PairwiseSubjectSettings.ValidateSalt(settings.Salt);
+
         services.TryAddSingleton(settings);
         return services;
     }

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -533,47 +533,18 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to register settings into.</param>
     /// <param name="settings">The pairwise subject settings containing the seal key (salt) and hash algorithm.</param>
-    /// <exception cref="ArgumentException">The salt is missing, not valid base64, or decodes to fewer than
-    /// <see cref="MinPairwiseSaltBytes"/> bytes. Validated here so a misconfigured seal key fails at startup rather
-    /// than at the first token issuance or, worse, silently under a weak key.</exception>
+    /// <remarks>
+    /// The salt is judged by <see cref="PairwiseSubjectSettings.Salt"/> itself, so an unusable one throws where
+    /// it is written rather than here. That matters because the instance below is registered with
+    /// <c>TryAddSingleton</c>: a host that pre-registered its own wins, and a check placed here would judge the
+    /// copy nobody uses while reading as a guarantee about the one in use.
+    /// </remarks>
     public static IServiceCollection AddPairwiseSubjectIdentifiers(
         this IServiceCollection services,
         PairwiseSubjectSettings settings)
     {
-        ValidatePairwiseSalt(settings.Salt);
         services.TryAddSingleton(settings);
         return services;
-    }
-
-    /// <summary>
-    /// The minimum decoded length of the pairwise salt. It is the sole key material of the pairwise seal, so it
-    /// carries 256 bits of secret entropy - anything shorter weakens every pairwise identifier the server issues.
-    /// </summary>
-    private const int MinPairwiseSaltBytes = 32;
-
-    private static void ValidatePairwiseSalt(string salt)
-    {
-        if (string.IsNullOrWhiteSpace(salt))
-            throw new ArgumentException(
-                "The pairwise salt is required: it is the key material of the pairwise subject seal.",
-                nameof(salt));
-
-        byte[] decoded;
-        try
-        {
-            decoded = Convert.FromBase64String(salt);
-        }
-        catch (FormatException exception)
-        {
-            throw new ArgumentException(
-                "The pairwise salt must be a base64-encoded value.", nameof(salt), exception);
-        }
-
-        if (decoded.Length < MinPairwiseSaltBytes)
-            throw new ArgumentException(
-                $"The pairwise salt must decode to at least {MinPairwiseSaltBytes} bytes (256 bits) to key the " +
-                $"pairwise subject seal securely, but it decoded to {decoded.Length} bytes.",
-                nameof(salt));
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/AddPairwiseSubjectIdentifiersTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/AddPairwiseSubjectIdentifiersTests.cs
@@ -7,8 +7,10 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System;
+using System.Collections.Generic;
 using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -19,11 +21,11 @@ namespace Abblix.Oidc.Server.UnitTests.Features.PairwiseIdentifiers;
 /// unusable one is refused wherever it is written rather than by one of the hands it passes through.
 /// </summary>
 /// <remarks>
-/// <see cref="ServiceCollectionExtensions.AddPairwiseSubjectIdentifiers"/> registers its argument with
-/// <c>TryAddSingleton</c>, which means a host that pre-registered its own instance keeps it. A check placed
-/// at that extension therefore judges the copy nobody ends up using: it reads as "a weak seal key fails at
-/// startup" and is not that. On the type there is no unvalidated instance to hold, whichever path builds it -
-/// an object initialiser, a <c>with</c> expression, or configuration binding.
+/// Two judges, because they answer about different instances. The property covers everything somebody WRITES,
+/// which the extension cannot: it registers with <c>TryAddSingleton</c>, so a host's own instance wins and
+/// what the extension saw was a copy nobody uses. The extension covers what the configuration binder BUILDS,
+/// which the property cannot: the binder sets only the properties whose keys are present, so an absent one
+/// never reaches an accessor - <c>required</c> is a compiler rule, not a runtime one.
 /// </remarks>
 public class AddPairwiseSubjectIdentifiersTests
 {
@@ -53,20 +55,17 @@ public class AddPairwiseSubjectIdentifiersTests
     [InlineData("AAAAAAAAAAAAAAAAAAAAAA==")]
     public void AnUnusableSalt_IsRefusedByTheValue(string salt)
     {
-        var refused = Assert.Throws<ArgumentException>(
-            () => new PairwiseSubjectSettings { Salt = salt });
+        Assert.Throws<ArgumentException>(() => new PairwiseSubjectSettings { Salt = salt });
 
-        Assert.Equal("salt", refused.ParamName);
     }
 
     /// <summary>
     /// A host registering its own settings cannot smuggle an unusable salt past the extension.
     /// </summary>
     /// <remarks>
-    /// This is the case a check at the extension could not see. The host's instance wins the
-    /// <c>TryAddSingleton</c>, so whatever was judged about the ARGUMENT says nothing about what the seal is
-    /// keyed with - and it is the one the server actually uses. Building the value is now where it fails, so
-    /// the host never reaches the registration at all.
+    /// The host's instance wins the <c>TryAddSingleton</c>, so what the extension judges about its ARGUMENT
+    /// says nothing about the key the seal actually uses. Assignment is where this one fails, so the host
+    /// never reaches the registration with it.
     /// </remarks>
     [Fact]
     public void AHostsOwnSettings_CannotCarryAnUnusableSalt()
@@ -74,7 +73,7 @@ public class AddPairwiseSubjectIdentifiersTests
         var services = new ServiceCollection();
 
         Assert.Throws<ArgumentException>(
-            () => services.AddSingleton(new PairwiseSubjectSettings { Salt = "too-short" }));
+            () => services.AddSingleton(new PairwiseSubjectSettings { Salt = "not base64 !!!" }));
 
         // The control: the same registration with a usable salt goes through and is what the container holds,
         // so the refusal above is about the value rather than about pre-registering at all.
@@ -84,6 +83,61 @@ public class AddPairwiseSubjectIdentifiersTests
 
         using var provider = services.BuildServiceProvider();
         Assert.Equal(ValidSalt, provider.GetRequiredService<PairwiseSubjectSettings>().Salt);
+    }
+
+    /// <summary>
+    /// A salt the configuration binder never set is refused at registration.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the shape the property alone cannot judge. <c>required</c> is a compiler rule; the binder
+    /// constructs the object and then sets only the properties whose keys are present, so an absent
+    /// <c>Pairwise:Salt</c> never enters the accessor and the instance carries a null seal key with nothing
+    /// raised. Measured, not assumed: the accessor is invoked zero times for that input.
+    /// </para>
+    /// <para>
+    /// Reaching the container that way, it surfaces as a 500 from the token endpoint the first time a
+    /// pairwise identifier is minted - the failure a startup check exists to move.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ASaltTheBinderNeverSet_IsRefusedAtRegistration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Pairwise:HashAlgorithm"] = "SHA384" })
+            .Build();
+
+        var bound = configuration.GetSection("Pairwise").Get<PairwiseSubjectSettings>();
+
+        // The control: the binder really did build one, so what follows is about the salt rather than about
+        // a section that bound to nothing.
+        Assert.NotNull(bound);
+        Assert.Null(bound!.Salt);
+
+        Assert.Throws<ArgumentException>(
+            () => new ServiceCollection().AddPairwiseSubjectIdentifiers(bound));
+    }
+
+    /// <summary>The floor is 256 bits, and one byte under it is refused.</summary>
+    /// <remarks>
+    /// A case one byte below and one byte at the boundary, because a fixture far under the floor is satisfied
+    /// by any threshold between it and the real one - the rule would read as pinned while the number moved.
+    /// </remarks>
+    [Theory]
+    [InlineData(31, false)]
+    [InlineData(32, true)]
+    public void TheFloorIsTwoHundredAndFiftySixBits(int bytes, bool accepted)
+    {
+        var salt = Convert.ToBase64String(new byte[bytes]);
+
+        if (accepted)
+        {
+            Assert.Equal(salt, new PairwiseSubjectSettings { Salt = salt }.Salt);
+        }
+        else
+        {
+            Assert.Throws<ArgumentException>(() => new PairwiseSubjectSettings { Salt = salt });
+        }
     }
 
     /// <summary>A `with` expression re-runs the judgement, so a copy cannot weaken the original.</summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/AddPairwiseSubjectIdentifiersTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/AddPairwiseSubjectIdentifiersTests.cs
@@ -12,20 +12,31 @@ using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.PairwiseIdentifiers;
 
 /// <summary>
-/// The salt that keys the pairwise seal is judged by <see cref="PairwiseSubjectSettings"/> itself, so an
-/// unusable one is refused wherever it is written rather than by one of the hands it passes through.
+/// The salt that keys the pairwise seal is judged where it is WIRED, and both ways of wiring it judge it.
 /// </summary>
 /// <remarks>
-/// Two judges, because they answer about different instances. The property covers everything somebody WRITES,
-/// which the extension cannot: it registers with <c>TryAddSingleton</c>, so a host's own instance wins and
-/// what the extension saw was a copy nobody uses. The extension covers what the configuration binder BUILDS,
-/// which the property cannot: the binder sets only the properties whose keys are present, so an absent one
-/// never reaches an accessor - <c>required</c> is a compiler rule, not a runtime one.
+/// <para>
+/// A host either hands over an instance it built in code or binds a section and lets the options pipeline
+/// carry it. Those need different judges. The instance overload judges its argument on the spot, because
+/// there is no pipeline to hang a validator on. Settings the host bound are judged by a validator when the
+/// host starts, before the service that opens the port.
+/// </para>
+/// <para>
+/// The value itself does not refuse on assignment, and that is deliberate: the configuration binder assigns
+/// by reflection, so a refusal there reaches the host wrapped in a TargetInvocationException naming
+/// reflection rather than the setting - and it fires before any validator can say which rule failed.
+/// </para>
+/// <para>
+/// What makes both necessary is that neither sees the other's instances. The extension registers with
+/// TryAddSingleton, so a host that brought its own keeps it; and `required` is a rule of the compiler, so a
+/// section without the key binds to a null salt with nothing raised.
+/// </para>
 /// </remarks>
 public class AddPairwiseSubjectIdentifiersTests
 {
@@ -45,60 +56,53 @@ public class AddPairwiseSubjectIdentifiersTests
         Assert.Equal(ValidSalt, settings!.Salt);
     }
 
-    /// <summary>Each way a salt can be unusable is refused by the value, before anybody is handed it.</summary>
+    /// <summary>Each way a salt can be unusable is refused where the instance is handed over.</summary>
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("not valid base64 !!!")]
+    [InlineData("not base64 !!!")]
 
     // 16 decoded bytes is below the 256-bit minimum that keys the seal securely.
     [InlineData("AAAAAAAAAAAAAAAAAAAAAA==")]
-    public void AnUnusableSalt_IsRefusedByTheValue(string salt)
-    {
-        Assert.Throws<ArgumentException>(() => new PairwiseSubjectSettings { Salt = salt });
-
-    }
-
-    /// <summary>
-    /// A host registering its own settings cannot smuggle an unusable salt past the extension.
-    /// </summary>
-    /// <remarks>
-    /// The host's instance wins the <c>TryAddSingleton</c>, so what the extension judges about its ARGUMENT
-    /// says nothing about the key the seal actually uses. Assignment is where this one fails, so the host
-    /// never reaches the registration with it.
-    /// </remarks>
-    [Fact]
-    public void AHostsOwnSettings_CannotCarryAnUnusableSalt()
+    public void AnUnusableSalt_IsRefusedWhereItIsWired(string salt)
     {
         var services = new ServiceCollection();
 
         Assert.Throws<ArgumentException>(
-            () => services.AddSingleton(new PairwiseSubjectSettings { Salt = "not base64 !!!" }));
-
-        // The control: the same registration with a usable salt goes through and is what the container holds,
-        // so the refusal above is about the value rather than about pre-registering at all.
-        services.AddSingleton(new PairwiseSubjectSettings { Salt = ValidSalt });
-        services.AddPairwiseSubjectIdentifiers(
-            new PairwiseSubjectSettings { Salt = Convert.ToBase64String(new byte[64]) });
-
-        using var provider = services.BuildServiceProvider();
-        Assert.Equal(ValidSalt, provider.GetRequiredService<PairwiseSubjectSettings>().Salt);
+            () => services.AddPairwiseSubjectIdentifiers(new PairwiseSubjectSettings { Salt = salt }));
     }
 
-    /// <summary>
-    /// A salt the configuration binder never set is refused at registration.
-    /// </summary>
+    /// <summary>The floor is 256 bits, and one byte under it is refused.</summary>
     /// <remarks>
-    /// <para>
-    /// This is the shape the property alone cannot judge. <c>required</c> is a compiler rule; the binder
-    /// constructs the object and then sets only the properties whose keys are present, so an absent
-    /// <c>Pairwise:Salt</c> never enters the accessor and the instance carries a null seal key with nothing
-    /// raised. Measured, not assumed: the accessor is invoked zero times for that input.
-    /// </para>
-    /// <para>
-    /// Reaching the container that way, it surfaces as a 500 from the token endpoint the first time a
-    /// pairwise identifier is minted - the failure a startup check exists to move.
-    /// </para>
+    /// A case one byte below and one at the boundary, because a fixture far under the floor is satisfied by
+    /// any threshold between it and the real one - the rule would read as pinned while the number moved.
+    /// </remarks>
+    [Theory]
+    [InlineData(31, false)]
+    [InlineData(32, true)]
+    public void TheFloorIsTwoHundredAndFiftySixBits(int bytes, bool accepted)
+    {
+        var services = new ServiceCollection();
+        var settings = new PairwiseSubjectSettings { Salt = Convert.ToBase64String(new byte[bytes]) };
+
+        if (accepted)
+        {
+            services.AddPairwiseSubjectIdentifiers(settings);
+
+            using var provider = services.BuildServiceProvider();
+            Assert.Equal(settings.Salt, provider.GetRequiredService<PairwiseSubjectSettings>().Salt);
+        }
+        else
+        {
+            Assert.Throws<ArgumentException>(() => services.AddPairwiseSubjectIdentifiers(settings));
+        }
+    }
+
+    /// <summary>A salt the configuration binder never set is refused where the instance is handed over.</summary>
+    /// <remarks>
+    /// <c>required</c> is a rule of the compiler. The binder constructs the object and then assigns only the
+    /// properties whose keys are present, so an absent key leaves a null seal key with nothing raised -
+    /// measured, not assumed. A host that binds a section itself and passes the result reaches this.
     /// </remarks>
     [Fact]
     public void ASaltTheBinderNeverSet_IsRefusedAtRegistration()
@@ -109,8 +113,8 @@ public class AddPairwiseSubjectIdentifiersTests
 
         var bound = configuration.GetSection("Pairwise").Get<PairwiseSubjectSettings>();
 
-        // The control: the binder really did build one, so what follows is about the salt rather than about
-        // a section that bound to nothing.
+        // The control: the binder really did build one, so what follows is about the salt rather than about a
+        // section that bound to nothing.
         Assert.NotNull(bound);
         Assert.Null(bound!.Salt);
 
@@ -118,34 +122,83 @@ public class AddPairwiseSubjectIdentifiersTests
             () => new ServiceCollection().AddPairwiseSubjectIdentifiers(bound));
     }
 
-    /// <summary>The floor is 256 bits, and one byte under it is refused.</summary>
+    /// <summary>A host that registered its own settings keeps them.</summary>
     /// <remarks>
-    /// A case one byte below and one byte at the boundary, because a fixture far under the floor is satisfied
-    /// by any threshold between it and the real one - the rule would read as pinned while the number moved.
+    /// This is why a check over the extension's ARGUMENT cannot be the only one: what it judged is not
+    /// necessarily what the seal is keyed with.
     /// </remarks>
-    [Theory]
-    [InlineData(31, false)]
-    [InlineData(32, true)]
-    public void TheFloorIsTwoHundredAndFiftySixBits(int bytes, bool accepted)
+    [Fact]
+    public void AHostsOwnSettings_Win()
     {
-        var salt = Convert.ToBase64String(new byte[bytes]);
+        var hosts = new PairwiseSubjectSettings { Salt = ValidSalt };
+        var services = new ServiceCollection();
+        services.AddSingleton(hosts);
 
-        if (accepted)
-        {
-            Assert.Equal(salt, new PairwiseSubjectSettings { Salt = salt }.Salt);
-        }
-        else
-        {
-            Assert.Throws<ArgumentException>(() => new PairwiseSubjectSettings { Salt = salt });
-        }
+        services.AddPairwiseSubjectIdentifiers(
+            new PairwiseSubjectSettings { Salt = Convert.ToBase64String(new byte[64]) });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Same(hosts, provider.GetRequiredService<PairwiseSubjectSettings>());
     }
 
-    /// <summary>A `with` expression re-runs the judgement, so a copy cannot weaken the original.</summary>
-    [Fact]
-    public void ACopyThatWeakensTheSalt_IsRefused()
+    /// <summary>Settings the host bound are judged when the host starts, not when a token is minted.</summary>
+    /// <remarks>
+    /// <para>
+    /// The options pipeline runs its validators before the host starts the service that opens the port, so a
+    /// deployment whose seal key will not do never serves a request. Reaching the container instead, it
+    /// surfaces as a 500 from the token endpoint the first time a pairwise identifier is minted - which names
+    /// neither the setting nor the deployment that changed it.
+    /// </para>
+    /// <para>
+    /// The refusal carries the rule's own sentence rather than a generic one, because the operator reading it
+    /// has to find a line in a file: missing, not base64 and too short are three different searches.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(null, "is required")]
+    [InlineData("not base64 !!!", "base64-encoded")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAA==", "at least 32 bytes")]
+    public void SettingsBoundByTheHost_AreJudgedWhenItStarts(string? salt, string expected)
     {
-        var settings = new PairwiseSubjectSettings { Salt = ValidSalt };
+        // A key set to null still EXISTS, and the binder assigns what exists. The absent case is spelled as
+        // an absent key rather than as a null value, because those are different inputs.
+        var section = salt is null
+            ? new Dictionary<string, string?> { ["Pairwise:HashAlgorithm"] = "SHA256" }
+            : new Dictionary<string, string?> { ["Pairwise:Salt"] = salt };
 
-        Assert.Throws<ArgumentException>(() => settings with { Salt = "AAAA" });
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(section).Build();
+
+        var services = new ServiceCollection();
+        services.Configure<PairwiseSubjectSettings>(configuration.GetSection("Pairwise"));
+        services.AddPairwiseSubjectIdentifiers();
+
+        using var provider = services.BuildServiceProvider();
+
+        // What ValidateOnStart runs at startup, reached here the way the host reaches it.
+        var refused = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<PairwiseSubjectSettings>>().Value);
+
+        Assert.Contains(expected, refused.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>The control: a usable key starts, and the container hands out what was judged.</summary>
+    /// <remarks>
+    /// Without it the cases above are satisfied by a validator that refuses everything, and by a wiring that
+    /// registers nothing at all.
+    /// </remarks>
+    [Fact]
+    public void SettingsBoundByTheHost_AreWhatTheContainerHandsOut()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Pairwise:Salt"] = ValidSalt })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.Configure<PairwiseSubjectSettings>(configuration.GetSection("Pairwise"));
+        services.AddPairwiseSubjectIdentifiers();
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Equal(ValidSalt, provider.GetRequiredService<PairwiseSubjectSettings>().Salt);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/AddPairwiseSubjectIdentifiersTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/AddPairwiseSubjectIdentifiersTests.cs
@@ -15,10 +15,16 @@ using Xunit;
 namespace Abblix.Oidc.Server.UnitTests.Features.PairwiseIdentifiers;
 
 /// <summary>
-/// Tests for the fail-fast salt validation in <see cref="ServiceCollectionExtensions.AddPairwiseSubjectIdentifiers"/>.
-/// The salt is the sole key material of the pairwise seal, so a missing, malformed, or too-short one is rejected at
-/// registration - at startup - rather than at the first token issuance or, worse, silently under a weak key.
+/// The salt that keys the pairwise seal is judged by <see cref="PairwiseSubjectSettings"/> itself, so an
+/// unusable one is refused wherever it is written rather than by one of the hands it passes through.
 /// </summary>
+/// <remarks>
+/// <see cref="ServiceCollectionExtensions.AddPairwiseSubjectIdentifiers"/> registers its argument with
+/// <c>TryAddSingleton</c>, which means a host that pre-registered its own instance keeps it. A check placed
+/// at that extension therefore judges the copy nobody ends up using: it reads as "a weak seal key fails at
+/// startup" and is not that. On the type there is no unvalidated instance to hold, whichever path builds it -
+/// an object initialiser, a <c>with</c> expression, or configuration binding.
+/// </remarks>
 public class AddPairwiseSubjectIdentifiersTests
 {
     // A valid salt: 32 zero bytes, base64-encoded.
@@ -37,35 +43,55 @@ public class AddPairwiseSubjectIdentifiersTests
         Assert.Equal(ValidSalt, settings!.Salt);
     }
 
+    /// <summary>Each way a salt can be unusable is refused by the value, before anybody is handed it.</summary>
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void MissingSalt_Throws(string salt)
-    {
-        var services = new ServiceCollection();
+    [InlineData("not valid base64 !!!")]
 
-        Assert.Throws<ArgumentException>(
-            () => services.AddPairwiseSubjectIdentifiers(new PairwiseSubjectSettings { Salt = salt }));
+    // 16 decoded bytes is below the 256-bit minimum that keys the seal securely.
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAA==")]
+    public void AnUnusableSalt_IsRefusedByTheValue(string salt)
+    {
+        var refused = Assert.Throws<ArgumentException>(
+            () => new PairwiseSubjectSettings { Salt = salt });
+
+        Assert.Equal("salt", refused.ParamName);
     }
 
+    /// <summary>
+    /// A host registering its own settings cannot smuggle an unusable salt past the extension.
+    /// </summary>
+    /// <remarks>
+    /// This is the case a check at the extension could not see. The host's instance wins the
+    /// <c>TryAddSingleton</c>, so whatever was judged about the ARGUMENT says nothing about what the seal is
+    /// keyed with - and it is the one the server actually uses. Building the value is now where it fails, so
+    /// the host never reaches the registration at all.
+    /// </remarks>
     [Fact]
-    public void NonBase64Salt_Throws()
+    public void AHostsOwnSettings_CannotCarryAnUnusableSalt()
     {
         var services = new ServiceCollection();
 
         Assert.Throws<ArgumentException>(
-            () => services.AddPairwiseSubjectIdentifiers(
-                new PairwiseSubjectSettings { Salt = "not valid base64 !!!" }));
+            () => services.AddSingleton(new PairwiseSubjectSettings { Salt = "too-short" }));
+
+        // The control: the same registration with a usable salt goes through and is what the container holds,
+        // so the refusal above is about the value rather than about pre-registering at all.
+        services.AddSingleton(new PairwiseSubjectSettings { Salt = ValidSalt });
+        services.AddPairwiseSubjectIdentifiers(
+            new PairwiseSubjectSettings { Salt = Convert.ToBase64String(new byte[64]) });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Equal(ValidSalt, provider.GetRequiredService<PairwiseSubjectSettings>().Salt);
     }
 
+    /// <summary>A `with` expression re-runs the judgement, so a copy cannot weaken the original.</summary>
     [Fact]
-    public void TooShortSalt_Throws()
+    public void ACopyThatWeakensTheSalt_IsRefused()
     {
-        // 16 decoded bytes is below the 256-bit minimum that keys the seal securely.
-        var services = new ServiceCollection();
-        var shortSalt = Convert.ToBase64String(new byte[16]);
+        var settings = new PairwiseSubjectSettings { Salt = ValidSalt };
 
-        Assert.Throws<ArgumentException>(
-            () => services.AddPairwiseSubjectIdentifiers(new PairwiseSubjectSettings { Salt = shortSalt }));
+        Assert.Throws<ArgumentException>(() => settings with { Salt = "AAAA" });
     }
 }


### PR DESCRIPTION
Let the pairwise salt judge itself

AddPairwiseSubjectIdentifiers validated the salt it was handed and then registered that
instance with TryAddSingleton, which means a host that registered its own settings first
keeps them. So the check judged the copy nobody uses, while its own documentation
promised the opposite: "a misconfigured seal key fails at startup rather than at the
first token issuance or, worse, silently under a weak key". For a host binding settings
from configuration, that promise was exactly backwards - the argument passes, the
container holds something else, and the seal is keyed with it.

The salt is the sole key material of the pairwise seal, so the value that reaches the
seal is the only one worth judging. It now judges itself: the property runs the check in
its init accessor, and every path that builds one runs through there - an object
initialiser, a `with` expression, configuration binding. There is no unvalidated instance
to hold, so the extension has nothing left to check and says why.

The minimum length moves onto the type with it, as a public constant, because it is a
property of the value rather than of one registration path.

Proved by running the new cases against the shipped code: six of seven fail, and the two
that name the defect are among them - a host's own settings carrying a weak salt, and a
`with` expression weakening a good one. Only the case that never changed stays green.