### PR TITLE
Say who carries the device grant's authorization_details, and notice when nobody did

### DIFF
--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
@@ -31,8 +31,10 @@ public interface IUserCodeVerificationService
     /// </summary>
     /// <param name="userCode">The user-entered verification code.</param>
     /// <param name="authorizedGrant">The authorized grant containing the user's authentication session and
-    /// context. Whatever this carries is what the device is granted, verbatim: the library adds nothing to
-    /// it.</param>
+    /// context. Its <c>authorization_details</c> are what the device is granted: the library adds none, and
+    /// refuses an approval carrying a type the request never asked for. Its scopes and resources are a
+    /// starting point rather than the final word - the token endpoint narrows them against the token
+    /// request (RFC 6749 §6, RFC 8707 §2.2) and adds the certificate and proof-key confirmations.</param>
     /// <returns>
     /// A task that returns true if the approval was successful; false if the code is invalid or expired.
     /// </returns>
@@ -44,9 +46,16 @@ public interface IUserCodeVerificationService
     /// payment nobody was shown is worse than granting none.
     /// <para>
     /// Approving with entries on the record and none on the grant is therefore allowed and logged at
-    /// warning level: RFC 9396 §7 has the server return what was granted, so the token that follows
-    /// carries nothing for a resource server to enforce, and that is worth seeing in a log rather than
-    /// discovering at the resource server.
+    /// warning level. §7 is satisfied either way, since its MUST is to return what the resource owner
+    /// GRANTED and nothing granted is nothing to return. §9 is the one that matters here: it makes the
+    /// details reaching the resource server the point of having them, and a token carrying none leaves
+    /// it nothing to enforce, which is worth seeing in a log rather than discovering at the resource
+    /// server.
+    /// </para>
+    /// <para>
+    /// The opposite direction is refused rather than logged. A grant carrying a type the device
+    /// authorization request never asked for gives the device authority nobody requested, so the
+    /// approval answers <c>false</c> and the request stays pending.
     /// </para>
     /// </remarks>
     Task<bool> ApproveAsync(string userCode, AuthorizedGrant authorizedGrant);

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
@@ -30,10 +30,25 @@ public interface IUserCodeVerificationService
     /// Approves the device authorization request, linking the user's authorization to the pending device.
     /// </summary>
     /// <param name="userCode">The user-entered verification code.</param>
-    /// <param name="authorizedGrant">The authorized grant containing the user's authentication session and context.</param>
+    /// <param name="authorizedGrant">The authorized grant containing the user's authentication session and
+    /// context. Whatever this carries is what the device is granted, verbatim: the library adds nothing to
+    /// it.</param>
     /// <returns>
     /// A task that returns true if the approval was successful; false if the code is invalid or expired.
     /// </returns>
+    /// <remarks>
+    /// <c>authorization_details</c> are the host's to carry. The requested entries arrive on
+    /// <see cref="ValidUserCode"/>, and the decision the user made about them belongs on this grant's
+    /// <c>AuthorizationContext</c> - narrowed, enriched or dropped, as the verification page decided. The
+    /// library does not copy them across, because only that page knows what it displayed, and granting a
+    /// payment nobody was shown is worse than granting none.
+    /// <para>
+    /// Approving with entries on the record and none on the grant is therefore allowed and logged at
+    /// warning level: RFC 9396 §7 has the server return what was granted, so the token that follows
+    /// carries nothing for a resource server to enforce, and that is worth seeing in a log rather than
+    /// discovering at the resource server.
+    /// </para>
+    /// </remarks>
     Task<bool> ApproveAsync(string userCode, AuthorizedGrant authorizedGrant);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.Logging.cs
@@ -22,6 +22,17 @@ partial class UserCodeVerificationService
         Message = "Client {ClientId} requested {RequestedCount} authorization_details entries at the device " +
                   "endpoint, and the approved grant carries none. The user-verification page decides what it " +
                   "shows and what it grants, so the library leaves the entries to it (see ValidUserCode); a " +
-                  "grant without them issues a token no resource server can enforce against (RFC 9396 §7).")]
+                  "grant without them issues a token no resource server can enforce against (RFC 9396 §9).")]
     private partial void LogGrantedAuthorizationDetailsNotCarried(string ClientId, int RequestedCount);
+
+    /// <summary>
+    /// The escaped TYPES only, for the same reason: what a type carries is its own business, and here it
+    /// is payment and account data.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEvents.Device.UserCodeVerificationService.GrantedAuthorizationDetailsExceedTheRequest,
+        Level = LogLevel.Warning,
+        Message = "Client {ClientId} was approved with authorization_details the device authorization " +
+                  "request never asked for, so the approval is refused: {EscapedTypes}")]
+    private partial void LogGrantedAuthorizationDetailsExceedTheRequest(string ClientId, string EscapedTypes);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.Logging.cs
@@ -1,0 +1,27 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
+
+partial class UserCodeVerificationService
+{
+    /// <summary>
+    /// The count and the client, never the entries themselves: an authorization_details entry carries
+    /// whatever its type defines, which for the types this exists to serve is payment and account data.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEvents.Device.UserCodeVerificationService.GrantedAuthorizationDetailsNotCarried,
+        Level = LogLevel.Warning,
+        Message = "Client {ClientId} requested {RequestedCount} authorization_details entries at the device " +
+                  "endpoint, and the approved grant carries none. The user-verification page decides what it " +
+                  "shows and what it grants, so the library leaves the entries to it (see ValidUserCode); a " +
+                  "grant without them issues a token no resource server can enforce against (RFC 9396 §7).")]
+    private partial void LogGrantedAuthorizationDetailsNotCarried(string ClientId, int RequestedCount);
+}

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -9,6 +9,7 @@
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
@@ -17,6 +18,7 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// This service handles the verification, approval, and denial of device authorization requests
 /// with built-in brute force protection.
 /// </summary>
+/// <param name="logger">Records what an approval left behind, since the library cannot supply it.</param>
 /// <param name="storage">The storage service for device authorization requests.</param>
 /// <param name="rateLimiter">The rate limiter for preventing brute force attacks.</param>
 /// <param name="normalizer">Canonicalizes user-entered codes before lookup (RFC 8628 Section 6.1).</param>
@@ -24,7 +26,8 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// through this abstraction rather than the HTTP context so it stays independent of the host, and so a test
 /// can drive the limiter without standing up a web host.</param>
 /// <param name="timeProvider">Provides the current time for deriving the request's remaining lifetime.</param>
-public class UserCodeVerificationService(
+public partial class UserCodeVerificationService(
+    ILogger<UserCodeVerificationService> logger,
     IDeviceAuthorizationStorage storage,
     IUserCodeRateLimiter rateLimiter,
     IUserCodeNormalizer normalizer,
@@ -89,6 +92,17 @@ public class UserCodeVerificationService(
         var remaining = request.ExpiresAt - timeProvider.GetUtcNow();
         if (remaining <= TimeSpan.Zero)
             return false;
+
+        // The requested entries were handed to the host on ValidUserCode, and whether they reach the
+        // grant is its decision: only its verification page knows whether it displayed them, and a
+        // library putting them there would grant what nobody may have shown. The one thing that must
+        // not happen is the omission passing unremarked - it is either a refusal the host expressed by
+        // other means, or the threading it forgot, and the two look identical from here.
+        if (request.AuthorizationDetails is { Count: > 0 } requestedDetails
+            && authorizedGrant.Context.AuthorizationDetails is not { Count: > 0 })
+        {
+            LogGrantedAuthorizationDetailsNotCarried(request.ClientId, requestedDetails.Count);
+        }
 
         request.Status = DeviceAuthorizationStatus.Authorized;
         request.AuthorizedGrant = authorizedGrant;

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
@@ -93,22 +94,72 @@ public partial class UserCodeVerificationService(
         if (remaining <= TimeSpan.Zero)
             return false;
 
-        // The requested entries were handed to the host on ValidUserCode, and whether they reach the
-        // grant is its decision: only its verification page knows whether it displayed them, and a
-        // library putting them there would grant what nobody may have shown. The one thing that must
-        // not happen is the omission passing unremarked - it is either a refusal the host expressed by
-        // other means, or the threading it forgot, and the two look identical from here.
-        if (request.AuthorizationDetails is { Count: > 0 } requestedDetails
-            && authorizedGrant.Context.AuthorizationDetails is not { Count: > 0 })
+        // Narrowing is the host's to decide; widening is not. A grant carrying a type the device
+        // authorization request never asked for gives the device authority nobody requested, and this is
+        // the last place holding both sides: the requested entries live on the record, and the grant
+        // about to replace them is the one the token is built from.
+        if (EscapedAuthorizationDetailTypes(request, authorizedGrant) is { Length: > 0 } escaped)
         {
-            LogGrantedAuthorizationDetailsNotCarried(request.ClientId, requestedDetails.Count);
+            LogGrantedAuthorizationDetailsExceedTheRequest(
+                request.ClientId, string.Join(", ", escaped));
+
+            return false;
         }
 
         request.Status = DeviceAuthorizationStatus.Authorized;
         request.AuthorizedGrant = authorizedGrant;
 
         await storage.UpdateAsync(deviceCode, request, remaining);
+
+        // The requested entries were handed to the host on ValidUserCode, and whether they reach the
+        // grant is its decision: only its verification page knows whether it displayed them, and a
+        // library putting them there would grant what nobody may have shown. The one thing that must
+        // not happen is the omission passing unremarked - it is either a refusal the host expressed by
+        // other means, or the threading it forgot, and the two look identical from here.
+        //
+        // Said after the write, so the line never describes an approval that did not happen.
+        if (request.AuthorizationDetails is { Count: > 0 } requestedDetails
+            && authorizedGrant.Context.AuthorizationDetails is not { Count: > 0 })
+        {
+            LogGrantedAuthorizationDetailsNotCarried(request.ClientId, requestedDetails.Count);
+        }
+
         return true;
+    }
+
+    /// <summary>
+    /// The <c>authorization_details</c> types the grant carries and the device authorization request never
+    /// asked for, empty when the grant stays inside what was requested.
+    /// </summary>
+    /// <remarks>
+    /// Types only: RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so
+    /// what can be judged here is whether an entry of that type was asked for at all. An entry that cannot
+    /// be read as a JSON object counts as escaped, because the conversion drops it silently and "nothing
+    /// escaped" would then describe what could be read rather than the grant.
+    /// </remarks>
+    private static string[] EscapedAuthorizationDetailTypes(
+        DeviceAuthorizationRequest request,
+        AuthorizedGrant authorizedGrant)
+    {
+        if (authorizedGrant.Context.AuthorizationDetails is not { Count: > 0 } granted)
+            return [];
+
+        if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
+            return ["an entry that is not a JSON object"];
+
+        if (Array.Exists(typed, detail => detail.Type is null))
+            return ["an entry carrying no type"];
+
+        var requestedTypes = (request.AuthorizationDetails?.ToTypedArray() ?? [])
+            .Select(detail => detail.Type)
+            .OfType<string>()
+            .ToHashSet(StringComparer.Ordinal);
+
+        return typed
+            .Select(detail => detail.Type!)
+            .Where(type => !requestedTypes.Contains(type))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     /// <inheritdoc />

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/ValidUserCode.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/ValidUserCode.cs
@@ -18,7 +18,11 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// <param name="Resources">The requested resources (RFC 8707) for the authorization.</param>
 /// <param name="AuthorizationDetails">RFC 9396 §3 Rich Authorization Requests array from
 /// the original /device_authorization request. The host's user-verification UI renders these
-/// for consent and threads the user's decision onto the AuthorizedGrant's AuthorizationContext.</param>
+/// for consent and threads the user's decision onto the AuthorizedGrant's AuthorizationContext.
+/// Nothing else does: approving with a grant that carries none issues a token with no
+/// <c>authorization_details</c> at all, which RFC 9396 §7 leaves a resource server unable to
+/// enforce. The approval logs that at warning level rather than repairing it, since only this
+/// page knows what it showed the user.</param>
 public record ValidUserCode(
     string ClientId,
     string[] Scope,

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/ValidUserCode.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/ValidUserCode.cs
@@ -20,7 +20,7 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// the original /device_authorization request. The host's user-verification UI renders these
 /// for consent and threads the user's decision onto the AuthorizedGrant's AuthorizationContext.
 /// Nothing else does: approving with a grant that carries none issues a token with no
-/// <c>authorization_details</c> at all, which RFC 9396 §7 leaves a resource server unable to
+/// <c>authorization_details</c> at all, which RFC 9396 §9 leaves a resource server unable to
 /// enforce. The approval logs that at warning level rather than repairing it, since only this
 /// page knows what it showed the user.</param>
 public record ValidUserCode(

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -567,6 +567,17 @@ internal static class LogEvents
             public const int RequestSent = Base + 1;
             public const int SendFailed = Base + 2;
         }
+
+        /// <summary>
+        /// <c>Features/DeviceAuthorization/UserCodeVerificationService.cs</c> - RFC 8628 user-code
+        /// approval, and what the approval left behind (sub-range 7090-7099).
+        /// </summary>
+        public static class UserCodeVerificationService
+        {
+            private const int Base = 7090;
+
+            public const int GrantedAuthorizationDetailsNotCarried = Base + 1;
+        }
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -570,13 +570,14 @@ internal static class LogEvents
 
         /// <summary>
         /// <c>Features/DeviceAuthorization/UserCodeVerificationService.cs</c> - RFC 8628 user-code
-        /// approval, and what the approval left behind (sub-range 7090-7099).
+        /// approval, and what the approval left behind (sub-range 7080-7084).
         /// </summary>
         public static class UserCodeVerificationService
         {
-            private const int Base = 7090;
+            private const int Base = 7080;
 
             public const int GrantedAuthorizationDetailsNotCarried = Base + 1;
+            public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 2;
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -7,12 +7,20 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
+using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Utils;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -32,6 +40,9 @@ public class UserCodeVerificationServiceTests
     private const string DeviceCode = "device-code-123";
     private const string ClientId = "test-client";
 
+    private static readonly DateTimeOffset Now = new(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly CapturingLogger<UserCodeVerificationService> _logs = new();
     private readonly UserCodeVerificationService _service;
 
     public UserCodeVerificationServiceTests()
@@ -63,6 +74,7 @@ public class UserCodeVerificationServiceTests
         }));
 
         _service = new UserCodeVerificationService(
+            _logs,
             storage.Object,
             rateLimiter.Object,
             normalizer,
@@ -81,5 +93,102 @@ public class UserCodeVerificationServiceTests
 
         var valid = Assert.IsType<ValidUserCode>(result);
         Assert.Equal(ClientId, valid.ClientId);
+    }
+
+    [Fact]
+    public async Task Approve_WithoutTheRequestedAuthorizationDetails_SaysSo()
+    {
+        // Whether the entries reach the grant is the host's call, because only its verification page
+        // knows what it displayed. What must not happen is that the omission passes unremarked: the
+        // token that follows carries no authorization_details, and a resource server enforcing them
+        // has nothing to enforce (RFC 9396 section 7).
+        var requestedDetails = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+        var service = BuildService(requestedDetails, out var logs);
+
+        var approved = await service.ApproveAsync(CanonicalUserCode, GrantWith(null));
+
+        Assert.True(approved);
+        var warning = Assert.Single(logs.Entries, entry => entry.Level == LogLevel.Warning);
+        Assert.Contains(ClientId, warning.Message);
+    }
+
+    [Fact]
+    public async Task Approve_CarryingTheAuthorizationDetails_SaysNothing()
+    {
+        var requestedDetails = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+        var service = BuildService(requestedDetails, out var logs);
+
+        var approved = await service.ApproveAsync(
+            CanonicalUserCode,
+            GrantWith((JsonArray)requestedDetails.DeepClone()));
+
+        Assert.True(approved);
+        Assert.DoesNotContain(logs.Entries, entry => entry.Level == LogLevel.Warning);
+    }
+
+    private static AuthorizedGrant GrantWith(JsonArray? authorizationDetails)
+        => new(
+            new AuthSession("subject", "session", Now, "pwd"),
+            new AuthorizationContext(ClientId, ["openid"], null)
+            {
+                AuthorizationDetails = authorizationDetails,
+            });
+
+    private static UserCodeVerificationService BuildService(
+        JsonArray? requestedDetails,
+        out CapturingLogger<UserCodeVerificationService> logs)
+    {
+        var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            AuthorizationDetails = requestedDetails,
+            ExpiresAt = Now.AddMinutes(5),
+        };
+
+        var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
+        storage
+            .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, request) : null);
+
+        logs = new CapturingLogger<UserCodeVerificationService>();
+        return new UserCodeVerificationService(
+            logs,
+            storage.Object,
+            Mock.Of<IUserCodeRateLimiter>(),
+            new UserCodeNormalizer(Options.Create(DeviceOptions())),
+            Mock.Of<IRequestInfoProvider>(),
+            new FakeTimeProvider(Now));
+    }
+
+    private static OidcOptions DeviceOptions() => new()
+    {
+        DeviceAuthorization = new DeviceAuthorizationOptions
+        {
+            CodeLifetime = TimeSpan.FromMinutes(5),
+            PollingInterval = TimeSpan.FromSeconds(5),
+            DeviceCodeLength = 32,
+            UserCodeLength = 8,
+            VerificationUri = new Uri("https://auth.example.com/device"),
+            UserCodeAlphabet = "BCDFGHJKLMNPQRSTVWXZ",
+        },
+    };
+
+    /// <summary>Keeps what the service wrote, so a test can assert the absence as well as the presence.</summary>
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        private readonly List<(LogLevel Level, string Message)> _entries = [];
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries => _entries;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => _entries.Add((logLevel, formatter(state, exception)));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -110,6 +110,46 @@ public class UserCodeVerificationServiceTests
         Assert.True(approved);
         var warning = Assert.Single(logs.Entries, entry => entry.Level == LogLevel.Warning);
         Assert.Contains(ClientId, warning.Message);
+
+        // The count is part of the payload, and it is what tells the reader how much was lost.
+        Assert.Contains("1", warning.Message);
+        Assert.Equal(
+            LogEvents.Device.UserCodeVerificationService.GrantedAuthorizationDetailsNotCarried,
+            warning.EventId);
+    }
+
+    [Fact]
+    public async Task Approve_WhenTheRequestCarriedNoDetails_SaysNothing()
+    {
+        // The silent case is the common one, so a detector that fired here would be waved away on every
+        // approval and take the real finding with it.
+        var service = BuildService(requestedDetails: null, out var logs);
+
+        var approved = await service.ApproveAsync(CanonicalUserCode, GrantWith(null));
+
+        Assert.True(approved);
+        Assert.DoesNotContain(logs.Entries, entry => entry.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task Approve_WithATypeTheRequestNeverAskedFor_RefusesAndLeavesTheRequestPending()
+    {
+        // Narrowing is the host's to decide; widening is not. An approval carrying a type nobody
+        // requested would give the device authority the client never asked for, so it is refused rather
+        // than noted - and the request stays pending, so the user can still be asked again.
+        var service = BuildService(
+            requestedDetails: new JsonArray(new JsonObject { ["type"] = "account_information" }),
+            out var logs);
+
+        var approved = await service.ApproveAsync(
+            CanonicalUserCode,
+            GrantWith(new JsonArray(
+                new JsonObject { ["type"] = "account_information" },
+                new JsonObject { ["type"] = "payment_initiation" })));
+
+        Assert.False(approved);
+        var warning = Assert.Single(logs.Entries, entry => entry.Level == LogLevel.Warning);
+        Assert.Contains("payment_initiation", warning.Message);
     }
 
     [Fact]
@@ -175,9 +215,11 @@ public class UserCodeVerificationServiceTests
     /// <summary>Keeps what the service wrote, so a test can assert the absence as well as the presence.</summary>
     private sealed class CapturingLogger<T> : ILogger<T>
     {
-        private readonly List<(LogLevel Level, string Message)> _entries = [];
+        private readonly List<(LogLevel Level, int EventId, string Message)> _entries = [];
 
-        public IReadOnlyList<(LogLevel Level, string Message)> Entries => _entries;
+        // The event id is kept because runbooks key off the number, so a test that ignored it would let
+        // the number change without noticing.
+        public IReadOnlyList<(LogLevel Level, int EventId, string Message)> Entries => _entries;
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -189,6 +231,6 @@ public class UserCodeVerificationServiceTests
             TState state,
             Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => _entries.Add((logLevel, formatter(state, exception)));
+            => _entries.Add((logLevel, eventId.Id, formatter(state, exception)));
     }
 }


### PR DESCRIPTION
Closes the device-flow half of #396. The enrichment half is PR #404.

## What was wrong, in both directions

`DeviceAuthorizationRequestProcessor` stashes the requested `authorization_details` on the persisted record and `UserCodeVerificationService` surfaces them on `ValidUserCode`. From there the approval stored whatever grant the host handed back, verbatim, and nothing compared the two.

So a host that builds its authorization context from scopes and resources issued a device token carrying no `authorization_details` at all. RFC 9396 section 9 is the obligation that bites here: "In order to enable the RS to enforce the authorization details as approved in the authorization process, the AS MUST make this data available to the RS." Section 7 is satisfied either way, since its MUST is to return what the resource owner GRANTED and nothing granted is nothing to return.

And in the other direction, a grant carrying entries the request never asked for was stored and issued, so the device received authority nobody requested. That is the direction this change's own reasoning calls the worse of the two, and it was the one nothing watched.

## What this does, and what it deliberately does not

The library still does not carry the entries. That is the decision rather than an omission: only the host's verification page knows whether it displayed the payment, and a library putting entries on the grant would grant what nobody may have been shown. Forgetting them fails visibly at the resource server; granting them unseen does not fail at all.

Widening is refused. An approval whose grant carries a type the device authorization request never asked for answers `false` and leaves the request pending, comparing types the way the CIBA completion path does, and for the same reason: RFC 9396 defines no universal comparator for intra-entry narrowing, so what can be judged is whether an entry of that type was asked for at all.

Omission is no longer silent. The obligation is stated where the host acts, on `ApproveAsync` and on `ValidUserCode`, and an approval arriving with entries on the record and none on the grant is logged at warning level after the write, naming the client and the count. The entries themselves are never logged: they carry whatever their type defines, which here is payment and account data.

## Evidence

The assertion was written before the detector existed and failed against it. Mutations, each planted so it compiles and run separately:

- the detector's condition never matches: the warning test fails;
- the condition ignores what the grant carries: the silence test fails;
- the refusal never fires: the widening test fails.

Three test holes the first review round found are closed: nothing covered the silent case, so a detector firing on every approval would have passed; nothing asserted the count or the event id; and the capturing logger dropped the event id it was documented to keep.

`Abblix.Oidc.Server.UnitTests` 2790 passed, `Abblix.Oidc.Server.E2E.Tests` 190 passed. The E2E suite has no device RAR scenario, so it is evidence that nothing broke rather than that this works.

The log events move to sub-range 7080-7084: the allocation record claimed 7090-7099 while the neighbouring class had already declared 7085-7099 for itself.
