### PR TITLE
Report a licence once the list has stopped growing

### DIFF
--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseChecker.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseChecker.cs
@@ -48,6 +48,13 @@ public static partial class LicenseChecker
     internal static void AddLicense(License license) => LicenseManager.AddLicense(license);
 
     /// <summary>
+    /// Reports what the loaded licenses mean for the deployment, once loading has finished.
+    /// </summary>
+    /// <param name="utcNow">The moment to evaluate the licenses at.</param>
+    internal static void ReportLoadedLicenses(DateTimeOffset utcNow)
+        => LicenseManager.ReportLoadedLicenses(utcNow);
+
+    /// <summary>
     /// Asynchronously applies licensing checks to a task that returns client information.
     /// </summary>
     /// <param name="clientInfo">The task returning client information to be checked against licensing constraints.

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoader.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoader.cs
@@ -44,6 +44,18 @@ public static class LicenseLoader
     /// <exception cref="UnexpectedTypeException">Thrown if an unexpected validation result type is encountered.
     /// </exception>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Loading reports nothing, deliberately. A caller loads licenses one at a time, so every load but the
+    /// last sees a partial set, and a license in its grace period would be announced before the renewal
+    /// superseding it had arrived - once per superseded license, and only in the arrival order that puts
+    /// the older one first. What the licenses mean is said on the next consult instead, and once at
+    /// startup by the hosted service the registration extensions install, which is the moment the set has
+    /// provably stopped growing.
+    ///
+    /// A host loading licenses through this method after startup therefore gets no record from the load
+    /// itself. The consult that follows says everything except that a license still valid is expiring
+    /// soon, which is the one status a valid cached license never reaches.
+    /// </remarks>
     public static async Task LoadAsync(string licenseJwt)
     {
         var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoadingService.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoadingService.cs
@@ -25,9 +25,11 @@ namespace Abblix.Oidc.Server.Features.Licensing;
 /// </remarks>
 /// <param name="loggerFactory">Logger factory for initializing the license logger.</param>
 /// <param name="licenseJwtProvider">The provider used to retrieve the license JWT.</param>
+/// <param name="clock">The clock the loaded licenses are evaluated against once loading has finished.</param>
 internal class LicenseLoadingService(
     ILoggerFactory loggerFactory,
-    ILicenseJwtProvider licenseJwtProvider) : IHostedService
+    ILicenseJwtProvider licenseJwtProvider,
+    TimeProvider clock) : IHostedService
 {
     private readonly ILicenseJwtProvider _licenseJwtProvider = Init(loggerFactory, licenseJwtProvider);
 
@@ -59,6 +61,13 @@ internal class LicenseLoadingService(
                     await LicenseLoader.LoadAsync(license);
             }
         }
+
+        // The loop is where the list stops growing, so this is the first moment anything can be said about
+        // the licenses without the answer depending on the order they arrived in. It is also the only
+        // moment a deployment whose license is still valid says anything at all: every other route into
+        // the reporting is a request path, and one of them returns the cached license without evaluating
+        // it. A server that has just loaded a license expiring next week hears about it here or nowhere.
+        LicenseChecker.ReportLoadedLicenses(clock.GetUtcNow());
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoadingService.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoadingService.cs
@@ -63,10 +63,13 @@ internal class LicenseLoadingService(
         }
 
         // The loop is where the list stops growing, so this is the first moment anything can be said about
-        // the licenses without the answer depending on the order they arrived in. It is also the only
-        // moment a deployment whose license is still valid says anything at all: every other route into
-        // the reporting is a request path, and one of them returns the cached license without evaluating
-        // it. A server that has just loaded a license expiring next week hears about it here or nowhere.
+        // the licenses without the answer depending on the order they arrived in. For a deployment holding
+        // ONE valid license it is also the only moment: every other route into the reporting is a request
+        // path, and the request path returns the cached license without evaluating it while that license
+        // is still valid, so nothing would ever say it expires next week.
+        //
+        // The clock is the host's, while the enforcement in LicenseChecker reads the system clock. They
+        // agree wherever TimeProvider.System is registered, which is what the registration extensions do.
         LicenseChecker.ReportLoadedLicenses(clock.GetUtcNow());
     }
 

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -44,10 +44,10 @@ public partial class LicenseManager
             _licenses.Insert(i < 0 ? ~i : i, license);
 
             // The scan rather than the reporting wrapper, because the list is still arriving: a host
-            // loads licenses one at a time, so every insert but the last evaluates a PARTIAL list, and
-            // an expiry that a license still in the queue is about to supersede would be announced as a
-            // fallback to the free tier - once per superseded license, and only when the provider
-            // happens to yield oldest first, which makes the log depend on arrival order.
+            // loads licenses one at a time, so every insert but the last evaluates a PARTIAL list.
+            // Reporting from here announces an expiry, or a grace period, that a license still in the
+            // queue is about to supersede - and only when the provider happens to yield the older
+            // license first, which makes the log depend on arrival order.
             //
             // What an insert needs is the refreshed value. The report belongs where the license is
             // consulted, on a list that has stopped growing.
@@ -137,7 +137,17 @@ public partial class LicenseManager
     /// </remarks>
     internal License? GenerateActiveLicense(DateTimeOffset utcNow)
     {
-        var (result, expired) = Scan(utcNow);
+        var (result, expired, merged) = Scan(utcNow);
+
+        // What was MERGED is reported here rather than where it was merged, for the same reason the
+        // expiry below is: the scan runs on every insert while the list is still arriving, and a license
+        // in its grace period would then be announced before the renewal superseding it has been read.
+        // The status is carried out of the scan and reported once, on a list that has stopped growing.
+        if (merged is not null)
+        {
+            foreach (var (license, status) in merged)
+                ReportStatus(license, status, utcNow);
+        }
 
         // An expiry is reported only when nothing was left in force, which is the fact that makes it worth
         // reporting and the one the scan can only know at its end. A superseded license expired too, and
@@ -158,6 +168,33 @@ public partial class LicenseManager
     }
 
     /// <summary>
+    /// Reports what the loaded licenses mean for the deployment, once the list has stopped growing.
+    /// </summary>
+    /// <param name="utcNow">The moment to evaluate the licenses at.</param>
+    /// <remarks>
+    /// The one record a deployment gets without serving a request, and the only route by which an
+    /// expiring-soon warning can be heard at all. Every other route into the reporting runs from
+    /// <see cref="TryGetCurrentLicenseLimit"/>, which returns the cached license untouched while it is
+    /// still valid - so a server holding a license that expires next week would never evaluate it, and a
+    /// lapsed server taking no traffic would say nothing about that either.
+    ///
+    /// Called after loading rather than from each insert, which is the whole of the difference: here the
+    /// list has provably stopped growing, so what is said does not depend on the order it arrived in.
+    /// </remarks>
+    internal void ReportLoadedLicenses(DateTimeOffset utcNow)
+    {
+        _rwLock.EnterReadLock();
+        try
+        {
+            GenerateActiveLicense(utcNow);
+        }
+        finally
+        {
+            _rwLock.ExitReadLock();
+        }
+    }
+
+    /// <summary>
     /// Walks the licenses and returns what is in force, together with the expired ones seen on the way.
     /// </summary>
     /// <param name="utcNow">The moment to evaluate each license at.</param>
@@ -171,11 +208,16 @@ public partial class LicenseManager
     /// read lock, so advancing a shared start index here let racing readers overshoot a valid license and
     /// permanently degrade the server to FreeLicense. License lists are tiny, so a full scan is cheap.
     /// </remarks>
-    private (License? InForce, IReadOnlyList<License>? Expired) Scan(DateTimeOffset utcNow)
+    private (License? InForce, IReadOnlyList<License>? Expired, IReadOnlyList<(License License,
+        LicenseStatus Status)>? Merged) Scan(DateTimeOffset utcNow)
     {
         License? result = null;
         bool? activeLicenseFound = null;
         List<License>? expired = null;
+
+        // Allocated up front rather than on first use, because every merge appends to it and there are at
+        // most a handful of licenses. The caller decides whether any of it is worth saying.
+        List<(License License, LicenseStatus Status)> merged = [];
 
         for (var indexCurrent = 0; indexCurrent < _licenses.Count; indexCurrent++)
         {
@@ -189,14 +231,15 @@ public partial class LicenseManager
                     break;
 
                 case LicenseStatus.Active:
-                    result = AppendLicense(result, license, status, utcNow);
+                    result = AppendLicense(result, license, status, merged);
                     break;
 
                 case LicenseStatus.GracePeriod:
-                    activeLicenseFound ??= FindActiveLicensesInFuture(utcNow, ref indexCurrent, ref result);
+                    activeLicenseFound ??= FindActiveLicensesInFuture(
+                        utcNow, ref indexCurrent, ref result, merged);
 
                     if (activeLicenseFound == false)
-                        result = AppendLicense(result, license, status, utcNow);
+                        result = AppendLicense(result, license, status, merged);
 
                     break;
 
@@ -204,12 +247,21 @@ public partial class LicenseManager
                     // Licenses are held sorted by the moment they start, so everything past this one starts
                     // later still and the scan is over. Whatever the caller reports, it reports about the
                     // licenses already collected, which is all of them that could matter.
-                    return (result, expired);
+                    return (result, expired, Collected(merged));
             }
         }
 
-        return (result, expired);
+        return (result, expired, Collected(merged));
     }
+
+    /// <summary>The merged licenses, or <c>null</c> when nothing was merged.</summary>
+    /// <remarks>
+    /// Null rather than an empty list, so the two things a scan can carry read the same way at the call
+    /// site and neither invites a loop over nothing.
+    /// </remarks>
+    private static IReadOnlyList<(License License, LicenseStatus Status)>? Collected(
+        List<(License License, LicenseStatus Status)> merged)
+        => merged.Count > 0 ? merged : null;
 
     /// <summary>
     /// Looks past a license in its grace period for one that is active now, and merges that one instead.
@@ -218,6 +270,7 @@ public partial class LicenseManager
     /// <param name="indexCurrent">The index the search starts after, advanced past everything it stepped
     /// over when it finds an active license.</param>
     /// <param name="result">The result license, updated with the active license when one is found.</param>
+    /// <param name="merged">Collects what was merged, for a caller that decides whether to report it.</param>
     /// <returns>True when an active license was found and merged; otherwise, false.</returns>
     /// <remarks>
     /// Only an ACTIVE license answers this question, and that is the whole of it: a license whose terms do
@@ -231,12 +284,16 @@ public partial class LicenseManager
     /// the ones that still apply. A successor takes over on its own, at the moment
     /// <see cref="GetLicenseStatus"/> starts calling it active.
     ///
-    /// Nothing is reported from here, including the expired licenses the search leaps over. A true answer
-    /// merges an active license, so something is in force, and an expiry that changed nothing is exactly
-    /// what the caller declines to report. A false answer leaps over nothing, so the caller's own loop
-    /// meets every license itself.
+    /// The expired licenses the search leaps over are not collected, and nothing here is reported. A true
+    /// answer merges an active license, so something is in force, and an expiry that changed nothing is
+    /// exactly what the caller declines to report. A false answer leaps over nothing, so the caller's own
+    /// loop meets every license itself.
     /// </remarks>
-    private bool FindActiveLicensesInFuture(DateTimeOffset utcNow, ref int indexCurrent, ref License? result)
+    private bool FindActiveLicensesInFuture(
+        DateTimeOffset utcNow,
+        ref int indexCurrent,
+        ref License? result,
+        List<(License License, LicenseStatus Status)> merged)
     {
         for (var indexNext = indexCurrent + 1; indexNext < _licenses.Count; indexNext++)
         {
@@ -247,7 +304,7 @@ public partial class LicenseManager
 
             indexCurrent = indexNext;
 
-            result = AppendLicense(result, nextLicense, nextStatus, utcNow);
+            result = AppendLicense(result, nextLicense, nextStatus, merged);
             return true;
         }
 
@@ -261,15 +318,20 @@ public partial class LicenseManager
     /// <param name="result">The current result license, which may be updated by this method.</param>
     /// <param name="license">The license to append or compare against the result.</param>
     /// <param name="status">The status of the given license.</param>
-    /// <param name="utcNow">The current UTC time for evaluating the license's status.</param>
+    /// <param name="merged">Collects what was merged, for a caller that decides whether to report it.</param>
     /// <returns>The updated result license after considering the given license.</returns>
     /// <remarks>
-    /// Depending on the status of the given license, this method may log warnings or errors about license expiration
-    /// and updates the result license to reflect the most appropriate active license based on the current time.
+    /// Merges and records what it merged, and reports nothing. The two were one method, and joining them
+    /// is what made the reporting fire from every insert: the scan runs while the list is still arriving,
+    /// so it has to be able to merge without announcing anything.
     /// </remarks>
-    private static License AppendLicense(License? result, License license, LicenseStatus status, DateTimeOffset utcNow)
+    private static License AppendLicense(
+        License? result,
+        License license,
+        LicenseStatus status,
+        List<(License License, LicenseStatus Status)> merged)
     {
-        ReportStatus(license, status, utcNow);
+        merged.Add((license, status));
 
         if (result == null)
         {

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -178,7 +178,8 @@ public partial class LicenseManager
     /// would hear nothing about a license expiring next week, and a lapsed server taking no traffic would
     /// say nothing about that either. A deployment holding SEVERAL licenses does reach both statuses on a
     /// request path, because the cached value carries the shortest expiry among them: once that one passes,
-    /// every consult rescans and the licenses outliving it are judged again, expiring-soon included.
+    /// the NEXT consult rescans and the licenses outliving it are judged again, expiring-soon
+    /// included. Only the next one: that scan installs the survivor, so caching resumes behind it.
     ///
     /// The list has provably stopped growing when this is called, so what is said does not depend on the
     /// order it arrived in.
@@ -254,7 +255,13 @@ public partial class LicenseManager
                 case LicenseStatus.NotActiveYet:
                     // Licenses are held sorted by the moment they start, so everything past this one starts
                     // later still and the scan is over. Whatever the caller reports, it reports about the
-                    // licenses already collected, which is all of them that could matter.
+                    // licenses already collected, which is all of them that could matter for what is IN
+                    // FORCE now.
+                    //
+                    // It is not all of them that could matter for what is SAID. A renewal starting before
+                    // the current license expires sits past this return, so an expiring-soon warning is
+                    // issued to a deployment that has already renewed. Tracked as issue 425 rather than
+                    // fixed here: the answer reaches into this early exit rather than into the reporting.
                     return (result, expired, merged);
             }
         }

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -139,10 +139,10 @@ public partial class LicenseManager
     {
         var (result, expired, merged) = Scan(utcNow);
 
-        // What was MERGED is reported here rather than where it was merged, for the same reason the
-        // expiry below is: the scan runs on every insert while the list is still arriving, and a license
-        // in its grace period would then be announced before the renewal superseding it has been read.
-        // The status is carried out of the scan and reported once, on a list that has stopped growing.
+        // What was MERGED is reported by whoever consults the licenses, for the same reason the expiry
+        // below is: the scan also runs on every insert, while the list is still arriving, and a license in
+        // its grace period announced there would be announced before the renewal superseding it has been
+        // read. The status is carried out of the scan so it can be said once, on a settled list.
         if (merged is not null)
         {
             foreach (var (license, status) in merged)
@@ -172,14 +172,17 @@ public partial class LicenseManager
     /// </summary>
     /// <param name="utcNow">The moment to evaluate the licenses at.</param>
     /// <remarks>
-    /// The one record a deployment gets without serving a request, and the only route by which an
-    /// expiring-soon warning can be heard at all. Every other route into the reporting runs from
-    /// <see cref="TryGetCurrentLicenseLimit"/>, which returns the cached license untouched while it is
-    /// still valid - so a server holding a license that expires next week would never evaluate it, and a
-    /// lapsed server taking no traffic would say nothing about that either.
+    /// The one record a deployment gets without serving a request. Every other route into the reporting
+    /// runs from <see cref="TryGetCurrentLicenseLimit"/>, which returns the cached license untouched while
+    /// it is still valid, so a deployment holding one valid license reaches the reporting nowhere else: it
+    /// would hear nothing about a license expiring next week, and a lapsed server taking no traffic would
+    /// say nothing about that either. A deployment holding SEVERAL licenses does rescan on a request path,
+    /// because the cached value carries the shortest expiry among them and the ones behind it outlive it.
     ///
-    /// Called after loading rather than from each insert, which is the whole of the difference: here the
-    /// list has provably stopped growing, so what is said does not depend on the order it arrived in.
+    /// The list has provably stopped growing when this is called, so what is said does not depend on the
+    /// order it arrived in.
+    ///
+    /// Acquires the read lock, so it must not be called from anywhere holding the write lock.
     /// </remarks>
     internal void ReportLoadedLicenses(DateTimeOffset utcNow)
     {
@@ -215,9 +218,10 @@ public partial class LicenseManager
         bool? activeLicenseFound = null;
         List<License>? expired = null;
 
-        // Allocated up front rather than on first use, because every merge appends to it and there are at
-        // most a handful of licenses. The caller decides whether any of it is worth saying.
-        List<(License License, LicenseStatus Status)> merged = [];
+        // Allocated on first merge, like the expired list above. A deployment on the free tier merges
+        // nothing and consults the licenses several times per request, so a list allocated up front would
+        // be pure cost on the path that runs most.
+        List<(License License, LicenseStatus Status)>? merged = null;
 
         for (var indexCurrent = 0; indexCurrent < _licenses.Count; indexCurrent++)
         {
@@ -231,15 +235,15 @@ public partial class LicenseManager
                     break;
 
                 case LicenseStatus.Active:
-                    result = AppendLicense(result, license, status, merged);
+                    result = AppendLicense(result, license, status, ref merged);
                     break;
 
                 case LicenseStatus.GracePeriod:
                     activeLicenseFound ??= FindActiveLicensesInFuture(
-                        utcNow, ref indexCurrent, ref result, merged);
+                        utcNow, ref indexCurrent, ref result, ref merged);
 
                     if (activeLicenseFound == false)
-                        result = AppendLicense(result, license, status, merged);
+                        result = AppendLicense(result, license, status, ref merged);
 
                     break;
 
@@ -247,21 +251,12 @@ public partial class LicenseManager
                     // Licenses are held sorted by the moment they start, so everything past this one starts
                     // later still and the scan is over. Whatever the caller reports, it reports about the
                     // licenses already collected, which is all of them that could matter.
-                    return (result, expired, Collected(merged));
+                    return (result, expired, merged);
             }
         }
 
-        return (result, expired, Collected(merged));
+        return (result, expired, merged);
     }
-
-    /// <summary>The merged licenses, or <c>null</c> when nothing was merged.</summary>
-    /// <remarks>
-    /// Null rather than an empty list, so the two things a scan can carry read the same way at the call
-    /// site and neither invites a loop over nothing.
-    /// </remarks>
-    private static IReadOnlyList<(License License, LicenseStatus Status)>? Collected(
-        List<(License License, LicenseStatus Status)> merged)
-        => merged.Count > 0 ? merged : null;
 
     /// <summary>
     /// Looks past a license in its grace period for one that is active now, and merges that one instead.
@@ -293,7 +288,7 @@ public partial class LicenseManager
         DateTimeOffset utcNow,
         ref int indexCurrent,
         ref License? result,
-        List<(License License, LicenseStatus Status)> merged)
+        ref List<(License License, LicenseStatus Status)>? merged)
     {
         for (var indexNext = indexCurrent + 1; indexNext < _licenses.Count; indexNext++)
         {
@@ -304,7 +299,7 @@ public partial class LicenseManager
 
             indexCurrent = indexNext;
 
-            result = AppendLicense(result, nextLicense, nextStatus, merged);
+            result = AppendLicense(result, nextLicense, nextStatus, ref merged);
             return true;
         }
 
@@ -321,17 +316,17 @@ public partial class LicenseManager
     /// <param name="merged">Collects what was merged, for a caller that decides whether to report it.</param>
     /// <returns>The updated result license after considering the given license.</returns>
     /// <remarks>
-    /// Merges and records what it merged, and reports nothing. The two were one method, and joining them
-    /// is what made the reporting fire from every insert: the scan runs while the list is still arriving,
-    /// so it has to be able to merge without announcing anything.
+    /// Merges and records what it merged, and reports nothing. It runs from a scan that also runs on every
+    /// insert, while the list is still arriving, so it has to be able to merge without announcing
+    /// anything. Reporting from here reaches a partial list; the caller reaches a settled one.
     /// </remarks>
     private static License AppendLicense(
         License? result,
         License license,
         LicenseStatus status,
-        List<(License License, LicenseStatus Status)> merged)
+        ref List<(License License, LicenseStatus Status)>? merged)
     {
-        merged.Add((license, status));
+        (merged ??= []).Add((license, status));
 
         if (result == null)
         {

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -176,13 +176,17 @@ public partial class LicenseManager
     /// runs from <see cref="TryGetCurrentLicenseLimit"/>, which returns the cached license untouched while
     /// it is still valid, so a deployment holding one valid license reaches the reporting nowhere else: it
     /// would hear nothing about a license expiring next week, and a lapsed server taking no traffic would
-    /// say nothing about that either. A deployment holding SEVERAL licenses does rescan on a request path,
-    /// because the cached value carries the shortest expiry among them and the ones behind it outlive it.
+    /// say nothing about that either. A deployment holding SEVERAL licenses does reach both statuses on a
+    /// request path, because the cached value carries the shortest expiry among them: once that one passes,
+    /// every consult rescans and the licenses outliving it are judged again, expiring-soon included.
     ///
     /// The list has provably stopped growing when this is called, so what is said does not depend on the
     /// order it arrived in.
     ///
-    /// Acquires the read lock, so it must not be called from anywhere holding the write lock.
+    /// Acquires the read lock, and the lock forbids recursion, so this must not be called from anywhere
+    /// already holding EITHER lock. The read one is the likelier mistake: a maintainer wanting to report
+    /// from <see cref="TryGetCurrentLicenseLimit"/> is standing inside its read lock, and that throws just
+    /// as the write lock does.
     /// </remarks>
     internal void ReportLoadedLicenses(DateTimeOffset utcNow)
     {

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -469,6 +469,12 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, LicenseLoadingService>());
         services.TryAddSingleton<ILicenseJwtProvider, OptionsLicenseJwtProvider>();
+
+        // The hosted service evaluates the loaded licenses against this clock. Registered here rather than
+        // relied upon from elsewhere: this method is public and a host may call it on a collection that has
+        // nothing else of ours in it, where the missing registration surfaces at BuildServiceProvider as a
+        // failure to activate a type whose name says nothing about licensing.
+        services.TryAddSingleton(TimeProvider.System);
         return services;
     }
 
@@ -492,6 +498,10 @@ public static class ServiceCollectionExtensions
         // any ILicenseJwtProvider previously registered by AddLicenseFromOptions.
         services.Replace(ServiceDescriptor.Singleton<ILicenseJwtProvider>(
             sp => sp.CreateService<StaticLicenseJwtProvider>(Dependency.Override(licenseJwt))));
+
+        // See AddLicenseFromOptions: the hosted service needs a clock, and this method is equally reachable
+        // on a collection carrying nothing else of ours.
+        services.TryAddSingleton(TimeProvider.System);
         return services;
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
@@ -384,8 +384,8 @@ public class LicenseLoadingServiceTests
     ///
     /// The failure this pins arrives at <c>BuildServiceProvider</c> and names a type whose name says
     /// nothing about licensing, so it reads as a container defect rather than a missing registration.
-    /// <c>ValidateOnBuild</c> is what makes it arrive at all: without it the container answers happily
-    /// until something asks for the hosted services, which is host start.
+    /// In a host <c>ValidateOnBuild</c> is what makes it arrive at build time rather than at start; here
+    /// it arrives either way, because the assertion below is itself a resolution of the hosted services.
     ///
     /// Logging and options are supplied here rather than expected from the registration, because every
     /// ASP.NET host has both before any of this is called and a library registering its own logging would
@@ -407,10 +407,21 @@ public class LicenseLoadingServiceTests
         else
             services.AddLicense("not.a.real.jwt");
 
-        using var provider = services.BuildServiceProvider(
-            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+        try
+        {
+            using var provider = services.BuildServiceProvider(
+                new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
-        Assert.Single(provider.GetServices<IHostedService>());
+            Assert.Single(provider.GetServices<IHostedService>());
+        }
+        finally
+        {
+            // Activating the hosted service rebinds the process-wide logger to one from the container this
+            // test is about to dispose, and every write through a disposed logger is swallowed. The class
+            // joined the serial collection for exactly this reason, so the test that proves the point is
+            // the last one that may skip the restore.
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
     }
 
     /// <summary>A clock that answers one moment, so a test can stand anywhere on the timeline.</summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Abblix.Oidc.Server.Features.Licensing;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -38,6 +39,12 @@ namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
 ///
 /// Full integration testing with valid licenses requires actual Abblix license JWTs.
 /// </remarks>
+// Joins the non-parallel collection because starting the service writes to process-wide state that other
+// classes assert on: it replaces LicenseLogger.Instance with the factory it was given, and it reports the
+// loaded licenses once the loop closes. A class recording what the licensing writes would otherwise have
+// its recorder swapped out mid-assertion, or catch a record this class produced, rarely enough to arrive
+// as an unreproducible failure somewhere else.
+[Collection(nameof(LicenseEnforcementTests))]
 public class LicenseLoadingServiceTests
 {
     #region Helper Classes
@@ -70,7 +77,7 @@ public class LicenseLoadingServiceTests
         // Arrange
         var loggerFactory = NullLoggerFactory.Instance;
         var provider = new MockLicenseJwtProvider(null);
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         var cancellationToken = CancellationToken.None;
 
         // Act
@@ -90,7 +97,7 @@ public class LicenseLoadingServiceTests
         var loggerFactory = NullLoggerFactory.Instance;
         var emptyLicenses = AsyncEnumerable.Empty<string>();
         var provider = new MockLicenseJwtProvider(emptyLicenses);
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         var cancellationToken = CancellationToken.None;
 
         // Act
@@ -116,7 +123,7 @@ public class LicenseLoadingServiceTests
         var loggerFactory = NullLoggerFactory.Instance;
         var licenses = new[] { string.Empty }.ToAsyncEnumerable();
         var provider = new MockLicenseJwtProvider(licenses);
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         var cancellationToken = CancellationToken.None;
 
         // Act - Should skip empty string without throwing
@@ -136,7 +143,7 @@ public class LicenseLoadingServiceTests
         var loggerFactory = NullLoggerFactory.Instance;
         var licenses = new[] { "invalid.jwt.token" }.ToAsyncEnumerable();
         var provider = new MockLicenseJwtProvider(licenses);
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         var cancellationToken = CancellationToken.None;
 
         // Act & Assert - Invalid license should throw during validation
@@ -153,7 +160,7 @@ public class LicenseLoadingServiceTests
         // Arrange
         var loggerFactory = NullLoggerFactory.Instance;
         var provider = new MockLicenseJwtProvider(null);
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         var cancellationToken = CancellationToken.None;
 
         // Act
@@ -181,7 +188,7 @@ public class LicenseLoadingServiceTests
         }
 
         var provider = new MockLicenseJwtProvider(SlowLicenses(TestContext.Current.CancellationToken));
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         using var cts = new CancellationTokenSource();
 
         // Act - the token is already cancelled when enumeration starts, so the first await inside the sequence
@@ -204,7 +211,7 @@ public class LicenseLoadingServiceTests
         // Arrange
         var loggerFactory = NullLoggerFactory.Instance;
         var provider = new MockLicenseJwtProvider(null);
-        var service = new LicenseLoadingService(loggerFactory, provider);
+        var service = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
         using var cts = new CancellationTokenSource();
 
         // Act - Should complete immediately (no enumeration needed)
@@ -230,7 +237,7 @@ public class LicenseLoadingServiceTests
         var provider = new MockLicenseJwtProvider(null);
 
         // Act
-        _ = new LicenseLoadingService(loggerFactory, provider);
+        _ = new LicenseLoadingService(loggerFactory, provider, TimeProvider.System);
 
         // Assert - LicenseLogger.Instance should be initialized
         // We can verify this by checking if IsEnabled returns expected value
@@ -317,4 +324,55 @@ public class LicenseLoadingServiceTests
     }
 
     #endregion
+
+    /// <summary>
+    /// Starting the service reports what the loaded licenses mean, at the clock it was given.
+    /// </summary>
+    /// <remarks>
+    /// The call site, not the reporting, which <c>LicenseManagerTests</c> covers. Without a test here the
+    /// seam is a method nobody has shown runs, and the deployment it exists for is the one that starts
+    /// holding a valid license and then serves no traffic: every other route into the reporting is a
+    /// request path, and one of them returns the cached license without evaluating it.
+    ///
+    /// The provider yields nothing on purpose. What is reported is the license the assembly installs, so
+    /// the record proves the report happened after the loop rather than inside it, on whatever the manager
+    /// was holding by then.
+    ///
+    /// The clock is placed past that license's expiry, which is what makes the assertion deterministic
+    /// without a signing key: no test can mint an expired license, and every real one expires eventually.
+    /// The assembly's license runs into the twenty-second century, so the moment has to clear that rather
+    /// than merely be far away - at an earlier one the license is simply active and says nothing.
+    /// </remarks>
+    [Fact]
+    public async Task StartAsync_AfterLoading_ReportsWhatTheLicensesMean()
+    {
+        TestLicense.ResetChecker();
+        TestLicense.ClearLogThrottle();
+
+        var records = new RecordingLoggerFactory();
+        var service = new LicenseLoadingService(
+            records,
+            new MockLicenseJwtProvider(null),
+            new FixedClock(new DateTimeOffset(2200, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+        try
+        {
+            await service.StartAsync(CancellationToken.None);
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+            TestLicense.ClearLogThrottle();
+        }
+
+        Assert.Contains(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpired);
+    }
+
+    /// <summary>A clock that answers one moment, so a test can stand anywhere on the timeline.</summary>
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseLoadingServiceTests.cs
@@ -13,9 +13,12 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.Licensing;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -368,6 +371,46 @@ public class LicenseLoadingServiceTests
         Assert.Contains(
             records.Entries,
             entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpired);
+    }
+
+    /// <summary>
+    /// Either public licence registration builds a container the hosted service can be activated from.
+    /// </summary>
+    /// <remarks>
+    /// Both methods are public and take an <c>IServiceCollection</c>, so a host may call one on a
+    /// collection carrying nothing else of ours. Every dependency the hosted service takes has to be
+    /// registered by the method that registers the service, and a dependency supplied elsewhere in the
+    /// shipped composition is a property of that composition rather than of this method.
+    ///
+    /// The failure this pins arrives at <c>BuildServiceProvider</c> and names a type whose name says
+    /// nothing about licensing, so it reads as a container defect rather than a missing registration.
+    /// <c>ValidateOnBuild</c> is what makes it arrive at all: without it the container answers happily
+    /// until something asks for the hosted services, which is host start.
+    ///
+    /// Logging and options are supplied here rather than expected from the registration, because every
+    /// ASP.NET host has both before any of this is called and a library registering its own logging would
+    /// be reaching further than it needs to. So the collection stands for a host that has the framework
+    /// and nothing of ours, which is the case these methods have to survive.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LicenseRegistration_OnACollectionCarryingNothingElse_ActivatesTheHostedService(
+        bool fromOptions)
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddLogging();
+
+        if (fromOptions)
+            services.AddLicenseFromOptions();
+        else
+            services.AddLicense("not.a.real.jwt");
+
+        using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+        Assert.Single(provider.GetServices<IHostedService>());
     }
 
     /// <summary>A clock that answers one moment, so a test can stand anywhere on the timeline.</summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -789,4 +789,85 @@ public class LicenseManagerTests
 
         Assert.Equal(3, expiries.Count);
     }
+
+    /// <summary>
+    /// Loading a license in its grace period beside the renewal that supersedes it reports nothing.
+    /// </summary>
+    /// <remarks>
+    /// The twin of <see cref="AddLicense_LoadingLicenses_ReportsNothing"/>, one event id over and at Error
+    /// rather than Critical. "Renew immediately to maintain service access" is untrue of a deployment that
+    /// has already renewed, and whether it is said at all depends on the order the provider yields its
+    /// licenses in: the grace license is reported as it is inserted, before the renewal has arrived.
+    ///
+    /// Positioned against the wall clock rather than <see cref="Moment"/>, because <c>AddLicense</c> reads
+    /// the system clock directly. A license placed relative to any other instant is already expired when
+    /// the insert evaluates it, and an expired license takes an arm that reports nothing, so the
+    /// arrangement would prove itself silent for the wrong reason.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddLicense_GraceLicenseBesideItsRenewal_ReportsNothing(bool oldestFirst)
+    {
+        var inGrace = CreateLicense(notBefore: -20, expiresAt: -3, gracePeriod: 5) with { ClientLimit = 5 };
+        var renewal = CreateLicense(notBefore: -1, expiresAt: 60) with { ClientLimit = 50 };
+        var arriving = oldestFirst ? new[] { inGrace, renewal } : [renewal, inGrace];
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        var manager = new LicenseManager();
+        try
+        {
+            foreach (var license in arriving)
+                manager.AddLicense(license);
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        Assert.DoesNotContain(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseInGracePeriod);
+
+        // The control on the arrangement: without it the silence above would also hold over a manager that
+        // took no licenses in, which is silent for a reason nobody wants.
+        var active = manager.GenerateActiveLicense(TimeProvider.System.GetUtcNow());
+        Assert.NotNull(active);
+        Assert.Equal(50, active!.ClientLimit);
+    }
+
+    /// <summary>
+    /// A license in its grace period with no renewal behind it is reported when the license is consulted.
+    /// </summary>
+    /// <remarks>
+    /// The control for the silence above, and the reason that silence is a decision rather than the record
+    /// having been lost on the way to the recorder: the same license, with the renewal removed, produces
+    /// the record the operator needs.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_GraceLicenseWithNoRenewal_ReportsIt()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(CreateLicense(notBefore: -20, expiresAt: -3, gracePeriod: 5) with { ClientLimit = 5 });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            var active = manager.GenerateActiveLicense(TimeProvider.System.GetUtcNow());
+            Assert.NotNull(active);
+            Assert.Equal(5, active!.ClientLimit);
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        var record = Assert.Single(records.Entries);
+        Assert.Equal(LogEvents.Licensing.LicenseManager.LicenseInGracePeriod, record.EventId.Id);
+        Assert.Equal(LogLevel.Error, record.Level);
+    }
 }


### PR DESCRIPTION
Fixes the defect filed as #417.

Stacked on `fix/report-the-expired-licence` (#412) and should merge after it. The split this change extends is the one that pull request made, so building it on `develop` would have meant doing that split twice and conflicting on the merge.

## What was wrong

`AddLicense` re-evaluates on every insert, and a host loads licenses one at a time, so every insert but the last evaluated a partial list. `AppendLicense` merged and reported in one method, so a license in its grace period was reported the moment it was inserted, before the renewal that supersedes it had arrived.

The record says "Renew immediately to maintain service access", at Error, and it is simply untrue of a deployment that has already renewed. Worse, whether it appears at all depends on the order the provider yields:

| load order | settles on | grace records during load |
|---|---|---|
| grace license, then its renewal | valid, 50 clients | 1 |
| renewal, then the grace license | valid, 50 clients | 0 |
| grace license, no renewal | 5 clients | 1, correct |

Same licenses, same settled state, and nothing in any diff to explain why one deployment logs differently from another after a provider reshuffles its order.

## The change

Merging and reporting become two things. The scan carries out what it merged, and the caller decides whether any of it is worth saying. `AddLicense` takes the refreshed value and says nothing.

That opens a hole the expiry case did not have. Every route into the reporting runs from `TryGetCurrentLicenseLimit`, which returns the cached license without evaluating it while that license is still valid. So an expiring-soon warning would never be heard by a healthy deployment, and a lapsed server serving no traffic would say nothing either. `LicenseLoadingService` therefore reports once after its loop closes, on a list that has provably stopped growing, and takes a `TimeProvider` to do it.

## Evidence

Both tests were driven red before the change and green after.

The load test gives the grace license both positions and pins the invariant that holds in either, because `AddLicense` reads the wall clock and takes no `TimeProvider`, so a test cannot place a license relative to any other instant. Only one of the two positions failed beforehand, which is the order dependence itself.

The call-site test stands the clock past the assembly license's expiry. That is the only way to observe an expired license without a signing key, and it fails if the reporting call is removed.

`LicenseLoadingServiceTests` joins the non-parallel collection: starting the service replaces the process-wide `LicenseLogger` and now writes a record through it, so a class recording what the licensing says could otherwise have its recorder swapped out mid-assertion.

Unit suite 2855 passed, 0 failed.
