### PR TITLE
Do not warn about an expiry a loaded renewal already covers

### DIFF
--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -137,7 +137,7 @@ public partial class LicenseManager
     /// </remarks>
     internal License? GenerateActiveLicense(DateTimeOffset utcNow)
     {
-        var (result, expired, merged) = Scan(utcNow);
+        var (result, expired, merged, nextStartsAt) = Scan(utcNow);
 
         // What was MERGED is reported by whoever consults the licenses, for the same reason the expiry
         // below is: the scan also runs on every insert, while the list is still arriving, and a license in
@@ -146,7 +146,26 @@ public partial class LicenseManager
         if (merged is not null)
         {
             foreach (var (license, status) in merged)
+            {
+                // An expiry a loaded renewal already covers is not worth a warning. "Please renew promptly
+                // to avoid service interruption" is untrue of a deployment holding a license that starts
+                // before this one ends: there is no interruption to avoid, and the operator who acts on the
+                // record has nothing to do. A renewal starting AFTER the gap is a different matter and
+                // still says so, because the gap is real and only the operator can close it.
+                //
+                // Only the expiring-soon status is suppressed. A grace period means the license has already
+                // expired and the deployment is running on borrowed time, which a successor beginning later
+                // does not make untrue - and one beginning NOW is merged by the search above instead.
+                if (status == LicenseStatus.Active &&
+                    license.ExpiresAt is { } expiresAt &&
+                    nextStartsAt is { } starts &&
+                    starts <= expiresAt)
+                {
+                    continue;
+                }
+
                 ReportStatus(license, status, utcNow);
+            }
         }
 
         // An expiry is reported only when nothing was left in force, which is the fact that makes it worth
@@ -217,7 +236,7 @@ public partial class LicenseManager
     /// permanently degrade the server to FreeLicense. License lists are tiny, so a full scan is cheap.
     /// </remarks>
     private (License? InForce, IReadOnlyList<License>? Expired, IReadOnlyList<(License License,
-        LicenseStatus Status)>? Merged) Scan(DateTimeOffset utcNow)
+        LicenseStatus Status)>? Merged, DateTimeOffset? NextStartsAt) Scan(DateTimeOffset utcNow)
     {
         License? result = null;
         bool? activeLicenseFound = null;
@@ -254,19 +273,19 @@ public partial class LicenseManager
 
                 case LicenseStatus.NotActiveYet:
                     // Licenses are held sorted by the moment they start, so everything past this one starts
-                    // later still and the scan is over. Whatever the caller reports, it reports about the
-                    // licenses already collected, which is all of them that could matter for what is IN
-                    // FORCE now.
+                    // later still and the scan is over for what is IN FORCE now.
                     //
-                    // It is not all of them that could matter for what is SAID. A renewal starting before
-                    // the current license expires sits past this return, so an expiring-soon warning is
-                    // issued to a deployment that has already renewed. Tracked as issue 425 rather than
-                    // fixed here: the answer reaches into this early exit rather than into the reporting.
-                    return (result, expired, merged);
+                    // Not for what is worth SAYING, which is why this one moment travels out. The license
+                    // in hand is the EARLIEST-starting of the ones that have not begun, again because the
+                    // list is sorted, so a caller comparing it against an expiry learns whether the gap
+                    // between them is a gap at all - and a renewal already loaded that starts before the
+                    // current license ends leaves nothing to warn anybody about.
+                    return (result, expired, merged, license.NotBefore);
             }
         }
 
-        return (result, expired, merged);
+        // Nothing that has not started, so nothing to set against an expiry.
+        return (result, expired, merged, null);
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseManager.cs
@@ -137,7 +137,7 @@ public partial class LicenseManager
     /// </remarks>
     internal License? GenerateActiveLicense(DateTimeOffset utcNow)
     {
-        var (result, expired, merged, nextStartsAt) = Scan(utcNow);
+        var (result, expired, merged, next) = Scan(utcNow);
 
         // What was MERGED is reported by whoever consults the licenses, for the same reason the expiry
         // below is: the scan also runs on every insert, while the list is still arriving, and a license in
@@ -147,19 +147,19 @@ public partial class LicenseManager
         {
             foreach (var (license, status) in merged)
             {
-                // An expiry a loaded renewal already covers is not worth a warning. "Please renew promptly
-                // to avoid service interruption" is untrue of a deployment holding a license that starts
-                // before this one ends: there is no interruption to avoid, and the operator who acts on the
-                // record has nothing to do. A renewal starting AFTER the gap is a different matter and
-                // still says so, because the gap is real and only the operator can close it.
+                // An expiry a successor carries through is not worth a warning: "Please renew promptly
+                // to avoid service interruption" is untrue of a deployment that will not be interrupted,
+                // and the operator who acts on the record has nothing to do.
                 //
-                // Only the expiring-soon status is suppressed. A grace period means the license has already
-                // expired and the deployment is running on borrowed time, which a successor beginning later
-                // does not make untrue - and one beginning NOW is merged by the search above instead.
-                if (status == LicenseStatus.Active &&
-                    license.ExpiresAt is { } expiresAt &&
-                    nextStartsAt is { } starts &&
-                    starts <= expiresAt)
+                // What is NOT judged is what the successor is WORTH. One with fewer clients or a narrower
+                // issuer set carries the period and still changes what the deployment may do, and that is
+                // a different sentence - saying it through "renew promptly" would be untrue the other way.
+                //
+                // Only the expiring-soon status is suppressed. The arithmetic already excludes the others,
+                // since a license in its grace period has expired and nothing can start after now and
+                // before that - but the status is named anyway, so a later reader changing the dates does
+                // not silently widen what this covers.
+                if (status == LicenseStatus.Active && CarriedThrough(license, next))
                 {
                     continue;
                 }
@@ -236,7 +236,7 @@ public partial class LicenseManager
     /// permanently degrade the server to FreeLicense. License lists are tiny, so a full scan is cheap.
     /// </remarks>
     private (License? InForce, IReadOnlyList<License>? Expired, IReadOnlyList<(License License,
-        LicenseStatus Status)>? Merged, DateTimeOffset? NextStartsAt) Scan(DateTimeOffset utcNow)
+        LicenseStatus Status)>? Merged, License? Next) Scan(DateTimeOffset utcNow)
     {
         License? result = null;
         bool? activeLicenseFound = null;
@@ -280,7 +280,7 @@ public partial class LicenseManager
                     // list is sorted, so a caller comparing it against an expiry learns whether the gap
                     // between them is a gap at all - and a renewal already loaded that starts before the
                     // current license ends leaves nothing to warn anybody about.
-                    return (result, expired, merged, license.NotBefore);
+                    return (result, expired, merged, license);
             }
         }
 
@@ -373,6 +373,39 @@ public partial class LicenseManager
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="next"/> leaves no moment of <paramref name="license"/>'s expiry uncovered.
+    /// </summary>
+    /// <param name="license">The license about to expire.</param>
+    /// <param name="next">The earliest license that has not started yet, or <c>null</c> when there is none.
+    /// </param>
+    /// <remarks>
+    /// Two questions, and the second is the one that is easy to leave out. Starting before the expiry is
+    /// not the same as outliving it: a license that begins inside the window and ends FIRST is an add-on
+    /// bought alongside, or a short one issued by mistake, and the expiry is still coming. Suppressing
+    /// there would spend the last advance notice the deployment gets before it falls to the free tier,
+    /// which allows one issuer and throws on every other one this server has seen.
+    ///
+    /// The start is compared inclusively because <see cref="GetLicenseStatus"/> is: a license is active at
+    /// both of its endpoints, so a successor beginning at the instant this one ends leaves no moment
+    /// uncovered, and one beginning a tick later leaves exactly one.
+    ///
+    /// The end is compared strictly, for the mirror reason: a successor ending at the same instant moves
+    /// nothing, and the expiry a deployment is being warned about is still that instant. A successor with
+    /// no expiry outlives everything.
+    ///
+    /// Only the FIRST license that has not started is examined, which is the earliest of them. A chain
+    /// where a third license covers what the second does not therefore still produces the warning: that
+    /// errs toward saying something true and unnecessary rather than staying silent about a real lapse.
+    /// </remarks>
+    private static bool CarriedThrough(License license, License? next)
+    {
+        if (license.ExpiresAt is not { } expiresAt || next is not { NotBefore: { } starts })
+            return false;
+
+        return starts <= expiresAt && (next.ExpiresAt is not { } ends || expiresAt < ends);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -989,6 +989,48 @@ public class LicenseManagerTests
     }
 
     /// <summary>
+    /// A successor with no expiry outlives everything, so it silences the warning.
+    /// </summary>
+    /// <remarks>
+    /// A perpetual license is first-class here - <c>ExpiresAt</c> is nullable, the merge treats a null as
+    /// infinity, and the status walk falls straight through to Active - so this is an arrangement a
+    /// deployment can be in rather than a shape only a test can build.
+    ///
+    /// Pinned because the predicate says it in words: "A successor with no expiry outlives everything."
+    /// Requiring a non-null expiry there instead leaves every other test in this file green, so the
+    /// sentence would be the only thing holding the branch.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_PerpetualSuccessor_SaysNothing()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, 10) with { ClientLimit = 5 });
+        manager.AddLicense(
+            new License
+            {
+                NotBefore = Moment.AddDays(5),
+                ExpiresAt = null,
+                ClientLimit = 50,
+            });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.NotNull(manager.GenerateActiveLicense(Moment));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        Assert.DoesNotContain(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpiringSoon);
+    }
+
+    /// <summary>
     /// A successor starting at the exact moment the current license ends covers it; a tick later does not.
     /// </summary>
     /// <remarks>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -870,4 +870,79 @@ public class LicenseManagerTests
         Assert.Equal(LogEvents.Licensing.LicenseManager.LicenseInGracePeriod, record.EventId.Id);
         Assert.Equal(LogLevel.Error, record.Level);
     }
+
+    /// <summary>
+    /// A deployment whose renewal is already loaded is not told to renew promptly.
+    /// </summary>
+    /// <remarks>
+    /// "Please renew promptly to avoid service interruption" is untrue of a deployment that has renewed,
+    /// and the renewal here has not merely been bought: it is IN the manager, starting before the current
+    /// license ends, so there is no interruption to avoid.
+    ///
+    /// The successor sits past the scan's early return, which stops at the first license that has not
+    /// started. That return is right about what is IN FORCE - everything past it starts later still - and
+    /// wrong about what is worth SAYING, which is the whole of this.
+    ///
+    /// The renewal starts before the current license expires on purpose. A gap between them is a real
+    /// interruption and the warning is then the truth, which the test below holds.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_ExpiringSoonWithARenewalAlreadyLoaded_SaysNothing()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, 10) with { ClientLimit = 5 });
+        manager.AddLicense(LicenseAround(5, 100) with { ClientLimit = 50 });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            var active = manager.GenerateActiveLicense(Moment);
+            Assert.NotNull(active);
+            Assert.Equal(5, active!.ClientLimit);
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        Assert.DoesNotContain(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpiringSoon);
+    }
+
+    /// <summary>
+    /// A renewal that starts after the current license ends does not silence the warning.
+    /// </summary>
+    /// <remarks>
+    /// The control for the silence above, and the line the rule is drawn on. A successor beginning after
+    /// the gap is a successor the deployment will reach through an interruption, so "renew promptly" is
+    /// exactly right and the operator is the only one who can close it.
+    ///
+    /// Without this the same silence would hold over a manager that suppressed the warning whenever ANY
+    /// future license existed, which is the shape a guard written slightly too wide takes.
+    /// </remarks>
+    [Fact]
+    public void GenerateActiveLicense_ExpiringSoonWithARenewalStartingAfterTheGap_SaysSo()
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, 10) with { ClientLimit = 5 });
+        manager.AddLicense(LicenseAround(15, 100) with { ClientLimit = 50 });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.NotNull(manager.GenerateActiveLicense(Moment));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        var record = Assert.Single(records.Entries);
+        Assert.Equal(LogEvents.Licensing.LicenseManager.LicenseExpiringSoon, record.EventId.Id);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseManagerTests.cs
@@ -945,4 +945,95 @@ public class LicenseManagerTests
         var record = Assert.Single(records.Entries);
         Assert.Equal(LogEvents.Licensing.LicenseManager.LicenseExpiringSoon, record.EventId.Id);
     }
+
+    /// <summary>
+    /// A successor that starts in time and ends sooner does not silence the warning.
+    /// </summary>
+    /// <remarks>
+    /// Starting before the current license ends is not the same as carrying the deployment past it. An
+    /// add-on bought alongside, or a short licence issued by mistake, begins inside the window and is over
+    /// first - so the expiry is still coming, the warning is still true, and suppressing it would spend the
+    /// last advance notice the deployment gets. What follows is the free tier, which allows one issuer and
+    /// throws on every other one this server has seen.
+    ///
+    /// Three shapes, because they fail the same test for different reasons: one that ends before the
+    /// current license does, one whose own end precedes its own start, which is a record a host can write,
+    /// and one ending at the SAME instant - which moves nothing, since the expiry being warned about is
+    /// still that instant.
+    /// </remarks>
+    [Theory]
+    [InlineData(8)]
+    [InlineData(3)]
+    [InlineData(10)]
+    public void GenerateActiveLicense_SuccessorThatDoesNotOutliveTheCurrentOne_SaysSo(int successorExpiresAt)
+    {
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, 10) with { ClientLimit = 5 });
+        manager.AddLicense(LicenseAround(5, successorExpiresAt) with { ClientLimit = 50 });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.NotNull(manager.GenerateActiveLicense(Moment));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        Assert.Contains(
+            records.Entries,
+            entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpiringSoon);
+    }
+
+    /// <summary>
+    /// A successor starting at the exact moment the current license ends covers it; a tick later does not.
+    /// </summary>
+    /// <remarks>
+    /// The line the rule is drawn on, and it is drawn where <c>GetLicenseStatus</c> draws it: a license is
+    /// active at both of its endpoints, so a successor beginning at the instant the current one ends leaves
+    /// no moment uncovered, and one beginning a tick after leaves exactly one.
+    ///
+    /// Pinned because the comparison is a single character. Relaxing it to a strict one leaves every other
+    /// test in this file green, which is what makes the boundary worth its own arrangement rather than a
+    /// remark.
+    /// </remarks>
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    public void GenerateActiveLicense_SuccessorAtTheBoundary_SpeaksOnlyWhenAMomentIsUncovered(
+        int ticksAfterTheExpiry,
+        bool expectsWarning)
+    {
+        var expiresAt = Moment.AddDays(10);
+
+        var manager = new LicenseManager();
+        manager.AddLicense(LicenseAround(-20, 10) with { ClientLimit = 5 });
+        manager.AddLicense(
+            new License
+            {
+                NotBefore = expiresAt.AddTicks(ticksAfterTheExpiry),
+                ExpiresAt = Moment.AddDays(100),
+                ClientLimit = 50,
+            });
+
+        TestLicense.ClearLogThrottle();
+        var records = new RecordingLoggerFactory();
+        LicenseLogger.Instance.Init(records);
+        try
+        {
+            Assert.NotNull(manager.GenerateActiveLicense(Moment));
+        }
+        finally
+        {
+            LicenseLogger.Instance.Init(NullLoggerFactory.Instance);
+        }
+
+        Assert.Equal(
+            expectsWarning,
+            records.Entries.Any(
+                entry => entry.EventId.Id == LogEvents.Licensing.LicenseManager.LicenseExpiringSoon));
+    }
 }


### PR DESCRIPTION
Closes #425.

## What was said, and why it was wrong

A licence expiring in ten days beside a renewal that starts in five produced `License expiring soon: ... Please renew promptly to avoid service interruption`. The renewal was not merely bought - it was already in the manager, starting before the current licence ends, so there was no interruption to avoid and nothing for the operator to do with the record.

The scan stops at the first licence that has not started. That is right about what is IN FORCE: licences are held sorted by the moment each begins, so everything past that point begins later still and cannot apply now. It is not right about what is worth SAYING, and that is the whole of this.

## The change

The licence in hand at that early return is the earliest-starting of the ones that have not begun, again because the list is sorted. So one moment travels out of the scan, and the caller sets it against the expiry it is about to warn on.

Coverage is TWO conditions, not one. A successor must start at or before the expiry AND outlive it. The first draft had only the first half, and that is the half anybody thinks of first: a licence beginning inside the window and ending FIRST is an add-on bought alongside, or a short one issued by mistake - the expiry is still coming, the warning was true, and suppressing it spent the last advance notice the deployment gets. What follows is the free tier, which allows one issuer and throws on every other one this server has seen, so the silence would have ended at a request rather than at a log line.

The start compares inclusively and the end strictly, and the asymmetry is not a preference: a licence is active at both of its endpoints, so a successor beginning at the instant this one ends leaves no moment uncovered, while one ending at that instant moves nothing.

Only the expiring-soon status is suppressed. A grace period means the licence has already expired and the deployment is on borrowed time, which a successor beginning later does not make untrue - and one beginning now is merged by the search that already exists rather than reported.

Only the FIRST licence that has not started is examined. A chain where a third covers what the second does not therefore still warns, which errs toward saying something true and unnecessary rather than staying silent about a real lapse.

## Evidence

The suppression test was driven red before the change and is the only test that failed.

Five arrangements pin the condition, and each fails on its own clause alone:

| what was mutated | tests failed |
|---|---|
| require the successor to carry an expiry | 1 - the perpetual successor only |
| `starts <= expiresAt` weakened to `<` | 1 - the boundary case only |
| `expiresAt < ends` weakened to `<=` | 1 - the successor ending at the same instant only |
| drop the outlives clause entirely | 3 - all three coverage cases |
| drop `status == Active` | 0 - it guards a future edit, not a present input |

Each mutation compiled with zero errors before its count was read.

The control is the line the rule is drawn on: a renewal starting AFTER the current licence ends still produces the warning, because that gap is a real interruption and only the operator can close it. Widening the condition to "any future licence exists" fails that control and nothing else.

Unit project 2891 passed, 0 failed on the merged state.

## What this does not answer

What the successor is WORTH is not judged here. One that covers the period and grants less still changes what the deployment may do, and saying that through "renew promptly to avoid service interruption" would be untrue the other way round. Filed as #432.
