### PR TITLE
Report an expired licence instead of merging it

### DIFF
--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -129,11 +129,46 @@ public partial class LicenseManager
     /// </remarks>
     internal License? GenerateActiveLicense(DateTimeOffset utcNow)
     {
-        // Scans from the start every call and mutates no shared cursor: the method runs concurrently under
-        // the read lock, so advancing a shared start index here let racing readers overshoot a valid license
-        // and permanently degrade the server to FreeLicense. License lists are tiny, so a full scan is cheap.
+        var (result, expired) = Scan(utcNow);
+
+        // An expiry is reported only when nothing was left in force, which is the fact that makes it worth
+        // reporting and the one the scan can only know at its end. A superseded license expired too, and
+        // saying so daily at Critical for every license a deployment has ever loaded would bury the one
+        // record that means something under records that mean nothing - and they share an event id and a
+        // severity, so the operator who filters out the noise has filtered out the signal.
+        //
+        // With nothing in force the message is exactly true: the server is on the free tier, which allows
+        // one issuer, and a deployment serving more than one then refuses every issuer it has seen,
+        // including the first, until it restarts under a valid license.
+        if (result is null && expired is not null)
+        {
+            foreach (var license in expired)
+                ReportStatus(license, LicenseStatus.Expired, utcNow);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Walks the licenses and returns what is in force, together with the expired ones seen on the way.
+    /// </summary>
+    /// <param name="utcNow">The moment to evaluate each license at.</param>
+    /// <returns>The license in force, or <c>null</c> for the free tier, and the expired licenses.</returns>
+    /// <remarks>
+    /// Separate from <see cref="GenerateActiveLicense"/> so the early exit below stays an early exit while
+    /// the reporting keeps a single place to happen. Guarding two exits with the same condition is how the
+    /// two come to disagree.
+    ///
+    /// Scans from the start every call and mutates no shared cursor: the method runs concurrently under the
+    /// read lock, so advancing a shared start index here let racing readers overshoot a valid license and
+    /// permanently degrade the server to FreeLicense. License lists are tiny, so a full scan is cheap.
+    /// </remarks>
+    private (License? InForce, List<License>? Expired) Scan(DateTimeOffset utcNow)
+    {
         License? result = null;
         bool? activeLicenseFound = null;
+        List<License>? expired = null;
+
         for (var indexCurrent = 0; indexCurrent < _licenses.Count; indexCurrent++)
         {
             var license = _licenses[indexCurrent];
@@ -141,13 +176,8 @@ public partial class LicenseManager
             switch (status)
             {
                 case LicenseStatus.Expired:
-                    // Reported and not merged. The moment a license stops applying is the one an operator
-                    // alerts on, because what follows is not graceful: the server falls back to the free
-                    // tier, and a deployment serving more than one issuer then refuses every issuer it has
-                    // seen, including the first, until it restarts under a valid license. Drop the report
-                    // and that fallback happens in silence for the ordinary single-license installation,
-                    // which never reaches the report inside FindActiveLicensesInFuture.
-                    ReportStatus(license, status, utcNow);
+                    // Collected, never merged: its limits stopped applying, which is the whole event.
+                    (expired ??= []).Add(license);
                     break;
 
                 case LicenseStatus.Active:
@@ -163,11 +193,14 @@ public partial class LicenseManager
                     break;
 
                 case LicenseStatus.NotActiveYet:
-                    return result;
+                    // Licenses are held sorted by the moment they start, so everything past this one starts
+                    // later still and the scan is over. Whatever the caller reports, it reports about the
+                    // licenses already collected, which is all of them that could matter.
+                    return (result, expired);
             }
         }
 
-        return result;
+        return (result, expired);
     }
 
     /// <summary>
@@ -190,33 +223,19 @@ public partial class LicenseManager
     /// the ones that still apply. A successor takes over on its own, at the moment
     /// <see cref="GetLicenseStatus"/> starts calling it active.
     ///
-    /// Expired licenses stepped over on the way are reported HERE and only when the search succeeds,
-    /// because that is the one case where <paramref name="indexCurrent"/> leaps past them and the caller's
-    /// own loop never sees them. Reporting them on the way past would report them twice on every other
-    /// call, with nothing but the log throttle absorbing the second - and a throttle suppresses a symptom
-    /// rather than deciding anything.
+    /// Nothing is reported from here, including the expired licenses the search leaps over. A true answer
+    /// merges an active license, so something is in force, and an expiry that changed nothing is exactly
+    /// what the caller declines to report. A false answer leaps over nothing, so the caller's own loop
+    /// meets every license itself.
     /// </remarks>
     private bool FindActiveLicensesInFuture(DateTimeOffset utcNow, ref int indexCurrent, ref License? result)
     {
-        List<License>? expiredSteppedOver = null;
-
         for (var indexNext = indexCurrent + 1; indexNext < _licenses.Count; indexNext++)
         {
             var nextLicense = _licenses[indexNext];
             var nextStatus = GetLicenseStatus(nextLicense, utcNow);
             if (nextStatus != LicenseStatus.Active)
-            {
-                if (nextStatus == LicenseStatus.Expired)
-                    (expiredSteppedOver ??= []).Add(nextLicense);
-
                 continue;
-            }
-
-            if (expiredSteppedOver is not null)
-            {
-                foreach (var expired in expiredSteppedOver)
-                    ReportStatus(expired, LicenseStatus.Expired, utcNow);
-            }
 
             indexCurrent = indexNext;
 

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -144,7 +144,9 @@ public partial class LicenseManager
                     // Reported and not merged. The moment a license stops applying is the one an operator
                     // alerts on, because what follows is not graceful: the server falls back to the free
                     // tier, and a deployment serving more than one issuer then refuses every issuer it has
-                    // seen, including the first, until it restarts under a valid license.
+                    // seen, including the first, until it restarts under a valid license. Drop the report
+                    // and that fallback happens in silence for the ordinary single-license installation,
+                    // which never reaches the report inside FindActiveLicensesInFuture.
                     ReportStatus(license, status, utcNow);
                     break;
 
@@ -169,33 +171,51 @@ public partial class LicenseManager
     }
 
     /// <summary>
-    /// Searches for active licenses that will become valid in the future, starting from the current index in the licenses list.
+    /// Looks past a license in its grace period for one that is active now, and merges that one instead.
     /// </summary>
     /// <param name="utcNow">The current UTC time for license evaluation.</param>
-    /// <param name="indexCurrent">The current index in the licenses list from which to start the search.</param>
-    /// <param name="result">The license that has been determined to be active or will soon be active, to be updated by this method.</param>
-    /// <returns>True if an active license is found in the future; otherwise, false.</returns>
+    /// <param name="indexCurrent">The index the search starts after, advanced past everything it stepped
+    /// over when it finds an active license.</param>
+    /// <param name="result">The result license, updated with the active license when one is found.</param>
+    /// <returns>True when an active license was found and merged; otherwise, false.</returns>
     /// <remarks>
-    /// This method is used internally by GenerateActiveLicense to find licenses that are not yet active but will become so,
-    /// allowing for a seamless transition between licenses as they expire or become valid.
+    /// Only an ACTIVE license answers this question, and that is the whole of it: a license whose terms do
+    /// not apply at <paramref name="utcNow"/> cannot decide what applies at <paramref name="utcNow"/>.
+    /// One that has expired is over, and one that has not started is not the deployment's yet - handing
+    /// today the allowance of a license beginning next week is what <c>NotBefore</c> exists to forbid, and
+    /// the answer would stick, because <see cref="TryGetCurrentLicenseLimit"/> caches any result whose
+    /// <c>ExpiresAt</c> is still ahead.
+    ///
+    /// A false answer therefore leaves the grace-period license in force, which is correct: its terms are
+    /// the ones that still apply. A successor takes over on its own, at the moment
+    /// <see cref="GetLicenseStatus"/> starts calling it active.
+    ///
+    /// Expired licenses stepped over on the way are reported HERE and only when the search succeeds,
+    /// because that is the one case where <paramref name="indexCurrent"/> leaps past them and the caller's
+    /// own loop never sees them. Reporting them on the way past would report them twice on every other
+    /// call, with nothing but the log throttle absorbing the second - and a throttle suppresses a symptom
+    /// rather than deciding anything.
     /// </remarks>
     private bool FindActiveLicensesInFuture(DateTimeOffset utcNow, ref int indexCurrent, ref License? result)
     {
+        List<License>? expiredSteppedOver = null;
+
         for (var indexNext = indexCurrent + 1; indexNext < _licenses.Count; indexNext++)
         {
             var nextLicense = _licenses[indexNext];
             var nextStatus = GetLicenseStatus(nextLicense, utcNow);
-            if (nextStatus == LicenseStatus.GracePeriod)
-                continue;
-
-            // An expired license is no more a license found in the future than one in its grace period is.
-            // Taking it used to merge limits that had stopped applying into the license in force, and tell
-            // the caller a successor existed - so a deployment kept the allowance of a license it no longer
-            // held, on the strength of a later one that had already run out.
-            if (nextStatus == LicenseStatus.Expired)
+            if (nextStatus != LicenseStatus.Active)
             {
-                ReportStatus(nextLicense, nextStatus, utcNow);
+                if (nextStatus == LicenseStatus.Expired)
+                    (expiredSteppedOver ??= []).Add(nextLicense);
+
                 continue;
+            }
+
+            if (expiredSteppedOver is not null)
+            {
+                foreach (var expired in expiredSteppedOver)
+                    ReportStatus(expired, LicenseStatus.Expired, utcNow);
             }
 
             indexCurrent = indexNext;
@@ -248,14 +268,15 @@ public partial class LicenseManager
     /// <param name="status">Its status at <paramref name="utcNow"/>.</param>
     /// <param name="utcNow">The moment the status was evaluated at.</param>
     /// <remarks>
-    /// Separate from <see cref="AppendLicense"/> because reporting and merging answer to different callers.
-    /// An expired license has to be reported and must NOT be merged - its limits stopped applying, which is
-    /// the whole event - and while the two lived in one method the only way to report one was to fold its
-    /// limits into the license in force. So the arm was left empty, and a single-license deployment reached
-    /// the free tier in silence.
+    /// Separate from <see cref="AppendLicense"/> because the two answer different callers. An expired
+    /// license has to be reported and must NOT be merged, its limits having stopped applying, which is the
+    /// whole event; joining the two would make every report of an expired license also grant its limits.
     ///
-    /// The throttle is per license and status, so a list holding several expired licenses records each of
-    /// them once a day rather than on every evaluation.
+    /// The throttle key is the license VALUE paired with the status, not the instance: <see cref="License"/>
+    /// is a record, so two separately issued licenses carrying identical dates and limits are one key and
+    /// produce one record between them. Records are therefore per distinct set of terms per day, which is
+    /// what an operator reads them as anyway - and a license differing in any field, including a
+    /// <c>ValidIssuers</c> set held in another instance, is a key of its own.
     /// </remarks>
     private static void ReportStatus(License license, LicenseStatus status, DateTimeOffset utcNow)
     {

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -141,6 +141,11 @@ public partial class LicenseManager
             switch (status)
             {
                 case LicenseStatus.Expired:
+                    // Reported and not merged. The moment a license stops applying is the one an operator
+                    // alerts on, because what follows is not graceful: the server falls back to the free
+                    // tier, and a deployment serving more than one issuer then refuses every issuer it has
+                    // seen, including the first, until it restarts under a valid license.
+                    ReportStatus(license, status, utcNow);
                     break;
 
                 case LicenseStatus.Active:
@@ -183,6 +188,16 @@ public partial class LicenseManager
             if (nextStatus == LicenseStatus.GracePeriod)
                 continue;
 
+            // An expired license is no more a license found in the future than one in its grace period is.
+            // Taking it used to merge limits that had stopped applying into the license in force, and tell
+            // the caller a successor existed - so a deployment kept the allowance of a license it no longer
+            // held, on the strength of a later one that had already run out.
+            if (nextStatus == LicenseStatus.Expired)
+            {
+                ReportStatus(nextLicense, nextStatus, utcNow);
+                continue;
+            }
+
             indexCurrent = indexNext;
 
             result = AppendLicense(result, nextLicense, nextStatus, utcNow);
@@ -206,6 +221,43 @@ public partial class LicenseManager
     /// and updates the result license to reflect the most appropriate active license based on the current time.
     /// </remarks>
     private static License AppendLicense(License? result, License license, LicenseStatus status, DateTimeOffset utcNow)
+    {
+        ReportStatus(license, status, utcNow);
+
+        if (result == null)
+        {
+            result = license;
+        }
+        else
+        {
+            result = result with {
+                ClientLimit = result.ClientLimit.Greater(license.ClientLimit),
+                IssuerLimit = result.IssuerLimit.Greater(license.IssuerLimit),
+                ExpiresAt = result.ExpiresAt.Lesser(license.ExpiresAt),
+                ValidIssuers = result.ValidIssuers.Join(license.ValidIssuers),
+            };
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Records what a license's status means for the deployment, without deciding anything about it.
+    /// </summary>
+    /// <param name="license">The license the record is about.</param>
+    /// <param name="status">Its status at <paramref name="utcNow"/>.</param>
+    /// <param name="utcNow">The moment the status was evaluated at.</param>
+    /// <remarks>
+    /// Separate from <see cref="AppendLicense"/> because reporting and merging answer to different callers.
+    /// An expired license has to be reported and must NOT be merged - its limits stopped applying, which is
+    /// the whole event - and while the two lived in one method the only way to report one was to fold its
+    /// limits into the license in force. So the arm was left empty, and a single-license deployment reached
+    /// the free tier in silence.
+    ///
+    /// The throttle is per license and status, so a list holding several expired licenses records each of
+    /// them once a day rather than on every evaluation.
+    /// </remarks>
+    private static void ReportStatus(License license, LicenseStatus status, DateTimeOffset utcNow)
     {
         switch (status)
         {
@@ -233,22 +285,6 @@ public partial class LicenseManager
                     (int)(utcNow - expiresAt).TotalDays);
                 break;
         }
-
-        if (result == null)
-        {
-            result = license;
-        }
-        else
-        {
-            result = result with {
-                ClientLimit = result.ClientLimit.Greater(license.ClientLimit),
-                IssuerLimit = result.IssuerLimit.Greater(license.IssuerLimit),
-                ExpiresAt = result.ExpiresAt.Lesser(license.ExpiresAt),
-                ValidIssuers = result.ValidIssuers.Join(license.ValidIssuers),
-            };
-        }
-
-        return result;
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -43,7 +43,15 @@ public partial class LicenseManager
             var i = _licenses.BinarySearch(license, new ActivityPeriodComparer());
             _licenses.Insert(i < 0 ? ~i : i, license);
 
-            _currentLicense = GenerateActiveLicense(DateTimeOffset.UtcNow);
+            // The scan rather than the reporting wrapper, because the list is still arriving: a host
+            // loads licenses one at a time, so every insert but the last evaluates a PARTIAL list, and
+            // an expiry that a license still in the queue is about to supersede would be announced as a
+            // fallback to the free tier - once per superseded license, and only when the provider
+            // happens to yield oldest first, which makes the log depend on arrival order.
+            //
+            // What an insert needs is the refreshed value. The report belongs where the license is
+            // consulted, on a list that has stopped growing.
+            _currentLicense = Scan(DateTimeOffset.UtcNow).InForce;
         }
         finally
         {
@@ -163,7 +171,7 @@ public partial class LicenseManager
     /// read lock, so advancing a shared start index here let racing readers overshoot a valid license and
     /// permanently degrade the server to FreeLicense. License lists are tiny, so a full scan is cheap.
     /// </remarks>
-    private (License? InForce, List<License>? Expired) Scan(DateTimeOffset utcNow)
+    private (License? InForce, IReadOnlyList<License>? Expired) Scan(DateTimeOffset utcNow)
     {
         License? result = null;
         bool? activeLicenseFound = null;

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
@@ -275,39 +275,6 @@ public sealed class LicenseEnforcementTests : IDisposable
         }
     }
 
-    /// <summary>What a single log write carried.</summary>
-    private sealed record LogRecord(LogLevel Level, EventId EventId, string Message);
-
-    /// <summary>A factory whose loggers keep what was written, so a test can assert on the record itself.</summary>
-    private sealed class RecordingLoggerFactory : ILoggerFactory
-    {
-        public List<LogRecord> Entries { get; } = [];
-
-        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
-
-        public void AddProvider(ILoggerProvider provider)
-        {
-        }
-
-        public void Dispose()
-        {
-        }
-
-        private sealed class RecordingLogger(List<LogRecord> entries) : ILogger
-        {
-            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(
-                LogLevel logLevel,
-                EventId eventId,
-                TState state,
-                Exception? exception,
-                Func<TState, Exception?, string> formatter)
-                => entries.Add(new LogRecord(logLevel, eventId, formatter(state, exception)));
-        }
-    }
 
     /// <summary>A factory whose loggers fail on write, standing in for one whose provider has been disposed.</summary>
     private sealed class ThrowingLoggerFactory : ILoggerFactory

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseEnforcementTests.cs
@@ -275,7 +275,6 @@ public sealed class LicenseEnforcementTests : IDisposable
         }
     }
 
-
     /// <summary>A factory whose loggers fail on write, standing in for one whose provider has been disposed.</summary>
     private sealed class ThrowingLoggerFactory : ILoggerFactory
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -698,6 +698,63 @@ public class LicenseManagerTests
     }
 
     /// <summary>
+    /// Loading licenses reports nothing, whatever order they arrive in.
+    /// </summary>
+    /// <remarks>
+    /// A host loads licenses one at a time, so every insert but the last evaluates a PARTIAL list. Reporting
+    /// there announces a fallback to the free tier for a license the next insert is about to supersede, and
+    /// whether it does so depends on the order the provider happens to yield - the same deployment logs
+    /// differently after a reshuffle, with nothing in the diff to explain it. An insert therefore takes the
+    /// value and leaves the reporting to whoever consults the license.
+    ///
+    /// Both orders are driven, though neither is what makes this test bite: `AddLicense` reads the wall
+    /// clock and takes no <c>TimeProvider</c>, so a test cannot place these licenses relative to the instant
+    /// it will use. Against that clock all three are past, which is enough to prove the insert must not
+    /// report at all - the invariant that holds whatever the order, and the one worth pinning.
+    ///
+    /// The recorder is bound around the LOAD rather than around a single evaluation, which is why nothing
+    /// caught this: every other test here calls GenerateActiveLicense on a list that has stopped growing.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddLicense_LoadingLicenses_ReportsNothing(bool oldestFirst)
+    {
+        var superseded = new[]
+        {
+            LicenseAround(-40, -30) with { ClientLimit = 1 },
+            LicenseAround(-30, -20) with { ClientLimit = 2 },
+            LicenseAround(-20, -3, gracePeriod: -1) with { ClientLimit = 3 },
+        };
+        var renewal = LicenseAround(-1, 30) with { ClientLimit = 50 };
+        var arriving = oldestFirst ? [..superseded, renewal] : new[] { renewal }.Concat(superseded).ToArray();
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        var manager = new LicenseManager();
+        try
+        {
+            foreach (var license in arriving)
+                manager.AddLicense(license);
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        Assert.DoesNotContain(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpired);
+
+        // The control on the arrangement itself: without it the silence above would also hold over a
+        // manager that never took the licenses in, which is silent for a reason nobody wants.
+        var active = manager.GenerateActiveLicense(Moment);
+        Assert.NotNull(active);
+        Assert.Equal(50, active!.ClientLimit);
+    }
+
+    /// <summary>
     /// Every expired license is reported when nothing was left in force.
     /// </summary>
     /// <remarks>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -21,6 +21,12 @@ using Xunit;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 
+// Joins the non-parallel collection because the tests below reach the same process-wide state it exists to
+// protect: LicenseLogger.Instance is a singleton, and ClearLogThrottle empties the whole shared window map
+// rather than one key. Running beside a class that asserts on the throttle, or on being the single writer,
+// would let this one wipe a window mid-assertion or capture a foreign write into its own recorder - rarely,
+// and therefore as an unreproducible failure in whichever class happened to be running.
+[Collection(nameof(LicenseEnforcementTests))]
 public class LicenseManagerTests
 {
     private static License CreateLicense(int? notBefore, int? expiresAt, int? gracePeriod = null)
@@ -519,14 +525,13 @@ public class LicenseManagerTests
     #endregion
 
     /// <summary>
-    /// A fixed instant the two tests below measure against, so the day counts they assert on are the ones
-    /// they arranged rather than whatever the clock happened to say between building a licence and judging
-    /// it.
+    /// A fixed instant the tests below measure against, so the day count a record carries is the one they
+    /// arranged rather than whatever the clock says between building a license and judging it.
     /// </summary>
     private static readonly DateTimeOffset Moment = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
 
-    /// <summary>A licence positioned in days relative to <see cref="Moment"/>.</summary>
-    private static License LicenceAround(int notBefore, int expiresAt, int? gracePeriod = null)
+    /// <summary>A license positioned in days relative to <see cref="Moment"/>.</summary>
+    private static License LicenseAround(int notBefore, int expiresAt, int? gracePeriod = null)
         => new()
         {
             NotBefore = Moment.AddDays(notBefore),
@@ -535,24 +540,22 @@ public class LicenseManagerTests
         };
 
     /// <summary>
-    /// One licence, expired past its grace period, is reported.
+    /// One license, expired past its grace period, is reported.
     /// </summary>
     /// <remarks>
-    /// The ordinary shape of a deployment, and the one the record was unreachable for: an installation
-    /// holding a single licence saw a warning while expiry approached, an error once a day through the
-    /// grace period, and then nothing at the moment the licence stopped applying and the server fell back
-    /// to the free tier. That instant is the one an operator alerts on, because the fallback is not
-    /// graceful - a deployment serving more than one issuer starts refusing every issuer it has seen.
+    /// The ordinary shape of a deployment, and the one an operator alerts on: without this record the
+    /// server falls back to the free tier in silence, and the fallback is not graceful - a deployment
+    /// serving more than one issuer starts refusing every issuer it has seen.
     ///
-    /// Deliberately not the two-licence arrangement that already reached the record. That one enters
-    /// through the grace-period search and pins a path a single-licence installation never takes, so a
-    /// test built on it would be green while the gap stayed open.
+    /// Deliberately not the two-license arrangement that also reaches the record. That one enters through
+    /// the grace-period search and exercises a path a single-license installation never takes, so a test
+    /// built on it would say nothing about the ordinary case.
     /// </remarks>
     [Fact]
-    public void GenerateActiveLicense_OneExpiredLicence_RecordsTheExpiry()
+    public void GenerateActiveLicense_OneExpiredLicense_RecordsTheExpiry()
     {
         var manager = new LicenseManager();
-        manager.AddLicense(LicenceAround(notBefore: -30, expiresAt: -10, gracePeriod: -5));
+        manager.AddLicense(LicenseAround(notBefore: -30, expiresAt: -10, gracePeriod: -5));
 
         TestLicense.ClearLogThrottle();
         var records = new RecordingLoggerFactory();
@@ -576,20 +579,20 @@ public class LicenseManagerTests
     }
 
     /// <summary>
-    /// An expired licence is reported without its limits reaching the licence in force.
+    /// An expired license reaching the outer loop lends its limits to nothing.
     /// </summary>
     /// <remarks>
-    /// The reason the arm reporting this was left empty: reporting and merging used to be one method, so
-    /// the only way to report an expired licence was to fold its limits into the result. This pins the
-    /// separation from the other side - a generous expired licence beside a modest active one must not
-    /// raise what the active one allows, or an installation would keep the limits it stopped paying for.
+    /// A standing invariant rather than a guard on any one arm: reporting an expired license must never
+    /// become merging it, whichever site does the reporting. It holds today because the arm reporting it
+    /// does not merge, and it is the assertion that would fail if somebody later reached for AppendLicense
+    /// there - which is the obvious way to add a second thing that arm should do.
     /// </remarks>
     [Fact]
-    public void GenerateActiveLicense_ExpiredLicenceBesideAnActiveOne_DoesNotRaiseTheActiveLimits()
+    public void GenerateActiveLicense_ExpiredLicenseBesideAnActiveOne_DoesNotRaiseTheActiveLimits()
     {
         var manager = new LicenseManager();
-        manager.AddLicense(LicenceAround(-30, -10, -5) with { ClientLimit = 1000, IssuerLimit = 1000 });
-        manager.AddLicense(LicenceAround(-1, 10) with { ClientLimit = 5, IssuerLimit = 1 });
+        manager.AddLicense(LicenseAround(-30, -10, -5) with { ClientLimit = 1000, IssuerLimit = 1000 });
+        manager.AddLicense(LicenseAround(-1, 10) with { ClientLimit = 5, IssuerLimit = 1 });
 
         TestLicense.ClearLogThrottle();
         var active = manager.GenerateActiveLicense(Moment);
@@ -600,23 +603,22 @@ public class LicenseManagerTests
     }
 
     /// <summary>
-    /// A licence in its grace period followed by an expired one keeps the grace licence's own limits.
+    /// A license in its grace period followed by an expired one keeps the grace license's own limits.
     /// </summary>
     /// <remarks>
-    /// The search for a successor is entered only from a grace-period licence, and it used to accept an
-    /// expired licence as that successor: the expired limits merged into the result, and the grace licence
-    /// whose limits actually still applied was never appended at all. So a deployment holding a generous
-    /// licence that had already run out kept its allowance on the strength of the one still in grace.
+    /// The search for an active successor is entered only from a license in its grace period, and only an
+    /// active license answers it. An expired one is over, so it cannot decide what applies now, and taking
+    /// it would both lend limits that stopped applying and suppress the grace license whose limits still do.
     ///
-    /// Ordering matters to the arrangement and is not incidental: licences are held sorted by the moment
-    /// they start, so the expired one has to start later than the grace one to be looked at by the search.
+    /// Ordering is part of the arrangement rather than incidental: licenses are held sorted by the moment
+    /// they start, so the expired one has to start later than the grace one for the search to reach it.
     /// </remarks>
     [Fact]
-    public void GenerateActiveLicense_ExpiredLicenceAfterOneInGrace_DoesNotLendItsLimits()
+    public void GenerateActiveLicense_ExpiredLicenseAfterOneInGrace_DoesNotLendItsLimits()
     {
         var manager = new LicenseManager();
-        manager.AddLicense(LicenceAround(-20, -3, gracePeriod: 5) with { ClientLimit = 5, IssuerLimit = 1 });
-        manager.AddLicense(LicenceAround(-10, -1) with { ClientLimit = 1000, IssuerLimit = 1000 });
+        manager.AddLicense(LicenseAround(-20, -3, gracePeriod: 5) with { ClientLimit = 5, IssuerLimit = 1 });
+        manager.AddLicense(LicenseAround(-10, -1) with { ClientLimit = 1000, IssuerLimit = 1000 });
 
         TestLicense.ClearLogThrottle();
         var active = manager.GenerateActiveLicense(Moment);
@@ -624,5 +626,75 @@ public class LicenseManagerTests
         Assert.NotNull(active);
         Assert.Equal(5, active!.ClientLimit);
         Assert.Equal(1, active.IssuerLimit);
+    }
+
+    /// <summary>
+    /// A license that has not started lends nothing to the license in force today.
+    /// </summary>
+    /// <remarks>
+    /// What <c>NotBefore</c> means: a renewal beginning next week decides nothing about this week. The
+    /// answer would also stick, because <c>TryGetCurrentLicenseLimit</c> caches any result whose
+    /// <c>ExpiresAt</c> is still ahead, so a future license's generous terms would be served unchanged
+    /// until that date - past the end of the grace period the deployment is actually in.
+    ///
+    /// The expired license in the middle is what makes the search walk far enough to meet the future one,
+    /// and it is the arrangement a renewal purchased late produces.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_FutureLicenseBeyondAnExpiredOne_DoesNotLendItsLimits()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, -3, gracePeriod: 5) with { ClientLimit = 5, IssuerLimit = 1 });
+        manager.AddLicense(LicenseAround(-15, -1) with { ClientLimit = 10, IssuerLimit = 10 });
+        manager.AddLicense(LicenseAround(2, 100) with { ClientLimit = 1000, IssuerLimit = 1000 });
+
+        TestLicense.ClearLogThrottle();
+        var active = manager.GenerateActiveLicense(Moment);
+
+        Assert.NotNull(active);
+        Assert.Equal(5, active!.ClientLimit);
+        Assert.Equal(1, active.IssuerLimit);
+    }
+
+    /// <summary>
+    /// An expired license the successor search steps over is still reported.
+    /// </summary>
+    /// <remarks>
+    /// Finding an active successor leaps the index past everything on the way, so the caller's own loop
+    /// never sees those licenses and the search is the only place that can report them. Without that the
+    /// expiry an operator alerts on goes unrecorded for exactly the deployment holding a renewal.
+    ///
+    /// The count is asserted for shape rather than as proof of anything: reporting the same license twice
+    /// in one evaluation produces one record either way, because the throttle keys on the license and
+    /// status and suppresses the second. That the search reports only on this path is therefore not
+    /// observable here, and is a property of the code rather than of what it writes.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_ExpiredLicenseSteppedOver_IsStillRecorded()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, -3, gracePeriod: 5) with { ClientLimit = 5 });
+        manager.AddLicense(LicenseAround(-15, -1) with { ClientLimit = 10 });
+        manager.AddLicense(LicenseAround(-1, 30) with { ClientLimit = 50 });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            var active = manager.GenerateActiveLicense(Moment);
+            Assert.NotNull(active);
+            Assert.Equal(50, active!.ClientLimit);
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        var expiries = records.Entries
+            .Where(entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpired)
+            .ToList();
+
+        Assert.Single(expiries);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -657,24 +657,25 @@ public class LicenseManagerTests
     }
 
     /// <summary>
-    /// An expired license the successor search steps over is still reported.
+    /// A deployment that renewed in time hears nothing about the licenses it superseded.
     /// </summary>
     /// <remarks>
-    /// Finding an active successor leaps the index past everything on the way, so the caller's own loop
-    /// never sees those licenses and the search is the only place that can report them. Without that the
-    /// expiry an operator alerts on goes unrecorded for exactly the deployment holding a renewal.
+    /// The expiry record says service access will be affected, and for a renewed installation that is
+    /// simply untrue - a valid license is in force. Saying it once a day for every license a customer has
+    /// ever loaded would bury the one record that means something under records that mean nothing, and
+    /// they carry the same event id and the same severity, so an operator who filters out the noise has
+    /// filtered out the signal too.
     ///
-    /// The count is asserted for shape rather than as proof of anything: reporting the same license twice
-    /// in one evaluation produces one record either way, because the throttle keys on the license and
-    /// status and suppresses the second. That the search reports only on this path is therefore not
-    /// observable here, and is a property of the code rather than of what it writes.
+    /// Three superseded licenses rather than one, because the cost of getting this wrong grows with the
+    /// number of renewals and a single-license arrangement would not show it.
     /// </remarks>
     [Fact]
-    public void GenerateActiveLicense_ExpiredLicenseSteppedOver_IsStillRecorded()
+    public void GenerateActiveLicense_SupersededLicensesBesideAnActiveOne_AreNotReported()
     {
         var manager = new LicenseManager();
-        manager.AddLicense(LicenseAround(-20, -3, gracePeriod: 5) with { ClientLimit = 5 });
-        manager.AddLicense(LicenseAround(-15, -1) with { ClientLimit = 10 });
+        manager.AddLicense(LicenseAround(-40, -30) with { ClientLimit = 1 });
+        manager.AddLicense(LicenseAround(-30, -20) with { ClientLimit = 2 });
+        manager.AddLicense(LicenseAround(-20, -3, gracePeriod: -1) with { ClientLimit = 3 });
         manager.AddLicense(LicenseAround(-1, 30) with { ClientLimit = 50 });
 
         TestLicense.ClearLogThrottle();
@@ -691,10 +692,44 @@ public class LicenseManagerTests
             LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
         }
 
+        Assert.DoesNotContain(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpired);
+    }
+
+    /// <summary>
+    /// Every expired license is reported when nothing was left in force.
+    /// </summary>
+    /// <remarks>
+    /// The control for the silence above, and the reason that silence is a decision rather than the report
+    /// having been lost: the same three licenses, with the renewal removed, produce a record each. The
+    /// throttle keys on the license value paired with the status, so three licenses carrying distinct
+    /// terms are three keys and three records.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_SeveralExpiredAndNothingInForce_ReportsEach()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-40, -30) with { ClientLimit = 1 });
+        manager.AddLicense(LicenseAround(-30, -20) with { ClientLimit = 2 });
+        manager.AddLicense(LicenseAround(-20, -3, gracePeriod: -1) with { ClientLimit = 3 });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.Null(manager.GenerateActiveLicense(Moment));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
         var expiries = records.Entries
             .Where(entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpired)
             .ToList();
 
-        Assert.Single(expiries);
+        Assert.Equal(3, expiries.Count);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -13,6 +13,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Abblix.Oidc.Server.Features.Licensing;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -514,4 +517,112 @@ public class LicenseManagerTests
     }
 
     #endregion
+
+    /// <summary>
+    /// A fixed instant the two tests below measure against, so the day counts they assert on are the ones
+    /// they arranged rather than whatever the clock happened to say between building a licence and judging
+    /// it.
+    /// </summary>
+    private static readonly DateTimeOffset Moment = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A licence positioned in days relative to <see cref="Moment"/>.</summary>
+    private static License LicenceAround(int notBefore, int expiresAt, int? gracePeriod = null)
+        => new()
+        {
+            NotBefore = Moment.AddDays(notBefore),
+            ExpiresAt = Moment.AddDays(expiresAt),
+            GracePeriod = gracePeriod.HasValue ? Moment.AddDays(gracePeriod.Value) : null,
+        };
+
+    /// <summary>
+    /// One licence, expired past its grace period, is reported.
+    /// </summary>
+    /// <remarks>
+    /// The ordinary shape of a deployment, and the one the record was unreachable for: an installation
+    /// holding a single licence saw a warning while expiry approached, an error once a day through the
+    /// grace period, and then nothing at the moment the licence stopped applying and the server fell back
+    /// to the free tier. That instant is the one an operator alerts on, because the fallback is not
+    /// graceful - a deployment serving more than one issuer starts refusing every issuer it has seen.
+    ///
+    /// Deliberately not the two-licence arrangement that already reached the record. That one enters
+    /// through the grace-period search and pins a path a single-licence installation never takes, so a
+    /// test built on it would be green while the gap stayed open.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_OneExpiredLicence_RecordsTheExpiry()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenceAround(notBefore: -30, expiresAt: -10, gracePeriod: -5));
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.Null(manager.GenerateActiveLicense(Moment));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        var record = Assert.Single(records.Entries);
+        Assert.Equal(LogEvents.Licensing.LicenseManager.LicenseExpired, record.EventId.Id);
+        Assert.Equal(LogLevel.Critical, record.Level);
+
+        // The count of days is what tells an operator whether this started ten minutes or ten weeks ago,
+        // and it is computed rather than carried, so it is worth reading out of the message.
+        Assert.Contains("10 days ago", record.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An expired licence is reported without its limits reaching the licence in force.
+    /// </summary>
+    /// <remarks>
+    /// The reason the arm reporting this was left empty: reporting and merging used to be one method, so
+    /// the only way to report an expired licence was to fold its limits into the result. This pins the
+    /// separation from the other side - a generous expired licence beside a modest active one must not
+    /// raise what the active one allows, or an installation would keep the limits it stopped paying for.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_ExpiredLicenceBesideAnActiveOne_DoesNotRaiseTheActiveLimits()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenceAround(-30, -10, -5) with { ClientLimit = 1000, IssuerLimit = 1000 });
+        manager.AddLicense(LicenceAround(-1, 10) with { ClientLimit = 5, IssuerLimit = 1 });
+
+        TestLicense.ClearLogThrottle();
+        var active = manager.GenerateActiveLicense(Moment);
+
+        Assert.NotNull(active);
+        Assert.Equal(5, active!.ClientLimit);
+        Assert.Equal(1, active.IssuerLimit);
+    }
+
+    /// <summary>
+    /// A licence in its grace period followed by an expired one keeps the grace licence's own limits.
+    /// </summary>
+    /// <remarks>
+    /// The search for a successor is entered only from a grace-period licence, and it used to accept an
+    /// expired licence as that successor: the expired limits merged into the result, and the grace licence
+    /// whose limits actually still applied was never appended at all. So a deployment holding a generous
+    /// licence that had already run out kept its allowance on the strength of the one still in grace.
+    ///
+    /// Ordering matters to the arrangement and is not incidental: licences are held sorted by the moment
+    /// they start, so the expired one has to start later than the grace one to be looked at by the search.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_ExpiredLicenceAfterOneInGrace_DoesNotLendItsLimits()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenceAround(-20, -3, gracePeriod: 5) with { ClientLimit = 5, IssuerLimit = 1 });
+        manager.AddLicense(LicenceAround(-10, -1) with { ClientLimit = 1000, IssuerLimit = 1000 });
+
+        TestLicense.ClearLogThrottle();
+        var active = manager.GenerateActiveLicense(Moment);
+
+        Assert.NotNull(active);
+        Assert.Equal(5, active!.ClientLimit);
+        Assert.Equal(1, active.IssuerLimit);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/RecordingLoggerFactory.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/RecordingLoggerFactory.cs
@@ -1,0 +1,55 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+
+/// <summary>What a single log write carried.</summary>
+internal sealed record LogRecord(LogLevel Level, EventId EventId, string Message);
+
+/// <summary>
+/// A factory whose loggers keep what was written, so a test can assert on the record itself.
+/// </summary>
+/// <remarks>
+/// Shared because a record is the only observable a decision taken in a log leaves behind. Where the
+/// product reports rather than returns - a licence limit refused, a licence expired - asserting that the
+/// decision happened means asserting the write, and a test without a recorder can only observe silence,
+/// which is what an unreported decision looks like too.
+/// </remarks>
+internal sealed class RecordingLoggerFactory : ILoggerFactory
+{
+    public List<LogRecord> Entries { get; } = [];
+
+    public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class RecordingLogger(List<LogRecord> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => entries.Add(new LogRecord(logLevel, eventId, formatter(state, exception)));
+    }
+}


### PR DESCRIPTION
Closes #378.

## What was unreachable

The Critical `LicenseExpired` record never fired for a deployment holding one licence. Such an installation saw `LicenseExpiringSoon` while expiry approached, `LicenseInGracePeriod` once a day through the grace period, and then nothing at the instant the licence stopped applying.

That instant is the one worth alerting on. The fallback is not graceful: the server drops to the free tier, which allows one issuer, and `CheckIssuer` keeps every issuer it has seen in a process-wide set and adds before comparing, so a deployment serving two starts throwing on both, discovery and token and userinfo alike, until the process restarts under a valid licence.

## Why the arm was empty

Reporting and merging were one method. `AppendLicense` began with a `switch` that wrote the record and continued into the merge, so calling it for an expired licence would have folded that licence's limits into the licence in force, handing a deployment the allowance it had stopped paying for. Leaving the arm empty avoided that and lost the record with it.

`ReportStatus` now holds the switch and decides nothing. `AppendLicense` calls it and then merges; the expired arm calls it and stops.

## The second hole the split exposed

`FindActiveLicensesInFuture` is entered only from a licence in its grace period, and it accepted an expired licence as the successor it was looking for. It merged limits that had already stopped applying and returned true, which told the caller not to append the grace-period licence at all. So a deployment holding a generous licence that had run out kept its allowance on the strength of the one still in grace. An expired licence found there is now reported and skipped, exactly as one in a grace period already was.

## Evidence

Three tests, two of which fail without the change:

- One licence, expired past its grace period, requires the record. Without the fix: `Assert.Single() Failure: The collection was empty`.
- A grace-period licence followed by an expired one keeps its own limits. Without the fix: `Assert.Equal() Failure: Values differ`, 1000 against 5.
- A licence in its grace period followed by one that has not started keeps its own limits. Without the successor search accepting only an active licence: `Expected: 5 / Actual: 1000`, and cached until that future licence expires.
- An expired licence stepped over by a successful successor search is still recorded. Without the report on that path: the collection is empty.
- An expired licence beside an active one does not raise the active limits. This one is green on unmodified develop as well, so it proves no hunk here - it is a standing invariant, kept because it is the assertion that fails if somebody later reaches for AppendLicense in the arm that reports.

Deliberately not built on the two-licence arrangement that already reached the record: that one enters through the grace-period search and pins a path a single-licence installation never takes, so a test on it would be green while the gap stayed open.

Both new tests are arranged around a fixed instant rather than the wall clock, so the day count the record carries is the one the test set up rather than whatever the clock said between building a licence and judging it.

The recording logger factory moved from a private nested class into the shared test infrastructure. A decision the product reports rather than returns can only be asserted through the write it leaves behind, and two suites now need that.

## Not in this change

The production hardening page tells operators to alert on the expiry date held outside the server, because nothing was logged at this instant. That advice is correct for the released version and becomes wrong when this ships, so it belongs to the release rather than to the merge.

