### PR TITLE
Ask the per-type validator a granted-phase question, so consent can enrich

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -110,7 +110,7 @@ public class ConsentConstraintEnforcer(
         // the per-type validators and per-client allowlist and let the per-type validator own that
         // decision. A rejection means a granted entry's content escalated beyond what the validator
         // permits for this client.
-        var revalidation = await authorizationDetailsPolicy.ApplyAsync(
+        var revalidation = await authorizationDetailsPolicy.ApplyGrantedAsync(
             grantedAuthorizationDetails, request.ClientInfo, cancellationToken);
 
         if (revalidation.TryGetFailure(out var error))

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -35,10 +35,42 @@ namespace Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 internal sealed class AuthorizationDetailsPolicy(
     IServiceProvider serviceProvider) : IAuthorizationDetailsPolicy
 {
+    /// <summary>
+    /// The per-entry question, which is the only thing the request phase and the granted phase differ
+    /// in: everything around it (object shape, known type, per-client allowlist) binds in both.
+    /// </summary>
+    private delegate Task<Result<AuthorizationDetail, OidcError>> AskValidator(
+        IAuthorizationDetailValidator validator,
+        AuthorizationDetail detail,
+        ClientInfo client,
+        CancellationToken token);
+
     /// <inheritdoc/>
-    public async Task<Result<JsonArray?, OidcError>> ApplyAsync(
+    public Task<Result<JsonArray?, OidcError>> ApplyAsync(
         JsonArray? raw,
         ClientInfo client,
+        CancellationToken token)
+        => ApplyCoreAsync(
+            raw,
+            client,
+            static (validator, detail, client, token) => validator.ValidateAsync(detail, client, token),
+            token);
+
+    /// <inheritdoc/>
+    public Task<Result<JsonArray?, OidcError>> ApplyGrantedAsync(
+        JsonArray? granted,
+        ClientInfo client,
+        CancellationToken token)
+        => ApplyCoreAsync(
+            granted,
+            client,
+            static (validator, detail, client, token) => validator.ValidateGrantedAsync(detail, client, token),
+            token);
+
+    private async Task<Result<JsonArray?, OidcError>> ApplyCoreAsync(
+        JsonArray? raw,
+        ClientInfo client,
+        AskValidator ask,
         CancellationToken token)
     {
         if (raw is not { Count: > 0 })
@@ -71,7 +103,7 @@ internal sealed class AuthorizationDetailsPolicy(
                 return Reject($"Authorization detail types not allowed for this client: {string.Join(", ", disallowed)}");
         }
 
-        var result = await ValidateAsync(authorizationDetails, client, token);
+        var result = await ValidateAsync(authorizationDetails, client, ask, token);
 
         // Rebuild the raw array from the validated typed list (RFC 9396 §7.1 narrow / extend).
         // When per-type validators left their input untouched the result is byte-equivalent
@@ -86,6 +118,7 @@ internal sealed class AuthorizationDetailsPolicy(
     private async Task<Result<IReadOnlyList<AuthorizationDetail>, OidcError>> ValidateAsync(
         IEnumerable<AuthorizationDetail> details,
         ClientInfo client,
+        AskValidator ask,
         CancellationToken cancellationToken)
     {
         var validated = new List<AuthorizationDetail>();
@@ -106,7 +139,7 @@ internal sealed class AuthorizationDetailsPolicy(
                     $"unknown authorization_details type: '{detail.Type}'");
             }
 
-            var result = await validator.ValidateAsync(detail, client, cancellationToken);
+            var result = await ask(validator, detail, client, cancellationToken);
             if (result.TryGetFailure(out var failure))
             {
                 return failure;

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailValidator.cs
@@ -57,6 +57,39 @@ public interface IAuthorizationDetailValidator
         CancellationToken token);
 
     /// <summary>
+    /// Validates a single entry as the consent decision left it, which may carry values the server
+    /// itself added while the end-user was choosing. Defaults to <see cref="ValidateAsync"/>, so a
+    /// type that does not enrich answers the same question in both phases.
+    /// </summary>
+    /// <remarks>
+    /// RFC 9396 §7.1 says that "Whether enrichment is allowed and specifics of how it works are
+    /// necessarily part of the definition of the respective authorization details type", and in this
+    /// library the definition of a type is this validator. Its worked example (Figures 16 and 17) is
+    /// an <c>account_information</c> entry whose empty arrays are placeholders the server fills with
+    /// the identifiers the user picked.
+    /// <para>
+    /// That shape is one a conforming request-time validator has to REFUSE: RFC 9396 §5 makes the
+    /// server reject an entry "containing fields with invalid values for the authorization details
+    /// type", and a client choosing the accounts is exactly that. So a validator for an enrichable
+    /// type overrides this member to accept what the consent decision produced, while
+    /// <see cref="ValidateAsync"/> keeps refusing the same shape when a client sends it.
+    /// </para>
+    /// </remarks>
+    /// <param name="detail">The granted entry, whose <see cref="AuthorizationDetail.Type"/> matches
+    /// this validator's <see cref="Type"/>.</param>
+    /// <param name="client">The client the grant is being issued to.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The validated (and possibly normalised) detail on success, or an
+    /// <see cref="OidcError"/> describing the rejection. A rejection here means the consent decision
+    /// escalated beyond what this type permits, which is a host-side defect rather than a client
+    /// error.</returns>
+    Task<Result<AuthorizationDetail, OidcError>> ValidateGrantedAsync(
+        AuthorizationDetail detail,
+        ClientInfo client,
+        CancellationToken token)
+        => ValidateAsync(detail, client, token);
+
+    /// <summary>
     /// Optional: produces a host-renderable <see cref="AuthorizationDetailDescriptor"/> describing
     /// what consenting to this entry authorises, so the consent UI can render a meaningful screen
     /// instead of a raw JSON dump. Default returns <c>null</c>; hosts that opt out simply fall back

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailValidator.cs
@@ -68,11 +68,20 @@ public interface IAuthorizationDetailValidator
     /// an <c>account_information</c> entry whose empty arrays are placeholders the server fills with
     /// the identifiers the user picked.
     /// <para>
-    /// That shape is one a conforming request-time validator has to REFUSE: RFC 9396 §5 makes the
-    /// server reject an entry "containing fields with invalid values for the authorization details
-    /// type", and a client choosing the accounts is exactly that. So a validator for an enrichable
-    /// type overrides this member to accept what the consent decision produced, while
-    /// <see cref="ValidateAsync"/> keeps refusing the same shape when a client sends it.
+    /// That shape is one the request-time question may legitimately refuse: RFC 9396 §5 has the server
+    /// reject an entry that "contains fields with invalid values for the authorization details type",
+    /// and a type whose definition says the client must not choose the accounts makes a populated
+    /// placeholder exactly that. Such a type overrides this member so the consent decision's own
+    /// output is accepted, while <see cref="ValidateAsync"/> keeps refusing it from a client.
+    /// </para>
+    /// <para>
+    /// An override MUST still refuse everything <see cref="ValidateAsync"/> refuses, apart from the
+    /// fields its type declares enrichable. This is the anti-escalation re-check, and the consent
+    /// decision reaching it has often crossed the browser: what the library still guarantees for an
+    /// overriding type is only that entries are JSON objects, that their types are known, requested
+    /// and on the client's allowlist. Everything inside an entry - an amount, an account, a list of
+    /// locations - is guaranteed by this method and by nothing else. An override that returns its
+    /// input unconditionally hands a tampered consent decision straight to the issued token.
     /// </para>
     /// </remarks>
     /// <param name="detail">The granted entry, whose <see cref="AuthorizationDetail.Type"/> matches

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailValidator.cs
@@ -83,6 +83,13 @@ public interface IAuthorizationDetailValidator
     /// locations - is guaranteed by this method and by nothing else. An override that returns its
     /// input unconditionally hands a tampered consent decision straight to the issued token.
     /// </para>
+    /// <para>
+    /// Note what this method is NOT given: the entry the client originally sent, and the end user who
+    /// answered. So an enrichable field can be bounded here only by rules that hold on their own - a
+    /// ceiling, a format, a per-client limit - and not by comparing the value against the request it
+    /// came from. A type whose enrichment needs that comparison has to make it where both sides are in
+    /// hand, which today is the consent provider that produced the decision.
+    /// </para>
     /// </remarks>
     /// <param name="detail">The granted entry, whose <see cref="AuthorizationDetail.Type"/> matches
     /// this validator's <see cref="Type"/>.</param>

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
@@ -59,4 +59,27 @@ public interface IAuthorizationDetailsPolicy
         JsonArray? raw,
         ClientInfo client,
         CancellationToken token);
+
+    /// <summary>
+    /// The same validation applied to a set the consent decision produced rather than one a client
+    /// sent, dispatching each entry to
+    /// <see cref="IAuthorizationDetailValidator.ValidateGrantedAsync"/>. Defaults to
+    /// <see cref="ApplyAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Everything outside the per-type question is phase-independent and still applies: the entries
+    /// must be JSON objects, their types must be known, and the per-client allowlist still binds.
+    /// Only the question put to the per-type validator differs, because RFC 9396 §7.1 lets the server
+    /// add values during consent that §5 obliges it to refuse from a client.
+    /// </remarks>
+    /// <param name="granted">The <c>authorization_details</c> the consent decision granted.</param>
+    /// <param name="client">The client the grant is being issued to.</param>
+    /// <param name="token">Cancellation token forwarded to per-type validators.</param>
+    /// <returns>The same shape as <see cref="ApplyAsync"/>: the post-validation array on success, or
+    /// an <see cref="OidcError"/> naming the entry that was refused.</returns>
+    Task<Result<JsonArray?, OidcError>> ApplyGrantedAsync(
+        JsonArray? granted,
+        ClientInfo client,
+        CancellationToken token)
+        => ApplyAsync(granted, client, token);
 }

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
@@ -71,6 +71,13 @@ public interface IAuthorizationDetailsPolicy
     /// must be JSON objects, their types must be known, and the per-client allowlist still binds.
     /// Only the question put to the per-type validator differs, because RFC 9396 §7.1 lets the server
     /// add values during consent that §5 obliges it to refuse from a client.
+    /// <para>
+    /// A decorator around this interface MUST forward this member too. The default sends it to
+    /// <see cref="ApplyAsync"/>, so a decorator that implements only that one turns the granted phase
+    /// back into the request phase for everything it wraps - silently, since the call still succeeds
+    /// and the pipeline still runs. The same holds for a mock: a strict one refuses the call, and a
+    /// loose one answers with a null task result the caller then dereferences.
+    /// </para>
     /// </remarks>
     /// <param name="granted">The <c>authorization_details</c> the consent decision granted.</param>
     /// <param name="client">The client the grant is being issued to.</param>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -64,17 +64,10 @@ public class AuthorizationRequestProcessorTests
         _identityTokenService = new Mock<IIdentityTokenService>(MockBehavior.Strict);
         _authorizationDetailsPolicy = new Mock<IAuthorizationDetailsPolicy>(MockBehavior.Strict);
 
-        // The anti-escalation backstop re-runs granted authorization_details through the per-type
-        // policy. For the processor tests the granted set is already a valid narrowing, so the
-        // policy passes it through unchanged; AD escalation/failure cases are covered in
-        // ConsentConstraintEnforcerTests against the real enforcer.
-        _authorizationDetailsPolicy
-            .Setup(p => p.ApplyAsync(
-                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => ad);
-
-        // The backstop asks the GRANTED-phase question (RFC 9396 section 7.1), which is a different
-        // member on the policy and therefore a different setup on a strict mock.
+        // The processor reaches the policy only through the backstop, which asks the GRANTED-phase
+        // question (RFC 9396 section 7.1). For these tests the granted set is already a valid
+        // narrowing, so the policy passes it through unchanged; escalation and failure cases are
+        // covered in ConsentConstraintEnforcerTests against the real enforcer.
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -73,6 +73,13 @@ public class AuthorizationRequestProcessorTests
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => ad);
 
+        // The backstop asks the GRANTED-phase question (RFC 9396 section 7.1), which is a different
+        // member on the policy and therefore a different setup on a strict mock.
+        _authorizationDetailsPolicy
+            .Setup(p => p.ApplyGrantedAsync(
+                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => ad);
+
         _timeProvider = new FakeTimeProvider();
 
         // No cutoff recorded is the ordinary case; the tests about revocation build their own.

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -1,4 +1,4 @@
-// Abblix OIDC Server Library
+﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -10,6 +10,7 @@ using System;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Endpoints.Authorization;
@@ -20,6 +21,7 @@ using Abblix.Oidc.Server.Features.Consents;
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -76,7 +78,7 @@ public class ConsentConstraintEnforcerTests
 
     private void SetupPolicyPassThrough() =>
         _authorizationDetailsPolicy
-            .Setup(p => p.ApplyAsync(
+            .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) =>
                 Result<JsonArray?, OidcError>.Success(ad));
@@ -142,7 +144,7 @@ public class ConsentConstraintEnforcerTests
 
         // The type-level subset check fails before any per-type re-validation is attempted.
         _authorizationDetailsPolicy.Verify(
-            p => p.ApplyAsync(It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()),
+            p => p.ApplyGrantedAsync(It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -156,7 +158,7 @@ public class ConsentConstraintEnforcerTests
 
         // The per-type policy rejects the granted entry (e.g. amount escalated beyond the client's cap).
         _authorizationDetailsPolicy
-            .Setup(p => p.ApplyAsync(
+            .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<JsonArray?, OidcError>.Failure(
                 new OidcError(ErrorCodes.InvalidAuthorizationDetails, "amount exceeds the client's cap")));
@@ -178,5 +180,71 @@ public class ConsentConstraintEnforcerTests
             () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
 
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_ConsentEnrichedTheEntry_DoesNotThrow()
+    {
+        // RFC 9396 section 7.1, worked in Figures 16 and 17: the client asks for account information
+        // with empty placeholders, the user picks the accounts, and the server writes the identifiers
+        // in. A validator implementing section 5 refuses populated placeholders in a REQUEST, because
+        // the client must not choose the accounts - so re-running the granted entry through the
+        // request-time question rejects what the specification says the server may do.
+        //
+        // A real composite policy, not a mock: the permissive stub is what kept this green.
+        var services = new ServiceCollection();
+        services.AddRichAuthorizationRequests();
+        services.AddAuthorizationDetailValidator<PlaceholderAccountValidator>(
+            PlaceholderAccountValidator.AccountInformation);
+        var enforcer = new ConsentConstraintEnforcer(
+            services.BuildServiceProvider().GetRequiredService<IAuthorizationDetailsPolicy>());
+
+        var request = CreateRequest(authorizationDetails: new JsonArray(
+            new JsonObject
+            {
+                ["type"] = PlaceholderAccountValidator.AccountInformation,
+                ["access"] = new JsonObject { ["accounts"] = new JsonArray() },
+            }));
+
+        var granted = Granted(authorizationDetails: new JsonArray(
+            new JsonObject
+            {
+                ["type"] = PlaceholderAccountValidator.AccountInformation,
+                ["access"] = new JsonObject
+                {
+                    ["accounts"] = new JsonArray(
+                        new JsonObject { ["iban"] = "DE2310010010123456789" }),
+                },
+            }));
+
+        var exception = await Record.ExceptionAsync(
+            () => enforcer.EnforceAsync(request, granted, CancellationToken.None));
+
+        Assert.Null(exception);
+    }
+
+    /// <summary>
+    /// A conforming validator for an enrichable type: it refuses a request whose placeholders are
+    /// already filled (RFC 9396 section 5, "invalid values for the authorization details type"), and
+    /// accepts the filled shape once the consent decision produced it (section 7.1).
+    /// </summary>
+    private sealed class PlaceholderAccountValidator : IAuthorizationDetailValidator
+    {
+        public const string AccountInformation = "account_information";
+
+        public string Type => AccountInformation;
+
+        public Task<Result<AuthorizationDetail, OidcError>> ValidateAsync(
+            AuthorizationDetail detail, ClientInfo client, CancellationToken token)
+            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(
+                detail.Json["access"]?["accounts"] is JsonArray { Count: > 0 }
+                    ? new OidcError(
+                        ErrorCodes.InvalidAuthorizationDetails,
+                        "access.accounts is chosen by the end-user, so a request must leave it empty")
+                    : detail);
+
+        public Task<Result<AuthorizationDetail, OidcError>> ValidateGrantedAsync(
+            AuthorizationDetail detail, ClientInfo client, CancellationToken token)
+            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(detail);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -1,4 +1,4 @@
-﻿// Abblix OIDC Server Library
+// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
 // SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
@@ -236,15 +236,23 @@ public class ConsentConstraintEnforcerTests
 
         public Task<Result<AuthorizationDetail, OidcError>> ValidateAsync(
             AuthorizationDetail detail, ClientInfo client, CancellationToken token)
-            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(
+            => Task.FromResult(
                 detail.Json["access"]?["accounts"] is JsonArray { Count: > 0 }
-                    ? new OidcError(
-                        ErrorCodes.InvalidAuthorizationDetails,
-                        "access.accounts is chosen by the end-user, so a request must leave it empty")
-                    : detail);
+                    ? Refuse("access.accounts is chosen by the end-user, so a request must leave it empty")
+                    : SharedRules(detail));
 
+        // Only the enrichable field is exempt. Everything else this type refuses, it refuses in both
+        // phases, because a consent decision that crossed the browser is not more trusted than a client.
         public Task<Result<AuthorizationDetail, OidcError>> ValidateGrantedAsync(
             AuthorizationDetail detail, ClientInfo client, CancellationToken token)
-            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(detail);
+            => Task.FromResult(SharedRules(detail));
+
+        private static Result<AuthorizationDetail, OidcError> SharedRules(AuthorizationDetail detail)
+            => detail.Json["access"] is JsonObject
+                ? detail
+                : Refuse("access is required for account_information");
+
+        private static Result<AuthorizationDetail, OidcError> Refuse(string description)
+            => new OidcError(ErrorCodes.InvalidAuthorizationDetails, description);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -386,6 +386,50 @@ public class AuthorizationDetailsPolicyTests
         Assert.Equal(wire, validated!.ToJsonString());
     }
 
+    [Fact]
+    public async Task ApplyGrantedAsync_without_an_override_asks_the_request_time_question()
+    {
+        // The granted phase is a distinct question, not a weaker one: a type that does not enrich
+        // answers the same way in both phases, so the anti-escalation re-check keeps biting for
+        // every validator written before this member existed.
+        var sp = BuildProvider(registerValidators: services => services
+            .AddAuthorizationDetailValidator<RejectingValidator>("payment_initiation"));
+        var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
+        var raw = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+
+        var result = await composite.ApplyGrantedAsync(raw, TestClient, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Contains(RejectingValidator.Reason, error.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task ApplyGrantedAsync_uses_the_overridden_granted_phase()
+    {
+        // RFC 9396 §7.1 enrichment: the same entry that must be refused from a client is the one the
+        // consent decision produces, so the two phases have to be able to disagree.
+        var sp = BuildProvider(registerValidators: services => services
+            .AddAuthorizationDetailValidator<EnrichableAccountValidator>("account_information"));
+        var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
+        var enriched = new JsonArray(new JsonObject
+        {
+            ["type"] = "account_information",
+            ["access"] = new JsonObject
+            {
+                ["accounts"] = new JsonArray(new JsonObject { ["iban"] = "DE2310010010123456789" }),
+            },
+        });
+
+        var asRequest = await composite.ApplyAsync(
+            (JsonArray)enriched.DeepClone(), TestClient, TestContext.Current.CancellationToken);
+        var asGranted = await composite.ApplyGrantedAsync(
+            enriched, TestClient, TestContext.Current.CancellationToken);
+
+        Assert.True(asRequest.TryGetFailure(out _));
+        Assert.True(asGranted.TryGetSuccess(out var validated));
+        Assert.NotNull(validated);
+    }
+
     private static ServiceProvider BuildProvider(Action<IServiceCollection>? registerValidators = null)
     {
         var services = new ServiceCollection();
@@ -431,6 +475,28 @@ public class AuthorizationDetailsPolicyTests
             AuthorizationDetail detail, ClientInfo client, CancellationToken token)
             => Task.FromResult<Result<AuthorizationDetail, OidcError>>(
                 new OidcError(ErrorCodes.InvalidAuthorizationDetails, Reason));
+    }
+
+    /// <summary>
+    /// An enrichable type, in the shape of RFC 9396 §7.1 Figures 16 and 17: the client sends empty
+    /// placeholders, and the server writes the identifiers the user picked into them.
+    /// </summary>
+    private sealed class EnrichableAccountValidator : IAuthorizationDetailValidator
+    {
+        public string Type => "account_information";
+
+        public Task<Result<AuthorizationDetail, OidcError>> ValidateAsync(
+            AuthorizationDetail detail, ClientInfo client, CancellationToken token)
+            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(
+                detail.Json["access"]?["accounts"] is JsonArray { Count: > 0 }
+                    ? new OidcError(
+                        ErrorCodes.InvalidAuthorizationDetails,
+                        "access.accounts is chosen by the end-user, so a request must leave it empty")
+                    : detail);
+
+        public Task<Result<AuthorizationDetail, OidcError>> ValidateGrantedAsync(
+            AuthorizationDetail detail, ClientInfo client, CancellationToken token)
+            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(detail);
     }
 
     private sealed class InvocationCounter

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -432,7 +432,9 @@ public class AuthorizationDetailsPolicyTests
 
     [Theory]
     [InlineData("allowlist")]
+    [InlineData("empty-allowlist")]
     [InlineData("unknown-type")]
+    [InlineData("missing-type")]
     [InlineData("not-an-object")]
     public async Task ApplyGrantedAsync_keeps_every_check_outside_the_per_type_question(string shape)
     {
@@ -450,10 +452,18 @@ public class AuthorizationDetailsPolicyTests
                 new ClientInfo("c") { AuthorizationDetailsTypes = ["account_information"] },
                 new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
                 "payment_initiation"),
+            "empty-allowlist" => (
+                new ClientInfo("c") { AuthorizationDetailsTypes = [] },
+                new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
+                "not permitted"),
             "unknown-type" => (
                 new ClientInfo("c"),
                 new JsonArray(new JsonObject { ["type"] = "never_registered" }),
                 "unknown"),
+            "missing-type" => (
+                new ClientInfo("c"),
+                new JsonArray(new JsonObject { ["amount"] = "999999" }),
+                "type"),
             "not-an-object" => (
                 new ClientInfo("c"),
                 new JsonArray(JsonValue.Create("payment_initiation")),
@@ -476,13 +486,19 @@ public class AuthorizationDetailsPolicyTests
         // accepting everything. A host that implements the interface itself is the case it protects.
         IAuthorizationDetailsPolicy policy = new RefusingPolicy();
 
-        var result = await policy.ApplyGrantedAsync(
-            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
-            TestClient,
-            TestContext.Current.CancellationToken);
+        var granted = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+
+        var result = await policy.ApplyGrantedAsync(granted, TestClient, TestContext.Current.CancellationToken);
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(RefusingPolicy.Reason, error.ErrorDescription);
+
+        // Forwarded, not merely reached: a default that called ApplyAsync with nothing would take the
+        // "no entries" exit and answer success for every granted set, and a policy that ignores its
+        // arguments cannot tell the two apart.
+        var refusing = (RefusingPolicy)policy;
+        Assert.Same(granted, refusing.LastRaw);
+        Assert.Same(TestClient, refusing.LastClient);
     }
 
     [Fact]
@@ -586,10 +602,19 @@ public class AuthorizationDetailsPolicyTests
     {
         public const string Reason = "refused by the host's own policy";
 
+        public JsonArray? LastRaw { get; private set; }
+
+        public ClientInfo? LastClient { get; private set; }
+
         public Task<Result<JsonArray?, OidcError>> ApplyAsync(
             JsonArray? raw, ClientInfo client, CancellationToken token)
-            => Task.FromResult<Result<JsonArray?, OidcError>>(
+        {
+            LastRaw = raw;
+            LastClient = client;
+
+            return Task.FromResult<Result<JsonArray?, OidcError>>(
                 new OidcError(ErrorCodes.InvalidAuthorizationDetails, Reason));
+        }
     }
 
     private sealed class InvocationCounter

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -430,6 +430,77 @@ public class AuthorizationDetailsPolicyTests
         Assert.NotNull(validated);
     }
 
+    [Theory]
+    [InlineData("allowlist")]
+    [InlineData("unknown-type")]
+    [InlineData("not-an-object")]
+    public async Task ApplyGrantedAsync_keeps_every_check_outside_the_per_type_question(string shape)
+    {
+        // The granted phase changes ONE question. The claim that everything around it still binds is
+        // otherwise carried by prose alone, and prose does not fail when an implementation stops
+        // honouring it: a granted path that skipped these would take a type the client may not use,
+        // a type nobody implements, or an entry that is not an object at all.
+        var sp = BuildProvider(registerValidators: services => services
+            .AddAuthorizationDetailValidator<PaymentValidator>("payment_initiation"));
+        var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
+
+        var (client, granted, expected) = shape switch
+        {
+            "allowlist" => (
+                new ClientInfo("c") { AuthorizationDetailsTypes = ["account_information"] },
+                new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
+                "payment_initiation"),
+            "unknown-type" => (
+                new ClientInfo("c"),
+                new JsonArray(new JsonObject { ["type"] = "never_registered" }),
+                "unknown"),
+            "not-an-object" => (
+                new ClientInfo("c"),
+                new JsonArray(JsonValue.Create("payment_initiation")),
+                "JSON object"),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unhandled shape"),
+        };
+
+        var result = await composite.ApplyGrantedAsync(granted, client, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, error.Error);
+        Assert.Contains(expected, error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ApplyGrantedAsync_falls_back_to_ApplyAsync_when_a_policy_does_not_override_it()
+    {
+        // The default member is what makes this addition non-breaking, and the shipped composite
+        // overrides it - so nothing would notice if the default stopped deferring and started
+        // accepting everything. A host that implements the interface itself is the case it protects.
+        IAuthorizationDetailsPolicy policy = new RefusingPolicy();
+
+        var result = await policy.ApplyGrantedAsync(
+            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
+            TestClient,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(RefusingPolicy.Reason, error.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task ApplyGrantedAsync_still_applies_the_rules_the_type_did_not_exempt()
+    {
+        // An enrichable type exempts the field the server fills in, and nothing else. Its other rules
+        // hold against a consent decision exactly as they hold against a client.
+        var sp = BuildProvider(registerValidators: services => services
+            .AddAuthorizationDetailValidator<EnrichableAccountValidator>("account_information"));
+        var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
+        var granted = new JsonArray(new JsonObject { ["type"] = "account_information" });
+
+        var result = await composite.ApplyGrantedAsync(granted, TestClient, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Contains("access is required", error.ErrorDescription);
+    }
+
     private static ServiceProvider BuildProvider(Action<IServiceCollection>? registerValidators = null)
     {
         var services = new ServiceCollection();
@@ -487,16 +558,38 @@ public class AuthorizationDetailsPolicyTests
 
         public Task<Result<AuthorizationDetail, OidcError>> ValidateAsync(
             AuthorizationDetail detail, ClientInfo client, CancellationToken token)
-            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(
+            => Task.FromResult(
                 detail.Json["access"]?["accounts"] is JsonArray { Count: > 0 }
-                    ? new OidcError(
-                        ErrorCodes.InvalidAuthorizationDetails,
-                        "access.accounts is chosen by the end-user, so a request must leave it empty")
-                    : detail);
+                    ? Refuse("access.accounts is chosen by the end-user, so a request must leave it empty")
+                    : SharedRules(detail));
 
+        // Only the enrichable field is exempt here. Everything else the type refuses, it refuses in
+        // both phases: a consent decision that crossed the browser is not more trusted than a client.
         public Task<Result<AuthorizationDetail, OidcError>> ValidateGrantedAsync(
             AuthorizationDetail detail, ClientInfo client, CancellationToken token)
-            => Task.FromResult<Result<AuthorizationDetail, OidcError>>(detail);
+            => Task.FromResult(SharedRules(detail));
+
+        private static Result<AuthorizationDetail, OidcError> SharedRules(AuthorizationDetail detail)
+            => detail.Json["access"] is JsonObject
+                ? detail
+                : Refuse("access is required for account_information");
+
+        private static Result<AuthorizationDetail, OidcError> Refuse(string description)
+            => new OidcError(ErrorCodes.InvalidAuthorizationDetails, description);
+    }
+
+    /// <summary>
+    /// A host's own policy: it implements the interface and knows nothing of the granted phase, which
+    /// is the shape the default member exists for.
+    /// </summary>
+    private sealed class RefusingPolicy : IAuthorizationDetailsPolicy
+    {
+        public const string Reason = "refused by the host's own policy";
+
+        public Task<Result<JsonArray?, OidcError>> ApplyAsync(
+            JsonArray? raw, ClientInfo client, CancellationToken token)
+            => Task.FromResult<Result<JsonArray?, OidcError>>(
+                new OidcError(ErrorCodes.InvalidAuthorizationDetails, Reason));
     }
 
     private sealed class InvocationCounter


### PR DESCRIPTION
Closes the enrichment half of #396. The device-flow half is PR #405, and the third bullet of that issue is deliberately left open, see below.

## The defect

The consent backstop re-ran granted `authorization_details` through `IAuthorizationDetailValidator.ValidateAsync`, the same question the request-time pipeline asks. RFC 9396 section 5 has that question refuse an entry that "contains fields with invalid values for the authorization details type", and section 7.1 has the server producing exactly such an entry during consent: its worked example is an `account_information` object whose empty arrays are placeholders the server fills with the accounts the user picked.

A validator for such a type therefore refuses what the specification says the server may do. The refusal became an `InvalidOperationException`, which nothing in the authorization pipeline catches, so the end user met a 500 in the middle of the flow.

## Why the fix is shaped this way

Section 7.1 settles who decides:

> Whether enrichment is allowed and specifics of how it works are necessarily part of the definition of the respective authorization details type.

In this library that definition is the type's validator, which is already the thing the backstop consults. What was missing is that the validator could not hear which phase it was in.

So `IAuthorizationDetailValidator` gains `ValidateGrantedAsync`, defaulting to `ValidateAsync`. A type that does not enrich behaves exactly as before, and the anti-escalation re-check keeps biting for every validator written so far. `IAuthorizationDetailsPolicy` gains the matching `ApplyGrantedAsync`, also defaulting, and the backstop asks that one. Everything around the per-type question is phase-independent and still applies: entries must be JSON objects, their types must be known, and the per-client allowlist still binds. Those three are now covered by tests on the granted path, because a version that skipped all of them passed the whole suite.

An override owes everything the request-time question refuses, apart from the fields its type declares enrichable. That is the guarantee the library cannot make for an enriching type, and it is now stated on the member and modelled in both fixtures: one rule exempted, another kept in both phases. An override that returns its input unconditionally hands a tampered consent decision to the issued token.

## Compatibility, stated precisely

Both members are default interface members, so nothing stops compiling. That is narrower than "no host has to change":

- a host that implements `IAuthorizationDetailsPolicy` itself, and does not override the new member, keeps working through the default;
- a host that DECORATES the policy and forwards only `ApplyAsync` silently turns the granted phase back into the request phase, which is now stated on the interface;
- a strict mock refuses the new call and a loose one answers null, so test doubles for these interfaces need a line adding. Two setups in this repository needed it, and five tests fail without them.

`IAuthorizationDetailValidator` already used a default member for `BuildConsentDescriptorAsync`; `IAuthorizationDetailsPolicy` had none before this change.

## What this does not fix

The third bullet of #396 asks whether an `InvalidOperationException` should be how a consent decision fails at all. It is deferred, not answered: for a conforming enriching type the exception stops firing, but a genuine escalation still surfaces as a 500 to the end user. The issue stays open for that decision.

Related: the value the granted phase returns is currently discarded by the enforcer, which is #394 and PR #403 on the same line. Whichever lands first, the other rebases.

## Evidence

The enforcer test was written first, against a real composite policy rather than the permissive stub that kept this green, and failed with the exception quoted above. Each mutation below was planted so it compiles and run separately:

- the granted phase dispatching to `ValidateAsync`: the policy test for the override and the enforcer's enrichment test fail, nothing else;
- the default member accepting every entry instead of deferring: the policy test for a validator without an override fails, nothing else;
- the granted path bypassing the shared checks: the allowlist and non-object cases fail;
- the policy interface's default accepting everything: the hand-written-policy test fails.

`Abblix.Oidc.Server.UnitTests` 2796 passed, `Abblix.Oidc.Server.E2E.Tests` 190 passed. The E2E suite carries no case for this behaviour: its payment validator does not override the new member, so it is evidence of nothing having broken rather than of the fix working.



A second review round added two things. The member now says what an override CANNOT check, because it receives neither the entry the client sent nor the end user who answered, so an enrichable field can be bounded here only by rules that hold on their own. And two more test holes are closed: the default member's forwarding was unasserted, and the granted-path theory covered three of the five phase-independent refusals rather than all five.
