### PR TITLE
Let a resource server introspect the authorization_details addressed to it

### DIFF
--- a/src/Abblix.Jwt/AuthorizationDetail.cs
+++ b/src/Abblix.Jwt/AuthorizationDetail.cs
@@ -97,13 +97,24 @@ public record AuthorizationDetail(JsonObject Json)
     /// <see cref="Json"/> and are accessed by per-type validators directly through the
     /// <see cref="System.Text.Json.Nodes"/> API on the wrapped node.
     /// </summary>
-    private static class Parameters
+    public static class Parameters
     {
+        /// <summary>The authorization detail type identifier, REQUIRED on every entry.</summary>
         public const string Type = "type";
+
+        /// <summary>The locations of the resource servers the entry is addressed to.</summary>
         public const string Locations = "locations";
+
+        /// <summary>The actions the entry authorises at those locations.</summary>
         public const string Actions = "actions";
+
+        /// <summary>The kinds of data the entry authorises access to.</summary>
         public const string Datatypes = "datatypes";
+
+        /// <summary>The identifier of the specific resource the entry is about.</summary>
         public const string Identifier = "identifier";
+
+        /// <summary>The privileges the entry asks for at those locations.</summary>
         public const string Privileges = "privileges";
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
@@ -210,29 +210,37 @@ public class IntrospectionRequestProcessor(
 			.Select(location => location.OriginalString)
 			.ToHashSet(StringComparer.Ordinal);
 
-		var addressed = new JsonArray();
-		foreach (var detail in details.ToTypedArray() ?? [])
-		{
-			if (detail.Locations is not { } locations)
-				continue;
+		var addressed = (details.ToTypedArray() ?? [])
+			.Select(detail => (Detail: detail, Matched: MatchedLocations(detail)))
+			.Where(pair => pair.Matched.Length > 0)
+			.Select(pair => Disclose(pair.Detail, pair.Matched))
+			.ToArray();
 
-			var matched = locations.Where(registered.Contains).ToArray();
-			if (matched.Length == 0)
-				continue;
+		if (addressed.Length == 0)
+			return;
 
-			// Written as an array rather than through the typed setter, which collapses a single value
-			// to a bare string: §9.2 has the member carry "the same structure defined in Section 2", and
-			// §2.2 defines locations as an array of strings.
-			var disclosed = (JsonObject)detail.Json.DeepClone();
-			disclosed[AuthorizationDetail.Parameters.Locations] = new JsonArray(
-				matched.Select(location => (JsonNode)JsonValue.Create(location)).ToArray());
+		narrowed[IanaClaimTypes.AuthorizationDetails] = new JsonArray(addressed);
 
-			addressed.Add(disclosed);
-		}
+		string[] MatchedLocations(AuthorizationDetail detail)
+			=> detail.Locations is { } locations
+				? locations.Where(registered.Contains).ToArray()
+				: [];
+	}
 
-		if (addressed.Count > 0)
-		{
-			narrowed[IanaClaimTypes.AuthorizationDetails] = addressed;
-		}
+	/// <summary>
+	/// The entry as this caller receives it: its own copy, carrying only the locations it matched.
+	/// </summary>
+	/// <remarks>
+	/// The locations are written as an array rather than through the typed setter, which collapses a
+	/// single value to a bare string: §9.2 has the member carry "the same structure defined in Section 2",
+	/// and §2.2 defines <c>locations</c> as an array of strings.
+	/// </remarks>
+	private static JsonNode Disclose(AuthorizationDetail detail, string[] matchedLocations)
+	{
+		var disclosed = (JsonObject)detail.Json.DeepClone();
+		disclosed[AuthorizationDetail.Parameters.Locations] = new JsonArray(
+			matchedLocations.Select(location => (JsonNode)JsonValue.Create(location)).ToArray());
+
+		return disclosed;
 	}
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
@@ -14,6 +14,7 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
+using Abblix.Oidc.Server.Features.UriValidation;
 using Abblix.Utils;
 
 namespace Abblix.Oidc.Server.Endpoints.Introspection;
@@ -70,7 +71,7 @@ public class IntrospectionRequestProcessor(
 		var payload = request.Token.Payload.Json;
 		if (request.Token.Payload.ClientId != request.ClientInfo.ClientId)
 		{
-			payload = WithoutPrivateClaims(payload);
+			payload = WithoutPrivateClaims(payload, request.ClientInfo);
 
 			var pseudonym = await PseudonymForCallerAsync(request);
 			if (pseudonym != null)
@@ -150,7 +151,7 @@ public class IntrospectionRequestProcessor(
 	/// an introspection response is the simplest way of minimizing privacy issues". Section 2.2 grants the
 	/// latitude to answer such a caller differently.
 	/// </remarks>
-	private static JsonObject WithoutPrivateClaims(JsonObject payload)
+	private static JsonObject WithoutPrivateClaims(JsonObject payload, ClientInfo caller)
 	{
 		var narrowed = new JsonObject();
 		foreach (var name in ClaimsSafeForAnyCaller)
@@ -161,6 +162,55 @@ public class IntrospectionRequestProcessor(
 			}
 		}
 
+		AddAuthorizationDetailsAddressedTo(caller, payload, narrowed);
 		return narrowed;
+	}
+
+	/// <summary>
+	/// Adds the RFC 9396 <c>authorization_details</c> entries this caller is the resource server for.
+	/// </summary>
+	/// <remarks>
+	/// RFC 9396 §9: "In order to enable the RS to enforce the authorization details as approved in the
+	/// authorization process, the AS MUST make this data available to the RS", by the access token or by
+	/// introspection. §9.2 governs the shape when it comes this way: the member carries "the same
+	/// structure defined in Section 2, potentially filtered and extended for the RS making the
+	/// introspection request", which is the filter applied here.
+	/// <para>
+	/// An entry reaches a caller only by naming it in <c>locations</c>. An entry without them is
+	/// addressed to nobody in particular and stays withheld: §2.2 makes <c>locations</c> optional, so
+	/// its absence says the client did not name a resource server, not that every one may read it.
+	/// </para>
+	/// <para>
+	/// Addresses are compared the way every other registered address on this server is, through
+	/// <see cref="UriValidatorFactory"/>, so a location that is not an absolute URI matches nothing.
+	/// </para>
+	/// </remarks>
+	private static void AddAuthorizationDetailsAddressedTo(
+		ClientInfo caller,
+		JsonObject payload,
+		JsonObject narrowed)
+	{
+		if (caller.ResourceLocations is not { Length: > 0 } callerLocations ||
+		    payload[IanaClaimTypes.AuthorizationDetails] is not JsonArray details)
+			return;
+
+		var callerAddresses = UriValidatorFactory.Create(callerLocations);
+
+		var addressed = new JsonArray();
+		foreach (var detail in details.ToTypedArray() ?? [])
+		{
+			if (detail.Locations is { } locations && locations.Any(AddressesTheCaller))
+			{
+				addressed.Add(detail.Json.DeepClone());
+			}
+		}
+
+		if (addressed.Count > 0)
+		{
+			narrowed[IanaClaimTypes.AuthorizationDetails] = addressed;
+		}
+
+		bool AddressesTheCaller(string location)
+			=> Uri.TryCreate(location, UriKind.Absolute, out var uri) && callerAddresses.IsValid(uri);
 	}
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
@@ -14,7 +14,6 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
-using Abblix.Oidc.Server.Features.UriValidation;
 using Abblix.Utils;
 
 namespace Abblix.Oidc.Server.Endpoints.Introspection;
@@ -181,8 +180,21 @@ public class IntrospectionRequestProcessor(
 	/// its absence says the client did not name a resource server, not that every one may read it.
 	/// </para>
 	/// <para>
-	/// Addresses are compared the way every other registered address on this server is, through
-	/// <see cref="UriValidatorFactory"/>, so a location that is not an absolute URI matches nothing.
+	/// Addresses are compared as TEXT, byte for byte. RFC 9396 §12: "All string comparisons in an
+	/// authorization_details parameter are to be done as defined by [RFC8259]. No additional
+	/// transformation or normalization is to be done in evaluating equivalence of string values."
+	/// Parsing both sides into <see cref="Uri"/> and comparing those would be that transformation, and
+	/// it decides in the disclosing direction: it folds case, elides a default port, collapses dot
+	/// segments, decodes percent-escapes and ignores a fragment, so <c>https://api.example.com/accounts/../payments</c>
+	/// written by the CLIENT would open the payments resource server's entry to the accounts one.
+	/// The registered side stays <see cref="Uri"/> because a host writing a location that is not one
+	/// should hear about it where it was written; only the comparison is textual.
+	/// </para>
+	/// <para>
+	/// What is disclosed is filtered too. §9.2 allows the member to be "filtered and extended for the RS
+	/// making the introspection request", and §13 asks that this data be shared "on a 'need to know'
+	/// basis": the entry goes out with its <c>locations</c> reduced to the ones this caller matched, so
+	/// one resource server does not learn the addresses of the others from an entry naming several.
 	/// </para>
 	/// </remarks>
 	private static void AddAuthorizationDetailsAddressedTo(
@@ -194,23 +206,33 @@ public class IntrospectionRequestProcessor(
 		    payload[IanaClaimTypes.AuthorizationDetails] is not JsonArray details)
 			return;
 
-		var callerAddresses = UriValidatorFactory.Create(callerLocations);
+		var registered = callerLocations
+			.Select(location => location.OriginalString)
+			.ToHashSet(StringComparer.Ordinal);
 
 		var addressed = new JsonArray();
 		foreach (var detail in details.ToTypedArray() ?? [])
 		{
-			if (detail.Locations is { } locations && locations.Any(AddressesTheCaller))
-			{
-				addressed.Add(detail.Json.DeepClone());
-			}
+			if (detail.Locations is not { } locations)
+				continue;
+
+			var matched = locations.Where(registered.Contains).ToArray();
+			if (matched.Length == 0)
+				continue;
+
+			// Written as an array rather than through the typed setter, which collapses a single value
+			// to a bare string: §9.2 has the member carry "the same structure defined in Section 2", and
+			// §2.2 defines locations as an array of strings.
+			var disclosed = (JsonObject)detail.Json.DeepClone();
+			disclosed[AuthorizationDetail.Parameters.Locations] = new JsonArray(
+				matched.Select(location => (JsonNode)JsonValue.Create(location)).ToArray());
+
+			addressed.Add(disclosed);
 		}
 
 		if (addressed.Count > 0)
 		{
 			narrowed[IanaClaimTypes.AuthorizationDetails] = addressed;
 		}
-
-		bool AddressesTheCaller(string location)
-			=> Uri.TryCreate(location, UriKind.Absolute, out var uri) && callerAddresses.IsValid(uri);
 	}
 }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -280,10 +280,20 @@ public record ClientInfo(string ClientId)
     /// the disclosure, since the details ride in the token. One encrypting them to its own keys has
     /// only introspection left, and this is how a resource server names itself for it.
     /// <para>
-    /// Absent by default, so no existing deployment starts disclosing anything. Matching is the
-    /// exact-match comparison this server uses for every other registered address, so a location that
-    /// is not an absolute URI never matches - §2.2 calls its strings "typically URIs", and a host
-    /// whose locations are something else keeps the details in the access token instead.
+    /// Absent by default, so no existing deployment starts disclosing anything.
+    /// </para>
+    /// <para>
+    /// Matching is TEXTUAL and exact. RFC 9396 §12 requires it: "No additional transformation or
+    /// normalization is to be done in evaluating equivalence of string values". A location is
+    /// therefore compared to what is written here character for character, so a trailing slash, a
+    /// spelled-out default port or a different case is a different location. Write the value exactly
+    /// as the clients spell it in <c>locations</c>.
+    /// </para>
+    /// <para>
+    /// The type is <see cref="Uri"/> so a value that is not one is refused where it was written, not
+    /// silently never matched. That catches most of what a typo produces and not all of it: a missing
+    /// scheme with a port (<c>payments.example.com:8443</c>) parses, with the whole name read as the
+    /// scheme and an empty host, and then matches nothing.
     /// </para>
     /// </remarks>
     public Uri[]? ResourceLocations { get; set; }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -268,6 +268,27 @@ public record ClientInfo(string ClientId)
     public string[]? TokenExchangeAllowedAudiences { get; set; }
 
     /// <summary>
+    /// The locations this client answers for when it acts as a resource server, matched against the
+    /// RFC 9396 §2.2 <c>locations</c> of an <c>authorization_details</c> entry. Introspecting a token
+    /// issued to somebody else returns the entries addressed to one of these, and nothing when the
+    /// list is absent.
+    /// </summary>
+    /// <remarks>
+    /// RFC 9396 §9 obliges the server to make the granted details available to the resource server
+    /// enforcing them, and allows either channel: the access token, or the introspection response.
+    /// A deployment whose access tokens are readable by their audience needs neither this member nor
+    /// the disclosure, since the details ride in the token. One encrypting them to its own keys has
+    /// only introspection left, and this is how a resource server names itself for it.
+    /// <para>
+    /// Absent by default, so no existing deployment starts disclosing anything. Matching is the
+    /// exact-match comparison this server uses for every other registered address, so a location that
+    /// is not an absolute URI never matches - §2.2 calls its strings "typically URIs", and a host
+    /// whose locations are something else keeps the details in the access token instead.
+    /// </para>
+    /// </remarks>
+    public Uri[]? ResourceLocations { get; set; }
+
+    /// <summary>
     /// RFC 8693 §1.3: by default this AS rejects a Token Exchange request where the
     /// <c>subject_token</c> was originally issued to a different client than the one presenting
     /// it -- the "confused deputy" anti-pattern. When this client is intended to operate as an

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestProcessorTests.cs
@@ -287,6 +287,104 @@ public class IntrospectionRequestProcessorTests
         Assert.False(success.Claims!.ContainsKey(IanaClaimTypes.AuthorizationDetails));
     }
 
+    /// <summary>
+    /// RFC 9396 §12: "No additional transformation or normalization is to be done in evaluating
+    /// equivalence of string values". Every input here is one that a parsed comparison would have called
+    /// equal, and each of them opens one resource server's entry to another - the dot-segment case joins
+    /// two resource servers separated only by a path, which is the ordinary deployment shape.
+    /// </summary>
+    [Theory]
+    [InlineData("https://api.example.com/accounts/../payments")]
+    [InlineData("https://api.example.com/pa%79ments")]
+    [InlineData("HTTPS://API.EXAMPLE.COM/PAYMENTS")]
+    [InlineData("https://api.example.com:443/payments")]
+    [InlineData("https://api.example.com/payments/")]
+    [InlineData("https://api.example.com/payments#fragment")]
+    [InlineData("https://someone@api.example.com/payments")]
+    [InlineData("  https://api.example.com/payments  ")]
+    public async Task ProcessAsync_ForALocationThatOnlyMatchesAfterNormalisation_WithholdsTheDetails(
+        string location)
+    {
+        var request = CreateIntrospectionRequest();
+        var token = CreateValidToken();
+        token.Payload.Json[IanaClaimTypes.AuthorizationDetails] = new JsonArray(
+            new JsonObject
+            {
+                ["type"] = "payment_initiation",
+                ["locations"] = new JsonArray(location),
+            });
+
+        var validRequest = CreateValidIntrospectionRequest(
+            request,
+            token,
+            callerClientId: "payments_resource_server",
+            callerResourceLocations: [new Uri("https://api.example.com/payments")]);
+
+        var result = await _processor.ProcessAsync(validRequest);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        Assert.False(success.Claims!.ContainsKey(IanaClaimTypes.AuthorizationDetails));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ForAnEntryNamingSeveralLocations_DisclosesOnlyTheCallersOwn()
+    {
+        // RFC 7662 §2.2 grants the latitude to answer resources differently "to prevent a protected
+        // resource from learning more about the larger network than is necessary for its operation", and
+        // §9.2 of RFC 9396 allows the member to be filtered for the caller. An entry naming three
+        // addresses would otherwise hand each of them the other two.
+        var request = CreateIntrospectionRequest();
+        var token = CreateValidToken();
+        token.Payload.Json[IanaClaimTypes.AuthorizationDetails] = new JsonArray(
+            new JsonObject
+            {
+                ["type"] = "payment_initiation",
+                ["locations"] = new JsonArray(
+                    "https://payments.example.com",
+                    "https://internal-ledger.corp.example/private"),
+            });
+
+        var validRequest = CreateValidIntrospectionRequest(
+            request,
+            token,
+            callerClientId: "payments_resource_server",
+            callerResourceLocations: [new Uri("https://payments.example.com")]);
+
+        var result = await _processor.ProcessAsync(validRequest);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        var details = Assert.IsType<JsonArray>(success.Claims![IanaClaimTypes.AuthorizationDetails]);
+        var locations = Assert.IsType<JsonArray>(Assert.Single(details)!["locations"]);
+
+        Assert.Equal("https://payments.example.com", Assert.Single(locations)!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ForACallerOnTheSameHostButAnotherPath_WithholdsTheDetails()
+    {
+        // Two resource servers behind one host is the ordinary shape, and a comparison that stopped at
+        // the host would hand each of them the other's entries.
+        var request = CreateIntrospectionRequest();
+        var token = CreateValidToken();
+        token.Payload.Json[IanaClaimTypes.AuthorizationDetails] = new JsonArray(
+            new JsonObject
+            {
+                ["type"] = "payment_initiation",
+                ["locations"] = new JsonArray("https://api.example.com/payments"),
+            });
+
+        var validRequest = CreateValidIntrospectionRequest(
+            request,
+            token,
+            callerClientId: "accounts_resource_server",
+            callerResourceLocations: [new Uri("https://api.example.com/accounts")]);
+
+        var result = await _processor.ProcessAsync(validRequest);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        Assert.False(success.Claims!.ContainsKey(IanaClaimTypes.AuthorizationDetails));
+    }
+
     [Fact]
     public async Task ProcessAsync_ForTheTokensOwnClient_ReturnsTheDetailsWithoutAnyFilter()
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Introspection/IntrospectionRequestProcessorTests.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Jwt;
@@ -65,10 +66,12 @@ public class IntrospectionRequestProcessorTests
     private static ValidIntrospectionRequest CreateValidIntrospectionRequest(
         IntrospectionRequest request,
         JsonWebToken? token = null,
-        string? callerClientId = null)
+        string? callerClientId = null,
+        Uri[]? callerResourceLocations = null)
     {
         var clientId = callerClientId ?? token?.Payload.ClientId ?? "test_client";
-        return new ValidIntrospectionRequest(request, new ClientInfo(clientId), token!);
+        var caller = new ClientInfo(clientId) { ResourceLocations = callerResourceLocations };
+        return new ValidIntrospectionRequest(request, caller, token!);
     }
 
     /// <summary>
@@ -218,6 +221,88 @@ public class IntrospectionRequestProcessorTests
         // The caller still gets what it came for: who the token is for and what it may do.
         Assert.Equal("client_456", success.Claims[IanaClaimTypes.ClientId]?.GetValue<string>());
         Assert.Equal("openid profile", success.Claims[IanaClaimTypes.Scope]?.GetValue<string>());
+    }
+
+    /// <summary>
+    /// RFC 9396 §9 makes the granted authorization_details reaching the resource server a MUST, by the
+    /// access token or by introspection. A deployment encrypting its access tokens to its own keys has
+    /// only the second, and the caller names itself through the locations it answers for (§2.2), which
+    /// is the filter §9.2 sanctions.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_ForAResourceServerNamedInLocations_ReturnsItsOwnEntries()
+    {
+        var request = CreateIntrospectionRequest();
+        var token = CreateValidToken();
+        token.Payload.Json[IanaClaimTypes.AuthorizationDetails] = new JsonArray(
+            new JsonObject
+            {
+                ["type"] = "payment_initiation",
+                ["locations"] = new JsonArray("https://payments.example.com"),
+            },
+            new JsonObject
+            {
+                ["type"] = "account_information",
+                ["locations"] = new JsonArray("https://accounts.example.com"),
+            },
+            new JsonObject { ["type"] = "addressed_to_nobody" });
+
+        var validRequest = CreateValidIntrospectionRequest(
+            request,
+            token,
+            callerClientId: "payments_resource_server",
+            callerResourceLocations: [new Uri("https://payments.example.com")]);
+
+        var result = await _processor.ProcessAsync(validRequest);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        var details = Assert.IsType<JsonArray>(success.Claims![IanaClaimTypes.AuthorizationDetails]);
+
+        // Its own entry, and only that one: the other resource server's is not its business, and an
+        // entry naming no location is addressed to nobody in particular.
+        var entry = Assert.Single(details);
+        Assert.Equal("payment_initiation", entry!["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ForACallerThatNamesNoLocations_WithholdsTheDetails()
+    {
+        // The disclosure is opt-in per client, so a deployment that has not named any resource server
+        // answers exactly as it did before this existed.
+        var request = CreateIntrospectionRequest();
+        var token = CreateValidToken();
+        token.Payload.Json[IanaClaimTypes.AuthorizationDetails] = new JsonArray(
+            new JsonObject
+            {
+                ["type"] = "payment_initiation",
+                ["locations"] = new JsonArray("https://payments.example.com"),
+            });
+
+        var validRequest = CreateValidIntrospectionRequest(
+            request, token, callerClientId: "payments_resource_server");
+
+        var result = await _processor.ProcessAsync(validRequest);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        Assert.False(success.Claims!.ContainsKey(IanaClaimTypes.AuthorizationDetails));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ForTheTokensOwnClient_ReturnsTheDetailsWithoutAnyFilter()
+    {
+        // The token's own client receives its payload as it stands, which is what it already holds.
+        var request = CreateIntrospectionRequest();
+        var token = CreateValidToken();
+        token.Payload.Json[IanaClaimTypes.AuthorizationDetails] = new JsonArray(
+            new JsonObject { ["type"] = "payment_initiation" });
+
+        var validRequest = CreateValidIntrospectionRequest(request, token);
+
+        var result = await _processor.ProcessAsync(validRequest);
+
+        Assert.True(result.TryGetSuccess(out var success));
+        var details = Assert.IsType<JsonArray>(success.Claims![IanaClaimTypes.AuthorizationDetails]);
+        Assert.Single(details);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #395.

## What the specification obliges, and where we stood

RFC 9396 section 9 puts the obligation on the data reaching the resource server and leaves the channel open:

> In order to enable the RS to enforce the authorization details as approved in the authorization process, the AS MUST make this data available to the RS. The AS MAY add the authorization_details field to access tokens in JSON Web Token (JWT) format or to token introspection responses.

Section 9.2 is conditional: it governs the shape when the details come that way, not whether they must.

Every access token this server mints carries the granted array, so a deployment whose resource servers read the token was already covered. The gap is the deployment whose access tokens are encrypted to the server's own keys rather than to the audience's, where the token is opaque to the resource server and introspection is the only channel left. Worth naming plainly: `ServiceTokenOptions.Encrypt` defaults to "encrypt when a server encryption key is available", so any deployment holding such a key is in that shape by default.

## The change

`ClientInfo` gains `ResourceLocations`: the locations this client answers for when it acts as a resource server. Introspecting a token issued to somebody else returns the `authorization_details` entries naming one of them, which is the filter section 9.2 sanctions, "filtered and extended for the RS making the introspection request".

Four properties, each deliberate:

- absent by default, so no deployment starts disclosing anything by upgrading;
- an entry without `locations` is addressed to nobody in particular and stays withheld, because section 2.2 makes the member optional and its absence says the client named no resource server rather than that every one may read it;
- matching is TEXTUAL and exact, per section 12: "All string comparisons in an authorization_details parameter are to be done as defined by [RFC8259]. No additional transformation or normalization is to be done in evaluating equivalence of string values." Parsing both sides into a `Uri` and comparing those is that transformation, and every difference it forgives opens one resource server's entry to another. The sharp case is a dot segment, because two resource servers behind one host separated only by a path are the ordinary shape and the joining string is written by the client;
- what goes out is filtered as well as selected. An entry naming several locations leaves with its `locations` reduced to the ones this caller matched, which is what section 13's "need to know" and RFC 7662 section 2.2's "learning more about the larger network than is necessary" both ask for.

`ResourceLocations` is `Uri[]` so a value that is not a URI is refused where it was written rather than silently never matching. That catches most of what a typo produces and not all of it, and the member says which: a missing scheme with a port parses, with the whole name read as the scheme, and then matches nothing.

## Evidence

Mutations, each planted so it compiles and run separately:

- an entry without `locations` treated as addressed to everybody: the filtering test fails;
- the opt-in ignored, so a caller that named no locations receives the entries: the withholding test fails.

The first review round found that the suite could not tell a working comparison from a host-only one, and that eight normalisation shapes all disclosed. Those eight are now a theory, alongside the same-host-different-path case and the multi-location case.

`Abblix.Oidc.Server.UnitTests` 2799 passed, `Abblix.Oidc.Server.E2E.Tests` 190 passed.

## Known limits, stated rather than hidden

The disclosure key is the client-authored `locations`, so a client can address its own entry to a resource server of its choosing. That party must already hold the token to introspect it, which bounds the exposure to somebody the token was handed to.

The entry is disclosed whole, minus the other locations. RFC 9396 section 9 exists so the resource server can enforce what was approved, and the fields it must enforce are the payload; trimming further would defeat the obligation this closes.
