### PR TITLE
Say why the receiver refused

### DIFF
--- a/src/Abblix.SharedSignals/LogEvents.cs
+++ b/src/Abblix.SharedSignals/LogEvents.cs
@@ -41,8 +41,8 @@ public static class LogEvents
         /// <summary>A delivery pass outlived its claim and was cut off at the deadline.</summary>
         public const int PushPassCutOff = Base + 6;
 
-        /// <summary>The receiver refused one SET for good, and said why.</summary>
-        public const int SetRefusedByReceiver = Base + 7;
+        /// <summary>The receiver refused SETs on one pass, and said why.</summary>
+        public const int SetsRefusedByReceiver = Base + 7;
 
         /// <summary>The receiver objected to this transmitter rather than to the SET, so the queue is held.</summary>
         public const int ReceiverObjected = Base + 8;

--- a/src/Abblix.SharedSignals/LogEvents.cs
+++ b/src/Abblix.SharedSignals/LogEvents.cs
@@ -40,5 +40,11 @@ public static class LogEvents
 
         /// <summary>A delivery pass outlived its claim and was cut off at the deadline.</summary>
         public const int PushPassCutOff = Base + 6;
+
+        /// <summary>The receiver refused one SET for good, and said why.</summary>
+        public const int SetRefusedByReceiver = Base + 7;
+
+        /// <summary>The receiver objected to this transmitter rather than to the SET, so the queue is held.</summary>
+        public const int ReceiverObjected = Base + 8;
     }
 }

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.Logging.cs
@@ -12,22 +12,39 @@ namespace Abblix.SharedSignals.Transmitter;
 public sealed partial class PushDeliverySender
 {
     /// <summary>
-    /// Stands in for a receiver that answered 400 without the error body RFC 8935 Section 2.3 asks of it.
+    /// The receiver refused SETs and they are out of the queue.
     /// </summary>
     /// <remarks>
-    /// Written into the log rather than left empty so that the two cases read differently: a receiver that
-    /// explained itself and one that did not are different problems, and an absent field looks the same as a
-    /// field nobody wrote.
+    /// <para>
+    /// One line for the pass rather than one per SET. The queue is read whole, so a receiver refusing a
+    /// backlog would otherwise write a line per event - thousands in a pass, differing only in an
+    /// identifier, which is the drowning this exists to prevent.
+    /// </para>
+    /// <para>
+    /// It says the events are out of the queue rather than that they can never be delivered, because those
+    /// are different claims and only the first is certain. <c>invalid_key</c> is treated as final - a
+    /// retransmission of the same bytes cannot succeed - yet the specification's own example of it is a
+    /// revoked key (RFC 8935 Section 2.3), which the transmitter fixes on its own side. What the operator
+    /// must know is that these events are gone, and why the receiver said so.
+    /// </para>
     /// </remarks>
-    private const string NoVerdict = "(the receiver sent no error body)";
-
     [LoggerMessage(
-        EventId = LogEvents.Transmitter.SetRefusedByReceiver,
+        EventId = LogEvents.Transmitter.SetsRefusedByReceiver,
         Level = LogLevel.Warning,
-        Message = "The receiver refused SET {JwtId} on stream {StreamId} for good and it will not be sent "
-            + "again: {ErrorCode} - {ErrorDescription}")]
-    private partial void LogSetRefused(string StreamId, string JwtId, string ErrorCode, string ErrorDescription);
+        Message = "The receiver refused {RefusedCount} SET(s) on stream {StreamId} and they are out of the "
+            + "queue: {ErrorCode} - {ErrorDescription}")]
+    private partial void LogSetsRefused(
+        string StreamId, int RefusedCount, string ErrorCode, string ErrorDescription);
 
+    /// <summary>
+    /// The receiver objected to this transmitter rather than to the SET, so the queue is held.
+    /// </summary>
+    /// <remarks>
+    /// A separate event because the queue disposition differs, which is what an operator acts on: nothing is
+    /// lost here, and the events go out once the credential or the grant is put right. The pass stops at the
+    /// first such answer, so this is one line per stream per pass - paced by whatever drives the passes, and
+    /// the package's own sweeper carries no backoff.
+    /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Transmitter.ReceiverObjected,
         Level = LogLevel.Warning,

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.Logging.cs
@@ -1,0 +1,37 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.SharedSignals.Transmitter;
+
+public sealed partial class PushDeliverySender
+{
+    /// <summary>
+    /// Stands in for a receiver that answered 400 without the error body RFC 8935 Section 2.3 asks of it.
+    /// </summary>
+    /// <remarks>
+    /// Written into the log rather than left empty so that the two cases read differently: a receiver that
+    /// explained itself and one that did not are different problems, and an absent field looks the same as a
+    /// field nobody wrote.
+    /// </remarks>
+    private const string NoVerdict = "(the receiver sent no error body)";
+
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.SetRefusedByReceiver,
+        Level = LogLevel.Warning,
+        Message = "The receiver refused SET {JwtId} on stream {StreamId} for good and it will not be sent "
+            + "again: {ErrorCode} - {ErrorDescription}")]
+    private partial void LogSetRefused(string StreamId, string JwtId, string ErrorCode, string ErrorDescription);
+
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.ReceiverObjected,
+        Level = LogLevel.Warning,
+        Message = "The receiver objected to this transmitter rather than to the SET on stream {StreamId}, so "
+            + "the queue is held for a later pass: {ErrorCode} - {ErrorDescription}")]
+    private partial void LogReceiverObjected(string StreamId, string ErrorCode, string ErrorDescription);
+}

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -12,6 +12,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using Abblix.SecurityEvents.Delivery;
+using Microsoft.Extensions.Logging;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 
@@ -27,10 +28,12 @@ namespace Abblix.SharedSignals.Transmitter;
 /// <param name="httpClient">The client transmissions travel through.</param>
 /// <param name="outbox">The queues being drained.</param>
 /// <param name="addressPolicy">Judges the receiver's address before anything is sent to it.</param>
-public sealed class PushDeliverySender(
+/// <param name="logger">Carries the receiver's own reason for a refusal into this deployment's log.</param>
+public sealed partial class PushDeliverySender(
     HttpClient httpClient,
     IEventOutbox outbox,
-    ReceiverAddressPolicy addressPolicy)
+    ReceiverAddressPolicy addressPolicy,
+    ILogger<PushDeliverySender> logger)
 {
     /// <summary>
     /// Sends what one stream has pending.
@@ -104,8 +107,17 @@ public sealed class PushDeliverySender(
                     {
                         // The receiver objects to this transmitter, not to this event: leave it queued so a
                         // later pass can deliver it once the credentials or the grant are put right.
+                        LogReceiverObjected(
+                            stream.StreamId, verdict?.Error ?? NoVerdict, verdict?.Description ?? NoVerdict);
                         break;
                     }
+
+                    // The receiver owes a reason with a 400 (RFC 8935 Section 2.3) and it arrives here, where
+                    // it was previously read for the final-or-transient decision and then dropped. Nothing else
+                    // carries it: this side sees a status code and the receiver's own log is not ours to read,
+                    // so a stream refusing every SET looked from here exactly like one refusing none.
+                    LogSetRefused(
+                        stream.StreamId, item.JwtId, verdict?.Error ?? NoVerdict, verdict?.Description ?? NoVerdict);
 
                     await outbox.AcknowledgeAsync(stream.StreamId, [item.JwtId], cancellationToken);
                     rejected++;

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -35,6 +35,39 @@ public sealed partial class PushDeliverySender(
     ReceiverAddressPolicy addressPolicy,
     ILogger<PushDeliverySender> logger)
 {
+    /// <summary>How much of the receiver's description is carried into the log.</summary>
+    /// <remarks>
+    /// The field is the receiver's to fill and RFC 8935 Section 2.3 puts no bound on it - "the exact content
+    /// of this field is implementation specific" - so it arrives as text of any length from a party this
+    /// deployment does not control. A diagnostic that does not fit in this much is not a diagnostic.
+    /// </remarks>
+    private const int DescriptionBudget = 256;
+
+    /// <summary>Stands in for a receiver that answered 400 without the error body it owes.</summary>
+    /// <remarks>
+    /// A code rather than a sentence, because the code is the field a log query groups by: a bucket named
+    /// with prose sits beside invalid_audience and access_denied and cannot be told from one of them.
+    /// </remarks>
+    private static readonly DeliveryError Unexplained = new("(none)", string.Empty);
+
+    /// <summary>The receiver's own words, bounded and stripped of anything that could forge a log line.</summary>
+    /// <remarks>
+    /// Control characters go first. A plain-text sink writes a newline as a newline, so a receiver could
+    /// otherwise put a whole fabricated entry into this deployment's log through a field it fills itself -
+    /// and the escapes that clear a terminal or rewrite its title ride the same path.
+    /// </remarks>
+    private static string Readable(string? description)
+    {
+        if (string.IsNullOrEmpty(description))
+        {
+            return "(none)";
+        }
+
+        var kept = description.Length <= DescriptionBudget ? description : description[..DescriptionBudget];
+        var text = new string([.. kept.Select(character => char.IsControl(character) ? ' ' : character)]);
+        return description.Length <= DescriptionBudget ? text : text + "...";
+    }
+
     /// <summary>
     /// Sends what one stream has pending.
     /// </summary>
@@ -84,6 +117,12 @@ public sealed partial class PushDeliverySender(
 
         var delivered = 0;
         var rejected = 0;
+
+        // The first refusal of the pass, kept so the summary below can name a reason. Per-SET logging
+        // is what the queue's own shape rules out: it is read whole, so a receiver that refuses a
+        // backlog would write one line per event - thousands in one pass, differing only in the
+        // identifier, which is the drowning this line exists to prevent rather than cause.
+        DeliveryError? firstRefusal = null;
         foreach (var item in pending)
         {
             HttpResponseMessage response;
@@ -107,17 +146,12 @@ public sealed partial class PushDeliverySender(
                     {
                         // The receiver objects to this transmitter, not to this event: leave it queued so a
                         // later pass can deliver it once the credentials or the grant are put right.
-                        LogReceiverObjected(
-                            stream.StreamId, verdict?.Error ?? NoVerdict, verdict?.Description ?? NoVerdict);
+                        // Non-null by construction: IsFinal answers false only for a code it recognises.
+                        LogReceiverObjected(stream.StreamId, verdict!.Error, Readable(verdict.Description));
                         break;
                     }
 
-                    // The receiver owes a reason with a 400 (RFC 8935 Section 2.3) and it arrives here, where
-                    // it was previously read for the final-or-transient decision and then dropped. Nothing else
-                    // carries it: this side sees a status code and the receiver's own log is not ours to read,
-                    // so a stream refusing every SET looked from here exactly like one refusing none.
-                    LogSetRefused(
-                        stream.StreamId, item.JwtId, verdict?.Error ?? NoVerdict, verdict?.Description ?? NoVerdict);
+                    firstRefusal ??= verdict ?? Unexplained;
 
                     await outbox.AcknowledgeAsync(stream.StreamId, [item.JwtId], cancellationToken);
                     rejected++;
@@ -132,6 +166,16 @@ public sealed partial class PushDeliverySender(
                 await outbox.AcknowledgeAsync(stream.StreamId, [item.JwtId], cancellationToken);
                 delivered++;
             }
+        }
+
+        // Once for the pass, naming the count and the first reason. The receiver owes a reason with a
+        // 400 (RFC 8935 Section 2.3) and it is read here to decide whether a retransmission could ever
+        // succeed; nothing else carries it onward, so without this the only thing this side holds about
+        // a stream refusing everything is a number that looks like a stream refusing nothing.
+        if (rejected > 0)
+        {
+            LogSetsRefused(
+                stream.StreamId, rejected, firstRefusal!.Error, Readable(firstRefusal.Description));
         }
 
         return new PushDeliveryPassOutcome(delivered, rejected);

--- a/tests/Abblix.SharedSignals.E2E.Tests/SharedSignalsEndToEndTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/SharedSignalsEndToEndTests.cs
@@ -25,6 +25,7 @@ using Abblix.SharedSignals.Transmitter;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Abblix.SharedSignals.E2E.Tests;
@@ -307,7 +308,7 @@ public sealed class SharedSignalsEndToEndTests : IAsyncLifetime
         var sender = new PushDeliverySender(
             _receiver.GetTestClient(),
             _transmitter.Services.GetRequiredService<IEventOutbox>(),
-            _transmitter.Services.GetRequiredService<ReceiverAddressPolicy>());
+            _transmitter.Services.GetRequiredService<ReceiverAddressPolicy>(), NullLogger<PushDeliverySender>.Instance);
 
         return await sender.SendPendingAsync(stream!, cancellationToken);
     }

--- a/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Abblix.SharedSignals.UnitTests;
@@ -141,7 +142,7 @@ public class ReceiverAddressPolicyTests
         var outbox = new InMemoryEventOutbox();
         await outbox.EnqueueAsync("s-1", new OutboxItem("jti-1", "a.a.a"), TestContext.Current.CancellationToken);
 
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox, Policy());
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, Policy(), NullLogger<PushDeliverySender>.Instance);
         var stream = new StreamState
         {
             ReceiverId = "receiver-a",

--- a/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
@@ -11,6 +11,7 @@ using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
 using Abblix.SecurityEvents.Delivery;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -74,7 +75,7 @@ public class TransmitterDeliveryTests
             .Enqueue(HttpStatusCode.Accepted)
             .Enqueue(HttpStatusCode.Accepted);
         var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"), new OutboxItem("jti-2", "b.b.b"));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, NullLogger<PushDeliverySender>.Instance);
 
         var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
@@ -96,7 +97,7 @@ public class TransmitterDeliveryTests
             new OutboxItem("jti-1", "a.a.a"),
             new OutboxItem("jti-2", "b.b.b"),
             new OutboxItem("jti-3", "c.c.c"));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, NullLogger<PushDeliverySender>.Instance);
 
         var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
@@ -105,6 +106,81 @@ public class TransmitterDeliveryTests
             ["jti-2", "jti-3"],
             (await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken))
             .Select(item => item.JwtId));
+    }
+
+    /// <summary>The receiver's own reason for refusing a SET reaches this deployment's log.</summary>
+    /// <remarks>
+    /// <para>
+    /// RFC 8935 Section 2.3 makes the receiver owe an error body with a 400, and it arrives here - it was
+    /// already read to decide whether the refusal is final. Dropping it after that decision left this side
+    /// holding a status code, and the receiver's own log is not ours to read, so a stream refusing every SET
+    /// looked from here exactly like a stream refusing none.
+    /// </para>
+    /// <para>
+    /// Both halves are asserted, because a code without a description names a class of problem and a
+    /// description without a code cannot be grouped.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task Push_BadRequest_CarriesTheReceiversReasonIntoTheLog()
+    {
+        var handler = new StubHttpHandler().Enqueue(
+            HttpStatusCode.BadRequest,
+            """{"err": "invalid_audience", "description": "aud names a receiver this stream is not"}""");
+        var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"));
+        var logger = new CapturingLogger();
+
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, logger);
+        await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
+
+        var written = Assert.Single(logger.Written);
+        Assert.Contains("invalid_audience", written, StringComparison.Ordinal);
+        Assert.Contains("aud names a receiver this stream is not", written, StringComparison.Ordinal);
+
+        // The SET is named too: a deployment with several queued events needs to know WHICH one was refused.
+        Assert.Contains("jti-1", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>The control: a delivery the receiver accepts writes nothing.</summary>
+    /// <remarks>
+    /// Without it the assertion above is satisfied by a sender that logs on every pass, which would bury the
+    /// refusals it exists to surface - the shape this whole line of work started from.
+    /// </remarks>
+    [Fact]
+    public async Task Push_Accepted_WritesNothing()
+    {
+        var handler = new StubHttpHandler().Enqueue(HttpStatusCode.Accepted);
+        var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"));
+        var logger = new CapturingLogger();
+
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, logger);
+        await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
+
+        Assert.Empty(logger.Written);
+    }
+
+    /// <summary>Keeps what was written, formatted the way a log sink would render it.</summary>
+    private sealed class CapturingLogger : ILogger<PushDeliverySender>
+    {
+        public List<string> Written { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Written.Add(formatter(state, exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 
     /// <summary>
@@ -122,7 +198,7 @@ public class TransmitterDeliveryTests
         var outbox = await OutboxWithAsync(
             new OutboxItem("jti-1", "a.a.a"),
             new OutboxItem("jti-2", "b.b.b"));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, NullLogger<PushDeliverySender>.Instance);
 
         var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
@@ -147,7 +223,7 @@ public class TransmitterDeliveryTests
     {
         var handler = new StubHttpHandler().Enqueue(HttpStatusCode.BadRequest, body, mediaType);
         var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, NullLogger<PushDeliverySender>.Instance);
 
         var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
@@ -164,7 +240,7 @@ public class TransmitterDeliveryTests
         var outbox = await OutboxWithAsync(
             new OutboxItem("jti-1", "a.a.a"),
             new OutboxItem("jti-2", "b.b.b", IsStatusAnnouncement: true));
-        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver);
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, NullLogger<PushDeliverySender>.Instance);
 
         var outcome = await sender.SendPendingAsync(
             PushStream(StreamStatuses.Paused), TestContext.Current.CancellationToken);

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
@@ -11,6 +11,7 @@ using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Transmitter;
 using Abblix.SecurityEvents.Delivery;
+using Abblix.SharedSignals;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -108,25 +109,69 @@ public class TransmitterDeliveryTests
             .Select(item => item.JwtId));
     }
 
-    /// <summary>The receiver's own reason for refusing a SET reaches this deployment's log.</summary>
+    /// <summary>The receiver's own reason for refusing SETs reaches this deployment's log, once for the pass.</summary>
     /// <remarks>
     /// <para>
-    /// RFC 8935 Section 2.3 makes the receiver owe an error body with a 400, and it arrives here - it was
-    /// already read to decide whether the refusal is final. Dropping it after that decision left this side
-    /// holding a status code, and the receiver's own log is not ours to read, so a stream refusing every SET
-    /// looked from here exactly like a stream refusing none.
+    /// RFC 8935 Section 2.3 makes the receiver owe an error body with a 400, and it is read here to decide
+    /// whether a retransmission could ever succeed. Nothing else carries it onward: this side holds a status
+    /// code, the receiver's log is not ours to read, and a stream refusing everything is indistinguishable
+    /// from one refusing nothing.
     /// </para>
     /// <para>
-    /// Both halves are asserted, because a code without a description names a class of problem and a
-    /// description without a code cannot be grouped.
+    /// Three queued events and ONE line, because the queue is read whole: a line per SET would write
+    /// thousands in a pass for a receiver refusing a backlog, differing only in an identifier. The count
+    /// carries what the repetition would have.
+    /// </para>
+    /// <para>
+    /// The level and the event id are asserted because they are what a log pipeline filters on. A level
+    /// below the host's floor makes the line invisible and an id nobody publishes makes a runbook miss it,
+    /// and the rendered text is identical in both cases.
     /// </para>
     /// </remarks>
     [Fact]
-    public async Task Push_BadRequest_CarriesTheReceiversReasonIntoTheLog()
+    public async Task Push_BadRequest_CarriesTheReceiversReasonIntoTheLog_OncePerPass()
+    {
+        var handler = new StubHttpHandler();
+        for (var i = 0; i < 3; i++)
+        {
+            handler.Enqueue(
+                HttpStatusCode.BadRequest,
+                """{"err": "invalid_audience", "description": "aud names a receiver this stream is not"}""");
+        }
+
+        var outbox = await OutboxWithAsync(
+            new OutboxItem("jti-1", "a.a.a"), new OutboxItem("jti-2", "b.b.b"), new OutboxItem("jti-3", "c.c.c"));
+        var logger = new CapturingLogger();
+
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, logger);
+        var outcome = await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, outcome.Rejected);
+
+        var written = Assert.Single(logger.Written);
+        Assert.Equal(LogLevel.Warning, written.Level);
+        Assert.Equal(LogEvents.Transmitter.SetsRefusedByReceiver, written.Event.Id);
+        Assert.Contains("invalid_audience", written.Text, StringComparison.Ordinal);
+        Assert.Contains("aud names a receiver this stream is not", written.Text, StringComparison.Ordinal);
+
+        // The count and the stream are asserted where they belong in the sentence: a pair swapped at the
+        // call site renders a plausible line and compiles, because both sides are what the template expects.
+        Assert.Contains("refused 3 SET(s)", written.Text, StringComparison.Ordinal);
+        Assert.Contains("on stream s-1", written.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>An objection to the transmitter is its own event, and it holds the queue.</summary>
+    /// <remarks>
+    /// The queue disposition is what an operator acts on, and it is the opposite of the case above: nothing
+    /// is lost, and the events go out once the credential or the grant is put right. Told apart by event id
+    /// rather than by reading the sentence, because that is what a runbook keys on.
+    /// </remarks>
+    [Fact]
+    public async Task Push_BadRequestAboutTheTransmitter_SaysSoAndHoldsTheQueue()
     {
         var handler = new StubHttpHandler().Enqueue(
             HttpStatusCode.BadRequest,
-            """{"err": "invalid_audience", "description": "aud names a receiver this stream is not"}""");
+            $$"""{"err": "{{DeliveryErrorCodes.AccessDenied}}", "description": "no grant for this stream"}""");
         var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"));
         var logger = new CapturingLogger();
 
@@ -134,17 +179,48 @@ public class TransmitterDeliveryTests
         await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
 
         var written = Assert.Single(logger.Written);
-        Assert.Contains("invalid_audience", written, StringComparison.Ordinal);
-        Assert.Contains("aud names a receiver this stream is not", written, StringComparison.Ordinal);
+        Assert.Equal(LogLevel.Warning, written.Level);
+        Assert.Equal(LogEvents.Transmitter.ReceiverObjected, written.Event.Id);
+        Assert.Contains("no grant for this stream", written.Text, StringComparison.Ordinal);
 
-        // The SET is named too: a deployment with several queued events needs to know WHICH one was refused.
-        Assert.Contains("jti-1", written, StringComparison.Ordinal);
+        // The event is still owed to the receiver, so it stays queued.
+        Assert.Single(await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>The receiver's words are bounded and cannot forge a line of their own.</summary>
+    /// <remarks>
+    /// The field is the receiver's to fill and RFC 8935 Section 2.3 puts no bound on it, so it arrives as
+    /// text of any length from a party this deployment does not control. A plain-text sink writes a newline
+    /// as a newline, which is a whole fabricated entry in somebody else's gift.
+    /// </remarks>
+    [Fact]
+    public async Task Push_BadRequest_NeitherLetsTheReceiverWriteALineNorRunAway()
+    {
+        var forged = "bad\\n2026-08-23 warn: a line the receiver wrote itself" + new string('x', 5000);
+        var handler = new StubHttpHandler().Enqueue(
+            HttpStatusCode.BadRequest,
+            $$"""{"err": "invalid_request", "description": "{{forged}}"}""");
+        var outbox = await OutboxWithAsync(new OutboxItem("jti-1", "a.a.a"));
+        var logger = new CapturingLogger();
+
+        var sender = new PushDeliverySender(handler.CreateClient(), outbox, ReachingTheTestReceiver, logger);
+        await sender.SendPendingAsync(PushStream(), TestContext.Current.CancellationToken);
+
+        var written = Assert.Single(logger.Written).Text;
+
+        Assert.DoesNotContain('\n', written);
+        Assert.DoesNotContain('\r', written);
+        Assert.True(written.Length < 600, $"the line grew to {written.Length} characters");
+
+        // The control: the beginning of what the receiver said survives, so the bound above is not
+        // satisfied by dropping the description altogether.
+        Assert.Contains("bad", written, StringComparison.Ordinal);
     }
 
     /// <summary>The control: a delivery the receiver accepts writes nothing.</summary>
     /// <remarks>
-    /// Without it the assertion above is satisfied by a sender that logs on every pass, which would bury the
-    /// refusals it exists to surface - the shape this whole line of work started from.
+    /// Without it the assertions above are satisfied by a sender that logs on every pass, which would bury
+    /// the refusals it exists to surface.
     /// </remarks>
     [Fact]
     public async Task Push_Accepted_WritesNothing()
@@ -159,10 +235,14 @@ public class TransmitterDeliveryTests
         Assert.Empty(logger.Written);
     }
 
-    /// <summary>Keeps what was written, formatted the way a log sink would render it.</summary>
+    /// <summary>Keeps what was written, with the two properties a log pipeline filters on.</summary>
+    /// <remarks>
+    /// The level and the id are kept rather than discarded, because a level below the host's floor and an id
+    /// nobody publishes both render the identical sentence while the line reaches nobody.
+    /// </remarks>
     private sealed class CapturingLogger : ILogger<PushDeliverySender>
     {
-        public List<string> Written { get; } = [];
+        public List<(LogLevel Level, EventId Event, string Text)> Written { get; } = [];
 
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
 
@@ -174,7 +254,7 @@ public class TransmitterDeliveryTests
             TState state,
             Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => Written.Add(formatter(state, exception));
+            => Written.Add((logLevel, eventId, formatter(state, exception)));
 
         private sealed class NullScope : IDisposable
         {


### PR DESCRIPTION
Say why the receiver refused

A receiver owes an error body with a 400 (RFC 8935 Section 2.3), and it arrives here:
the sender already reads it to decide whether the refusal is final or transient, and
then drops it. So this side is left holding a status code, the receiver's own log is not
ours to read, and a stream refusing every SET looks from here exactly like one refusing
none. The counters say how many were rejected; nothing said why any of them was.

That is not hypothetical. A live stream began delivering after its address was permitted
and the receiver answered 400 to every push. The reason was on the wire each time, read
into a local, used for one boolean, and discarded - and the investigation had nowhere to
start.

Both refusals are written now, and they are different events because the remedy differs:
one is the receiver's judgment of THAT token, which no retransmission changes, and the
other is its objection to this transmitter, which leaves the queue held until credentials
or a grant are put right. The SET is named as well as the stream, because a deployment
with several queued events needs to know which one was refused.

A receiver that answers 400 with no body at all is written as such rather than as an
empty field: a receiver that explained itself and one that did not are different
problems, and an absent value looks the same as a value nobody wrote.

The control asserts an accepted delivery writes nothing - a sender that logged on every
pass would bury the refusals it exists to surface, which is the shape this started from.