### PR TITLE
Emit the authorization_details the validators returned, not the ones consent handed in

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -166,14 +166,7 @@ public class AuthorizationRequestProcessor(
 		// child of its own DTO, the second serialise will throw because the JsonNode is parented
 		// twice. DeepClone defensively on the boundary so the two consumers each see independent
 		// trees -- matches the DeepClone discipline applied elsewhere (ApplyTo, resolvers).
-		// Which SOURCE speaks is decided by the provider's own opinion, never by what the enforcer
-		// happened to return: a provider that expressed one has its re-validated array emitted even
-		// when the per-type validators narrowed it to nothing, while only the legacy null falls back
-		// to the request. Reading the enforcer's null as "no opinion" would conflate the two and
-		// resurrect entries the validators dropped.
-		var sourceAd = userConsents.Granted.AuthorizationDetails is null
-			? request.AuthorizationDetails
-			: enforcedAuthorizationDetails;
+		var sourceAd = enforcedAuthorizationDetails ?? request.AuthorizationDetails;
 		var emittedAuthorizationDetails = sourceAd is { Count: > 0 }
 			? (JsonArray?)sourceAd.DeepClone()
 			: null;

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -157,7 +157,8 @@ public class AuthorizationRequestProcessor(
 		// browser tampering it failed to intersect against the request), so it surfaces as an
 		// exception rather than an escalated grant. Symmetric with the strictly narrowing-only
 		// TokenAuthorizationContextEvaluator at the token endpoint.
-		await consentConstraintEnforcer.EnforceAsync(request, userConsents.Granted, CancellationToken.None);
+		var enforcedAuthorizationDetails = await consentConstraintEnforcer.EnforceAsync(
+			request, userConsents.Granted, CancellationToken.None);
 
 		// C2 (PR #135 review): the JsonArray reference passed to the consent provider and the
 		// one placed on AuthorizationContext travel through System.Text.Json on the way to the
@@ -165,7 +166,14 @@ public class AuthorizationRequestProcessor(
 		// child of its own DTO, the second serialise will throw because the JsonNode is parented
 		// twice. DeepClone defensively on the boundary so the two consumers each see independent
 		// trees -- matches the DeepClone discipline applied elsewhere (ApplyTo, resolvers).
-		var sourceAd = userConsents.Granted.AuthorizationDetails ?? request.AuthorizationDetails;
+		// Which SOURCE speaks is decided by the provider's own opinion, never by what the enforcer
+		// happened to return: a provider that expressed one has its re-validated array emitted even
+		// when the per-type validators narrowed it to nothing, while only the legacy null falls back
+		// to the request. Reading the enforcer's null as "no opinion" would conflate the two and
+		// resurrect entries the validators dropped.
+		var sourceAd = userConsents.Granted.AuthorizationDetails is null
+			? request.AuthorizationDetails
+			: enforcedAuthorizationDetails;
 		var emittedAuthorizationDetails = sourceAd is { Count: > 0 }
 			? (JsonArray?)sourceAd.DeepClone()
 			: null;

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -94,10 +94,10 @@ public class ConsentConstraintEnforcer(
         // {A, B} that requested only {A} must not have a {B} entry injected by the consent decision.
         var requestedTypes = (request.AuthorizationDetails?.ToTypedArray() ?? [])
             .Select(detail => detail.Type)
-            .Where(type => type is not null)
+            .OfType<string>()
             .ToHashSet(StringComparer.Ordinal);
 
-        RefuseUnrequestedTypes(grantedAuthorizationDetails);
+        var grantedTypes = RefuseTypesOutside(requestedTypes, grantedAuthorizationDetails);
 
         // Intra-entry narrowing: RFC 9396 defines no universal comparator for "is B a narrowing of
         // A" (an amount, a locations list within one entry), so re-run the granted entries through
@@ -116,32 +116,55 @@ public class ConsentConstraintEnforcer(
                 revalidation.GetFailure().ErrorDescription);
         }
 
-        // Nothing returned means nothing to change, which is the reading the request-time, CIBA and
-        // device validators all give the same result, so the granted array stands as it was.
-        if (revalidated is not { Count: > 0 })
+        // Nothing at all means nothing to change, which is how the request-time, CIBA and device
+        // validators read the same result, so the granted array stands as it was.
+        if (revalidated is null)
             return grantedAuthorizationDetails;
+
+        // An EMPTY array is a different statement, and this request has already decided what it means:
+        // a consent decision granting no entries against a request that carried some answers
+        // access_denied, one step before this call. Reaching here with one says the validators removed
+        // every entry, so returning the granted set would put back exactly what they removed.
+        if (revalidated.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "The per-type re-validation of the granted authorization_details returned an empty set. " +
+                "A policy signals 'nothing to change' by returning null; an empty array says every entry " +
+                "was removed, and there is no set left to issue a grant for.");
+        }
 
         // What comes back is the decision, not a copy of what went in: a validator narrowing an entry
         // says so by returning the narrowed one. Returning the granted array here instead would
         // re-derive from raw input the fact this call just computed, and every entry the two disagree
         // on would travel in the form nobody approved.
         //
-        // Which is also why the type check has to run again on it. Nothing in the per-type validator's
-        // contract stops the entry it returns from carrying a different type than the one it was asked
-        // about, and the array leaving this method is the one the grant is built from.
-        RefuseUnrequestedTypes(revalidated);
+        // Which is also why the type check has to run again, and against what the consent decision
+        // GRANTED rather than against what was requested: nothing in the per-type validator's contract
+        // stops the entry it returns from carrying another type, and a type the request carried but the
+        // user did not grant is one this array must not bring back.
+        RefuseTypesOutside(grantedTypes, revalidated);
         return revalidated;
 
-        void RefuseUnrequestedTypes(JsonArray details)
+        HashSet<string> RefuseTypesOutside(HashSet<string> allowed, JsonArray details)
         {
-            var escapedTypes = (details.ToTypedArray() ?? [])
-                .Select(detail => detail.Type)
-                .Where(type => type is not null && !requestedTypes.Contains(type))
+            // ToTypedArray drops whatever is not a JSON object, so a shorter result means an entry this
+            // guard cannot read - and "no escaped types" would then describe what it managed to look at
+            // rather than the array it was handed.
+            if (details.ToTypedArray() is not { } typed || typed.Length != details.Count)
+                throw Violation("authorization_details entries", ["an entry that is not a JSON object"]);
+
+            // A missing type is refused rather than skipped. RFC 9396 §2 makes type REQUIRED on every
+            // entry, and an entry without one satisfies "not among the escaped" by being unreadable.
+            var escapedTypes = typed
+                .Select(detail => detail.Type ?? "(no type)")
+                .Where(type => !allowed.Contains(type))
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
 
             if (escapedTypes.Length > 0)
-                throw Violation("authorization_details types", escapedTypes!);
+                throw Violation("authorization_details types", escapedTypes);
+
+            return typed.Select(detail => detail.Type!).ToHashSet(StringComparer.Ordinal);
         }
     }
 

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -97,14 +97,7 @@ public class ConsentConstraintEnforcer(
             .Where(type => type is not null)
             .ToHashSet(StringComparer.Ordinal);
 
-        var escapedTypes = (grantedAuthorizationDetails.ToTypedArray() ?? [])
-            .Select(detail => detail.Type)
-            .Where(type => type is not null && !requestedTypes.Contains(type))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        if (escapedTypes.Length > 0)
-            throw Violation("authorization_details types", escapedTypes!);
+        RefuseUnrequestedTypes(grantedAuthorizationDetails);
 
         // Intra-entry narrowing: RFC 9396 defines no universal comparator for "is B a narrowing of
         // A" (an amount, a locations list within one entry), so re-run the granted entries through
@@ -123,11 +116,33 @@ public class ConsentConstraintEnforcer(
                 revalidation.GetFailure().ErrorDescription);
         }
 
+        // Nothing returned means nothing to change, which is the reading the request-time, CIBA and
+        // device validators all give the same result, so the granted array stands as it was.
+        if (revalidated is not { Count: > 0 })
+            return grantedAuthorizationDetails;
+
         // What comes back is the decision, not a copy of what went in: a validator narrowing an entry
-        // says so by returning the narrowed one, exactly as the request-time path already treats it.
-        // Returning the granted array here instead would re-derive from raw input the fact this call
-        // just computed, and every entry the two disagree on would travel in the form nobody approved.
+        // says so by returning the narrowed one. Returning the granted array here instead would
+        // re-derive from raw input the fact this call just computed, and every entry the two disagree
+        // on would travel in the form nobody approved.
+        //
+        // Which is also why the type check has to run again on it. Nothing in the per-type validator's
+        // contract stops the entry it returns from carrying a different type than the one it was asked
+        // about, and the array leaving this method is the one the grant is built from.
+        RefuseUnrequestedTypes(revalidated);
         return revalidated;
+
+        void RefuseUnrequestedTypes(JsonArray details)
+        {
+            var escapedTypes = (details.ToTypedArray() ?? [])
+                .Select(detail => detail.Type)
+                .Where(type => type is not null && !requestedTypes.Contains(type))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (escapedTypes.Length > 0)
+                throw Violation("authorization_details types", escapedTypes!);
+        }
     }
 
     private static InvalidOperationException Violation(string category, string[] escaped) =>

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Features.Consents;
@@ -25,14 +26,14 @@ public class ConsentConstraintEnforcer(
     IAuthorizationDetailsPolicy authorizationDetailsPolicy) : IConsentConstraintEnforcer
 {
     /// <inheritdoc />
-    public async Task EnforceAsync(
+    public async Task<JsonArray?> EnforceAsync(
         ValidAuthorizationRequest request,
         ConsentDefinition granted,
         CancellationToken cancellationToken)
     {
         EnforceScopes(request, granted);
         EnforceResources(request, granted);
-        await EnforceAuthorizationDetailsAsync(request, granted, cancellationToken);
+        return await EnforceAuthorizationDetailsAsync(request, granted, cancellationToken);
     }
 
     private static void EnforceScopes(ValidAuthorizationRequest request, ConsentDefinition granted)
@@ -80,13 +81,13 @@ public class ConsentConstraintEnforcer(
         }
     }
 
-    private async Task EnforceAuthorizationDetailsAsync(
+    private async Task<JsonArray?> EnforceAuthorizationDetailsAsync(
         ValidAuthorizationRequest request,
         ConsentDefinition granted,
         CancellationToken cancellationToken)
     {
         if (granted.AuthorizationDetails is not { Count: > 0 } grantedAuthorizationDetails)
-            return;
+            return null;
 
         // Type-level subset: every granted entry's type must appear among the requested types. The
         // per-client allowlist (re-checked below) is not enough on its own - a client allowed types
@@ -113,13 +114,20 @@ public class ConsentConstraintEnforcer(
         var revalidation = await authorizationDetailsPolicy.ApplyAsync(
             grantedAuthorizationDetails, request.ClientInfo, cancellationToken);
 
-        if (revalidation.TryGetFailure(out var error))
+        if (!revalidation.TryGetSuccess(out var revalidated))
         {
             throw new InvalidOperationException(
                 "The IUserConsentsProvider granted authorization_details that fail per-type re-validation, " +
                 "so the granted set is not a valid narrowing of the request " +
-                $"(the consent provider violated the granted ⊆ requested contract): {error.ErrorDescription}");
+                "(the consent provider violated the granted ⊆ requested contract): " +
+                revalidation.GetFailure().ErrorDescription);
         }
+
+        // What comes back is the decision, not a copy of what went in: a validator narrowing an entry
+        // says so by returning the narrowed one, exactly as the request-time path already treats it.
+        // Returning the granted array here instead would re-derive from raw input the fact this call
+        // just computed, and every entry the two disagree on would travel in the form nobody approved.
+        return revalidated;
     }
 
     private static InvalidOperationException Violation(string category, string[] escaped) =>

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -46,7 +46,7 @@ public class ConsentConstraintEnforcer(
             .ToArray();
 
         if (escaped.Length > 0)
-            throw Violation("scopes", escaped);
+            throw Violation(nameof(IUserConsentsProvider), "scopes", escaped);
     }
 
     private static void EnforceResources(ValidAuthorizationRequest request, ConsentDefinition granted)
@@ -67,7 +67,7 @@ public class ConsentConstraintEnforcer(
         foreach (var grantedResource in granted.Resources)
         {
             if (!requested.TryGetValue(grantedResource.Resource, out var requestedScopes))
-                throw Violation("resources", [grantedResource.Resource.OriginalString]);
+                throw Violation(nameof(IUserConsentsProvider), "resources", [grantedResource.Resource.OriginalString]);
 
             // RFC 8707: a resource indicator scopes down. The granted resource's nested scopes must
             // not exceed what was requested for that same resource.
@@ -77,7 +77,7 @@ public class ConsentConstraintEnforcer(
                 .ToArray();
 
             if (escapedScopes.Length > 0)
-                throw Violation($"scopes for resource '{grantedResource.Resource}'", escapedScopes);
+                throw Violation(nameof(IUserConsentsProvider), $"scopes for resource '{grantedResource.Resource}'", escapedScopes);
         }
     }
 
@@ -97,7 +97,8 @@ public class ConsentConstraintEnforcer(
             .OfType<string>()
             .ToHashSet(StringComparer.Ordinal);
 
-        var grantedTypes = RefuseTypesOutside(requestedTypes, grantedAuthorizationDetails);
+        var grantedTypes = RefuseTypesOutside(
+            requestedTypes, grantedAuthorizationDetails, nameof(IUserConsentsProvider));
 
         // Intra-entry narrowing: RFC 9396 defines no universal comparator for "is B a narrowing of
         // A" (an amount, a locations list within one entry), so re-run the granted entries through
@@ -117,9 +118,15 @@ public class ConsentConstraintEnforcer(
         }
 
         // Nothing at all means nothing to change, which is how the request-time, CIBA and device
-        // validators read the same result, so the granted array stands as it was.
+        // validators read the same result, so the granted array stands as it was - but it is re-checked
+        // all the same. A validator that narrows by editing the entry IN PLACE, which is what every
+        // narrowing fixture in this repository does, has already written into this array by the time it
+        // answers, and the types read before the call are the only untouched copy of what was granted.
         if (revalidated is null)
+        {
+            RefuseTypesOutside(grantedTypes, grantedAuthorizationDetails, nameof(IAuthorizationDetailsPolicy));
             return grantedAuthorizationDetails;
+        }
 
         // An EMPTY array is a different statement, and this request has already decided what it means:
         // a consent decision granting no entries against a request that carried some answers
@@ -142,35 +149,48 @@ public class ConsentConstraintEnforcer(
         // GRANTED rather than against what was requested: nothing in the per-type validator's contract
         // stops the entry it returns from carrying another type, and a type the request carried but the
         // user did not grant is one this array must not bring back.
-        RefuseTypesOutside(grantedTypes, revalidated);
+        RefuseTypesOutside(grantedTypes, revalidated, nameof(IAuthorizationDetailsPolicy));
         return revalidated;
 
-        HashSet<string> RefuseTypesOutside(HashSet<string> allowed, JsonArray details)
+        HashSet<string> RefuseTypesOutside(HashSet<string> allowed, JsonArray details, string culprit)
         {
             // ToTypedArray drops whatever is not a JSON object, so a shorter result means an entry this
             // guard cannot read - and "no escaped types" would then describe what it managed to look at
             // rather than the array it was handed.
             if (details.ToTypedArray() is not { } typed || typed.Length != details.Count)
-                throw Violation("authorization_details entries", ["an entry that is not a JSON object"]);
+                throw Violation(culprit, "authorization_details entries", ["an entry that is not a JSON object"]);
 
-            // A missing type is refused rather than skipped. RFC 9396 §2 makes type REQUIRED on every
-            // entry, and an entry without one satisfies "not among the escaped" by being unreadable.
+            // A missing type is refused on its own, never folded into a stand-in string. RFC 9396 §2 makes
+            // type REQUIRED, and a stand-in would be a value a client can request: naming it as its own
+            // type would then admit every entry that has none.
+            if (Array.Exists(typed, detail => detail.Type is null))
+                throw Violation(culprit, "authorization_details entries", ["an entry carrying no type"]);
+
             var escapedTypes = typed
-                .Select(detail => detail.Type ?? "(no type)")
+                .Select(detail => detail.Type!)
                 .Where(type => !allowed.Contains(type))
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
 
             if (escapedTypes.Length > 0)
-                throw Violation("authorization_details types", escapedTypes);
+                throw Violation(culprit, "authorization_details types", escapedTypes);
 
             return typed.Select(detail => detail.Type!).ToHashSet(StringComparer.Ordinal);
         }
     }
 
-    private static InvalidOperationException Violation(string category, string[] escaped) =>
-        new($"The IUserConsentsProvider granted {category} absent from the authorization request: " +
-            $"{string.Join(", ", escaped)}. The granted set must be a subset of what the request carried " +
-            "(granted ⊆ requested); returning a broader set violates the IUserConsentsProvider " +
-            "contract documented on ConsentDefinition and would let the end-user escalate their own grant.");
+    /// <summary>
+    /// The refusal, naming the component whose output failed it.
+    /// </summary>
+    /// <remarks>
+    /// The culprit is a parameter because this exception is the entire diagnostic an operator receives:
+    /// it surfaces as a server error with no other trace, and the consent decision and the per-type
+    /// validators are different components owned by different code. Blaming one for the other's output
+    /// sends whoever reads it to audit the wrong file.
+    /// </remarks>
+    private static InvalidOperationException Violation(string culprit, string category, string[] escaped) =>
+        new($"The {culprit} produced {category} the request did not authorize: " +
+            $"{string.Join(", ", escaped)}. What reaches the grant must stay inside what the request " +
+            "carried and the end-user granted (granted ⊆ requested); a broader set would let the " +
+            "end-user, or whoever tampered with the decision on the way here, escalate the grant.");
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
 using Abblix.Oidc.Server.Features.Consents;
 
@@ -32,17 +33,26 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization;
 public interface IConsentConstraintEnforcer
 {
     /// <summary>
-    /// Asserts that the granted consent does not exceed the request. The granted set is left
-    /// unchanged on success.
+    /// Asserts that the granted consent does not exceed the request, and returns the
+    /// <c>authorization_details</c> as the per-type validators left them.
     /// </summary>
     /// <param name="request">The validated authorization request carrying the requested scopes,
     /// resources and <c>authorization_details</c>.</param>
     /// <param name="granted">The consent decision produced by <see cref="IUserConsentsProvider"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The granted <c>authorization_details</c> as re-validated, or <c>null</c> when the
+    /// consent decision carried none.</returns>
+    /// <remarks>
+    /// RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so the
+    /// per-type validator owns that decision - and a normalising validator expresses it by RETURNING
+    /// a modified entry rather than by failing. The value that comes back is therefore the decision
+    /// itself, and the caller emits it; emitting what went in instead would put content in the token
+    /// that no validator approved.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown when the granted set contains a scope,
     /// resource, resource scope or <c>authorization_details</c> entry absent from - or broader than -
     /// the request.</exception>
-    Task EnforceAsync(
+    Task<JsonArray?> EnforceAsync(
         ValidAuthorizationRequest request,
         ConsentDefinition granted,
         CancellationToken cancellationToken);

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
@@ -41,7 +41,8 @@ public interface IConsentConstraintEnforcer
     /// <param name="granted">The consent decision produced by <see cref="IUserConsentsProvider"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The granted <c>authorization_details</c> as re-validated, or <c>null</c> when the
-    /// consent decision carried none.</returns>
+    /// consent decision carried none. A re-validation that returns nothing leaves the granted set
+    /// standing, so <c>null</c> never means "the validators emptied it".</returns>
     /// <remarks>
     /// RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so the
     /// per-type validator owns that decision - and a normalising validator expresses it by RETURNING

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
@@ -44,6 +44,13 @@ public interface IConsentConstraintEnforcer
     /// consent decision carried none. A re-validation that returns nothing leaves the granted set
     /// standing, so <c>null</c> never means "the validators emptied it".</returns>
     /// <remarks>
+    /// What this bounds is TYPES and shapes, and deliberately not cardinality: a per-type validator
+    /// answering with several entries of a type the user did grant is accepted, because RFC 9396 offers
+    /// no comparator that would say whether three entries of a type narrow one. A deployment that needs
+    /// that bound sets it inside the per-type validator, which is the only place that knows what a
+    /// second entry of its own type means.
+    /// </remarks>
+    /// <remarks>
     /// RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so the
     /// per-type validator owns that decision - and a normalising validator expresses it by RETURNING
     /// a modified entry rather than by failing. The value that comes back is therefore the decision

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
@@ -52,7 +52,10 @@ public interface IConsentConstraintEnforcer
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown when the granted set contains a scope,
     /// resource, resource scope or <c>authorization_details</c> entry absent from - or broader than -
-    /// the request.</exception>
+    /// the request; and equally when the array leaving the per-type re-validation does, since that is
+    /// the one the grant is built from. Also thrown when an entry cannot be read as a JSON object,
+    /// when one carries no <c>type</c>, and when the re-validation answers with an empty set, which
+    /// says every entry was removed and leaves nothing to issue a grant for.</exception>
     Task<JsonArray?> EnforceAsync(
         ValidAuthorizationRequest request,
         ConsentDefinition granted,

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1660,7 +1660,7 @@ public class AuthorizationRequestProcessorTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => CapAmount(ad, 1000m));
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => CapAmount(ad, 800m));
 
         var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
 
@@ -1668,7 +1668,7 @@ public class AuthorizationRequestProcessorTests
 
         Assert.NotNull(capture.Grant);
         var emitted = capture.Grant.Context.AuthorizationDetails!;
-        Assert.Equal("1000", emitted[0]!["amount"]!.GetValue<string>());
+        Assert.Equal("800", emitted[0]!["amount"]!.GetValue<string>());
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -7,6 +7,7 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -1636,6 +1637,66 @@ public class AuthorizationRequestProcessorTests
         // Defensive DeepClone at the boundary (C2): the AuthorizationContext receives a clone,
         // not the same reference -- assert value-equality through the wire JSON instead.
         Assert.Equal(narrowedAd.ToJsonString(), capture.Grant.Context.AuthorizationDetails!.ToJsonString());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PolicyNormalisesGrantedDetails_TokenReflectsTheNormalisedSet()
+    {
+        // The request already carries the capped amount, because the request-time validator narrowed
+        // it before consent was asked. A provider that rebuilds its granted array from the original
+        // client request hands back the uncapped one; its type was requested, so the type-level subset
+        // check passes, and the per-type validator answers by RETURNING the capped entry rather than
+        // by failing - which is how a normalising validator says "this far and no further".
+        // Emitting the provider's number instead of the returned one would put an amount in the token
+        // that no validator ever approved.
+        var requestedAd = new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation", ["amount"] = "1000" });
+        var grantedAd = new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation", ["amount"] = "5000" });
+        var request = CreateRequest(authorizationDetails: requestedAd);
+        var session = CreateAuthSession();
+        var consents = CreateConsents(grantedAuthorizationDetails: grantedAd);
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => CapAmount(ad, 1000m));
+
+        var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.NotNull(capture.Grant);
+        var emitted = capture.Grant.Context.AuthorizationDetails!;
+        Assert.Equal("1000", emitted[0]!["amount"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// A normalising per-type validator: over the cap it returns a capped CLONE rather than mutating
+    /// the entry it was handed, which is what makes the returned value the only place the decision lives.
+    /// </summary>
+    private static JsonArray? CapAmount(JsonArray? details, decimal cap)
+    {
+        if (details is null)
+            return null;
+
+        var capped = new JsonArray();
+        foreach (var entry in details)
+        {
+            var clone = (JsonObject)entry!.DeepClone();
+            var parsed = decimal.TryParse(
+                clone["amount"]?.GetValue<string>(),
+                NumberStyles.Number,
+                CultureInfo.InvariantCulture,
+                out var amount);
+
+            if (parsed && amount > cap)
+                clone["amount"] = cap.ToString(CultureInfo.InvariantCulture);
+
+            capped.Add(clone);
+        }
+
+        return capped;
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -166,6 +166,43 @@ public class ConsentConstraintEnforcerTests
     }
 
     [Fact]
+    public async Task EnforceAsync_PolicyNormalisesGrantedDetails_ReturnsWhatThePolicyReturned()
+    {
+        // A per-type validator that narrows by RETURNING a capped entry is making the decision in its
+        // return value, so the enforcer must hand that value on. Returning the granted array instead
+        // would leave the cap behind in a variable nobody reads.
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "1000" }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "5000" }));
+        var capped = new JsonArray(new JsonObject { ["type"] = "payment_initiation", ["amount"] = "1000" });
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(capped));
+
+        var enforced = await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+
+        Assert.Same(capped, enforced);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedCarriesNoAuthorizationDetails_ReturnsNull()
+    {
+        // Null is how a consent provider says it has no authorization_details opinion at all, and the
+        // caller keys its fall-back to the request on exactly that. The policy is never consulted,
+        // which the strict mock asserts by construction.
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted();
+
+        var enforced = await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+
+        Assert.Null(enforced);
+    }
+
+    [Fact]
     public async Task EnforceAsync_GrantedAuthorizationDetailsValidNarrowing_DoesNotThrow()
     {
         var request = CreateRequest(authorizationDetails:

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -188,6 +188,52 @@ public class ConsentConstraintEnforcerTests
     }
 
     [Fact]
+    public async Task EnforceAsync_PolicyReturnsAnUnrequestedType_Throws()
+    {
+        // The array that leaves this method is the one the grant is built from, so the type check has
+        // to cover it. Nothing in the per-type validator's contract stops the entry it returns from
+        // carrying a different type than the one it was asked about, and an entry whose type nobody
+        // requested is the escalation this backstop exists to refuse.
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(
+                new JsonArray(new JsonObject { ["type"] = "admin_access" })));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Contains("admin_access", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_PolicyReturnsNothing_KeepsTheGrantedSet()
+    {
+        // A null result means "nothing to change" everywhere else this policy is consumed - the
+        // request-time, CIBA and device validators all keep what they had - so reading it here as
+        // "the validators emptied the set" would drop authorization_details RFC 9396 section 7
+        // obliges the server to return, on a path where nobody can tell.
+        var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails: grantedAd);
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(null));
+
+        var enforced = await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
+
+        Assert.Same(grantedAd, enforced);
+    }
+
+    [Fact]
     public async Task EnforceAsync_GrantedCarriesNoAuthorizationDetails_ReturnsNull()
     {
         // Null is how a consent provider says it has no authorization_details opinion at all, and the

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -256,6 +256,105 @@ public class ConsentConstraintEnforcerTests
     }
 
     [Fact]
+    public async Task EnforceAsync_PolicyReturnsAnEntryWithoutATypeAndTheRequestNamedTheStandIn_Throws()
+    {
+        // A missing type must not be compared as a value. If it were folded into a stand-in string, a
+        // client could ask for a type spelled exactly that way and thereby admit every typeless entry
+        // the validators return - the guard would read them as a type the request carried.
+        const string standIn = "(no type)";
+
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = standIn }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = standIn }));
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+                new JsonObject { ["type"] = standIn },
+                new JsonObject { ["amount"] = "999999" })));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task EnforceAsync_PolicyReturnsSeveralEntriesAndOneEscapes_Throws()
+    {
+        // The granted array here has two entries, so a guard that read only the first would pass. The
+        // escaping entry is the second on BOTH sides, which is the shape a single-entry fixture cannot
+        // tell apart from a guard that works.
+        var request = CreateRequest(authorizationDetails: new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation" },
+            new JsonObject { ["type"] = "account_information" }));
+        var granted = Granted(authorizationDetails: new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation" },
+            new JsonObject { ["type"] = "account_information" }));
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+                new JsonObject { ["type"] = "payment_initiation" },
+                new JsonObject { ["type"] = "admin_access" })));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Contains("admin_access", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_PolicyReturnsAnEntryThatIsNotAnObject_Throws()
+    {
+        // The shape guard has to cover the array that LEAVES, not only the one that arrived: the entry
+        // the caller emits is the policy's output, and the conversion the guard reads through drops a
+        // non-object silently.
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+                new JsonObject { ["type"] = "payment_initiation" },
+                JsonValue.Create("payment_initiation"))));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task EnforceAsync_ValidatorEditsTheTypeInPlaceAndReturnsNothing_Throws()
+    {
+        // Every narrowing validator in this repository's own fixtures edits the entry IN PLACE and
+        // returns the same wrapper, and the typed wrappers alias the source nodes - so a policy that
+        // answers "nothing to change" can still have rewritten the array it was handed. The types read
+        // before the call are the only untouched copy, and that path has to be guarded too.
+        var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails: grantedAd);
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) =>
+            {
+                ad![0]!["type"] = "wire_transfer";
+                return Result<JsonArray?, OidcError>.Success(null);
+            });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Contains("wire_transfer", ex.Message);
+    }
+
+    [Fact]
     public async Task EnforceAsync_PolicyReturnsAnEmptySet_Throws()
     {
         // Null and empty are different statements. Empty says every entry was removed, and this same

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -188,12 +188,38 @@ public class ConsentConstraintEnforcerTests
     }
 
     [Fact]
-    public async Task EnforceAsync_PolicyReturnsAnUnrequestedType_Throws()
+    public async Task EnforceAsync_PolicyReturnsATypeTheUserDidNotGrant_Throws()
     {
         // The array that leaves this method is the one the grant is built from, so the type check has
-        // to cover it. Nothing in the per-type validator's contract stops the entry it returns from
-        // carrying a different type than the one it was asked about, and an entry whose type nobody
-        // requested is the escalation this backstop exists to refuse.
+        // to cover it - and against what the consent decision GRANTED, not merely against what was
+        // requested. Here the user was asked about two types and granted one; an entry of the other
+        // coming back from re-validation resurrects what they refused. It is the SECOND entry, because
+        // a guard that stops at the first reads as working on every single-entry fixture.
+        var request = CreateRequest(authorizationDetails: new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation" },
+            new JsonObject { ["type"] = "account_information" }));
+        var granted = Granted(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+                new JsonObject { ["type"] = "payment_initiation" },
+                new JsonObject { ["type"] = "account_information" })));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Contains("account_information", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_PolicyReturnsAnEntryWithoutAType_Throws()
+    {
+        // A missing type passes "not among the types nobody granted" by being unreadable, and RFC 9396
+        // §2 makes type REQUIRED on every entry - so the answer is a refusal, not a skip. Change the
+        // type and the guard refuses; delete it and it must not wave the entry through.
         var request = CreateRequest(authorizationDetails:
             new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
         var granted = Granted(authorizationDetails:
@@ -203,12 +229,50 @@ public class ConsentConstraintEnforcerTests
             .Setup(p => p.ApplyAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<JsonArray?, OidcError>.Success(
-                new JsonArray(new JsonObject { ["type"] = "admin_access" })));
+                new JsonArray(new JsonObject { ["amount"] = "999999" })));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task EnforceAsync_GrantedCarriesAnEntryThatIsNotAnObject_Throws()
+    {
+        // The guard reads entries through a conversion that DROPS anything that is not an object, so a
+        // shorter result would let it report "no escaped types" about an array it could not read.
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails: new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation" },
+            JsonValue.Create("payment_initiation")));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
             () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
 
-        Assert.Contains("admin_access", ex.Message);
+        // Refused before the policy is consulted: it is the guard's own reading that failed.
+        _authorizationDetailsPolicy.Verify(
+            p => p.ApplyAsync(It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_PolicyReturnsAnEmptySet_Throws()
+    {
+        // Null and empty are different statements. Empty says every entry was removed, and this same
+        // request answers access_denied to a consent decision that granted none - so emitting the
+        // granted set here would put back exactly what the validators took out.
+        var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+        var request = CreateRequest(authorizationDetails:
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
+        var granted = Granted(authorizationDetails: grantedAd);
+
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray()));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #394.

## The defect

`ConsentConstraintEnforcer` re-ran the granted `authorization_details` through the per-type validators and read only the failure bit. RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so the per-type validator owns that decision, and a validator that normalises expresses it by RETURNING a modified entry rather than by failing. That returned value was dropped, and the processor emitted the consent provider's array as it arrived.

Which validators this bites is worth stating precisely. All three narrowing validators in this repository's own fixtures mutate `detail.Json` in place and return the same wrapper, and the typed wrappers alias the source nodes, so their narrowing already landed on the granted array. The defect bites a validator that treats the entry as immutable and returns a new one, which the interface's own contract permits and documents.

## The change

`IConsentConstraintEnforcer.EnforceAsync` returns the `authorization_details` as re-validated, and the processor emits that.

Because the emitted array is now the validator's output rather than the consent provider's input, the type check runs on it as well, and against what the consent decision GRANTED rather than against what was requested: a type the user was asked about but did not grant must not come back. That guard also runs on the path where the policy answers "nothing to change", because every narrowing validator here edits in place, so by then the array it was handed may already carry another type.

Three things the guard refuses on its own rather than folding into a comparison: an entry that cannot be read as a JSON object, an entry carrying no `type` (RFC 9396 section 2 makes it REQUIRED, and a stand-in value would be one a client could request), and a re-validation that answers with an empty array, which says every entry was removed and leaves nothing to issue a grant for.

The refusal names the component whose output failed it. This exception is the whole diagnostic an operator gets, and the consent decision and the per-type validators are different code owned by different people.

## Compatibility

`IConsentConstraintEnforcer` is absent from every canonical release, up to and including `v2.3`, so no released package carries the old signature. Dev prereleases published from `develop` do, which is the honest bound; the one host in this workspace implements neither this interface nor `IUserConsentsProvider`.

## Evidence

The processor test was written first and failed against the old code with the issue's own numbers. Every mutation below was planted so it compiles and run separately, against the current head:

- enforcer returns the granted array instead of the re-validated one: the processor test and the enforcer's return-value test fail;
- processor re-derives from the granted array: the processor test fails, and nothing else - that one test is what stands between this defect and a regression;
- processor emits the request value instead: the processor test fails alongside three pre-existing narrowing tests;
- the emitted array is not re-checked: the escalation test and the missing-type test fail;
- a null re-validation empties the set: the keep-the-granted-set test fails;
- the guard reads only the first entry, or compares against the requested rather than the granted types: the two-entry escalation test fails.

`Abblix.Oidc.Server.UnitTests` 2798 passed, `Abblix.Oidc.Server.E2E.Tests` 190 passed. The E2E suite carries no case for this behaviour, so it is evidence that nothing broke rather than that the fix works.

Three adversarial review rounds ran against this branch; the second and third each found real defects in the fixes of the round before, which is what the last two commits answer.
