### PR TITLE
Give CIBA a place to say what the end user approved, and judge it there

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -141,10 +141,14 @@ public class BackChannelAuthenticationRequestProcessor(
 			// on the stored request before completing it, which is the shape the interface documents.
 			RequestedSubjects = namedSubjects,
 
-			// Kept as the client sent it, beside the copy on the grant. The grant's copy is what will be
+			// The post-validation array, beside the copy on the grant. The grant's copy is what will be
 			// issued and the host replaces it when the end user approves part of the request; this one is
 			// what that answer is judged against, and there is no other copy left by then.
-			RequestedAuthorizationDetails = request.AuthorizationDetails,
+			//
+			// An EMPTY array when the request carried none, never null: null is what a request written by
+			// a build without this field reads back as, and the two must not be confused. Denying such a
+			// request would refuse, mid-upgrade, every in-flight authentication the user had approved.
+			RequestedAuthorizationDetails = request.AuthorizationDetails ?? [],
 
 			// The client may poll from the moment it holds the request id, so the first allowed poll is
 			// now, matching the device flow. CIBA section 11 adopts RFC 8628's polling rules, and section

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -141,6 +141,11 @@ public class BackChannelAuthenticationRequestProcessor(
 			// on the stored request before completing it, which is the shape the interface documents.
 			RequestedSubjects = namedSubjects,
 
+			// Kept as the client sent it, beside the copy on the grant. The grant's copy is what will be
+			// issued and the host replaces it when the end user approves part of the request; this one is
+			// what that answer is judged against, and there is no other copy left by then.
+			RequestedAuthorizationDetails = request.AuthorizationDetails,
+
 			// The client may poll from the moment it holds the request id, so the first allowed poll is
 			// now, matching the device flow. CIBA section 11 adopts RFC 8628's polling rules, and section
 			// 3.2 there defines the interval as the minimum to wait "between polling requests to the token

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
@@ -88,6 +89,9 @@ public class BackChannelAuthenticationGrantHandler(
         if (!NamesTheRequestedEndUser(request.RequestedSubjects, request.AuthorizedGrant, clientInfo))
             return NotTheRequestedEndUser();
 
+        if (WidensTheRequest(request, request.AuthorizedGrant))
+            return NotWhatTheRequestAskedFor();
+
         var result = await processor.ProcessAuthenticatedRequestAsync(authenticationRequestId, request);
         if (result.TryGetFailure(out var error))
             return error;
@@ -99,13 +103,47 @@ public class BackChannelAuthenticationGrantHandler(
         // same storage - can replace what is stored, which is the ordinary shape of a retried or corrected
         // completion rather than an attack. Approving one grant and handing over another is the whole
         // failure this comparison exists to prevent.
-        return NamesTheRequestedEndUser(request.RequestedSubjects, grant, clientInfo)
-            ? grant
-            : NotTheRequestedEndUser();
+        if (!NamesTheRequestedEndUser(request.RequestedSubjects, grant, clientInfo))
+            return NotTheRequestedEndUser();
+
+        // And the same for what the grant authorises. The completion path judges this too, but a host can
+        // complete with a narrowed grant and then store a wider one before the client polls - the same
+        // window the subject comparison above exists for, and the same answer.
+        return WidensTheRequest(request, grant) ? NotWhatTheRequestAskedFor() : grant;
     }
 
     private static OidcError NotTheRequestedEndUser()
         => new(ErrorCodes.AccessDenied, "The authenticated end user is not the one the request named");
+
+    private static OidcError NotWhatTheRequestAskedFor()
+        => new(ErrorCodes.AccessDenied,
+            "The grant carries authorization_details the authentication request did not ask for");
+
+    /// <summary>
+    /// Whether the grant carries an <c>authorization_details</c> type the request never asked for.
+    /// </summary>
+    /// <remarks>
+    /// Types only, for the reason the completion path gives: RFC 9396 defines no universal comparator for
+    /// intra-entry narrowing. A null baseline means the request predates the field rather than asked for
+    /// nothing, and is left alone, since refusing it would deny an authentication the end user approved
+    /// before the upgrade.
+    /// </remarks>
+    private static bool WidensTheRequest(StoredRequest request, AuthorizedGrant grant)
+    {
+        if (grant.Context.AuthorizationDetails is not { Count: > 0 } granted ||
+            request.RequestedAuthorizationDetails is not { } requested)
+            return false;
+
+        if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
+            return true;
+
+        var requestedTypes = requested.ToTypedArray()!
+            .Select(detail => detail.Type)
+            .OfType<string>()
+            .ToHashSet(StringComparer.Ordinal);
+
+        return !typed.All(detail => detail.Type is { } type && requestedTypes.Contains(type));
+    }
 
     /// <summary>
     /// Specifies the grant types supported by this handler, specifically the "CIBA" (Client-Initiated Backchannel

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
@@ -24,4 +24,16 @@ partial class AuthenticationCompletionHandler
         Message = "The end user authenticated for auth_req_id {AuthReqId} is not the one the request named, " +
                   "so it is refused. ClientId: {ClientId}")]
     private partial void LogAuthenticatedUserNotTheOneRequested(string AuthReqId, string ClientId);
+
+    /// <summary>
+    /// The escaped TYPES, never the entries: an authorization_details entry carries whatever its type
+    /// defines, which for the types this serves is payment and account data.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEvents.Device.AuthenticationCompletionHandler.GrantedAuthorizationDetailsExceedTheRequest,
+        Level = LogLevel.Warning,
+        Message = "The grant completing auth_req_id {AuthReqId} carries authorization_details the request " +
+                  "never asked for, so it is refused. ClientId: {ClientId}, types: {EscapedTypes}")]
+    private partial void LogGrantedAuthorizationDetailsExceedTheRequest(
+        string AuthReqId, string ClientId, string EscapedTypes);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -80,6 +80,13 @@ public abstract partial class AuthenticationCompletionHandler(
         // Narrowing is the host's to make; widening is not. The types are compared against what the
         // client actually sent, kept on the stored request precisely because the grant's own copy is the
         // one the host has just overwritten.
+        //
+        // An EMPTY granted set completes rather than refusing, and that differs on purpose from the
+        // authorization endpoint, which answers access_denied to a consent decision that granted no
+        // entries. There the refusal has somewhere to go: a browser is waiting and the client learns why.
+        // Here the only way to say "the user refused" is to deny the whole request, which a host does
+        // through its own denial path; turning an empty set into a denial would take that choice away and
+        // refuse a host that legitimately issues a token with no authorization_details at all.
         if (EscapedAuthorizationDetailTypes(request) is { Length: > 0 } escaped)
         {
             LogGrantedAuthorizationDetailsExceedTheRequest(

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -110,16 +110,29 @@ public abstract partial class AuthenticationCompletionHandler(
         if (request.AuthorizedGrant.Context.AuthorizationDetails is not { Count: > 0 } granted)
             return [];
 
+        // Null means the request predates this field, not that it asked for nothing: a build that did
+        // not record it stored the requested entries on the grant alone. Judging those against an empty
+        // baseline would refuse, on the first completion after an upgrade, an authentication the end
+        // user has already approved. A request this build stored says "asked for nothing" with an empty
+        // array instead.
+        if (request.RequestedAuthorizationDetails is not { } requested)
+            return [];
+
         if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
             return ["an entry that is not a JSON object"];
 
-        var requestedTypes = (request.RequestedAuthorizationDetails?.ToTypedArray() ?? [])
+        // Absence is refused on its own rather than compared as a stand-in value, which a client could
+        // otherwise request as a real type and thereby admit every entry that has none.
+        if (Array.Exists(typed, detail => detail.Type is null))
+            return ["an entry carrying no type"];
+
+        var requestedTypes = requested.ToTypedArray()!
             .Select(detail => detail.Type)
             .OfType<string>()
             .ToHashSet(StringComparer.Ordinal);
 
         return typed
-            .Select(detail => detail.Type ?? "(no type)")
+            .Select(detail => detail.Type!)
             .Where(type => !requestedTypes.Contains(type))
             .Distinct(StringComparer.Ordinal)
             .ToArray();

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -7,6 +7,7 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Diagnostics.CodeAnalysis;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
@@ -71,10 +72,57 @@ public abstract partial class AuthenticationCompletionHandler(
             return;
         }
 
+        // The end user's answer arrives here and nowhere else, which makes this the seam a narrowed
+        // authorization_details set travels through: a host whose device interaction let them approve
+        // part of the request replaces the grant's context before completing, and RFC 9396 §7 then has
+        // the server return what was GRANTED rather than what was asked for.
+        //
+        // Narrowing is the host's to make; widening is not. The types are compared against what the
+        // client actually sent, kept on the stored request precisely because the grant's own copy is the
+        // one the host has just overwritten.
+        if (EscapedAuthorizationDetailTypes(request) is { Length: > 0 } escaped)
+        {
+            LogGrantedAuthorizationDetailsExceedTheRequest(
+                authenticationRequestId, clientInfo.ClientId, string.Join(", ", escaped));
+
+            await RefuseAsync(authenticationRequestId, request, expiresIn);
+            return;
+        }
+
         // Update status to Authenticated before handling delivery
         request.Status = BackChannelAuthenticationStatus.Authenticated;
 
         await HandleDeliveryAsync(authenticationRequestId, request, clientInfo, expiresIn);
+    }
+
+    /// <summary>
+    /// The <c>authorization_details</c> types the grant carries and the request never asked for, empty when
+    /// the grant stays inside what was requested.
+    /// </summary>
+    /// <remarks>
+    /// Types only. RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so
+    /// what can be judged without knowing a type's schema is whether an entry of that type was asked for at
+    /// all. An entry that cannot be read as a JSON object counts as escaped: the conversion drops it silently,
+    /// and "nothing escaped" would then be a statement about what could be read rather than about the grant.
+    /// </remarks>
+    private static string[] EscapedAuthorizationDetailTypes(BackChannelAuthenticationRequest request)
+    {
+        if (request.AuthorizedGrant.Context.AuthorizationDetails is not { Count: > 0 } granted)
+            return [];
+
+        if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
+            return ["an entry that is not a JSON object"];
+
+        var requestedTypes = (request.RequestedAuthorizationDetails?.ToTypedArray() ?? [])
+            .Select(detail => detail.Type)
+            .OfType<string>()
+            .ToHashSet(StringComparer.Ordinal);
+
+        return typed
+            .Select(detail => detail.Type ?? "(no type)")
+            .Where(type => !requestedTypes.Contains(type))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelAuthenticationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelAuthenticationRequest.cs
@@ -69,8 +69,9 @@ public record BackChannelAuthenticationRequest(AuthorizedGrant AuthorizedGrant, 
     public string[]? RequestedSubjects { get; set; }
 
     /// <summary>
-    /// The RFC 9396 <c>authorization_details</c> the client asked for, as it sent them, or <c>null</c> when
-    /// the request carried none.
+    /// The RFC 9396 <c>authorization_details</c> the client asked for, as the request-time validators
+    /// left them. EMPTY when the request carried none; <c>null</c> only on a request stored before this
+    /// field existed, which is why the two are not the same answer.
     /// </summary>
     /// <remarks>
     /// Kept apart from the array on <see cref="BackChannelAuthenticationRequest.AuthorizedGrant"/>, which is

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelAuthenticationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelAuthenticationRequest.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 
 namespace Abblix.Oidc.Server.Features.BackChannelAuthentication;
@@ -66,4 +67,22 @@ public record BackChannelAuthenticationRequest(AuthorizedGrant AuthorizedGrant, 
     /// </para>
     /// </remarks>
     public string[]? RequestedSubjects { get; set; }
+
+    /// <summary>
+    /// The RFC 9396 <c>authorization_details</c> the client asked for, as it sent them, or <c>null</c> when
+    /// the request carried none.
+    /// </summary>
+    /// <remarks>
+    /// Kept apart from the array on <see cref="BackChannelAuthenticationRequest.AuthorizedGrant"/>, which is
+    /// what will be issued. The two are the same until the end user answers: a host whose device UI let them
+    /// approve part of the request replaces the grant's context before completing, and this is what that
+    /// answer is judged against.
+    /// <para>
+    /// Recorded rather than derived, for the reason <see cref="RequestedSubjects"/> is: in a decoupled flow
+    /// the answer arrives long after the request, through
+    /// <see cref="Interfaces.IAuthenticationCompletionHandler.CompleteAsync"/>, and by then the only copy of
+    /// what was asked for would be the one the host has just overwritten.
+    /// </para>
+    /// </remarks>
+    public JsonArray? RequestedAuthorizationDetails { get; set; }
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -116,6 +116,26 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///   </item>
 /// </list>
 ///
+/// <para><strong>Partial consent (RFC 9396 authorization_details):</strong></para>
+/// <para>
+/// The grant carried on the stored request is what will be issued, so an end user who approved part of
+/// what the client asked for is expressed by replacing its <c>AuthorizationContext</c> before completing:
+/// keep the entries they agreed to, drop the ones they refused, and hand the result to
+/// <see cref="IAuthenticationCompletionHandler.CompleteAsync"/>. The example above copies the context
+/// unchanged, which is the "they agreed to all of it" case.
+/// </para>
+/// <para>
+/// This is the only moment such an answer exists. <see cref="IUserDeviceAuthenticationHandler.InitiateAuthenticationAsync"/>
+/// runs before the end user has seen anything - the session it returns names who is about to be reached,
+/// and the request is stored pending either way - so there is nothing to narrow there.
+/// </para>
+/// <para>
+/// Narrowing is yours to decide; widening is refused. Completion compares the grant's
+/// <c>authorization_details</c> types against what the client actually sent, and a type the request never
+/// carried denies the request rather than issuing it. RFC 9396 §7 has the server return what was granted,
+/// which is only meaningful while "granted" stays inside "requested".
+/// </para>
+///
 /// <para><strong>Additional Key Points:</strong></para>
 /// <list type="bullet">
 ///   <item><strong>Binding Message:</strong> Display request.Model.BindingMessage to user for transaction confirmation</item>

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/BackChannelAuthenticationRequest.proto
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/BackChannelAuthenticationRequest.proto
@@ -54,4 +54,10 @@ message BackChannelAuthenticationRequest {
   // which a request reaches by naming a value outside its own list of values. A repeated
   // field cannot tell the two apart, so the constraint would vanish on the way back.
   AcceptedSubjects requested_subjects = 7;
+
+  // The authorization_details the client asked for, serialised as a JSON string, kept apart
+  // from the ones on the grant. The grant carries what will be issued, and the host replaces
+  // it when the end user narrows the request; this is what that answer is judged against, and
+  // it stays as the client sent it. Same scheme as the device authorization request.
+  optional string requested_authorization_details_json = 8;
 }

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/BackChannelAuthenticationRequest.proto
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/BackChannelAuthenticationRequest.proto
@@ -58,6 +58,8 @@ message BackChannelAuthenticationRequest {
   // The authorization_details the client asked for, serialised as a JSON string, kept apart
   // from the ones on the grant. The grant carries what will be issued, and the host replaces
   // it when the end user narrows the request; this is what that answer is judged against, and
-  // it stays as the client sent it. Same scheme as the device authorization request.
+  // it stays as the request-time validators left it. Absent means a request written before this
+  // field existed, which is not the same as a request that asked for nothing: that one is stored as
+  // an empty array. Same scheme as the device authorization request.
   optional string requested_authorization_details_json = 8;
 }

--- a/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/BackChannelAuthenticationRequestMapper.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/Proto/Mappers/BackChannelAuthenticationRequestMapper.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Text.Json.Nodes;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Abblix.Oidc.Server.Features.Storages.Proto.Mappers;
@@ -44,6 +45,9 @@ internal static class BackChannelAuthenticationRequestMapper
             proto.RequestedSubjects.Values.AddRange(accepted);
         }
 
+        if (source.RequestedAuthorizationDetails is { } requestedDetails)
+            proto.RequestedAuthorizationDetailsJson = requestedDetails.ToJsonString();
+
         return proto;
     }
 
@@ -62,6 +66,9 @@ internal static class BackChannelAuthenticationRequestMapper
                 ? new Uri(source.ClientNotificationEndpoint)
                 : null,
             RequestedSubjects = source.RequestedSubjects?.Values.ToArray(),
+            RequestedAuthorizationDetails = source.HasRequestedAuthorizationDetailsJson
+                ? JsonNode.Parse(source.RequestedAuthorizationDetailsJson) as JsonArray
+                : null,
             ClientNotificationToken = source.HasClientNotificationToken
                 ? source.ClientNotificationToken
                 : null,

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -477,6 +477,7 @@ internal static class LogEvents
 
             public const int MissingNotificationConfig = Base + 1;
             public const int AuthenticatedUserNotTheOneRequested = Base + 2;
+            public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 3;
         }
 
         /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -7,6 +7,7 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
@@ -217,6 +218,50 @@ public class BackChannelAuthenticationGrantHandlerTests
 
         // Verify the request was removed from storage
         _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
+    }
+
+    /// <summary>
+    /// The completion path judges what the end user approved, and the redemption judges it again, for the
+    /// reason the subject comparison beside it already does: the host owns the same storage and can replace
+    /// the stored grant between the two, which is the ordinary shape of a retried or corrected completion.
+    /// A host that never calls the completion path at all reaches this check and nothing else.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticatedRequest_WhoseGrantWidensTheRequest_ReturnsAccessDenied()
+    {
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll,
+        };
+        var tokenRequest = new TokenRequest { AuthenticationRequestId = AuthReqId };
+
+        var widened = new AuthorizedGrant(
+            new AuthSession(UserId, "session_123", _currentTime, "backchannel"),
+            new AuthorizationContext(ClientId, [Scopes.OpenId], null)
+            {
+                AuthorizationDetails = new JsonArray(
+                    new JsonObject { ["type"] = "account_information" },
+                    new JsonObject { ["type"] = "payment_initiation" }),
+            });
+
+        var authRequest = new BackChannelAuthenticationRequest(widened, _currentTime.AddMinutes(5))
+        {
+            Status = BackChannelAuthenticationStatus.Authenticated,
+            RequestedAuthorizationDetails =
+                new JsonArray(new JsonObject { ["type"] = "account_information" }),
+        };
+
+        _storage.Setup(s => s.TryGetAsync(AuthReqId)).ReturnsAsync(authRequest);
+        _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(authRequest);
+
+        var result = await _handler.AuthorizeAsync(tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.AccessDenied, error.Error);
+
+        // Refused before the request is consumed: an irreversible removal is not spent on a grant that
+        // was never going to be issued.
+        _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Never);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -9,6 +9,7 @@
 using System;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -653,4 +654,93 @@ public class AuthenticationCompletionHandlerTests
             RequestedSubjects = requested is null ? null : [requested],
             ClientNotificationToken = NotificationToken,
         };
+
+    /// <summary>
+    /// A request whose client asked for <paramref name="requestedTypes"/> and whose host completed it with
+    /// <paramref name="grantedTypes"/> on the grant, which is how a device interaction expresses what the
+    /// end user actually approved.
+    /// </summary>
+    private static BackChannelAuthenticationRequest CreateRequestWithAuthorizationDetails(
+        string[] requestedTypes,
+        string[] grantedTypes)
+        => new(
+            new AuthorizedGrant(
+                new AuthSession(UserId, "session_1", DateTimeOffset.UnixEpoch, "test"),
+                new AuthorizationContext(ClientId, [Scopes.OpenId], null)
+                {
+                    AuthorizationDetails = Details(grantedTypes),
+                }),
+            DateTimeOffset.UnixEpoch.AddHours(1))
+        {
+            ClientNotificationToken = NotificationToken,
+            RequestedAuthorizationDetails = Details(requestedTypes),
+        };
+
+    private static JsonArray Details(string[] types)
+    {
+        var details = new JsonArray();
+        foreach (var type in types)
+            details.Add(new JsonObject { ["type"] = type });
+
+        return details;
+    }
+
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheGrantNarrowsTheRequest_Completes()
+    {
+        // The end user approved one of the two entries the client asked for. That is the whole point of the
+        // seam, and RFC 9396 §7 has the server return what was granted rather than what was asked for.
+        var request = CreateRequestWithAuthorizationDetails(
+            requestedTypes: ["payment_initiation", "account_information"],
+            grantedTypes: ["account_information"]);
+
+        _storage
+            .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Returns(Task.CompletedTask);
+
+        await CreatePollModeHandler().CompleteAuthenticationAsync(
+            AuthReqId, request, PollClient(), _expiresIn);
+
+        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, request.Status);
+    }
+
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheGrantCarriesAnUnrequestedType_Denies()
+    {
+        // Narrowing is the host's to decide; widening is not. The comparison is against what the client
+        // actually sent, which is why the request keeps its own copy: the grant's copy is the one the host
+        // has just replaced.
+        var request = CreateRequestWithAuthorizationDetails(
+            requestedTypes: ["account_information"],
+            grantedTypes: ["account_information", "payment_initiation"]);
+
+        _storage
+            .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Returns(Task.CompletedTask);
+
+        await CreatePollModeHandler().CompleteAuthenticationAsync(
+            AuthReqId, request, PollClient(), _expiresIn);
+
+        Assert.Equal(BackChannelAuthenticationStatus.Denied, request.Status);
+    }
+
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheGrantCarriesDetailsAndTheRequestCarriedNone_Denies()
+    {
+        // Nothing was asked for, so nothing can have been granted: an entry appearing here came from the
+        // host rather than from the client, and the client would receive authority it never requested.
+        var request = CreateRequestWithAuthorizationDetails(
+            requestedTypes: [],
+            grantedTypes: ["payment_initiation"]);
+        request.RequestedAuthorizationDetails = null;
+
+        _storage
+            .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Returns(Task.CompletedTask);
+
+        await CreatePollModeHandler().CompleteAuthenticationAsync(
+            AuthReqId, request, PollClient(), _expiresIn);
+
+        Assert.Equal(BackChannelAuthenticationStatus.Denied, request.Status);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -725,14 +725,56 @@ public class AuthenticationCompletionHandlerTests
     }
 
     [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheGrantSwapsATypeForAnother_Denies()
+    {
+        // Same number of entries on both sides, one of them a type nobody asked for. A comparison that
+        // counted rather than compared would pass this, and counting is what every fixture with a
+        // different number of entries silently allows.
+        var request = CreateRequestWithAuthorizationDetails(
+            requestedTypes: ["payment_initiation", "account_information"],
+            grantedTypes: ["account_information", "medical_record"]);
+
+        _storage
+            .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Returns(Task.CompletedTask);
+
+        await CreatePollModeHandler().CompleteAuthenticationAsync(
+            AuthReqId, request, PollClient(), _expiresIn);
+
+        Assert.Equal(BackChannelAuthenticationStatus.Denied, request.Status);
+    }
+
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheRequestPredatesTheRecordedBaseline_Completes()
+    {
+        // A request stored by a build that did not record what was asked for reads back with a null
+        // baseline and its entries on the grant. Judging that against an empty baseline would refuse,
+        // on the first completion after an upgrade, an authentication the end user has already approved.
+        var request = CreateRequestWithAuthorizationDetails(
+            requestedTypes: ["payment_initiation"],
+            grantedTypes: ["payment_initiation"]);
+        request.RequestedAuthorizationDetails = null;
+
+        _storage
+            .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Returns(Task.CompletedTask);
+
+        await CreatePollModeHandler().CompleteAuthenticationAsync(
+            AuthReqId, request, PollClient(), _expiresIn);
+
+        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, request.Status);
+    }
+
+    [Fact]
     public async Task CompleteAuthenticationAsync_WhenTheGrantCarriesDetailsAndTheRequestCarriedNone_Denies()
     {
         // Nothing was asked for, so nothing can have been granted: an entry appearing here came from the
         // host rather than from the client, and the client would receive authority it never requested.
+        // An EMPTY baseline, which is how a request this build stored says the client asked for nothing.
+        // Null would mean something else: a request written before the field existed.
         var request = CreateRequestWithAuthorizationDetails(
             requestedTypes: [],
             grantedTypes: ["payment_initiation"]);
-        request.RequestedAuthorizationDetails = null;
 
         _storage
             .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/Proto/MappersTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/Proto/MappersTests.cs
@@ -695,6 +695,32 @@ public class MappersTests
         Assert.Equal(subjects, result.RequestedSubjects);
     }
 
+    /// <summary>
+    /// What the client asked for has to survive the store, because the answer it is compared against arrives
+    /// after a round trip: the end user authenticates out of band, and by then the grant's own copy is the one
+    /// the host replaced with the narrowed set.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("""[]""")]
+    [InlineData("""[{"type":"payment_initiation","instructedAmount":{"currency":"EUR","amount":"123.50"}}]""")]
+    public void BackChannelAuthenticationRequestMapper_RoundTrip_KeepsRequestedAuthorizationDetails(string? wire)
+    {
+        var moment = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var session = new AuthSession("user-123", "session-456", moment, "local");
+        var context = new AuthorizationContext("client-123", [TestConstants.DefaultScope], null);
+        var requested = wire is null ? null : (JsonArray)JsonNode.Parse(wire)!;
+        var request = new BackChannelAuthenticationRequest(
+            new AuthorizedGrant(session, context), moment.AddMinutes(5))
+        {
+            RequestedAuthorizationDetails = requested,
+        };
+
+        var result = request.ToProto().FromProto();
+
+        Assert.Equal(wire, result.RequestedAuthorizationDetails?.ToJsonString());
+    }
+
     [Fact]
     public void BackChannelAuthenticationRequestMapper_ToProto_HandlesNextPollAt()
     {


### PR DESCRIPTION
Closes #393.

## What was missing

`BackChannelAuthenticationRequestProcessor` copied the client's `authorization_details` onto the grant verbatim, and `IUserDeviceAuthenticationHandler` answers with an `AuthSession` or an error. So a backchannel request had two outcomes, all of it or none of it. RFC 9396 section 3 names the case in its own Note: "The user may also grant a subset of the requested authorization details."

It was a capability gap rather than a conformance defect. Denying the whole request is a conforming answer; what the flow could not do is issue the smaller half.

## Where the seam is, and why there is only one

The completion path. `InitiateAuthenticationAsync` runs before the end user has seen anything, and the code says so in its own comment: the session it returns names who is about to be reached, and the request is stored pending either way. A narrowed set expressed there would be a decision nobody has made yet.

The grant carried on the stored request is what will be issued, so the host expresses the narrowing by replacing that grant's `AuthorizationContext` before calling `CompleteAsync`. That is now stated on the handler interface next to the worked example that copies the context unchanged.

## Narrowing is the host's, widening is refused twice

Completion compares the grant's `authorization_details` types against what the client actually sent, and denies on a type the request never carried. That check sits where the authenticated end user is already judged, so every delivery mode refuses the way it already refuses its own failures.

The redemption compares them again, before the stored request is consumed. The subject comparison beside it already runs twice for the stated reason: the host owns the same storage and can replace the stored grant between completion and the client's poll, which is the ordinary shape of a retried completion. And a host that never calls the completion path at all reaches the token endpoint and nothing else.

What the client asked for is kept on the stored request, for the reason `RequestedSubjects` already is: in a decoupled flow the answer arrives after a round trip through the store, and by then the grant's own copy is the one the host has just replaced.

An empty array records "the client asked for nothing"; a null baseline means the request predates the field. Confusing the two would deny, on the first completion after an upgrade, every in-flight authentication the end user had already approved.

## Known limits, stated rather than hidden

The comparison is by type only. RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so contents escalated inside a type the request did carry are not caught here, and neither is a repeated entry of such a type. The authorization-code path has more, because its consent seam can re-run the per-type validators against a client; making CIBA equal to it is a larger change than this one and is not attempted here.

An entry that cannot be read as a JSON object, and one carrying no `type`, both count as escaped rather than as nothing to see.

## Evidence

Mutations, each planted so it compiles and run separately:

- the completion check never fires: both denial tests fail;
- the comparison inverted, asking whether the grant dropped anything: all three completion tests fail, including the one that says narrowing must complete.

The first review round found that the three original cases differed in entry COUNT, so a comparison that counted instead of comparing types passed all of them, and that nothing covered the upgrade path. A type swapped at equal count and a null baseline now cover both, and the redemption check has its own case asserting that the stored request is not consumed on refusal.

`Abblix.Oidc.Server.UnitTests` 2795 passed, `Abblix.Oidc.Server.E2E.Tests` 190 passed. The E2E suite has no CIBA RAR scenario, so it is evidence that nothing broke rather than that this works.

The proto field is additive and optional, and a request written by an older build is recognised as such rather than judged against an empty baseline.
