### PR TITLE
Point every RFC citation at the section it means, and check it on every pull request

### DIFF
--- a/.github/scripts/verify-rfc-citations.py
+++ b/.github/scripts/verify-rfc-citations.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Verify that every "RFC NNNN section X.Y" cited in the sources names a section
+that actually exists in that RFC.
+
+A wrong section number in a comment reads as checkable and nobody checks it, so it
+survives review and propagates into commit messages and release notes. This walks
+the tree, extracts citations by their grammar rather than by a list of known ones,
+fetches each cited RFC from rfc-editor.org and compares against its heading list.
+
+    python .github/scripts/verify-rfc-citations.py [root] [--cache DIR]
+
+Exit code 1 when a citation names a section the RFC does not have.
+
+What it cannot do: judge whether the section says what the comment claims. A
+citation pointing at a real but wrong section passes here and needs a reader.
+"""
+import argparse
+import collections
+import os
+import re
+import sys
+import urllib.request
+
+# The grammar of a citation, not the instances anyone happened to fix: "RFC" then
+# the number, an optional comma, then the section sign or the word, then the number.
+CITATION = re.compile(r'RFC\s?(\d{3,4}),?\s*(?:\u00a7|[Ss]ection\s+)(\d+(?:\.\d+)*)')
+
+# A heading in an RFC text file starts at column 0 and is followed by its title.
+# The trailing dot is optional: RFC 3394 writes "2.2.1 Key Wrap", RFC 8628 writes
+# "5.1.  User Code Brute Forcing". The lookahead for a non-digit keeps numbered
+# list items, which are indented anyway, from being read as headings.
+HEADING = re.compile(r'^(\d+(?:\.\d+)*)\.?\s+(?=\D)')
+
+SKIP_DIRS = {'bin', 'obj', '.git', 'node_modules', 'TestResults'}
+EXTENSIONS = ('.cs', '.md')
+
+
+def sections_of(rfc, cache):
+    path = os.path.join(cache, f'rfc{rfc}.txt')
+    if not os.path.exists(path):
+        url = f'https://www.rfc-editor.org/rfc/rfc{rfc}.txt'
+        try:
+            urllib.request.urlretrieve(url, path)
+        except Exception as error:
+            print(f'  cannot fetch {url}: {error}', file=sys.stderr)
+            return None
+    with open(path, encoding='utf-8', errors='replace') as handle:
+        text = handle.read()
+    return {match.group(1) for match in map(HEADING.match, text.split('\n')) if match}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('root', nargs='?', default='.')
+    parser.add_argument('--cache', default=os.path.join(os.path.expanduser('~'), '.cache', 'rfc-citations'))
+    arguments = parser.parse_args()
+    os.makedirs(arguments.cache, exist_ok=True)
+
+    known = {}
+    bad = collections.defaultdict(list)
+    unfetchable = set()
+    checked = 0
+
+    for directory, subdirectories, filenames in os.walk(arguments.root):
+        subdirectories[:] = [name for name in subdirectories if name not in SKIP_DIRS]
+        for filename in filenames:
+            if not filename.endswith(EXTENSIONS):
+                continue
+            full = os.path.join(directory, filename)
+            with open(full, encoding='utf-8', errors='replace') as handle:
+                lines = handle.read().split('\n')
+            for number, line in enumerate(lines, 1):
+                for rfc, section in CITATION.findall(line):
+                    checked += 1
+                    if rfc not in known:
+                        known[rfc] = sections_of(rfc, arguments.cache)
+                    if known[rfc] is None:
+                        unfetchable.add(rfc)
+                    elif section not in known[rfc]:
+                        relative = os.path.relpath(full, arguments.root).replace(os.sep, '/')
+                        bad[f'RFC {rfc} section {section}'].append(f'{relative}:{number}')
+
+    print(f'{checked} citations across {len(known)} RFCs')
+    if unfetchable:
+        # Said out loud rather than counted as a pass: an RFC that could not be read
+        # was not checked, and silence here would read as "every citation is good".
+        print(f'NOT CHECKED, could not be fetched: {", ".join(sorted(unfetchable))}')
+    for key in sorted(bad):
+        print(f'\n{key} does not exist:')
+        for site in bad[key]:
+            print(f'    {site}')
+
+    if bad:
+        print(f'\n{sum(len(sites) for sites in bad.values())} citation(s) name a section that does not exist')
+        return 1
+    print('every cited section exists')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/verify-rfc-citations.py
+++ b/.github/scripts/verify-rfc-citations.py
@@ -35,6 +35,22 @@ SKIP_DIRS = {'bin', 'obj', '.git', 'node_modules', 'TestResults'}
 EXTENSIONS = ('.cs', '.md')
 
 
+def citations(root):
+    """Yield (relative path, line number, rfc, section) for every citation under root."""
+    for directory, subdirectories, filenames in os.walk(root):
+        subdirectories[:] = [name for name in subdirectories if name not in SKIP_DIRS]
+        for filename in filenames:
+            if not filename.endswith(EXTENSIONS):
+                continue
+            full = os.path.join(directory, filename)
+            relative = os.path.relpath(full, root).replace(os.sep, '/')
+            with open(full, encoding='utf-8', errors='replace') as handle:
+                lines = handle.read().split('\n')
+            for number, line in enumerate(lines, 1):
+                for rfc, section in CITATION.findall(line):
+                    yield relative, number, rfc, section
+
+
 def sections_of(rfc, cache):
     path = os.path.join(cache, f'rfc{rfc}.txt')
     if not os.path.exists(path):
@@ -53,7 +69,19 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('root', nargs='?', default='.')
     parser.add_argument('--cache', default=os.path.join(os.path.expanduser('~'), '.cache', 'rfc-citations'))
+    parser.add_argument(
+        '--list-rfcs',
+        action='store_true',
+        help='print the cited RFC numbers, one per line, and fetch nothing. This is what a cache of '
+             'the fetched texts is keyed on: the documents never change, so the only thing that '
+             'invalidates such a cache is a citation naming an RFC that was not cited before.')
     arguments = parser.parse_args()
+
+    if arguments.list_rfcs:
+        for rfc in sorted({rfc for _, _, rfc, _ in citations(arguments.root)}, key=int):
+            print(rfc)
+        return 0
+
     os.makedirs(arguments.cache, exist_ok=True)
 
     known = {}
@@ -61,24 +89,14 @@ def main():
     unfetchable = set()
     checked = 0
 
-    for directory, subdirectories, filenames in os.walk(arguments.root):
-        subdirectories[:] = [name for name in subdirectories if name not in SKIP_DIRS]
-        for filename in filenames:
-            if not filename.endswith(EXTENSIONS):
-                continue
-            full = os.path.join(directory, filename)
-            with open(full, encoding='utf-8', errors='replace') as handle:
-                lines = handle.read().split('\n')
-            for number, line in enumerate(lines, 1):
-                for rfc, section in CITATION.findall(line):
-                    checked += 1
-                    if rfc not in known:
-                        known[rfc] = sections_of(rfc, arguments.cache)
-                    if known[rfc] is None:
-                        unfetchable.add(rfc)
-                    elif section not in known[rfc]:
-                        relative = os.path.relpath(full, arguments.root).replace(os.sep, '/')
-                        bad[f'RFC {rfc} section {section}'].append(f'{relative}:{number}')
+    for relative, number, rfc, section in citations(arguments.root):
+        checked += 1
+        if rfc not in known:
+            known[rfc] = sections_of(rfc, arguments.cache)
+        if known[rfc] is None:
+            unfetchable.add(rfc)
+        elif section not in known[rfc]:
+            bad[f'RFC {rfc} section {section}'].append(f'{relative}:{number}')
 
     print(f'{checked} citations across {len(known)} RFCs')
     if unfetchable:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -73,15 +73,59 @@ jobs:
         run: dotnet build Abblix.Oidc.slnx --no-restore -c Release
         timeout-minutes: 3
 
+  citations:
+    # A section number cited in a comment reads as checkable, which is exactly why nobody checks it,
+    # so it survives review and is then repeated in commit messages and release notes. This asks each
+    # cited document whether the section exists at all. It cannot tell whether a real section says
+    # what the comment claims - that still needs a reader - and it says so when it could not fetch a
+    # document, rather than counting the unread ones as good.
+    name: RFC citations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      # Audit rather than block: the job fetches from rfc-editor.org on a cache miss, and the point
+      # of the baseline is to show that it talks to nothing else.
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+        timeout-minutes: 3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Nothing here reads history, and this may run on an untrusted fork PR, so strip the
+          # GITHUB_TOKEN from the runner git config after checkout.
+          persist-credentials: false
+        timeout-minutes: 3
+      - name: List the cited RFCs
+        # Written to a file because the cache key is derived from it. A published RFC never changes,
+        # so the one thing that can make a cached copy insufficient is a citation naming a document
+        # nobody cited before - which is precisely what this list says.
+        run: python3 .github/scripts/verify-rfc-citations.py . --list-rfcs > .rfc-cited.txt
+        timeout-minutes: 3
+      - name: Cache the RFC texts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/rfc-citations
+          key: ${{ runner.os }}-rfc-texts-${{ hashFiles('.rfc-cited.txt') }}
+          # A partial hit is worth taking: the documents it holds are still the current ones, and
+          # only the newly cited RFC is fetched.
+          restore-keys: ${{ runner.os }}-rfc-texts-
+        timeout-minutes: 3
+      - name: Verify every cited section exists
+        run: python3 .github/scripts/verify-rfc-citations.py .
+        timeout-minutes: 3
+
   test:
-    # Single required status check aggregating the shards and the multi-framework build: it succeeds
-    # only when both did. It stays a job of THIS workflow on purpose - a job inside a called workflow
+    # Single required status check aggregating the shards, the multi-framework build and the citation
+    # check: it succeeds only when all three did. It stays a job of THIS workflow on purpose - a job inside a called workflow
     # is reported as "<caller job> / <job name>", which would rename the check that branch protection
     # requires and leave every pull request waiting for a check that no longer appears. The name is
     # narrower than what it now covers, and stays that way for the same reason: renaming it silently
     # detaches branch protection from the only gate a pull request has.
     name: Unit tests
-    needs: [shards, build]
+    needs: [shards, build, citations]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -93,4 +137,7 @@ jobs:
         run: exit 1
       - name: Fail if the multi-framework build failed
         if: needs.build.result != 'success'
+        run: exit 1
+      - name: Fail if a cited RFC section does not exist
+        if: needs.citations.result != 'success'
         run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -394,3 +394,6 @@ RELEASE_NOTES*
 # a project outside src/ carries the same shared template.
 !*.sln.DotSettings
 !*.csproj.DotSettings
+
+# Written by the RFC citation check so its cache key can be derived from it.
+.rfc-cited.txt

--- a/src/Abblix.Jwt/AuthorizationDetail.cs
+++ b/src/Abblix.Jwt/AuthorizationDetail.cs
@@ -36,7 +36,8 @@ public record AuthorizationDetail(JsonObject Json)
     public JsonObject Json { get; } = Json;
 
     /// <summary>
-    /// The authorization-detail type identifier per RFC 9396 §2.1. Required by the spec;
+    /// The authorization-detail type identifier. RFC 9396 §2 makes it REQUIRED, and §2.1 governs
+    /// what a value may be;
     /// the per-type validator rejects entries where this member is missing with
     /// <c>invalid_authorization_details</c>.
     /// </summary>

--- a/src/Abblix.Jwt/AuthorizationDetail.cs
+++ b/src/Abblix.Jwt/AuthorizationDetail.cs
@@ -54,7 +54,7 @@ public record AuthorizationDetail(JsonObject Json)
     public IEnumerable<string>? Locations
     {
         get => Json.GetArrayOfStringsOrNull(Parameters.Locations);
-        set => Json.SetArrayOrStringOrNull(Parameters.Locations, value);
+        set => Json.SetArrayOrNull(Parameters.Locations, value);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public record AuthorizationDetail(JsonObject Json)
     public IEnumerable<string>? Actions
     {
         get => Json.GetArrayOfStringsOrNull(Parameters.Actions);
-        set => Json.SetArrayOrStringOrNull(Parameters.Actions, value);
+        set => Json.SetArrayOrNull(Parameters.Actions, value);
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ public record AuthorizationDetail(JsonObject Json)
     public IEnumerable<string>? Datatypes
     {
         get => Json.GetArrayOfStringsOrNull(Parameters.Datatypes);
-        set => Json.SetArrayOrStringOrNull(Parameters.Datatypes, value);
+        set => Json.SetArrayOrNull(Parameters.Datatypes, value);
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ public record AuthorizationDetail(JsonObject Json)
     public IEnumerable<string>? Privileges
     {
         get => Json.GetArrayOfStringsOrNull(Parameters.Privileges);
-        set => Json.SetArrayOrStringOrNull(Parameters.Privileges, value);
+        set => Json.SetArrayOrNull(Parameters.Privileges, value);
     }
 
     /// <summary>

--- a/src/Abblix.Jwt/JsonWebTokenExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebTokenExtensions.cs
@@ -165,6 +165,29 @@ public static class JsonWebTokenExtensions
     }
 
     /// <summary>
+    /// Assigns a collection of strings to a property as a JSON array whatever its length, or removes the
+    /// property when the collection is <c>null</c> or empty.
+    /// </summary>
+    /// <param name="json">The object to write to.</param>
+    /// <param name="name">The name of the property.</param>
+    /// <param name="values">The values to assign, or <c>null</c> to remove the property.</param>
+    /// <remarks>
+    /// The single-element case is the whole difference from <see cref="SetArrayOrStringOrNull"/>, and it
+    /// is why both exist. A JWT claim a specification defines as "a string or an array of strings" - aud,
+    /// per RFC 7519 Section 4.1.3 - may collapse; a member defined as "an array of strings" may not, and
+    /// writing a bare string there produces a document that parses and does not conform. Neither reader
+    /// complains, so the divergence is only ever noticed by the party that rejects the token.
+    /// </remarks>
+    public static void SetArrayOrNull(this JsonObject json, string name, IEnumerable<string>? values)
+    {
+        var array = values is null
+            ? null
+            : new JsonArray(values.Select(value => (JsonNode?)JsonValue.Create(value)).ToArray());
+
+        json.SetProperty(name, array is { Count: > 0 } ? array : null);
+    }
+
+    /// <summary>
     /// Converts a collection of strings to a JSON node, which will be either a single JSON value if there's only one string,
     /// or a JSON array if there are multiple strings.
     /// </summary>

--- a/src/Abblix.Jwt/ReplayPrevention/IReplayCache.cs
+++ b/src/Abblix.Jwt/ReplayPrevention/IReplayCache.cs
@@ -10,7 +10,7 @@ namespace Abblix.Jwt.ReplayPrevention;
 /// <summary>
 /// Remembers the identifiers of single-use tokens so a second presentation of the same one can
 /// be told from the first. Every JWT profile that forbids replay needs this and needs it in the
-/// same shape - a DPoP proof (RFC 9449 Section 11.1), a client assertion (RFC 7523 Section 5.2)
+/// same shape - a DPoP proof (RFC 9449 Section 11.1), a client assertion (RFC 7523 Section 3)
 /// and a Security Event Token (RFC 8417 Section 2.2) differ in what they call the identifier and
 /// how long it stays interesting, never in the question they ask of the cache.
 /// </summary>

--- a/src/Abblix.Oidc.Server/Common/Configuration/DeviceAuthorizationOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/DeviceAuthorizationOptions.cs
@@ -26,7 +26,7 @@ public record DeviceAuthorizationOptions
 
     /// <summary>
     /// The minimum device code length in bytes (128 bits). The device code is never displayed to
-    /// the user, so it carries no usability constraint and RFC 8628 Section 5.2 requires very high
+    /// the user, so it carries no usability constraint and RFC 8628 Section 5.2 asks for very high
     /// entropy; 128 bits is the conventional cryptographic floor for a non-guessable random value.
     /// </summary>
     private const int MinDeviceCodeLengthBytes = 16;
@@ -73,7 +73,8 @@ public record DeviceAuthorizationOptions
     /// <summary>
     /// The user-facing URI where users can enter their user code.
     /// This should be short and easy to remember as users will manually type it.
-    /// MUST use HTTPS for security per RFC 8628 Section 6.1.
+    /// Must use HTTPS. RFC 8628 does not say so for verification_uri; the requirement is RFC 6749
+    /// Section 3.1's, which asks for TLS wherever the user authenticates.
     /// </summary>
     public required Uri VerificationUri
     {
@@ -91,7 +92,8 @@ public record DeviceAuthorizationOptions
             if (!string.Equals(value.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException(
-                    "The verification_uri MUST use HTTPS for security per RFC 8628 Section 6.1",
+                    "The verification_uri must use HTTPS: the user authenticates there, and RFC 6749 "
+                    + "Section 3.1 requires TLS for that",
                     nameof(VerificationUri));
             }
             _verificationUri = value;
@@ -100,7 +102,8 @@ public record DeviceAuthorizationOptions
 
     /// <summary>
     /// The maximum number of failed user code verification attempts before exponential backoff is applied.
-    /// Recommended by RFC 8628 Section 5.2 to prevent brute force attacks.
+    /// RFC 8628 Section 5.1 recommends rate-limiting user code attempts, the user code being short
+    /// enough to type and therefore short enough to guess.
     /// </summary>
     public int MaxFailuresBeforeBackoff { get; set; } = 3;
 

--- a/src/Abblix.Oidc.Server/Common/Configuration/JwtBearerOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/JwtBearerOptions.cs
@@ -31,14 +31,17 @@ public record JwtBearerOptions
 	/// <summary>
 	/// The clock skew tolerance for JWT validation.
 	/// Allows for small differences in clock times between the JWT issuer and this server.
-	/// Default is 5 minutes, as recommended by RFC 7523 Section 3.
+	/// Default is 5 minutes. RFC 7523 Section 3 allows for clock skew without naming a bound,
+	/// so the number is this server's choice rather than the specification's.
 	/// </summary>
 	public TimeSpan ClockSkew { get; set; } = TimeSpan.FromMinutes(5);
 
 	/// <summary>
 	/// Indicates whether the 'jti' (JWT ID) claim is required for replay protection.
 	/// When enabled, JWTs without a jti claim will be rejected to prevent replay attacks.
-	/// Default is true per RFC 7523 Section 5.2 security recommendation.
+	/// Default is true. RFC 7523 Section 6 leaves replay protection optional and at the
+	/// implementation's discretion, so refusing an assertion without a jti is this server's
+	/// choice rather than a requirement it inherits.
 	/// </summary>
 	public bool RequireJti { get; set; } = true;
 

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -21,7 +21,7 @@ namespace Abblix.Oidc.Server.Endpoints.Authorization;
 /// </summary>
 /// <param name="authorizationDetailsPolicy">Re-runs granted <c>authorization_details</c> through the
 /// per-type validators and per-client allowlist; the per-type validator owns the "is B a narrowing
-/// of A" decision for intra-entry content (RFC 9396 has no universal comparator).</param>
+/// of A" decision for intra-entry content (RFC 9396 §6.1 has no universal comparator).</param>
 public class ConsentConstraintEnforcer(
     IAuthorizationDetailsPolicy authorizationDetailsPolicy) : IConsentConstraintEnforcer
 {
@@ -100,7 +100,7 @@ public class ConsentConstraintEnforcer(
         var grantedTypes = RefuseTypesOutside(
             requestedTypes, grantedAuthorizationDetails, nameof(IUserConsentsProvider));
 
-        // Intra-entry narrowing: RFC 9396 defines no universal comparator for "is B a narrowing of
+        // Intra-entry narrowing: RFC 9396 §6.1 defines no universal comparator for "is B a narrowing of
         // A" (an amount, a locations list within one entry), so re-run the granted entries through
         // the per-type validators and per-client allowlist and let the per-type validator own that
         // decision. A rejection means a granted entry's content escalated beyond what the validator

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/IConsentConstraintEnforcer.cs
@@ -51,7 +51,7 @@ public interface IConsentConstraintEnforcer
     /// second entry of its own type means.
     /// </remarks>
     /// <remarks>
-    /// RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so the
+    /// RFC 9396 §6.1 defines no universal comparator for "is this entry a narrowing of that one", so the
     /// per-type validator owns that decision - and a normalising validator expresses it by RETURNING
     /// a modified entry rather than by failing. The value that comes back is therefore the decision
     /// itself, and the caller emits it; emitting what went in instead would put content in the token

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
@@ -145,10 +146,18 @@ public class BackChannelAuthenticationRequestProcessor(
 			// issued and the host replaces it when the end user approves part of the request; this one is
 			// what that answer is judged against, and there is no other copy left by then.
 			//
+			// A CLONE rather than the same array, because the two are compared against each other later.
+			// Serialising through storage would separate them today, but that is a property of whichever
+			// IEntityStorage a host has registered, not of this code: an in-memory store handing both
+			// references back would let a host narrowing the grant in place move the baseline with it, and
+			// a check comparing an array against itself can never refuse anything.
+			//
 			// An EMPTY array when the request carried none, never null: null is what a request written by
 			// a build without this field reads back as, and the two must not be confused. Denying such a
 			// request would refuse, mid-upgrade, every in-flight authentication the user had approved.
-			RequestedAuthorizationDetails = request.AuthorizationDetails ?? [],
+			RequestedAuthorizationDetails = request.AuthorizationDetails is { } requested
+				? (JsonArray)requested.DeepClone()
+				: [],
 
 			// The client may poll from the moment it holds the request id, so the first allowed poll is
 			// now, matching the device flow. CIBA section 11 adopts RFC 8628's polling rules, and section

--- a/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Introspection/IntrospectionRequestProcessor.cs
@@ -231,16 +231,18 @@ public class IntrospectionRequestProcessor(
 	/// The entry as this caller receives it: its own copy, carrying only the locations it matched.
 	/// </summary>
 	/// <remarks>
-	/// The locations are written as an array rather than through the typed setter, which collapses a
-	/// single value to a bare string: §9.2 has the member carry "the same structure defined in Section 2",
-	/// and §2.2 defines <c>locations</c> as an array of strings.
+	/// Written through the typed setter, which keeps <c>locations</c> an array however few entries
+	/// survive the match: RFC 9396 §9.2 has the member carry "the same structure defined in Section 2",
+	/// and §2.2 defines it as an array of strings. A single surviving location is the case that would
+	/// otherwise leave this endpoint answering with a shape no caller is required to accept.
 	/// </remarks>
 	private static JsonNode Disclose(AuthorizationDetail detail, string[] matchedLocations)
 	{
-		var disclosed = (JsonObject)detail.Json.DeepClone();
-		disclosed[AuthorizationDetail.Parameters.Locations] = new JsonArray(
-			matchedLocations.Select(location => (JsonNode)JsonValue.Create(location)).ToArray());
+		var disclosed = new AuthorizationDetail((JsonObject)detail.Json.DeepClone())
+		{
+			Locations = matchedLocations,
+		};
 
-		return disclosed;
+		return disclosed.Json;
 	}
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -123,7 +123,8 @@ public class BackChannelAuthenticationGrantHandler(
     /// Whether the grant carries an <c>authorization_details</c> type the request never asked for.
     /// </summary>
     /// <remarks>
-    /// Types only, for the reason the completion path gives: RFC 9396 defines no universal comparator for
+    /// Types only, for the reason the completion path gives: RFC 9396 §6.1 defines no universal
+    /// comparator for
     /// intra-entry narrowing. A null baseline means the request predates the field rather than asked for
     /// nothing, and is left alone, since refusing it would deny an authentication the end user approved
     /// before the upgrade.

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -39,7 +39,8 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// - sub (subject): Identifies the principal that is the subject of the JWT
 /// - aud (audience): Identifies the recipients that the JWT is intended for (must include this authorization server)
 /// - exp (expiration time): Identifies the expiration time on or after which the JWT MUST NOT be accepted
-/// - jti (JWT ID): Optional but recommended for replay protection per RFC 7523 Section 5.2
+/// - jti (JWT ID): Optional per RFC 7523 Section 3, which lets the authorization server keep
+///   the set of used values and refuse a repeat
 ///
 /// The authorization server validates the JWT signature, claims, and ensures the issuer is trusted
 /// before issuing an access token.
@@ -273,7 +274,7 @@ public partial class JwtBearerGrantHandler(
 	}
 
 	/// <summary>
-	/// Validates that the JWT has not been used before (replay protection per RFC 7523 Section 5.2).
+	/// Validates that the JWT has not been used before (replay protection per RFC 7523 Section 3).
 	/// </summary>
 	private async Task<Result<ValidationContext, OidcError>> ValidateReplayProtectionAsync(ValidationContext ctx, ClientInfo clientInfo)
 	{

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -107,7 +107,8 @@ public abstract partial class AuthenticationCompletionHandler(
     /// the grant stays inside what was requested.
     /// </summary>
     /// <remarks>
-    /// Types only. RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so
+    /// Types only. RFC 9396 §6.1 defines no universal comparator for "is this entry a narrowing
+    /// of that one", so
     /// what can be judged without knowing a type's schema is whether an entry of that type was asked for at
     /// all. An entry that cannot be read as a JSON object counts as escaped: the conversion drops it silently,
     /// and "nothing escaped" would then be a statement about what could be read rather than about the grant.

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeRateLimiter.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeRateLimiter.cs
@@ -12,7 +12,9 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 
 /// <summary>
 /// Defines the contract for rate limiting user code verification attempts to prevent brute force attacks.
-/// Per RFC 8628 Section 5.2, implementations SHOULD implement rate limiting to prevent abuse.
+/// RFC 8628 Section 5.1 recommends that the server rate-limit user code attempts. The word there is
+/// lowercase, so this is a mitigation the server chooses rather than one it inherits - and the choice
+/// is what makes the entropy argument in that section hold.
 /// </summary>
 public interface IUserCodeRateLimiter
 {

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
@@ -34,7 +34,7 @@ public interface IUserCodeVerificationService
     /// context. Its <c>authorization_details</c> are what the device is granted: the library adds none, and
     /// refuses an approval carrying a type the request never asked for. Its scopes and resources are a
     /// starting point rather than the final word - the token endpoint narrows them against the token
-    /// request (RFC 6749 §6, RFC 8707 §2.2) and adds the certificate and proof-key confirmations.</param>
+    /// request (RFC 8707 §2.2) and adds the certificate and proof-key confirmations.</param>
     /// <returns>
     /// A task that returns true if the approval was successful; false if the code is invalid or expired.
     /// </returns>
@@ -46,8 +46,9 @@ public interface IUserCodeVerificationService
     /// payment nobody was shown is worse than granting none.
     /// <para>
     /// Approving with entries on the record and none on the grant is therefore allowed and logged at
-    /// warning level. §7 is satisfied either way, since its MUST is to return what the resource owner
-    /// GRANTED and nothing granted is nothing to return. §9 is the one that matters here: it makes the
+    /// warning level. RFC 9396 §7 is satisfied either way, since its MUST is to return what the
+    /// resource owner GRANTED and nothing granted is nothing to return. §9 of that document is the
+    /// one that matters here: it makes the
     /// details reaching the resource server the point of having them, and a token carrying none leaves
     /// it nothing to enforce, which is worth seeing in a log rather than discovering at the resource
     /// server.

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeGenerator.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeGenerator.cs
@@ -34,8 +34,9 @@ public class UserCodeGenerator(IOptions<OidcOptions> options) : IUserCodeGenerat
         for (var i = 0; i < length; i++)
         {
             // Use GetInt32 for uniform distribution without modulo bias
-            // RFC 8628 Section 6.1: User codes MUST contain only characters from a predefined character set
-            // with uniform random distribution for security
+            // RFC 8628 Section 6.1 recommends restricting the character set so the code is quick to
+            // type on a phone; it states no requirement, so the fixed alphabet is this server's choice.
+            // The uniform draw is what makes the entropy claim in Section 5.1 true of it.
             chars[i] = alphabet[RandomNumberGenerator.GetInt32(alphabet.Length)];
         }
 

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeRateLimiter.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeRateLimiter.cs
@@ -19,7 +19,7 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
 /// <summary>
 /// Implements rate limiting for user code verification attempts to prevent brute force attacks.
-/// Uses exponential backoff and per-IP rate limiting as recommended by RFC 8628 Section 5.2.
+/// Uses exponential backoff and per-IP rate limiting as recommended by RFC 8628 Section 5.1.
 /// </summary>
 /// <param name="logger">Logger for security events.</param>
 /// <param name="storage">The storage service for persisting rate limit state.</param>
@@ -80,7 +80,7 @@ public partial class UserCodeRateLimiter(
     {
         // NOTE: the counter updates below are a non-atomic get-increment-set. Under a highly concurrent
         // burst of failures the count can undercount (multiple callers read the same value and write
-        // value+1), weakening the backoff and per-IP cap (RFC 8628 §5.2). A precise limit requires a backend
+        // value+1), weakening the backoff and per-IP cap (RFC 8628 §5.1). A precise limit requires a backend
         // atomic increment (for example Redis INCR) or a CAS loop on a versioned record, which the current
         // IEntityStorage abstraction does not expose. Tracked as a follow-up
         var now = timeProvider.GetUtcNow();
@@ -148,7 +148,7 @@ public partial class UserCodeRateLimiter(
     {
         // Clear the per-user-code backoff: this code has now been verified, so its own attempt
         // history is no longer relevant. The per-IP counter is deliberately left intact - it caps
-        // brute-force attempts spanning many distinct codes from one source (RFC 8628 Section 5.2),
+        // brute-force attempts spanning many distinct codes from one source (RFC 8628 Section 5.1),
         // and an occasional successful verification must not reset that cross-code budget.
         var userCodeKey = keyFactory.UserCodeRateLimitKey(userCode);
         await storage.RemoveAsync(userCodeKey);

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -132,7 +132,8 @@ public partial class UserCodeVerificationService(
     /// asked for, empty when the grant stays inside what was requested.
     /// </summary>
     /// <remarks>
-    /// Types only: RFC 9396 defines no universal comparator for "is this entry a narrowing of that one", so
+    /// Types only: RFC 9396 §6.1 defines no universal comparator for "is this entry a narrowing
+    /// of that one", so
     /// what can be judged here is whether an entry of that type was asked for at all. An entry that cannot
     /// be read as a JSON object counts as escaped, because the conversion drops it silently and "nothing
     /// escaped" would then describe what could be read rather than the grant.

--- a/src/Abblix.Oidc.Server/Features/JwtBearer/IJwtBearerIssuerProvider.cs
+++ b/src/Abblix.Oidc.Server/Features/JwtBearer/IJwtBearerIssuerProvider.cs
@@ -19,7 +19,7 @@ namespace Abblix.Oidc.Server.Features.JwtBearer;
 /// This interface centralizes JWT Bearer security functionality to:
 /// - Validate that the JWT issuer (iss claim) is from a trusted identity provider
 /// - Resolve the signing keys (JWKS) for verifying the JWT signature
-/// - Provide replay protection per RFC 7523 Section 5.2
+/// - Provide replay protection per RFC 7523 Section 3
 /// - Expose configuration settings (clock skew, algorithm whitelist, etc.)
 /// </remarks>
 public interface IJwtBearerIssuerProvider

--- a/src/Abblix.Oidc.Server/Features/JwtBearer/JwtBearerIssuerProvider.cs
+++ b/src/Abblix.Oidc.Server/Features/JwtBearer/JwtBearerIssuerProvider.cs
@@ -23,7 +23,7 @@ namespace Abblix.Oidc.Server.Features.JwtBearer;
 /// </summary>
 /// <param name="logger">Logger for recording JWKS fetch operations and errors.</param>
 /// <param name="oidcOptions">OIDC configuration options containing JWT Bearer trusted issuers.</param>
-/// <param name="replayCache">Cache for JWT replay protection per RFC 7523 Section 5.2.</param>
+/// <param name="replayCache">Cache for JWT replay protection per RFC 7523 Section 3.</param>
 /// <param name="secureFetcher">HTTP fetcher with SSRF protection and caching.</param>
 /// <param name="timeProvider">Dates the fallback retention window for an assertion without an
 /// expiry.</param>

--- a/src/Abblix.Oidc.Server/Features/ReplayPrevention/IJwtReplayCache.cs
+++ b/src/Abblix.Oidc.Server/Features/ReplayPrevention/IJwtReplayCache.cs
@@ -13,7 +13,7 @@ namespace Abblix.Oidc.Server.Features.ReplayPrevention;
 
 /// <summary>
 /// Tracks JWT IDs (jti claims) presented to the server, so a JWT-bearing flow can detect
-/// replay attempts. Both RFC 7523 §5.2 (JWT-bearer-grant assertion replay) and RFC 9449
+/// replay attempts. Both RFC 7523 §3 (JWT-bearer-grant assertion replay) and RFC 9449
 /// §11.1 (DPoP proof replay) want this primitive; it is intentionally namespace-neutral
 /// so a single distributed-cache instance serves every consumer.
 /// </summary>

--- a/src/Abblix.Oidc.Server/Features/ReplayPrevention/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ReplayPrevention/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Abblix.Oidc.Server.Features.ReplayPrevention;
 
 /// <summary>
 /// Wires replay protection, which several unrelated features need and none of them owns:
-/// JWT-bearer assertions (RFC 7523 Section 5.2), client assertions, and DPoP proofs
+/// JWT-bearer assertions (RFC 7523 Section 3), client assertions, and DPoP proofs
 /// (RFC 9449 Section 11.1) all reserve identifiers in the same place.
 /// </summary>
 public static class ServiceCollectionExtensions

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -349,8 +349,8 @@ internal static class LogEvents
 
         /// <summary>
         /// <c>Features/ReplayPrevention/DistributedJwtReplayCache.cs</c> - JWT replay
-        /// protection via <c>IDistributedCache</c> per RFC 7523 Section 5.2 and
-        /// RFC 9449 §11.1.5 (sub-range 5040-5059).
+        /// protection via <c>IDistributedCache</c> per RFC 7523 Section 3 and
+        /// RFC 9449 §11.1 (sub-range 5040-5059).
         /// </summary>
         public static class DistributedJwtReplayCache
         {

--- a/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
@@ -249,4 +249,58 @@ public class AuthorizationDetailTests
         Assert.Equal([InitiateAction], detail.Actions);
         Assert.Null(detail.Identifier);
     }
+
+    /// <summary>
+    /// A single value assigned to an array member is written as an array of one, not as a bare string.
+    /// </summary>
+    /// <remarks>
+    /// RFC 9396 §2.2 defines locations, actions, datatypes and privileges as arrays of strings, and the
+    /// count of what a host happens to grant does not change that. The case matters because narrowing is
+    /// what these setters exist for: a validator that keeps one location out of three is the ordinary
+    /// path, and it is exactly the path that used to emit a shape no resource server owes us a reading of.
+    /// </remarks>
+    [Theory]
+    [InlineData("locations", "https://api.bank.example/payments")]
+    [InlineData("actions", InitiateAction)]
+    [InlineData("datatypes", "contacts")]
+    [InlineData("privileges", "admin")]
+    public void AuthorizationDetail_ArrayMemberWithOneValue_IsWrittenAsAnArray(string member, string value)
+    {
+        var detail = new AuthorizationDetail(new JsonObject { ["type"] = PaymentInitiationType });
+
+        switch (member)
+        {
+            case "locations": detail.Locations = [value]; break;
+            case "actions": detail.Actions = [value]; break;
+            case "datatypes": detail.Datatypes = [value]; break;
+            case "privileges": detail.Privileges = [value]; break;
+            default: throw new ArgumentOutOfRangeException(nameof(member), member, "Unknown array member");
+        }
+
+        Assert.Equal($$"""{"type":"{{PaymentInitiationType}}","{{member}}":["{{value}}"]}""",
+            detail.Json.ToJsonString());
+    }
+
+    /// <summary>
+    /// An empty collection removes the member rather than writing an empty array.
+    /// </summary>
+    /// <remarks>
+    /// RFC 9396 §2.2 makes every one of these members optional, so absence is the honest way to say
+    /// "none" - and it keeps the behaviour a caller already had before the single-value case was fixed,
+    /// which is what stops that fix from being a second, silent change.
+    /// </remarks>
+    [Fact]
+    public void AuthorizationDetail_ArrayMemberSetToEmpty_RemovesTheMember()
+    {
+        var detail = new AuthorizationDetail(new JsonObject
+        {
+            ["type"] = PaymentInitiationType,
+            ["locations"] = new JsonArray("https://api.bank.example/payments"),
+        });
+
+        detail.Locations = [];
+
+        Assert.Equal($$"""{"type":"{{PaymentInitiationType}}"}""", detail.Json.ToJsonString());
+        Assert.Null(detail.Locations);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1702,7 +1702,8 @@ public class AuthorizationRequestProcessorTests
     [Fact]
     public async Task ProcessAsync_ConsentDropsOneEntryFromMultiSet_TokenReflectsRemaining()
     {
-        // RFC 9396 §5 partial-consent drop-entry. Client requested two entries, user
+        // RFC 9396 §3 notes the user may grant a subset of what was requested, and §7 then has the
+        // server return what was granted. Client requested two entries, user
         // agreed to one. Consent layer is the right surface for this -- per-type
         // validators only see a single entry and cannot reason cross-entry.
         var requestedAd = new JsonArray(
@@ -1727,7 +1728,8 @@ public class AuthorizationRequestProcessorTests
     [Fact]
     public async Task ProcessAsync_ConsentAppliesCrossDetailCapAcrossEntries_TokenReflectsCappedSet()
     {
-        // RFC 9396 §5 cross-detail policy. Client requested three payment_initiation
+        // The same §3 note read across entries rather than within one. Client requested three
+        // payment_initiation
         // entries of 500 each (total 1500); host policy caps total at 1000; consent
         // provider sees the entire list and returns the cross-cut narrow with the
         // last entry zeroed out. Per-type validators have no signal that the third

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessorTests.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Abblix.Jwt;
@@ -78,7 +79,7 @@ public class BackChannelAuthenticationRequestProcessorTests
     }
 
     private ValidBackChannelAuthenticationRequest Request(
-        string? hintedSubject, string? claimsJson = null)
+        string? hintedSubject, string? claimsJson = null, JsonArray? authorizationDetails = null)
     {
         var hint = hintedSubject is null
             ? null
@@ -102,6 +103,7 @@ public class BackChannelAuthenticationRequestProcessorTests
                 Scope = [new ScopeDefinition(Scopes.OpenId)],
                 ExpiresIn = TimeSpan.FromMinutes(5),
                 IdToken = hint,
+                AuthorizationDetails = authorizationDetails,
             });
     }
 
@@ -115,6 +117,46 @@ public class BackChannelAuthenticationRequestProcessorTests
 
         _handler.Setup(h => h.InitiateAuthenticationAsync(It.IsAny<ValidBackChannelAuthenticationRequest>()))
             .Returns(Task.FromResult(session));
+    }
+
+    /// <summary>
+    /// Rewriting the grant's <c>authorization_details</c> in place leaves the requested set untouched.
+    /// </summary>
+    /// <remarks>
+    /// Narrowing in place is how a host says the end user approved part of the request, and the requested
+    /// set is the only record of what was asked for by the time that happens. Sharing one array between
+    /// the two would make the widening check at completion compare a value against itself, which cannot
+    /// refuse anything - and it would do so silently, because the shipped storage serialises both and
+    /// separates them, so the defect would wait for the first host that registers an in-memory
+    /// <c>IEntityStorage</c>. Reference identity is asserted through the behaviour it decides rather than
+    /// on its own, so the test still means something if the copy is made somewhere else.
+    /// </remarks>
+    [Fact]
+    public async Task NarrowingTheGrantInPlace_LeavesTheRequestedDetailsAsTheyWere()
+    {
+        HostAuthenticates(Approved);
+
+        StoredRequest? stored = null;
+        _storage
+            .Setup(s => s.StoreAsync(It.IsAny<StoredRequest>(), It.IsAny<TimeSpan>()))
+            .Callback((StoredRequest request, TimeSpan _) => stored = request)
+            .ReturnsAsync("auth-req-id");
+
+        var requested = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+
+        var result = await _processor.ProcessAsync(Request(null, authorizationDetails: requested));
+
+        Assert.True(result.TryGetSuccess(out _));
+        Assert.NotNull(stored);
+
+        var granted = stored.AuthorizedGrant.Context.AuthorizationDetails;
+        Assert.NotNull(granted);
+        granted.Clear();
+        granted.Add(new JsonObject { ["type"] = "admin_access" });
+
+        Assert.Equal(
+            """[{"type":"payment_initiation"}]""",
+            stored.RequestedAuthorizationDetails!.ToJsonString());
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -774,7 +774,8 @@ public class JwtBearerGrantHandlerTests
 
 	/// <summary>
 	/// Verifies that replay attacks are detected when the same jti is used twice.
-	/// Per RFC 7523 Section 5.2: JTI values MUST be unique to prevent replay attacks.
+	/// RFC 7523 Section 3 lets the authorization server keep the set of used jti values and
+	/// refuse a repeat. Uniqueness is not a MUST there - this server chooses to enforce it.
 	/// </summary>
 	[Fact]
 	public async Task ReplayAttack_WithReusedJti_ShouldReject()
@@ -834,7 +835,8 @@ public class JwtBearerGrantHandlerTests
 
 	/// <summary>
 	/// Verifies that JWTs without jti are rejected when RequireJti is enabled.
-	/// Per RFC 7523 Section 5.2: JTI claim is recommended for replay protection.
+	/// RFC 7523 Section 3 makes jti optional, so requiring it is this server's own setting;
+	/// what the test pins is that the setting, once on, actually refuses.
 	/// </summary>
 	[Fact]
 	public async Task ReplayProtection_WithMissingJti_WhenRequired_ShouldReject()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -365,9 +365,11 @@ public class AuthorizationDetailsPolicyTests
 
         Assert.True(result.TryGetSuccess(out var validated));
         var wire = validated!.ToJsonString();
-        // Single-element arrays collapse to a string per the OAuth single-or-array
-        // convention (see AuthorizationDetail.SetArrayOrStringOrNull).
-        Assert.Contains("\"actions\":\"initiate\"", wire);
+        // Still an array, though only one action survived deduplication. The single-or-array
+        // convention belongs to JWT claims such as aud (RFC 7519 Section 4.1.3); RFC 9396
+        // Section 2.2 defines actions as an array of strings and canonicalisation is precisely
+        // the path that reduces one to a single element.
+        Assert.Contains("\"actions\":[\"initiate\"]", wire);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -101,7 +101,7 @@ public class UserCodeVerificationServiceTests
         // Whether the entries reach the grant is the host's call, because only its verification page
         // knows what it displayed. What must not happen is that the omission passes unremarked: the
         // token that follows carries no authorization_details, and a resource server enforcing them
-        // has nothing to enforce (RFC 9396 section 7).
+        // has nothing to enforce (RFC 9396 section 9).
         var requestedDetails = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
         var service = BuildService(requestedDetails, out var logs);
 


### PR DESCRIPTION
Four changes found by reading the merged state of the `authorization_details` work. Three are corrections to what shipped; the fourth is the check that would have caught the first one.

## Every RFC citation points at the section it means

Eleven comments sent the reader to RFC 7523 section 5.2 for replay protection. That section does not exist: section 5 is Interoperability Considerations, and `jti` lives in section 3 item 7. One more pointed at RFC 9449 section 11.1.5, where DPoP stops at 11.1.

Three of them had also invented normative strength the documents disclaim. RFC 7523 section 6 says replay protection is "an optional feature, which implementations may employ at their own discretion", so `RequireJti` defaulting to true is this server's choice rather than an inherited requirement, and the five-minute clock skew is ours too. A test doc asserted that `jti` values MUST be unique on RFC 7523's authority, which says no such thing.

The device flow carried the same class. User-code rate limiting is RFC 8628 section 5.1, not 5.2, which is about the device code; section 5.1 recommends it in lowercase, so the SHOULD an interface claimed was not there. The user-code alphabet in section 6.1 is a usability recommendation with no keyword at all, and the `verification_uri` HTTPS rule is not in RFC 8628 - it is RFC 6749 section 3.1's, because the user authenticates at that address.

Also: the `type` member is REQUIRED by RFC 9396 section 2, while section 2.1 governs what a value may be; partial consent is the note in section 3 rather than section 5; and the six places arguing that no universal comparator exists now name section 6.1, which says exactly that, so the strongest architectural claim in the recent work can be checked rather than believed.

## `authorization_details` array members stay arrays

RFC 9396 section 2.2 defines `locations`, `actions`, `datatypes` and `privileges` as arrays of strings. All four went through the helper that collapses a one-element sequence to a bare string, which is right for `aud` per RFC 7519 section 4.1.3 and wrong for a member defined as an array.

Narrowing is what these setters exist for, so a single surviving value is the ordinary path. The library's own canonicalisation scenario proves it: three mixed-case actions deduplicate to one, and the existing test asserted the bare string as the expected output, citing the single-or-array convention that belongs to `aud`. That assertion is now the array.

## CIBA gets its own copy of the requested details

The stored request kept the requested array and the grant's array as one object. The grant's copy is what a host rewrites when the end user approves part of the request, and the requested copy is what that answer is judged against, so a host narrowing in place would move the baseline with it.

The shipped storage hides this by serialising both. `IEntityStorage` is a public seam, though, and a host registering an in-memory implementation on a single node would get a check comparing an array against itself, with nothing in the output to say so.

## The citation check runs on every pull request

A committed script nobody runs is a detector that works only when somebody remembers, so it is a job feeding the required check. Its cache key comes from the list of cited RFC numbers, because a published RFC never changes and the only thing that can make a cached copy insufficient is a document nobody cited before. A fetch that fails names the documents it could not read and passes the rest, rather than turning an unreachable rfc-editor.org into a red pull request.

It reports 1864 citations across 50 RFCs with every section present, and goes red on a planted one. It cannot tell whether a real section says what a comment claims - most of the corrections above are of that kind and still needed a reader.

Two follow-ups are filed separately: #409 and #410. Related: #278, #396.
