### PR TITLE
Compute the requested authorization_details types in one place

### DIFF
--- a/src/Abblix.Jwt/JsonArrayExtensions.cs
+++ b/src/Abblix.Jwt/JsonArrayExtensions.cs
@@ -5,6 +5,7 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 namespace Abblix.Jwt;
@@ -50,6 +51,14 @@ public static class JsonArrayExtensions
     /// </summary>
     /// <param name="jsonArray">The raw array, or <c>null</c>.</param>
     /// <returns>A wrapper array, or <c>null</c> when the input is <c>null</c>.</returns>
+    /// <remarks>
+    /// The attribute states in the type system what the sentence above states in prose: null in, null out,
+    /// and never null out for an input that was not. Without it a caller holding a non-null array still
+    /// gets a nullable result, and the way that is silenced is a null-forgiving operator - which then
+    /// keeps compiling if the guard above it is ever moved or removed, asserting something no longer true.
+    /// Here the compiler carries the claim instead, and re-checks it at every call site.
+    /// </remarks>
+    [return: NotNullIfNotNull(nameof(jsonArray))]
     public static AuthorizationDetail[]? ToTypedArray(this JsonArray? jsonArray)
     {
         return jsonArray?

--- a/src/Abblix.Jwt/JsonArrayExtensions.cs
+++ b/src/Abblix.Jwt/JsonArrayExtensions.cs
@@ -52,11 +52,14 @@ public static class JsonArrayExtensions
     /// <param name="jsonArray">The raw array, or <c>null</c>.</param>
     /// <returns>A wrapper array, or <c>null</c> when the input is <c>null</c>.</returns>
     /// <remarks>
-    /// The attribute states in the type system what the sentence above states in prose: null in, null out,
-    /// and never null out for an input that was not. Without it a caller holding a non-null array still
-    /// gets a nullable result, and the way that is silenced is a null-forgiving operator - which then
-    /// keeps compiling if the guard above it is ever moved or removed, asserting something no longer true.
-    /// Here the compiler carries the claim instead, and re-checks it at every call site.
+    /// The attribute states one half of the sentence above in the type system: never null out for an
+    /// input that was not. The other half, null in null out, is not expressible there and is pinned by a
+    /// test instead.
+    ///
+    /// Without it a caller holding a non-null array still gets a nullable result, and the way that gets
+    /// silenced is a null-forgiving operator - which keeps compiling after the guard it depends on is
+    /// moved or deleted, asserting something no longer true. With it the compiler carries the claim and
+    /// re-checks it at every call site.
     /// </remarks>
     [return: NotNullIfNotNull(nameof(jsonArray))]
     public static AuthorizationDetail[]? ToTypedArray(this JsonArray? jsonArray)

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -92,10 +92,7 @@ public class ConsentConstraintEnforcer(
         // Type-level subset: every granted entry's type must appear among the requested types. The
         // per-client allowlist (re-checked below) is not enough on its own - a client allowed types
         // {A, B} that requested only {A} must not have a {B} entry injected by the consent decision.
-        var requestedTypes = (request.AuthorizationDetails?.ToTypedArray() ?? [])
-            .Select(detail => detail.Type)
-            .OfType<string>()
-            .ToHashSet(StringComparer.Ordinal);
+        var requestedTypes = AuthorizationDetailTypes.NamedBy(request.AuthorizationDetails);
 
         var grantedTypes = RefuseTypesOutside(
             requestedTypes, grantedAuthorizationDetails, nameof(IUserConsentsProvider));

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -160,7 +160,7 @@ public partial class BackChannelAuthenticationGrantHandler(
         if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
             return true;
 
-        var requestedTypes = requested.ToTypedArray()!
+        var requestedTypes = requested.ToTypedArray()
             .Select(detail => detail.Type)
             .OfType<string>()
             .ToHashSet(StringComparer.Ordinal);

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -160,10 +160,7 @@ public partial class BackChannelAuthenticationGrantHandler(
         if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
             return true;
 
-        var requestedTypes = requested.ToTypedArray()
-            .Select(detail => detail.Type)
-            .OfType<string>()
-            .ToHashSet(StringComparer.Ordinal);
+        var requestedTypes = AuthorizationDetailTypes.NamedBy(requested);
 
         return !typed.All(detail => detail.Type is { } type && requestedTypes.Contains(type));
     }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -13,6 +13,8 @@ using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.PairwiseIdentifiers;
 using Microsoft.Extensions.Logging;
 
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+
 namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.AuthenticationNotifiers;
 
 /// <summary>
@@ -142,10 +144,7 @@ public abstract partial class AuthenticationCompletionHandler(
         if (Array.Exists(typed, detail => detail.Type is null))
             return ["an entry carrying no type"];
 
-        var requestedTypes = requested.ToTypedArray()
-            .Select(detail => detail.Type)
-            .OfType<string>()
-            .ToHashSet(StringComparer.Ordinal);
+        var requestedTypes = AuthorizationDetailTypes.NamedBy(requested);
 
         return typed
             .Select(detail => detail.Type!)

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -142,7 +142,7 @@ public abstract partial class AuthenticationCompletionHandler(
         if (Array.Exists(typed, detail => detail.Type is null))
             return ["an entry carrying no type"];
 
-        var requestedTypes = requested.ToTypedArray()!
+        var requestedTypes = requested.ToTypedArray()
             .Select(detail => detail.Type)
             .OfType<string>()
             .ToHashSet(StringComparer.Ordinal);

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
@@ -10,6 +10,8 @@ using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+
 namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
 /// <summary>
@@ -57,7 +59,7 @@ internal static class GrantedAuthorizationDetails
         if (Array.Exists(typed, detail => detail.Type is null))
             return ["an entry carrying no type"];
 
-        var requestedTypes = RequestedTypes(request.AuthorizationDetails);
+        var requestedTypes = AuthorizationDetailTypes.NamedBy(request.AuthorizationDetails);
 
         return typed
             .Select(detail => detail.Type!)
@@ -65,16 +67,4 @@ internal static class GrantedAuthorizationDetails
             .Distinct(StringComparer.Ordinal)
             .ToArray();
     }
-
-    /// <summary>The types the request asked for.</summary>
-    /// <remarks>
-    /// No arity guard here, unlike the grant side: an entry of the REQUEST that cannot be read as a JSON
-    /// object is dropped rather than refused, which narrows the baseline and therefore admits less. The
-    /// grant side has to refuse instead, because there the same silence would admit more.
-    /// </remarks>
-    private static HashSet<string> RequestedTypes(JsonArray? requested)
-        => (requested?.ToTypedArray() ?? [])
-            .Select(detail => detail.Type)
-            .OfType<string>()
-            .ToHashSet(StringComparer.Ordinal);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/GrantedAuthorizationDetails.cs
@@ -52,10 +52,11 @@ internal static class GrantedAuthorizationDetails
         if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)
             return ["an entry that is not a JSON object"];
 
-        // Absence is named rather than compared. A typeless entry is refused either way - the request side
-        // filters its own types with OfType<string>(), so no request can hold a null to match one with -
-        // and what this arm changes is the log: without it the refusal reports an empty string in the list
-        // of escaped types, which reads as a defect in the message rather than as the grant's shape.
+        // Absence is named rather than compared. A typeless entry is refused either way, because
+        // AuthorizationDetailTypes.NamedBy drops one from the baseline, so no request can hold a null to
+        // match one with. What this arm changes is the log: without it the refusal reports
+        // an empty string in the list of escaped types, which reads as a defect in the message rather
+        // than as the grant's shape.
         if (Array.Exists(typed, detail => detail.Type is null))
             return ["an entry carrying no type"];
 

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailTypes.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailTypes.cs
@@ -1,0 +1,49 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+
+namespace Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+
+/// <summary>
+/// The <c>authorization_details</c> types an array names.
+/// </summary>
+/// <remarks>
+/// One computation, because four places compare a grant against what was requested and every one of them
+/// needs the same answer to "which types does this array name". A predicate deciding a branch and a branch
+/// re-deriving the same fact by a slightly different test disagree on exactly the inputs nobody wrote a
+/// test for, and four verbatim copies are four chances for one of them to drift.
+/// </remarks>
+internal static class AuthorizationDetailTypes
+{
+    /// <summary>
+    /// The distinct types the entries name, comparing as text.
+    /// </summary>
+    /// <param name="details">The entries, or <c>null</c>.</param>
+    /// <returns>The named types; empty when there are none to name.</returns>
+    /// <remarks>
+    /// Unreadable and typeless entries are DROPPED rather than refused, which narrows the set and
+    /// therefore admits less wherever it is used as a baseline. The grant side of each comparison has to
+    /// refuse instead, because there the same silence would admit more, and that refusal stays with the
+    /// caller that owns it.
+    ///
+    /// Whether a null array means "asked for nothing" or "predates the field" is likewise the caller's
+    /// to decide, and the two flows decide it differently on purpose. This answers the same for both,
+    /// which is why it can be shared: a caller that treats null as unknown returns before asking.
+    ///
+    /// Compared as text, per RFC 9396 §12: "All string comparisons in an authorization_details parameter
+    /// are to be done as defined by [RFC8259]. No additional transformation or normalization is to be
+    /// done in evaluating equivalence of string values."
+    /// </remarks>
+    public static HashSet<string> NamedBy(JsonArray? details)
+        => (details?.ToTypedArray() ?? [])
+            .Select(detail => detail.Type)
+            .OfType<string>()
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
@@ -322,13 +322,13 @@ public class AuthorizationDetailTests
     {
         Assert.Null(((JsonArray?)null).ToTypedArray());
 
-        Assert.Empty(new JsonArray().ToTypedArray()!);
+        Assert.Empty(new JsonArray().ToTypedArray());
 
         // Nothing here is a JSON object, so every element is dropped and the result is empty rather
         // than null.
-        Assert.Empty(new JsonArray(JsonValue.Create(PaymentInitiationType), JsonValue.Create(1)).ToTypedArray()!);
+        Assert.Empty(new JsonArray(JsonValue.Create(PaymentInitiationType), JsonValue.Create(1)).ToTypedArray());
 
         var readable = new JsonArray(new JsonObject { ["type"] = PaymentInitiationType });
-        Assert.Equal(PaymentInitiationType, Assert.Single(readable.ToTypedArray()!).Type);
+        Assert.Equal(PaymentInitiationType, Assert.Single(readable.ToTypedArray()).Type);
     }
 }

--- a/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/AuthorizationDetailTests.cs
@@ -303,4 +303,32 @@ public class AuthorizationDetailTests
         Assert.Equal($$"""{"type":"{{PaymentInitiationType}}"}""", detail.Json.ToJsonString());
         Assert.Null(detail.Locations);
     }
+
+    /// <summary>
+    /// <c>ToTypedArray</c> answers null for a null array and never for one that is not null.
+    /// </summary>
+    /// <remarks>
+    /// The conversion drops every element it cannot read, so an array of nothing readable comes back
+    /// EMPTY rather than null - which is the case a caller is most likely to get wrong, and the one the
+    /// <c>NotNullIfNotNull</c> attribute now promises the compiler. An attribute is a claim the compiler
+    /// enforces at every call site and cannot check inside the method, so if the body ever started
+    /// answering null for an empty result the promise would become a lie that only crashes a caller.
+    ///
+    /// Both directions are asserted, because a test of the null case alone would also pass over a method
+    /// that answered null for everything.
+    /// </remarks>
+    [Fact]
+    public void ToTypedArray_AnswersNullOnlyForANullArray()
+    {
+        Assert.Null(((JsonArray?)null).ToTypedArray());
+
+        Assert.Empty(new JsonArray().ToTypedArray()!);
+
+        // Nothing here is a JSON object, so every element is dropped and the result is empty rather
+        // than null.
+        Assert.Empty(new JsonArray(JsonValue.Create(PaymentInitiationType), JsonValue.Create(1)).ToTypedArray()!);
+
+        var readable = new JsonArray(new JsonObject { ["type"] = PaymentInitiationType });
+        Assert.Equal(PaymentInitiationType, Assert.Single(readable.ToTypedArray()!).Type);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailTypesTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailTypesTests.cs
@@ -1,0 +1,79 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Text.Json.Nodes;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.AuthorizationDetails;
+
+/// <summary>
+/// The one computation four comparisons share: which <c>authorization_details</c> types an array names.
+/// </summary>
+public class AuthorizationDetailTypesTests
+{
+    /// <summary>
+    /// Types are compared as text, so two spellings differing only in case are two types.
+    /// </summary>
+    /// <remarks>
+    /// RFC 9396 section 12: "All string comparisons in an authorization_details parameter are to be done
+    /// as defined by [RFC8259]. No additional transformation or normalization is to be done in evaluating
+    /// equivalence of string values."
+    ///
+    /// Pinned here rather than left to the comparer's default, because every caller of this uses the
+    /// result as a BASELINE: a case-insensitive set admits an entry of a type nobody requested whenever
+    /// the two differ only in case, and it admits it silently, in the direction that grants more. The
+    /// comparer is one identifier and nothing else in the flow would notice it changing.
+    /// </remarks>
+    [Fact]
+    public void NamedBy_ComparesTypesAsText()
+    {
+        var named = AuthorizationDetailTypes.NamedBy(
+            new JsonArray(
+                new JsonObject { ["type"] = "payment_initiation" },
+                new JsonObject { ["type"] = "Payment_Initiation" }));
+
+        Assert.Equal(2, named.Count);
+        Assert.Contains("payment_initiation", named);
+        Assert.DoesNotContain("PAYMENT_INITIATION", named);
+    }
+
+    /// <summary>
+    /// An entry the conversion cannot read, and one carrying no type, are dropped rather than refused.
+    /// </summary>
+    /// <remarks>
+    /// Dropping narrows the baseline and therefore admits LESS wherever it is used as one, which is why
+    /// this side can be silent while the grant side of every comparison has to refuse instead - there the
+    /// same silence would admit more. Each caller owns that refusal.
+    /// </remarks>
+    [Fact]
+    public void NamedBy_DropsWhatItCannotRead()
+    {
+        var named = AuthorizationDetailTypes.NamedBy(
+            new JsonArray(
+                JsonValue.Create("payment_initiation"),
+                new JsonObject { ["actions"] = new JsonArray(JsonValue.Create("initiate")) },
+                new JsonObject { ["type"] = "account_information" }));
+
+        Assert.Equal("account_information", Assert.Single(named));
+    }
+
+    /// <summary>
+    /// A null array names nothing, which is what lets the callers decide what null MEANS.
+    /// </summary>
+    /// <remarks>
+    /// The two flows read it differently on purpose - CIBA treats a null member as a request that predates
+    /// the field and returns before asking, the device flow treats it as a request that asked for nothing -
+    /// and this answering the same for both is what makes it shareable rather than what makes it wrong.
+    /// </remarks>
+    [Fact]
+    public void NamedBy_NamesNothingForANullArray()
+    {
+        Assert.Empty(AuthorizationDetailTypes.NamedBy(null));
+    }
+}


### PR DESCRIPTION
Closes #423.

Correcting the issue first: it was filed on the reading that `requested.ToTypedArray()!` could throw, and it cannot. Both call sites sit behind `is not { } requested`, which returns before reaching them, and `ToTypedArray` answers null only for a null receiver. The operator asserted something true.

## What the suppressions were covering

Four places computed the same thing, in two different spellings of it. Two wrote

    (details?.ToTypedArray() ?? []).Select(detail => detail.Type).OfType<string>().ToHashSet(StringComparer.Ordinal)

and two wrote `requested.ToTypedArray()!.Select(…)` with the same tail - the null-forgiving operator being how a non-null argument silences a nullable return. That difference matters for anyone writing a detector: a pattern seeded from either spelling misses the other two sites, silently, in the direction that reads as coverage.

The four are `ConsentConstraintEnforcer`, `GrantedAuthorizationDetails`, `BackChannelAuthenticationGrantHandler` and `AuthenticationCompletionHandler`. They call one function now, `AuthorizationDetailTypes.NamedBy`, and the two suppressions go with the duplication rather than being moved.

Two of them are the halves of one comparison: CIBA judges the grant at completion in one file and again at redemption in another, and a copy that drifted by one clause would make those two disagree on exactly the inputs nobody wrote a test for, with both halves green. The device flow was never exposed that way - its two halves already shared `GrantedAuthorizationDetails.EscapedTypes`, which is what that class exists for - and the consent enforcer is a third, unpaired use.

The issue asked whether CIBA and the device flow should share this. The reason given for not sharing in the first version of this branch was wrong: nothing needs a flag, because the null baseline is decided by the CALLERS. CIBA returns before asking when the member is null; the device flow lets the empty answer be its baseline. One function serves both unchanged.

## The annotation

`[return: NotNullIfNotNull(nameof(jsonArray))]` on `ToTypedArray` states one half of its documented contract in the type system: never null out for an input that was not. The other half, null in null out, is not expressible there and is pinned by a test.

Folding the four call sites removed the two production sites that needed the attribute, so what rests on it now is the test: without it, asserting that a non-null array yields a non-null result needs a suppression, and with the suppression the test stops re-checking the claim at compile time. Deleting the attribute fails the test project at exactly those three lines.

## Evidence

Solution builds clean across all three target frameworks, no `ToTypedArray()!` left anywhere in `src` or `tests`.

The shared computation carries three assertions of its own, each driven red before it was believed. Types compare as text, per RFC 9396 section 12 - flipping the comparer to `OrdinalIgnoreCase` left the whole suite green before this, and a case-insensitive baseline admits a type nobody requested. What cannot be read is dropped rather than refused, which narrows the baseline and therefore admits less. And a null array names nothing, which is what leaves each caller free to decide what null means.

`Abblix.Jwt.UnitTests` 581 passed, `Abblix.Oidc.Server.UnitTests` 2883 passed, 0 failed.

## Not done

A detector against the duplication returning is filed as #429. It has to be a source-level check with its own planted positive, which is a unit of work rather than a clause of this one.
