### PR TITLE
Judge the device grant again when the code is redeemed

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -17,17 +17,24 @@ partial class DeviceCodeGrantHandler
     /// and here it is payment and account data.
     /// </summary>
     /// <remarks>
-    /// The refusal an operator has the least other evidence for. Its premise is that the stored grant
-    /// changed after approval, so the warning the approval path writes cannot have fired, and the client
-    /// sees an <c>access_denied</c> that says nothing about which type escaped.
+    /// The refusal an operator has the least other evidence for: the approval path refuses the same shape,
+    /// so its warning cannot have fired on this record, and the client sees an <c>access_denied</c> that
+    /// says nothing about which type escaped.
+    ///
+    /// The message states what was observed and what was done, and stops there. What it must NOT say is
+    /// which write produced the mismatch: the baseline and the grant live in the same host-owned record,
+    /// so narrowing the baseline reads identically to widening the grant, and a host may have replaced
+    /// <see cref="Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces.IUserCodeVerificationService"/>
+    /// so that no approval ran at all. Naming a cause the gate cannot establish sends an operator looking
+    /// for a write that never happened.
     /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Device.DeviceCodeGrantHandler.GrantedAuthorizationDetailsExceedTheRequest,
         Level = LogLevel.Warning,
-        Message = "Client {ClientId} redeemed a device code whose stored grant carries " +
-                  "authorization_details types the device authorization request never asked for: " +
-                  "{EscapedTypes}. The approval " +
-                  "refuses this, so the grant was written to storage after it (RFC 9396 §6.1 defines no " +
-                  "universal comparator, so the check is by type).")]
+        Message = "Client {ClientId} presented a device code whose stored grant carries " +
+                  "authorization_details types the device authorization request never asked for, so the " +
+                  "redemption is refused and no token was issued. Types: {EscapedTypes}. Either the stored " +
+                  "record changed after the approval refused this shape, or the approval was bypassed " +
+                  "(RFC 9396 §6.1 defines no universal comparator, so the check is by type).")]
     private partial void LogGrantedAuthorizationDetailsExceedTheRequest(string ClientId, string EscapedTypes);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -13,8 +13,8 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 partial class DeviceCodeGrantHandler
 {
     /// <summary>
-    /// The escaped TYPES only, matching the approval-side record: what a type carries is its own business,
-    /// and here it is payment and account data.
+    /// The escaped TYPES only, matching the approval-side record: what an entry of a type carries is that
+    /// type's own business, and naming it here would put a deployment's data in a log line.
     /// </summary>
     /// <remarks>
     /// The refusal an operator has the least other evidence for: the approval path refuses the same shape,
@@ -33,8 +33,8 @@ partial class DeviceCodeGrantHandler
         Level = LogLevel.Warning,
         Message = "Client {ClientId} presented a device code whose stored grant carries " +
                   "authorization_details types the device authorization request never asked for, so the " +
-                  "redemption is refused and no token was issued. Types: {EscapedTypes}. Either the stored " +
-                  "record changed after the approval refused this shape, or the approval was bypassed " +
-                  "(RFC 9396 §6.1 defines no universal comparator, so the check is by type).")]
+                  "redemption is refused and no token was issued. Types: {EscapedTypes}. The comparison " +
+                  "is by type, because RFC 9396 §6.1 defines no universal comparator for two arbitrary " +
+                  "entries.")]
     private partial void LogGrantedAuthorizationDetailsExceedTheRequest(string ClientId, string EscapedTypes);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -1,0 +1,33 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
+
+partial class DeviceCodeGrantHandler
+{
+    /// <summary>
+    /// The escaped TYPES only, matching the approval-side record: what a type carries is its own business,
+    /// and here it is payment and account data.
+    /// </summary>
+    /// <remarks>
+    /// The refusal an operator has the least other evidence for. Its premise is that the stored grant
+    /// changed after approval, so the warning the approval path writes cannot have fired, and the client
+    /// sees an <c>access_denied</c> that says nothing about which type escaped.
+    /// </remarks>
+    [LoggerMessage(
+        EventId = LogEvents.Device.DeviceCodeGrantHandler.GrantedAuthorizationDetailsExceedTheRequest,
+        Level = LogLevel.Warning,
+        Message = "Client {ClientId} redeemed a device code whose stored grant carries " +
+                  "authorization_details types the device authorization request never asked for: " +
+                  "{EscapedTypes}. The approval " +
+                  "refuses this, so the grant was written to storage after it (RFC 9396 §6.1 defines no " +
+                  "universal comparator, so the check is by type).")]
+    private partial void LogGrantedAuthorizationDetailsExceedTheRequest(string ClientId, string EscapedTypes);
+}

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -15,6 +15,7 @@ using Abblix.Oidc.Server.Features.DeviceAuthorization;
 using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
@@ -24,10 +25,13 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Grants;
 /// This handler validates token requests for the device authorization flow,
 /// checking the device code status and returning tokens when authorized.
 /// </summary>
+/// <param name="logger">Records a refusal the client learns nothing from, and the approval path cannot
+/// have reported.</param>
 /// <param name="storage">Service for storing and retrieving device authorization requests.</param>
 /// <param name="timeProvider">Provides access to the current time.</param>
 /// <param name="options">Configuration options containing polling interval settings.</param>
-public class DeviceCodeGrantHandler(
+public partial class DeviceCodeGrantHandler(
+    ILogger<DeviceCodeGrantHandler> logger,
     IDeviceAuthorizationStorage storage,
     TimeProvider timeProvider,
     IOptions<OidcOptions> options) : IAuthorizationGrantHandler
@@ -95,14 +99,22 @@ public class DeviceCodeGrantHandler(
                 // Judged again, on what is actually being redeemed. IUserCodeVerificationService refuses a
                 // widened grant when the end user approves, but the host owns the same storage and can
                 // write to it afterwards - a retried or corrected approval is the ordinary shape of that,
-                // not an attack. Approving one grant and handing over another is the whole failure the
-                // comparison exists to prevent, and it is why CIBA judges at both ends too.
+                // not an attack. CIBA judges at both ends for the same reason.
                 //
-                // The record still carries what the client asked for, so the comparison costs no new state.
+                // What this catches is a host that FORGOT, not one that lies: the baseline it compares
+                // against lives in the same host-owned record, so anything able to widen the grant can
+                // widen the baseline in the same write. Worth having anyway, because forgetting is what
+                // actually happens, and the record still carries what the client asked for, so the
+                // comparison costs no new state.
+                //
                 // The same computation as at approval, deliberately: a second, slightly different test here
                 // would disagree with the first on exactly the inputs nobody wrote a test for.
-                if (GrantedAuthorizationDetails.Escaping(deviceRequest, authorizedGrant) is { Length: > 0 })
+                if (GrantedAuthorizationDetails.EscapedTypes(deviceRequest, authorizedGrant) is
+                    { Length: > 0 } escaped)
                 {
+                    LogGrantedAuthorizationDetailsExceedTheRequest(
+                        clientInfo.ClientId, string.Join(", ", escaped));
+
                     return new OidcError(
                         ErrorCodes.AccessDenied,
                         "The grant carries authorization_details the device authorization request "

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -91,6 +91,24 @@ public class DeviceCodeGrantHandler(
 
             // User has authorized the device - return the authorized grant
             case { Status: DeviceAuthorizationStatus.Authorized, AuthorizedGrant: { } authorizedGrant }:
+
+                // Judged again, on what is actually being redeemed. IUserCodeVerificationService refuses a
+                // widened grant when the end user approves, but the host owns the same storage and can
+                // write to it afterwards - a retried or corrected approval is the ordinary shape of that,
+                // not an attack. Approving one grant and handing over another is the whole failure the
+                // comparison exists to prevent, and it is why CIBA judges at both ends too.
+                //
+                // The record still carries what the client asked for, so the comparison costs no new state.
+                // The same computation as at approval, deliberately: a second, slightly different test here
+                // would disagree with the first on exactly the inputs nobody wrote a test for.
+                if (GrantedAuthorizationDetails.Escaping(deviceRequest, authorizedGrant) is { Length: > 0 })
+                {
+                    return new OidcError(
+                        ErrorCodes.AccessDenied,
+                        "The grant carries authorization_details the device authorization request "
+                        + "did not ask for");
+                }
+
                 return authorizedGrant;
 
             // Authorization still pending - check polling rate

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
@@ -1,0 +1,72 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+
+namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
+
+/// <summary>
+/// Judges a device grant's <c>authorization_details</c> against what the device asked for.
+/// </summary>
+/// <remarks>
+/// The device flow asks this twice, at approval and again when the device code is redeemed, and the two
+/// have to agree on what escaping means. Sharing one computation is what makes them agree: a predicate
+/// deciding a branch and a branch re-deriving the same fact by a slightly different test disagree on
+/// exactly the inputs nobody wrote a test for.
+/// </remarks>
+internal static class GrantedAuthorizationDetails
+{
+    /// <summary>
+    /// The <c>authorization_details</c> types the grant carries and the request never asked for, empty
+    /// when the grant stays inside what was requested.
+    /// </summary>
+    /// <param name="request">The stored device authorization request, carrying what the client asked for.
+    /// </param>
+    /// <param name="grant">The grant a host handed back or stored.</param>
+    /// <returns>The escaped type names, or a single entry describing why the grant could not be read.
+    /// </returns>
+    /// <remarks>
+    /// Types only: RFC 9396 §6.1 defines no universal comparator for "is this entry a narrowing of that
+    /// one", so what can be judged here is whether an entry of that type was asked for at all. An entry
+    /// that cannot be read as a JSON object counts as escaped, because the conversion drops it silently
+    /// and "nothing escaped" would then describe what could be read rather than the grant.
+    ///
+    /// A request carrying no <c>authorization_details</c> is judged strictly rather than skipped: the
+    /// member predates this comparison on the stored record, so a null there says the client asked for
+    /// nothing rather than that the request was written by a build without the field.
+    /// </remarks>
+    public static string[] Escaping(DeviceAuthorizationRequest request, AuthorizedGrant grant)
+    {
+        if (grant.Context.AuthorizationDetails is not { Count: > 0 } granted)
+            return [];
+
+        if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
+            return ["an entry that is not a JSON object"];
+
+        // Absence is refused on its own rather than compared as a stand-in value, which a client could
+        // otherwise request as a real type and thereby admit every entry that has none.
+        if (Array.Exists(typed, detail => detail.Type is null))
+            return ["an entry carrying no type"];
+
+        var requestedTypes = RequestedTypes(request.AuthorizationDetails);
+
+        return typed
+            .Select(detail => detail.Type!)
+            .Where(type => !requestedTypes.Contains(type))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static HashSet<string> RequestedTypes(JsonArray? requested)
+        => (requested?.ToTypedArray() ?? [])
+            .Select(detail => detail.Type)
+            .OfType<string>()
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
@@ -50,8 +50,10 @@ internal static class GrantedAuthorizationDetails
         if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
             return ["an entry that is not a JSON object"];
 
-        // Absence is refused on its own rather than compared as a stand-in value, which a client could
-        // otherwise request as a real type and thereby admit every entry that has none.
+        // Absence is named rather than compared. A typeless entry is refused either way - the request side
+        // filters its own types with OfType<string>(), so no request can hold a null to match one with -
+        // and what this arm changes is the log: without it the refusal reports an empty string in the list
+        // of escaped types, which reads as a defect in the message rather than as the grant's shape.
         if (Array.Exists(typed, detail => detail.Type is null))
             return ["an entry carrying no type"];
 

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
@@ -42,7 +42,7 @@ internal static class GrantedAuthorizationDetails
     /// member predates this comparison on the stored record, so a null there says the client asked for
     /// nothing rather than that the request was written by a build without the field.
     /// </remarks>
-    public static string[] Escaping(DeviceAuthorizationRequest request, AuthorizedGrant grant)
+    public static string[] EscapedTypes(DeviceAuthorizationRequest request, AuthorizedGrant grant)
     {
         if (grant.Context.AuthorizationDetails is not { Count: > 0 } granted)
             return [];
@@ -64,6 +64,12 @@ internal static class GrantedAuthorizationDetails
             .ToArray();
     }
 
+    /// <summary>The types the request asked for.</summary>
+    /// <remarks>
+    /// No arity guard here, unlike the grant side: an entry of the REQUEST that cannot be read as a JSON
+    /// object is dropped rather than refused, which narrows the baseline and therefore admits less. The
+    /// grant side has to refuse instead, because there the same silence would admit more.
+    /// </remarks>
     private static HashSet<string> RequestedTypes(JsonArray? requested)
         => (requested?.ToTypedArray() ?? [])
             .Select(detail => detail.Type)

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -98,7 +98,7 @@ public partial class UserCodeVerificationService(
         // authorization request never asked for gives the device authority nobody requested, and this is
         // the last place holding both sides: the requested entries live on the record, and the grant
         // about to replace them is the one the token is built from.
-        if (EscapedAuthorizationDetailTypes(request, authorizedGrant) is { Length: > 0 } escaped)
+        if (GrantedAuthorizationDetails.Escaping(request, authorizedGrant) is { Length: > 0 } escaped)
         {
             LogGrantedAuthorizationDetailsExceedTheRequest(
                 request.ClientId, string.Join(", ", escaped));
@@ -125,42 +125,6 @@ public partial class UserCodeVerificationService(
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// The <c>authorization_details</c> types the grant carries and the device authorization request never
-    /// asked for, empty when the grant stays inside what was requested.
-    /// </summary>
-    /// <remarks>
-    /// Types only: RFC 9396 §6.1 defines no universal comparator for "is this entry a narrowing
-    /// of that one", so
-    /// what can be judged here is whether an entry of that type was asked for at all. An entry that cannot
-    /// be read as a JSON object counts as escaped, because the conversion drops it silently and "nothing
-    /// escaped" would then describe what could be read rather than the grant.
-    /// </remarks>
-    private static string[] EscapedAuthorizationDetailTypes(
-        DeviceAuthorizationRequest request,
-        AuthorizedGrant authorizedGrant)
-    {
-        if (authorizedGrant.Context.AuthorizationDetails is not { Count: > 0 } granted)
-            return [];
-
-        if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
-            return ["an entry that is not a JSON object"];
-
-        if (Array.Exists(typed, detail => detail.Type is null))
-            return ["an entry carrying no type"];
-
-        var requestedTypes = (request.AuthorizationDetails?.ToTypedArray() ?? [])
-            .Select(detail => detail.Type)
-            .OfType<string>()
-            .ToHashSet(StringComparer.Ordinal);
-
-        return typed
-            .Select(detail => detail.Type!)
-            .Where(type => !requestedTypes.Contains(type))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
     }
 
     /// <inheritdoc />

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -98,7 +98,7 @@ public partial class UserCodeVerificationService(
         // authorization request never asked for gives the device authority nobody requested, and this is
         // the last place holding both sides: the requested entries live on the record, and the grant
         // about to replace them is the one the token is built from.
-        if (GrantedAuthorizationDetails.Escaping(request, authorizedGrant) is { Length: > 0 } escaped)
+        if (GrantedAuthorizationDetails.EscapedTypes(request, authorizedGrant) is { Length: > 0 } escaped)
         {
             LogGrantedAuthorizationDetailsExceedTheRequest(
                 request.ClientId, string.Join(", ", escaped));

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -580,6 +580,17 @@ internal static class LogEvents
             public const int GrantedAuthorizationDetailsNotCarried = Base + 1;
             public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 2;
         }
+
+        /// <summary>
+        /// <c>Endpoints/Token/Grants/DeviceCodeGrantHandler.cs</c> - what the token endpoint refuses when
+        /// the stored grant no longer matches the request (sub-range 7085-7089).
+        /// </summary>
+        public static class DeviceCodeGrantHandler
+        {
+            private const int Base = 7085;
+
+            public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 1;
+        }
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -571,7 +571,7 @@ internal static class LogEvents
 
         /// <summary>
         /// <c>Features/DeviceAuthorization/UserCodeVerificationService.cs</c> - RFC 8628 user-code
-        /// approval, and what the approval left behind (sub-range 7080-7084).
+        /// approval, and what the approval left behind (sub-range 7080-7082).
         /// </summary>
         public static class UserCodeVerificationService
         {
@@ -583,13 +583,19 @@ internal static class LogEvents
 
         /// <summary>
         /// <c>Endpoints/Token/Grants/DeviceCodeGrantHandler.cs</c> - what the token endpoint refuses when
-        /// the stored grant no longer matches the request (sub-range 7085-7089).
+        /// the stored grant no longer matches the request (sub-range 7083-7084).
         /// </summary>
+        /// <remarks>
+        /// Two ids rather than a round ten, because this is what the Device range has left: 7085-7099
+        /// belongs to the back-channel logout sender above, which sits in this range and is not the device
+        /// flow at all. Moving it would change ids an operator may already alert on, so the misfiling stays
+        /// and the window here is honest about its size. A third event needs the range widened first.
+        /// </remarks>
         public static class DeviceCodeGrantHandler
         {
-            private const int Base = 7085;
+            private const int Base = 7083;
 
-            public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 1;
+            public const int GrantedAuthorizationDetailsExceedTheRequest = Base;
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -250,11 +250,16 @@ public class DeviceCodeGrantHandlerTests
     /// A grant this comparison cannot read is refused rather than read as carrying nothing.
     /// </summary>
     /// <remarks>
-    /// Both shapes reach the same conclusion by different routes, and both were uncovered. An entry that is
-    /// not a JSON object is dropped silently by the conversion, so counting what survived would report
-    /// "nothing escaped" about what could be read rather than about the grant. An entry carrying no type is
-    /// refused on its own rather than compared as if absence were a type, which a client could otherwise
-    /// request as a real type and thereby admit every entry that has none.
+    /// Both shapes are refused, by different routes and with different amounts of help from the code. An
+    /// entry that is not a JSON object is dropped silently by the conversion, so without the arity guard
+    /// the count of survivors would describe what could be read rather than what was granted: that guard
+    /// carries the verdict, and removing it lets this grant through.
+    ///
+    /// An entry carrying no type is refused whether or not its own arm exists, because the request side
+    /// filters its types with OfType and so can never hold a null to match one with. That arm changes the
+    /// LOG rather than the verdict. This test therefore pins the outcome of the arrangement without
+    /// pinning the arm, and holding the arm would mean asserting on the logged sentinel, which needs a
+    /// recording logger this handler test does not have.
     ///
     /// The request asks for a type in both arrangements, so a refusal here cannot be the ordinary
     /// escaped-type refusal wearing a different fixture.

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -208,6 +208,87 @@ public class DeviceCodeGrantHandlerTests
         Assert.Equal(UserId, grant!.AuthSession.Subject);
     }
 
+    /// <summary>
+    /// A device that asked for no <c>authorization_details</c> at all is not a device that asked for any.
+    /// </summary>
+    /// <remarks>
+    /// The escalation this whole gate exists for, and the one arrangement where the baseline is empty rather
+    /// than merely narrow: a request carrying nothing meets a stored grant carrying <c>admin_access</c>.
+    /// A null baseline is judged strictly rather than skipped, so every type in the grant escapes.
+    ///
+    /// Pinned separately because the strict reading is a decision rather than a consequence, and the
+    /// opposite one is a single early return away. CIBA takes that opposite reading deliberately, for a
+    /// reason that does not hold here: its stored member arrived after the flow shipped, so a null there
+    /// says the request predates the field, while the device record has carried this member since the
+    /// flow's first release and a null means the client asked for nothing.
+    /// </remarks>
+    [Fact]
+    public async Task AuthorizedGrantWhereTheRequestAskedForNone_IsRefusedWhenTheCodeIsRedeemed()
+    {
+        var clientInfo = new ClientInfo(ClientId);
+        var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
+
+        var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
+        {
+            Status = DeviceAuthorizationStatus.Authorized,
+            AuthorizedGrant = GrantWith(new JsonArray(new JsonObject { ["type"] = "admin_access" })),
+            AuthorizationDetails = null,
+            ExpiresAt = _currentTime.AddMinutes(15),
+        };
+
+        _storage.Setup(storage => storage.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync(deviceRequest);
+        _storage.Setup(storage => storage.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
+
+        var result = await _handler.AuthorizeAsync(
+            tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.AccessDenied, error.Error);
+    }
+
+    /// <summary>
+    /// A grant this comparison cannot read is refused rather than read as carrying nothing.
+    /// </summary>
+    /// <remarks>
+    /// Both shapes reach the same conclusion by different routes, and both were uncovered. An entry that is
+    /// not a JSON object is dropped silently by the conversion, so counting what survived would report
+    /// "nothing escaped" about what could be read rather than about the grant. An entry carrying no type is
+    /// refused on its own rather than compared as if absence were a type, which a client could otherwise
+    /// request as a real type and thereby admit every entry that has none.
+    ///
+    /// The request asks for a type in both arrangements, so a refusal here cannot be the ordinary
+    /// escaped-type refusal wearing a different fixture.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AuthorizedGrantTheComparisonCannotRead_IsRefusedWhenTheCodeIsRedeemed(bool notAnObject)
+    {
+        var clientInfo = new ClientInfo(ClientId);
+        var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
+
+        var unreadable = notAnObject
+            ? new JsonArray(JsonValue.Create("payment_initiation"))
+            : new JsonArray(new JsonObject { ["actions"] = new JsonArray(JsonValue.Create("initiate")) });
+
+        var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
+        {
+            Status = DeviceAuthorizationStatus.Authorized,
+            AuthorizedGrant = GrantWith(unreadable),
+            AuthorizationDetails = new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
+            ExpiresAt = _currentTime.AddMinutes(15),
+        };
+
+        _storage.Setup(storage => storage.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync(deviceRequest);
+        _storage.Setup(storage => storage.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
+
+        var result = await _handler.AuthorizeAsync(
+            tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.AccessDenied, error.Error);
+    }
+
     private AuthorizedGrant GrantWith(JsonArray authorizationDetails)
         => new(
             new AuthSession(UserId, "session_123", _currentTime, "device"),

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -7,6 +7,7 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
@@ -128,6 +129,83 @@ public class DeviceCodeGrantHandlerTests
 
         _storage.Verify(s => s.TryRemoveAsync(DeviceCode, UserCode), Times.Once);
     }
+
+    /// <summary>
+    /// A stored grant carrying a type the device never asked for is refused when the code is redeemed.
+    /// </summary>
+    /// <remarks>
+    /// The approval path already refuses a widened grant, and that check is not enough on its own: the host
+    /// owns this storage and can write to it after approving, which a retried or corrected approval does
+    /// routinely. Between the two the device polls, and whatever is stored by then is what would be issued.
+    ///
+    /// The comparison costs no new state because the record still carries what the client asked for, and it
+    /// is the same computation the approval path runs rather than a second one written to match.
+    /// </remarks>
+    [Fact]
+    public async Task AuthorizedGrantWideningTheRequest_IsRefusedWhenTheCodeIsRedeemed()
+    {
+        var clientInfo = new ClientInfo(ClientId);
+        var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
+
+        var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
+        {
+            Status = DeviceAuthorizationStatus.Authorized,
+            AuthorizedGrant = GrantWith(new JsonArray(new JsonObject { ["type"] = "admin_access" })),
+            AuthorizationDetails = new JsonArray(new JsonObject { ["type"] = "payment_initiation" }),
+            ExpiresAt = _currentTime.AddMinutes(15),
+        };
+
+        _storage.Setup(storage => storage.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync(deviceRequest);
+        _storage.Setup(storage => storage.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
+
+        var result = await _handler.AuthorizeAsync(
+            tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.AccessDenied, error.Error);
+    }
+
+    /// <summary>
+    /// A stored grant that stays inside what the device asked for is redeemed.
+    /// </summary>
+    /// <remarks>
+    /// The control for the refusal above. Without it the same assertions would hold over a handler that
+    /// refused every request carrying <c>authorization_details</c> at all, which is the shape a guard
+    /// written slightly too wide takes.
+    /// </remarks>
+    [Fact]
+    public async Task AuthorizedGrantInsideTheRequest_IsRedeemed()
+    {
+        var clientInfo = new ClientInfo(ClientId);
+        var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
+
+        var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
+        {
+            Status = DeviceAuthorizationStatus.Authorized,
+            AuthorizedGrant = GrantWith(new JsonArray(new JsonObject { ["type"] = "payment_initiation" })),
+            AuthorizationDetails = new JsonArray(
+                new JsonObject { ["type"] = "payment_initiation" },
+                new JsonObject { ["type"] = "account_information" }),
+            ExpiresAt = _currentTime.AddMinutes(15),
+        };
+
+        _storage.Setup(storage => storage.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync(deviceRequest);
+        _storage.Setup(storage => storage.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
+
+        var result = await _handler.AuthorizeAsync(
+            tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetSuccess(out var grant));
+        Assert.Equal(UserId, grant!.AuthSession.Subject);
+    }
+
+    private AuthorizedGrant GrantWith(JsonArray authorizationDetails)
+        => new(
+            new AuthSession(UserId, "session_123", _currentTime, "device"),
+            new AuthorizationContext(ClientId, [Scopes.OpenId], null)
+            {
+                AuthorizationDetails = authorizationDetails,
+            });
 
     /// <summary>
     /// Verifies that when atomic removal fails (race condition - another concurrent request claimed the device code),

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -19,6 +19,7 @@ using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Common.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -62,6 +63,7 @@ public class DeviceCodeGrantHandlerTests
         });
 
         _handler = new DeviceCodeGrantHandler(
+            NullLogger<DeviceCodeGrantHandler>.Instance,
             _storage.Object,
             timeProvider,
             options);
@@ -163,6 +165,13 @@ public class DeviceCodeGrantHandlerTests
 
         Assert.True(result.TryGetFailure(out var error));
         Assert.Equal(ErrorCodes.AccessDenied, error.Error);
+
+        // The arm that claims the code runs first, so the refusal follows a code that no longer exists and
+        // a second poll answers expired_token rather than access_denied. That is right - RFC 8628 section
+        // 3.5 has the client stop polling on any code other than authorization_pending or slow_down, and
+        // the user-denial refusal beside this one removes first for the same reason - but it depends on the
+        // order of the arms, which nothing else here would notice being changed.
+        _storage.Verify(storage => storage.TryRemoveAsync(DeviceCode, UserCode), Times.Once);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -153,6 +153,29 @@ public class UserCodeVerificationServiceTests
     }
 
     [Fact]
+    public async Task Approve_WithAnyTypeWhereTheRequestAskedForNone_RefusesAndLeavesTheRequestPending()
+    {
+        // A request carrying nothing is judged strictly rather than skipped, so every type in the grant
+        // escapes. Pinned on its own because the strict reading is a decision and its opposite is one
+        // early return away: skipping a null baseline would let a host attach any authority at all to a
+        // device that asked for none, which is the wider version of the case above rather than a
+        // different one.
+        //
+        // CIBA takes the opposite reading deliberately, for a reason that does not hold here: its stored
+        // member arrived after the flow shipped, so a null there says the request predates the field. The
+        // device record has carried this member since the flow's first release.
+        var service = BuildService(requestedDetails: null, out var logs);
+
+        var approved = await service.ApproveAsync(
+            CanonicalUserCode,
+            GrantWith(new JsonArray(new JsonObject { ["type"] = "admin_access" })));
+
+        Assert.False(approved);
+        var warning = Assert.Single(logs.Entries, entry => entry.Level == LogLevel.Warning);
+        Assert.Contains("admin_access", warning.Message);
+    }
+
+    [Fact]
     public async Task Approve_CarryingTheAuthorizationDetails_SaysNothing()
     {
         var requestedDetails = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -1,0 +1,87 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Abblix.Oidc.Server;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests;
+
+/// <summary>
+/// Every log event id belongs to one event.
+/// </summary>
+/// <remarks>
+/// Nothing else checks this. The compiler does not, because two classes may hold equal constants; the
+/// LoggerMessage generator does not, because it looks at one declaration at a time; and the build reports
+/// no warning. What ships is one number carrying two meanings - a warning about a refused authorization
+/// and a debug line about an outbound request, say - which defeats the only reason the file maintains
+/// documented sub-ranges at all: an operator alerting on an id gets both.
+///
+/// The failure is easy to walk into. The ranges are prose, so picking the next free number means reading
+/// every declaration rather than the nearest one, and the nearest one is what a reader reaches for. It has
+/// happened twice.
+///
+/// Read by reflection rather than by parsing the file, so a declaration written in any shape - Base plus
+/// an offset, a bare literal, a new nesting depth - is counted. The private Base constants are excluded by
+/// asking for public fields only, which is what makes them safe to reuse across classes.
+/// </remarks>
+public class LogEventUniquenessTests
+{
+    [Fact]
+    public void EveryLogEventIdIsDeclaredOnce()
+    {
+        var duplicates = EventIds()
+            .GroupBy(entry => entry.Id)
+            .Where(group => group.Count() > 1)
+            .Select(group => $"{group.Key}: {string.Join(", ", group.Select(entry => entry.Name))}")
+            .ToArray();
+
+        Assert.Empty(duplicates);
+    }
+
+    /// <summary>
+    /// The count is asserted so the walk itself cannot quietly stop finding anything.
+    /// </summary>
+    /// <remarks>
+    /// A uniqueness check over an empty set passes, and a walk that stops descending - a class nested one
+    /// level deeper than it expected, a field kind it does not recognise - reports exactly that. The number
+    /// is the instrument's own pulse rather than a fact about the product, so it is meant to be edited
+    /// whenever an event is added; what it refuses is the edit nobody made.
+    /// </remarks>
+    [Fact]
+    public void TheWalkFindsEveryDeclaredEvent()
+    {
+        Assert.Equal(145, EventIds().Count);
+    }
+
+    private static IReadOnlyList<(int Id, string Name)> EventIds()
+    {
+        var found = new List<(int, string)>();
+        Collect(typeof(LogEvents), string.Empty, found);
+        return found;
+    }
+
+    private static void Collect(Type type, string prefix, List<(int, string)> found)
+    {
+        const BindingFlags Declared = BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        foreach (var field in type.GetFields(Declared))
+        {
+            if (field is { IsLiteral: true, IsInitOnly: false } && field.FieldType == typeof(int))
+                found.Add(((int)field.GetRawConstantValue()!, prefix + field.Name));
+        }
+
+        foreach (var nested in type.GetNestedTypes(BindingFlags.Public))
+        {
+            Collect(nested, $"{prefix}{nested.Name}.", found);
+        }
+    }
+}


### PR DESCRIPTION
Closes #409.

## The gate that was missing

`UserCodeVerificationService.ApproveAsync` refuses a grant carrying a type the device never asked for, and then writes it. `DeviceCodeGrantHandler` handed the stored grant to the token endpoint without looking at it:

```csharp
case { Status: DeviceAuthorizationStatus.Authorized, AuthorizedGrant: { } authorizedGrant }:
    return authorizedGrant;
```

The host owns `IDeviceAuthorizationStorage`, so between the approval and the poll it can write a different grant. A retried or corrected approval does exactly that, which is why this is a gate rather than an attack surface. Whatever is stored by the time the device polls is what would be issued.

`BackChannelAuthenticationGrantHandler` already judges at both ends, and the comment there states the reason in the same words: a host can complete with a narrowed grant and then store a wider one before the client polls. The device flow has the identical shape.

The baseline is already on the record - `DeviceAuthorizationRequest.AuthorizationDetails` holds what the client asked for and is persisted - so the second comparison costs a comparison and no new state.

## The second hole it closes

The only gate lived inside `IUserCodeVerificationService`, registered `TryAddSingleton`. Owning the verification page means supplying that implementation, which is the documented way to do it, and doing so removed the check with nothing to say it had gone. The token endpoint is not replaced that way, which is what makes it the right place for the second look.

## One comparison, not a fifth copy

The type comparison moved out of `UserCodeVerificationService` into `GrantedAuthorizationDetails.EscapedTypes`, which both device sites call. A predicate deciding a branch and a branch re-deriving the same fact by a slightly different test disagree on exactly the inputs nobody wrote a test for, and this comparison already exists in four separately written forms across the flows. Whether those four should converge is #410; this change at least does not make it five.

The null baseline stays strict here and that is deliberate: `AuthorizationDetails` predates this comparison on the stored device record, so a null there says the client asked for nothing rather than that the record was written by a build without the field. CIBA reads its own null the other way, because its member is new, and the two readings are correct for their own records.

## Evidence

- A stored grant carrying `admin_access` against a request for `payment_initiation` is refused at redemption with `access_denied`. Without the change: the test fails, the grant is issued.
- A stored grant inside what the request asked for is redeemed. This is the control; without it both assertions would hold over a handler that refused every grant carrying `authorization_details` at all, which is the shape a guard written slightly too wide takes.

Full solution on the merged state: 4955 tests, 0 failed (one env-gated test skipped).


Pinned since: the strict null baseline, at both ends, so flipping it to the lenient reading fails one test at each. The two unreadable-grant branches, which fail when either is made to answer "nothing escaped". Unit project 2863 passed, 0 failed on the rebase onto current `develop`.

## Note for the release

`DeviceCodeGrantHandler`'s public constructor gains a leading `ILogger<DeviceCodeGrantHandler>` parameter. Dependency injection covers it, and the only manual construction in the tree is the test, but it is a source-breaking change to a public type in a published package.

Found while reviewing this and filed separately: #423.

