### PR TITLE
Refuse an authorized device record that carries no grant

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -108,10 +108,10 @@ public partial class BackChannelAuthenticationGrantHandler(
         var grant = result.GetSuccess();
 
         // Judged again, on what was actually consumed. The processor removes the stored entry and returns
-        // the grant it found there, so between the check above and that removal the host - which owns the
-        // same storage - can replace what is stored, which is the ordinary shape of a retried or corrected
-        // completion rather than an attack. Approving one grant and handing over another is the whole
-        // failure this comparison exists to prevent.
+        // the grant it found there, so between the check above and that removal a host - writing to that
+        // same storage through the public seam - can replace what is stored, which is the ordinary shape
+        // of a retried or corrected completion rather than an attack. Approving one grant and handing over
+        // another is the whole failure this comparison exists to prevent.
         if (!NamesTheRequestedEndUser(request.RequestedSubjects, grant, clientInfo))
             return NotTheRequestedEndUser();
 

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -81,8 +81,8 @@ public partial class BackChannelAuthenticationGrantHandler(
     /// Judged twice, on two different objects, because one comparison cannot do both jobs. Before the
     /// request is consumed, so an ordinary mismatch spends nothing - redeeming removes the stored entry.
     /// And again on the grant the processor returned, because the processor consumes the stored request
-    /// itself, and between the earlier read and that removal the host - which owns the same storage - can
-    /// replace what is stored. Judging only the earlier copy would approve one grant and hand over another.
+    /// itself, and between the earlier read and that removal a host - writing to that same storage through
+    /// the public seam - can replace what is stored. Judging only the earlier copy would approve one grant and hand over another.
     /// </para>
     /// </remarks>
     private async Task<Result<AuthorizedGrant, OidcError>> RedeemAsync(

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -69,7 +69,9 @@ partial class DeviceCodeGrantHandler
         Level = LogLevel.Error,
         Message = "Client {ClientId} presented a device code whose stored record is marked authorized " +
                   "and carries no AuthorizedGrant, so there is nothing to issue and the redemption is " +
-                  "refused. The record is written by whoever implements IDeviceAuthorizationStorage; " +
-                  "this library sets the grant and the status together.")]
+                  "refused. This library always sets the grant and the status together, so audit the " +
+                  "code outside it that writes a device authorization record - a call to " +
+                  "IDeviceAuthorizationStorage.UpdateAsync or StoreAsync, or a replacement registered " +
+                  "for that interface.")]
     private partial void LogAuthorizedRecordCarriesNoGrant(string ClientId);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -62,9 +62,10 @@ partial class DeviceCodeGrantHandler
     ///
     /// Error rather than Warning, and it names the MEMBER rather than the status: nothing in this library
     /// writes a record in this shape, so it is a defect in code outside it that WRITES one, and the
-    /// operator reading it needs to be sent to that writer rather than to the state machine. Not to
-    /// whoever implements the storage - this library ships and registers an implementation, so in a
-    /// default deployment that reader would be sent to look for code they never wrote.
+    /// operator reading it needs to be sent to that writer rather than to the state machine. The message
+    /// therefore leads with the calls a host makes, and names a replacement implementation only after
+    /// them: this library ships and registers one, so a reader sent to the implementer FIRST would go
+    /// looking for code they never wrote.
     /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Device.DeviceCodeGrantHandler.AuthorizedRecordCarriesNoGrant,

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -61,8 +61,10 @@ partial class DeviceCodeGrantHandler
     /// and a second poll answers expired_token. Nothing else says what was wrong with it.
     ///
     /// Error rather than Warning, and it names the MEMBER rather than the status: nothing in this library
-    /// writes a record in this shape, so it is a host-side defect in code that owns the storage, and the
-    /// operator reading it needs to be sent to the writer rather than to the state machine.
+    /// writes a record in this shape, so it is a defect in code outside it that WRITES one, and the
+    /// operator reading it needs to be sent to that writer rather than to the state machine. Not to
+    /// whoever implements the storage - this library ships and registers an implementation, so in a
+    /// default deployment that reader would be sent to look for code they never wrote.
     /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Device.DeviceCodeGrantHandler.AuthorizedRecordCarriesNoGrant,

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.Logging.cs
@@ -52,4 +52,24 @@ partial class DeviceCodeGrantHandler
         Message = "Client {ClientId} presented a device code whose stored grant the per-type validators " +
                   "will not issue, so the redemption is refused and no token was issued: {Reason}")]
     private partial void LogGrantedAuthorizationDetailsRefused(string ClientId, string Reason);
+
+    /// <summary>
+    /// The only account of a record that cannot be looked at afterwards.
+    /// </summary>
+    /// <remarks>
+    /// The device code is claimed before anything is judged, so by the time this fires the record is gone
+    /// and a second poll answers expired_token. Nothing else says what was wrong with it.
+    ///
+    /// Error rather than Warning, and it names the MEMBER rather than the status: nothing in this library
+    /// writes a record in this shape, so it is a host-side defect in code that owns the storage, and the
+    /// operator reading it needs to be sent to the writer rather than to the state machine.
+    /// </remarks>
+    [LoggerMessage(
+        EventId = LogEvents.Device.DeviceCodeGrantHandler.AuthorizedRecordCarriesNoGrant,
+        Level = LogLevel.Error,
+        Message = "Client {ClientId} presented a device code whose stored record is marked authorized " +
+                  "and carries no AuthorizedGrant, so there is nothing to issue and the redemption is " +
+                  "refused. The record is written by whoever implements IDeviceAuthorizationStorage; " +
+                  "this library sets the grant and the status together.")]
+    private partial void LogAuthorizedRecordCarriesNoGrant(string ClientId);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -158,10 +158,13 @@ public partial class DeviceCodeGrantHandler(
             // is why it names the missing member rather than the status, and why it sits at Error.
             //
             // Refusing WITHOUT consuming the code, so the record survives for an operator to inspect, is
-            // the real alternative, and it would have to be taken in that same claiming arm rather than
-            // here - by the time this is reached the code is spent. It is declined because that arm is
-            // where single use is enforced, and carving an exception out of it would make whether a device
-            // code survives redemption depend on which member of the record happened to be missing.
+            // the real alternative. It cannot be taken HERE, because by this point the code is already
+            // spent, but it could be taken in an arm of its own placed above the claiming one - a property
+            // pattern naming the missing member compiles there and leaves storage untouched.
+            //
+            // Declined anyway. Such an arm carves an exception out of single use, and makes whether a
+            // device code survives its redemption depend on which member of the record happened to be
+            // missing - a rule nobody would find while reading either arm on its own.
             //
             // invalid_grant rather than one of the device-specific codes: section 3.5 admits the errors of
             // RFC 6749 section 5.2 alongside its own four, and this is a grant that cannot be used rather

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -102,9 +102,9 @@ public partial class DeviceCodeGrantHandler(
             case { Status: DeviceAuthorizationStatus.Authorized, AuthorizedGrant: { } authorizedGrant }:
 
                 // Judged again, on what is actually being redeemed. IUserCodeVerificationService refuses a
-                // widened grant when the end user approves, but the host owns the same storage and can
-                // write to it afterwards - a retried or corrected approval is the ordinary shape of that,
-                // not an attack. CIBA judges at both ends for the same reason.
+                // widened grant when the end user approves, but a host writes to that same storage through
+                // the public seam and can do so afterwards - a retried or corrected approval is the ordinary
+                // shape of that, not an attack. CIBA judges at both ends for the same reason.
                 //
                 // What this catches is a host that FORGOT, not one that lies: the baseline it compares
                 // against lives in the same host-owned record, so anything able to widen the grant can
@@ -158,9 +158,10 @@ public partial class DeviceCodeGrantHandler(
             // is why it names the missing member rather than the status, and why it sits at Error.
             //
             // Refusing WITHOUT consuming the code, so the record survives for an operator to inspect, is
-            // the real alternative. It is declined because single use is enforced one arm above, and an
-            // exception here would be a second, quieter rule about when a device code survives
-            // redemption, triggered by which member of the record happened to be missing.
+            // the real alternative, and it would have to be taken in that same claiming arm rather than
+            // here - by the time this is reached the code is spent. It is declined because that arm is
+            // where single use is enforced, and carving an exception out of it would make whether a device
+            // code survives redemption depend on which member of the record happened to be missing.
             //
             // invalid_grant rather than one of the device-specific codes: section 3.5 admits the errors of
             // RFC 6749 section 5.2 alongside its own four, and this is a grant that cannot be used rather

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -142,6 +142,31 @@ public partial class DeviceCodeGrantHandler(
 
                 return authorizedGrant;
 
+            // Authorized, and nothing to issue from. Reached only when the grant is missing, because the
+            // arm above binds it - and nothing in this library writes such a record: approval sets the
+            // grant beside the status. A host owns this storage and can write the two apart.
+            //
+            // What it used to reach was the default arm, which threw naming the STATUS: "Unexpected device
+            // authorization status: Authorized", about a status this switch plainly handles. The client
+            // got HTTP 500 and an operator got a sentence pointing at a state machine that is not the
+            // problem.
+            //
+            // The code is already claimed by the arm two above, which removes before anything is judged,
+            // and RFC 8628 section 3.5 has each device code exchanged once - so the record is gone, a
+            // retry answers expired_token, and this log line is the only account of what happened. That is
+            // why it names the missing member rather than the status.
+            //
+            // invalid_grant rather than one of the device-specific codes: section 3.5 admits the errors of
+            // RFC 6749 section 5.2 alongside its own four, and this is a grant that cannot be used rather
+            // than one the end user denied or one that ran out of time.
+            case { Status: DeviceAuthorizationStatus.Authorized }:
+
+                LogAuthorizedRecordCarriesNoGrant(clientInfo.ClientId);
+
+                return new OidcError(
+                    ErrorCodes.InvalidGrant,
+                    "The device authorization cannot be redeemed");
+
             // Authorization still pending - check polling rate
             case { Status: DeviceAuthorizationStatus.Pending, NextPollAt: { } nextPollAt }
                 when now < nextPollAt:

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -90,9 +90,9 @@ public partial class DeviceCodeGrantHandler(
             case { Status: DeviceAuthorizationStatus.Authorized }
                 when !await storage.TryRemoveAsync(request.DeviceCode, deviceRequest.UserCode):
 
-                // Use atomic get-and-remove to prevent race conditions where two concurrent requests
-                // could both retrieve the authorized grant. Per RFC 8628 Section 3.5, each device code
-                // MUST only be exchanged for tokens once.
+                // Atomic get-and-remove, so two concurrent polls cannot both retrieve the authorized
+                // grant and both be issued tokens. RFC 8628 states no such rule anywhere - exchanging a
+                // device code once is this library's decision, and this arm is where it is enforced.
 
                 return new OidcError(
                     ErrorCodes.ExpiredToken,
@@ -144,17 +144,23 @@ public partial class DeviceCodeGrantHandler(
 
             // Authorized, and nothing to issue from. Reached only when the grant is missing, because the
             // arm above binds it - and nothing in this library writes such a record: approval sets the
-            // grant beside the status. A host owns this storage and can write the two apart.
+            // grant beside the status. Both members are public and settable on a record any host can read
+            // back through the public storage interface, so writing the two apart takes one line.
             //
             // What it used to reach was the default arm, which threw naming the STATUS: "Unexpected device
             // authorization status: Authorized", about a status this switch plainly handles. The client
             // got HTTP 500 and an operator got a sentence pointing at a state machine that is not the
             // problem.
             //
-            // The code is already claimed by the arm two above, which removes before anything is judged,
-            // and RFC 8628 section 3.5 has each device code exchanged once - so the record is gone, a
-            // retry answers expired_token, and this log line is the only account of what happened. That is
-            // why it names the missing member rather than the status.
+            // The code is already claimed by the arm two above, which removes it before anything is
+            // judged, so the record is gone by the time this is reached: a retry answers expired_token and
+            // nobody can look at what was stored. That makes this log line the only account of it, which
+            // is why it names the missing member rather than the status, and why it sits at Error.
+            //
+            // Refusing WITHOUT consuming the code, so the record survives for an operator to inspect, is
+            // the real alternative. It is declined because single use is enforced one arm above, and an
+            // exception here would be a second, quieter rule about when a device code survives
+            // redemption, triggered by which member of the record happened to be missing.
             //
             // invalid_grant rather than one of the device-specific codes: section 3.5 admits the errors of
             // RFC 6749 section 5.2 alongside its own four, and this is a grant that cannot be used rather

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -12,9 +12,16 @@ namespace Abblix.Oidc.Server;
 /// Named EventId constants for every <c>[LoggerMessage]</c> in this assembly,
 /// grouped into nested static classes per feature area. Refer to events as
 /// <c>LogEvents.Endpoints.SomeEvent</c>, <c>LogEvents.ClientAuth.SomeEvent</c>,
-/// etc., from the attribute. See <c>LOGGING.md</c> at the repository root for
-/// the canonical range allocation and authoring rules.
+/// etc., from the attribute.
 /// </summary>
+/// <remarks>
+/// This file is the range allocation; there is no companion document. Each range and sub-range carries
+/// its own bounds, and where the bounds are not round, the reason.
+///
+/// Read the neighbours before taking a number. Several windows are narrower than they look, because
+/// something that is not theirs sits inside them, and an id already in a deployment's alerts cannot move -
+/// so a class needing one more takes a second window rather than displacing anybody.
+/// </remarks>
 internal static class LogEvents
 {
     /// <summary>
@@ -447,9 +454,15 @@ internal static class LogEvents
     }
 
     /// <summary>
-    /// Range 7000-7099: <c>Features/DeviceAuthorization</c>,
+    /// Range 7000-7199: <c>Features/DeviceAuthorization</c>,
     /// <c>Features/BackChannelAuthentication</c>, <c>Features/LogoutNotification</c>.
     /// </summary>
+    /// <remarks>
+    /// Widened from 7000-7099 rather than continued elsewhere. 7000-7099 was allocated to the last id,
+    /// and the two sub-ranges that could have grown are hemmed in by a back-channel logout sender sitting
+    /// between them - moving that would change ids a deployment may already alert on. 7100-7199 was free,
+    /// so a class needing a third id takes a second window here and keeps its name.
+    /// </remarks>
     public static class Device
     {
         /// <summary>
@@ -584,13 +597,13 @@ internal static class LogEvents
 
         /// <summary>
         /// <c>Endpoints/Token/Grants/DeviceCodeGrantHandler.cs</c> - what the token endpoint refuses when
-        /// the stored grant no longer matches the request (sub-range 7083-7084).
+        /// the stored record is not one a token can be issued from (sub-ranges 7083-7084 and 7100-7119).
         /// </summary>
         /// <remarks>
-        /// Two ids rather than a round ten, because this is what the Device range has left: 7085-7099
+        /// Two windows rather than one, because 7083-7084 is all the original range had left: 7085-7099
         /// belongs to the back-channel logout sender above, which sits in this range and is not the device
-        /// flow at all. Moving it would change ids an operator may already alert on, so the misfiling stays
-        /// and the window here is honest about its size. A third event needs the range widened first.
+        /// flow at all. Moving either that or the two ids below would change ids a deployment may already
+        /// alert on, so the third event takes the range's continuation instead.
         /// </remarks>
         public static class DeviceCodeGrantHandler
         {
@@ -598,6 +611,10 @@ internal static class LogEvents
 
             public const int GrantedAuthorizationDetailsExceedTheRequest = Base;
             public const int GrantedAuthorizationDetailsRefused = Base + 1;
+
+            private const int Continued = 7100;
+
+            public const int AuthorizedRecordCarriesNoGrant = Continued;
         }
     }
 

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -207,7 +207,8 @@ public static class DistributedCacheExtensions
 		// The value must still exist at the moment we hold the lock. Without this check a caller whose lock
 		// window does not overlap a prior successful removal would still see its own token survive and wrongly
 		// report success - breaking exactly-once removal (two token requests both redeeming the same
-		// device_code / authorization code, RFC 8628 §3.5 / RFC 6749 §4.1.2). The documented contract is
+		// device_code or authorization code). RFC 6749 §4.1.2 forbids reusing an authorization code; for a
+		// device_code no RFC says so, and single use is this codebase's own rule. The documented contract is
 		// "false if ... the key didn't exist".
 		if (await cache.GetAsync(key, cancellationToken) == null)
 		{

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -226,8 +226,9 @@ public class BackChannelAuthenticationGrantHandlerTests
 
     /// <summary>
     /// The completion path judges what the end user approved, and the redemption judges it again, for the
-    /// reason the subject comparison beside it already does: the host owns the same storage and can replace
-    /// the stored grant between the two, which is the ordinary shape of a retried or corrected completion.
+    /// reason the subject comparison beside it already does: a host writes to that same storage through the
+    /// public seam and can replace the stored grant between the two, which is the ordinary shape of a retried
+    /// or corrected completion.
     /// A host that never calls the completion path at all reaches this check and nothing else.
     /// </summary>
     [Fact]
@@ -1262,9 +1263,9 @@ public class BackChannelAuthenticationGrantHandlerTests
     /// </summary>
     /// <remarks>
     /// The grant processor consumes the stored request itself: it removes the entry and returns the grant it
-    /// found there. Between the handler's read and that removal, the host - which owns the same storage -
-    /// can replace what is stored, which is the ordinary shape of a retried or corrected completion rather
-    /// than an attack. Judging the earlier copy would approve one grant and hand over another.
+    /// found there. Between the handler's read and that removal, a host - writing to that same storage
+    /// through the public seam - can replace what is stored, which is the ordinary shape of a retried or
+    /// corrected completion rather than an attack. Judging the earlier copy would approve one grant and hand over another.
     /// <para>
     /// Driven by making the two reads disagree, which is what every other test here cannot do: they stub
     /// both calls to return the same object, so no arrangement of them could observe this.

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -776,7 +776,7 @@ public class DeviceCodeGrantHandlerTests
     }
 
     /// <summary>
-    /// RFC 8628 §3.5: a poll that races a just-completed approval must not overwrite the Authorized
+    /// A poll that races a just-completed approval must not overwrite the Authorized
     /// status with its stale Pending snapshot. The handler must re-read and surface the granted tokens
     /// instead of persisting authorization_pending forever.
     /// </summary>
@@ -862,15 +862,19 @@ public class DeviceCodeGrantHandlerTests
     /// </summary>
     /// <remarks>
     /// Nothing in this library writes that record - the approval always sets the grant beside the status -
-    /// so it comes from a host writing the seam itself. What it used to reach was the switch's default
+    /// so it comes from a host writing the record itself, which takes one line: both members are public
+    /// and settable, and the storage that holds them is a public interface. What it used to reach was the
+    /// switch's default
     /// arm, which threw naming the status: "Unexpected device authorization status: Authorized", about a
     /// status the switch plainly handles. The client got HTTP 500 and an operator got a sentence pointing
     /// at a state machine that is not the problem.
     ///
     /// The device code is already gone by then, because the arm above claims it before anything else is
-    /// judged, and RFC 8628 section 3.5 has each code exchanged once - so a retry answers expired_token
-    /// and the record cannot be looked at afterwards. That makes the log line the only account of it, and
-    /// the reason it names the missing member rather than the status.
+    /// judged - so a retry answers expired_token and the record cannot be looked at afterwards. That makes
+    /// the log line the only account of it, and the reason it names the missing member rather than the
+    /// status. Exchanging a device code once is this library's decision rather than an RFC 8628 rule, and
+    /// refusing here without consuming the code was declined as a quieter second rule about when a code
+    /// survives redemption.
     ///
     /// invalid_grant rather than a device-specific code: section 3.5 admits the errors of RFC 6749
     /// section 5.2 alongside its own four, and this is a grant that is not usable rather than one the end

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -856,4 +856,46 @@ public class DeviceCodeGrantHandlerTests
         Assert.Equal(ErrorCodes.AuthorizationPending, error.Error);
         Assert.Equal(TimeSpan.FromMinutes(3), capturedTtl);
     }
+
+    /// <summary>
+    /// A record marked authorized with no grant on it is refused, not thrown at.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in this library writes that record - the approval always sets the grant beside the status -
+    /// so it comes from a host writing the seam itself. What it used to reach was the switch's default
+    /// arm, which threw naming the status: "Unexpected device authorization status: Authorized", about a
+    /// status the switch plainly handles. The client got HTTP 500 and an operator got a sentence pointing
+    /// at a state machine that is not the problem.
+    ///
+    /// The device code is already gone by then, because the arm above claims it before anything else is
+    /// judged, and RFC 8628 section 3.5 has each code exchanged once - so a retry answers expired_token
+    /// and the record cannot be looked at afterwards. That makes the log line the only account of it, and
+    /// the reason it names the missing member rather than the status.
+    ///
+    /// invalid_grant rather than a device-specific code: section 3.5 admits the errors of RFC 6749
+    /// section 5.2 alongside its own four, and this is a grant that is not usable rather than one the end
+    /// user denied or one that expired.
+    /// </remarks>
+    [Fact]
+    public async Task AuthorizedRecordWithNoGrant_IsRefusedRatherThanThrown()
+    {
+        var clientInfo = new ClientInfo(ClientId);
+        var tokenRequest = new TokenRequest { DeviceCode = DeviceCode };
+
+        var deviceRequest = new StoredDeviceAuthorizationRequest(ClientId, [Scopes.OpenId], null, UserCode)
+        {
+            Status = DeviceAuthorizationStatus.Authorized,
+            AuthorizedGrant = null,
+            ExpiresAt = _currentTime.AddMinutes(15),
+        };
+
+        _storage.Setup(storage => storage.TryGetByDeviceCodeAsync(DeviceCode)).ReturnsAsync(deviceRequest);
+        _storage.Setup(storage => storage.TryRemoveAsync(DeviceCode, UserCode)).ReturnsAsync(true);
+
+        var result = await _handler.AuthorizeAsync(
+            tokenRequest, clientInfo, TestContext.Current.CancellationToken);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -138,9 +138,10 @@ public class DeviceCodeGrantHandlerTests
     /// A stored grant carrying a type the device never asked for is refused when the code is redeemed.
     /// </summary>
     /// <remarks>
-    /// The approval path already refuses a widened grant, and that check is not enough on its own: the host
-    /// owns this storage and can write to it after approving, which a retried or corrected approval does
-    /// routinely. Between the two the device polls, and whatever is stored by then is what would be issued.
+    /// The approval path already refuses a widened grant, and that check is not enough on its own: a host
+    /// writes to that same storage through the public seam and can do so after approving, which a retried or
+    /// corrected approval does routinely. Between the two the device polls, and whatever is stored by then
+    /// is what would be issued.
     ///
     /// The comparison costs no new state because the record still carries what the client asked for, and it
     /// is the same computation the approval path runs rather than a second one written to match.

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -870,7 +870,7 @@ public class DeviceCodeGrantHandlerTests
     /// status the switch plainly handles. The client got HTTP 500 and an operator got a sentence pointing
     /// at a state machine that is not the problem.
     ///
-    /// The device code is already gone by then, because the arm above claims it before anything else is
+    /// The device code is already gone by then, because the claiming arm takes it before anything else is
     /// judged - so a retry answers expired_token and the record cannot be looked at afterwards. That makes
     /// the log line the only account of it, and the reason it names the missing member rather than the
     /// status. Exchanging a device code once is this library's decision rather than an RFC 8628 rule, and

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(148, EventIds().Count);
+        Assert.Equal(149, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Utils.UnitTests/DistributedCacheExtensionsTests.cs
+++ b/tests/Abblix.Utils.UnitTests/DistributedCacheExtensionsTests.cs
@@ -251,7 +251,8 @@ public class DistributedCacheExtensionsTests
 	{
 		// The documented contract is "false if ... the key didn't exist". Without a value-existence
 		// check the protocol only verified its own lock token survived and wrongly reported success,
-		// breaking exactly-once removal (RFC 8628 3.5, RFC 6749 4.1.2) across non-overlapping lock windows.
+		// breaking exactly-once removal across non-overlapping lock windows - which RFC 6749 4.1.2 requires
+		// of an authorization code, and which this codebase additionally chooses for a device_code.
 		var cache = CreateCache();
 
 		var result = await cache.TryRemoveAsync("nonexistent-key", cancellationToken: TestContext.Current.CancellationToken);


### PR DESCRIPTION
Closes #414.

## What it did

A stored device record marked `Authorized` with no `AuthorizedGrant` fell through every arm of the switch to the `default`, which threw naming the STATUS:

    Unexpected device authorization status: Authorized

about a status the switch plainly handles. The client got HTTP 500, and an operator reading that sentence went looking for a state-machine defect that is not there.

Nothing in this library writes such a record - approval sets the grant beside the status. It comes from code outside the library writing the record itself, which takes one line: `Status` and `AuthorizedGrant` are public and settable, and `UpdateAsync`/`StoreAsync` are public on a public interface. That is what the log line names, rather than the flow.

Note what it does NOT name. An earlier draft sent the operator to whoever implements `IDeviceAuthorizationStorage`, and in a default deployment that is this library: `ServiceCollectionExtensions` registers `DeviceAuthorizationStorage` with `TryAddSingleton`, so the reader would go looking for an implementation they never wrote and find Abblix's. The realistic writer CALLS the seam.

## Why the log line carries the weight

The record is gone by the time this is reached. The arm two above claims the device code before anything is judged, so a retry answers `expired_token` and nobody can look at what was stored afterwards. The log line is therefore the only account of it, which is why it names the missing member rather than the status, and why it is at Error.

Refusing WITHOUT consuming the code, so the record survives for an operator to inspect, is the alternative #414 asked about. Declined: single use is enforced one arm above, and an exception here would be a second, quieter rule about when a device code survives redemption, triggered by which member of the record happened to be missing.

`invalid_grant` on the wire: section 3.5 admits the errors of RFC 6749 section 5.2 alongside its own four ("In addition to the error codes defined in Section 5.2 of [RFC6749]..."), and this is a grant that cannot be used rather than one the end user denied or one that ran out of time.

## A citation that was not there

Five comments in this repository attributed single use of the device code to RFC 8628 section 3.5, one of them as a `MUST`. That section is the token endpoint's response: four error codes and the polling behaviour. Neither it nor any other part of RFC 8628 says a device code may be exchanged only once.

It mattered because it decided something - the alternative above was declined citing it. Single use is worth having on its own terms, and it is what the atomic get-and-remove one arm above is for, so two concurrent polls cannot both redeem one authorization. But it is this codebase's choice, and the comments now say so.

Two of the five paired the invention with a real reference, `RFC 8628 §3.5 / RFC 6749 §4.1.2`, which is how it survived a reader: 6749 §4.1.2 does carry "MUST NOT be used more than once" for an authorization code, and the true half lent the invented half its credibility. Those two live in `Abblix.Utils` and predate this branch; they are fixed here rather than left behind, because a repaired copy is what stops anyone looking at the rest.

## The event id, and the range that had none left

`DeviceCodeGrantHandler` had 7083-7084 and nothing more: 7085-7099 belongs to a back-channel logout sender that sits inside the Device range and is not the device flow, and neither that nor the two ids below it can move without changing what a deployment may already alert on. Its own comment said a third event needed the range widened first.

7100-7199 was unallocated, so the range is 7000-7199 now and the class takes a second window rather than displacing anybody.

## One thing found on the way

The file's header pointed at a `LOGGING.md` at the repository root for the canonical range allocation. There is no such file, and `git log` shows none was ever deleted. The header now says what is true - this file is the allocation - and carries the thing a reader most needs before taking a number: read the neighbours, because several windows are narrower than they look.

## Evidence

The test was driven red before the change: it failed on the thrown `InvalidOperationException`, which is what the arm replaces.

Five mutations, four of which built with 0 errors and produced a red test - restoring the throw, changing the error code, moving the arm so it catches the removed-record path instead, and putting a grant back on the record. The fifth is the compiler's: a `{ Status: Authorized }` case placed before `{ Status: Authorized, AuthorizedGrant: { } }` makes the latter unreachable and `error CS8120` refuses it on all three target frameworks.

The log-event id count was recounted independently by parsing brace scopes and evaluating every `const int`, ignoring comments: 149 public ids on the branch against 148 on develop, zero duplicates, nothing else occupying 7100-7199.

Unit project 2884 passed, 0 failed. `Abblix.Utils` 284 passed, 0 failed.
