### PR TITLE
Drive CIBA push delivery and authorization_details end to end

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/PushModeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/PushModeValidator.cs
@@ -37,8 +37,11 @@ public class PushModeValidator : IBackChannelAuthenticationContextValidator
                 "The client is not configured with a backchannel_client_notification_endpoint"));
         }
 
-        // HTTPS enforcement per CIBA spec Section 10.3.1:
-        // Push mode token delivery endpoint MUST use HTTPS for security
+        // CIBA Core 1.0 Section 9 states both rules in one sentence: "It MUST be an HTTPS URL and
+        // Communication with the Client Notification Endpoint MUST utilize TLS." Only the first is a
+        // property of the registered value and checkable here; the second is the transport the host
+        // establishes when it calls the endpoint. Section 10.3.1 is about what is delivered and says
+        // nothing about the scheme.
         if (!string.Equals(
             context.ClientInfo.BackChannelClientNotificationEndpoint.Scheme,
             Uri.UriSchemeHttps,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PingModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PingModeCompletionHandler.cs
@@ -36,7 +36,7 @@ public partial class PingModeCompletionHandler(
     private readonly IBackChannelRequestStorage _storage = storage;
 
     /// <summary>
-    /// Handles ping mode token delivery by storing tokens and sending a notification to the client.
+    /// Handles ping mode delivery by storing the authenticated request and sending a notification to the client.
     /// The client will poll the token endpoint after receiving the notification.
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PollModeCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PollModeCompletionHandler.Logging.cs
@@ -15,6 +15,7 @@ partial class PollModeCompletionHandler
     [LoggerMessage(
         EventId = LogEvents.Device.PollModeCompletionHandler.TokensStored,
         Level = LogLevel.Debug,
-        Message = "Poll mode - tokens stored for auth_req_id: {AuthReqId}")]
+        Message = "Poll mode - the authenticated request is stored for auth_req_id: {AuthReqId}. No " +
+                  "token exists yet; they are minted at the token endpoint when the client redeems")]
     private partial void LogTokensStored(string AuthReqId);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
@@ -33,7 +33,11 @@ partial class PushModeCompletionHandler
     [LoggerMessage(
         EventId = LogEvents.Device.PushModeCompletionHandler.PushDeliveryFailed,
         Level = LogLevel.Warning,
-        Message = "CIBA push delivery failed for auth_req_id: {AuthReqId}; the authenticated request is retained until it expires")]
+        Message = "CIBA push delivery failed for auth_req_id: {AuthReqId}. The tokens were minted and " +
+                  "are gone - nothing retries them. What is left in storage is the request as it stood " +
+                  "BEFORE the completion, still Pending and still carrying what the client asked for " +
+                  "rather than what the end user approved, because push never writes back. It expires on " +
+                  "its own and cannot be completed again from what is stored.")]
     private partial void LogPushDeliveryFailed(string AuthReqId);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
@@ -35,9 +35,11 @@ partial class PushModeCompletionHandler
         Level = LogLevel.Warning,
         Message = "CIBA push delivery failed for auth_req_id: {AuthReqId}. The tokens were minted and " +
                   "are gone - nothing retries them. What is left in storage is the request as it stood " +
-                  "BEFORE the completion, still Pending and still carrying what the client asked for " +
-                  "rather than what the end user approved, because push never writes back. It expires on " +
-                  "its own and cannot be completed again from what is stored.")]
+                  "BEFORE the completion, because push never writes back: still Pending, still carrying " +
+                  "what the client asked for rather than what the end user approved, and still carrying " +
+                  "the session from initiation. It expires on its own, and until it does it CAN be " +
+                  "completed again - which would deliver what the end user refused, so treat a retry " +
+                  "from this record as re-asking the user rather than as resending.")]
     private partial void LogPushDeliveryFailed(string AuthReqId);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -157,9 +157,11 @@ public partial class PushModeCompletionHandler(
                 }
                 else
                 {
-                    // Delivery failed: keep the request so the tokens are not silently lost. Push
-                    // clients cannot poll, so removing here would orphan an authenticated grant the
-                    // client never received; instead it is retained until it expires.
+                    // Delivery failed, and the tokens just minted are dropped with this lambda - nothing
+                    // retries them. What is kept is the authenticated REQUEST, and the only thing that can
+                    // turn it back into tokens is a host reading storage and calling CompleteAsync again,
+                    // which is why it is retained rather than removed: removing it would take that
+                    // possibility away too. Left alone it expires on its own.
                     LogPushDeliveryFailed(authenticationRequestId);
                 }
 
@@ -169,9 +171,9 @@ public partial class PushModeCompletionHandler(
             {
                 LogTokenGenerationFailed(authenticationRequestId, error.Error);
 
-                // Removed after the attempt either way, for the same reason: nothing will come to
-                // collect it. Not a requirement of CIBA Core 1.0, which does not say.
-                // Push mode clients cannot poll, so storing denied status would orphan the request
+                // No tokens were minted, so there is nothing a second attempt could deliver and nothing
+                // for a host to complete again. Removed rather than marked denied, because a push client
+                // never polls and would never read the mark. Not a requirement of CIBA Core 1.0.
                 await _storage.TryRemoveAsync(authenticationRequestId);
 
                 return null;

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -20,7 +20,7 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.AuthenticationNo
 /// <summary>
 /// Handles CIBA push mode token delivery where tokens are sent directly to the client's notification endpoint
 /// immediately upon authentication completion.
-/// In push mode, tokens are generated, delivered via HTTP POST, and the request is removed from storage per CIBA spec 10.3.1.
+/// In push mode, tokens are generated, delivered via HTTP POST, and the request is removed from storage.
 /// </summary>
 /// <param name="logger">Logger for tracking notification events.</param>
 /// <param name="storage">Storage for authentication requests.</param>
@@ -59,7 +59,8 @@ public partial class PushModeCompletionHandler(
 
     /// <summary>
     /// Handles push mode token delivery by generating tokens and delivering them directly to the client endpoint.
-    /// The authentication request is removed from storage after successful delivery per CIBA spec 10.3.1.
+    /// The authentication request is removed from storage after successful delivery, because a push client
+    /// never polls: one left behind is an authenticated grant nobody reads until it expires.
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="request">The authenticated request containing the authorized grant.</param>
@@ -147,7 +148,10 @@ public partial class PushModeCompletionHandler(
 
                 if (delivered)
                 {
-                    // Per CIBA spec 10.3.1, remove after push delivery (unlike poll/ping modes).
+                    // Removed here and not in poll or ping mode, because only this client is finished
+                    // with the request: it has the tokens and will never come to the token endpoint.
+                    // CIBA Core 1.0 does not require this - section 10.3.1 says nothing about what the OP
+                    // keeps - so it is a choice, made because the alternative is an orphan.
                     await _storage.TryRemoveAsync(authenticationRequestId);
                     LogTokensDelivered(authenticationRequestId);
                 }
@@ -165,7 +169,8 @@ public partial class PushModeCompletionHandler(
             {
                 LogTokenGenerationFailed(authenticationRequestId, error.Error);
 
-                // Per CIBA spec 10.3.1, remove from storage after push attempt (success or failure)
+                // Removed after the attempt either way, for the same reason: nothing will come to
+                // collect it. Not a requirement of CIBA Core 1.0, which does not say.
                 // Push mode clients cannot poll, so storing denied status would orphan the request
                 await _storage.TryRemoveAsync(authenticationRequestId);
 

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -65,7 +65,9 @@ public partial class PushModeCompletionHandler(
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="request">The authenticated request containing the authorized grant.</param>
     /// <param name="clientInfo">Client information for token generation.</param>
-    /// <param name="expiresIn">How long the request remains in storage if token generation fails.</param>
+    /// <param name="expiresIn">Unused here. Push removes the request on every outcome that ends the
+    /// flow, so there is no remaining lifetime to set; the parameter exists because the base class hands
+    /// it to every mode and poll and ping do use it.</param>
     protected override async Task HandleDeliveryAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request,
@@ -158,10 +160,18 @@ public partial class PushModeCompletionHandler(
                 else
                 {
                     // Delivery failed, and the tokens just minted are dropped with this lambda - nothing
-                    // retries them. What is kept is the authenticated REQUEST, and the only thing that can
-                    // turn it back into tokens is a host reading storage and calling CompleteAsync again,
-                    // which is why it is retained rather than removed: removing it would take that
-                    // possibility away too. Left alone it expires on its own.
+                    // retries them.
+                    //
+                    // What survives in storage is the record as it stood BEFORE the completion, because
+                    // push never writes back: the status and the narrowed grant were set on the in-memory
+                    // object, and only the poll and ping paths persist that with UpdateAsync. So the
+                    // stored record still reads Pending, still carries what the client originally asked
+                    // for rather than what the end user approved, and carries no session.
+                    //
+                    // It is left alone rather than removed so a host can see that the request existed and
+                    // decide what to do, and it expires on its own. What it is NOT is a grant that can be
+                    // completed again from storage - anything rebuilt from it would replay the request,
+                    // not the approval.
                     LogPushDeliveryFailed(authenticationRequestId);
                 }
 

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -60,8 +60,11 @@ public partial class PushModeCompletionHandler(
 
     /// <summary>
     /// Handles push mode token delivery by generating tokens and delivering them directly to the client endpoint.
-    /// The authentication request is removed from storage after successful delivery, because a push client
-    /// never polls: one left behind is an authenticated grant nobody reads until it expires.
+    /// The authentication request is removed from storage after successful delivery. Not hygiene: push
+    /// never writes back, so a record left behind is the PRE-completion one - Pending, carrying what the
+    /// client asked for rather than what the end user approved, and carrying the session - and a host that
+    /// finds it can complete it again. Removing it is what stops that on the path where the tokens did
+    /// arrive.
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="request">The authenticated request containing the authorized grant.</param>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -20,7 +20,8 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.AuthenticationNo
 /// <summary>
 /// Handles CIBA push mode token delivery where tokens are sent directly to the client's notification endpoint
 /// immediately upon authentication completion.
-/// In push mode, tokens are generated, delivered via HTTP POST, and the request is removed from storage.
+/// In push mode, tokens are generated, delivered via HTTP POST, and the request is removed from storage -
+/// except when the delivery itself fails, which is the one outcome that leaves the record behind.
 /// </summary>
 /// <param name="logger">Logger for tracking notification events.</param>
 /// <param name="storage">Storage for authentication requests.</param>
@@ -65,9 +66,10 @@ public partial class PushModeCompletionHandler(
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="request">The authenticated request containing the authorized grant.</param>
     /// <param name="clientInfo">Client information for token generation.</param>
-    /// <param name="expiresIn">Unused here. Push removes the request on every outcome that ends the
-    /// flow, so there is no remaining lifetime to set; the parameter exists because the base class hands
-    /// it to every mode and poll and ping do use it.</param>
+    /// <param name="expiresIn">Has no effect here. Push either removes the request or leaves it exactly
+    /// as it was - it never writes a new lifetime - so on the one outcome that keeps the record, a failed
+    /// delivery, what expires is the lifetime set when the request was stored. The parameter exists
+    /// because the base class hands it to every mode, and poll and ping do use it.</param>
     protected override async Task HandleDeliveryAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request,
@@ -164,14 +166,19 @@ public partial class PushModeCompletionHandler(
                     //
                     // What survives in storage is the record as it stood BEFORE the completion, because
                     // push never writes back: the status and the narrowed grant were set on the in-memory
-                    // object, and only the poll and ping paths persist that with UpdateAsync. So the
-                    // stored record still reads Pending, still carries what the client originally asked
-                    // for rather than what the end user approved, and carries no session.
+                    // object, and only the poll and ping paths persist that with UpdateAsync. So it still
+                    // reads Pending and still carries what the client ASKED for rather than what the end
+                    // user approved.
                     //
-                    // It is left alone rather than removed so a host can see that the request existed and
-                    // decide what to do, and it expires on its own. What it is NOT is a grant that can be
-                    // completed again from storage - anything rebuilt from it would replay the request,
-                    // not the approval.
+                    // It does carry a session - the one the device handler returned at initiation, naming
+                    // the end user - because AuthorizedGrant takes it as a non-nullable member and the
+                    // request was stored with it. That is what makes the leftover dangerous rather than
+                    // inert: it has everything CompleteAsync needs, so a host that reads it back and
+                    // completes it again succeeds, mints, and delivers the entries the end user refused.
+                    //
+                    // It is kept rather than removed so a host can see the request existed, and it expires
+                    // on its own. Anything a host rebuilds from it replays what was asked for, and nothing
+                    // here refuses that.
                     LogPushDeliveryFailed(authenticationRequestId);
                 }
 

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
@@ -17,8 +17,9 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.GrantProcessors;
 /// <summary>
 /// Handles CIBA ping mode token retrieval at the token endpoint.
 /// In ping mode, the server notifies the client, then the client makes a single token request.
-/// The auth_req_id is single-use (CIBA Core 1.0 Section 7.3), so the grant is removed from storage
-/// on retrieval - identically to poll mode (Section 10.1.1 defines their token responses the same).
+/// The auth_req_id is single-use - CIBA Core 1.0 Section 10.1.1: "Once redeemed for a successful token
+/// response, the auth_req_id value that was used is no longer valid" - so the grant is removed from
+/// storage on retrieval, identically to poll mode, whose token response the same section defines.
 /// </summary>
 /// <param name="storage">Storage for backchannel authentication requests.</param>
 public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
@@ -32,7 +33,7 @@ public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
 
     /// <summary>
     /// Atomically removes the authentication request from storage and returns its authorized grant.
-    /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 7.3), a second retrieval
+    /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 10.1.1), a second retrieval
     /// - or a concurrent one that lost the race - finds nothing and is rejected with
     /// <c>invalid_grant</c> rather than re-issuing tokens.
     /// </summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
@@ -17,7 +17,7 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.GrantProcessors;
 /// <summary>
 /// Handles CIBA poll mode token retrieval at the token endpoint.
 /// In poll mode, clients repeatedly poll until authentication completes.
-/// Tokens are removed from storage immediately after retrieval to prevent duplicate issuance.
+/// The stored request is removed immediately on retrieval to prevent duplicate issuance.
 /// Uses atomic try-remove operation to prevent race conditions.
 /// </summary>
 /// <param name="storage">Storage for backchannel authentication requests.</param>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
@@ -44,8 +44,14 @@ public interface INotificationDeliveryService
     /// </param>
     /// <returns>
     /// <c>true</c> if the client endpoint accepted the notification (2xx response); <c>false</c> if
-    /// delivery failed (non-success status or transport error). Push mode relies on this to avoid
-    /// discarding the grant when token delivery did not reach the client.
+    /// delivery failed (non-success status or transport error).
+    /// <para>
+    /// On <c>false</c> push keeps the stored record, and that is not a saved grant. The authenticated,
+    /// narrowed grant lives on the in-memory object and is dropped with it; what storage holds is the
+    /// PRE-completion record - Pending, carrying what the client asked for rather than what the end user
+    /// approved. It is kept so a host can see the request existed, not so delivery can be resumed, and a
+    /// host that completes it again delivers entries the end user refused. See issue 451.
+    /// </para>
     /// </returns>
     Task<bool> SendAsync(
         Uri clientNotificationEndpoint,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -100,19 +100,23 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 /// </para>
 /// <list type="bullet">
 ///   <item>
-///     <strong>Poll Mode:</strong> Stores tokens in <see cref="IBackChannelRequestStorage"/>.
-///     Client polls the token endpoint with <c>auth_req_id</c> until tokens are ready.
+///     <strong>Poll Mode:</strong> Stores the authenticated request in
+///     <see cref="IBackChannelRequestStorage"/>. No token exists yet - the client polls the token
+///     endpoint with its <c>auth_req_id</c>, and the tokens are minted there when it redeems.
 ///   </item>
 ///   <item>
-///     <strong>Ping Mode:</strong> Stores tokens and sends HTTP POST notification via
-///     <see cref="INotificationDeliveryService"/> to the client's <c>client_notification_endpoint</c>
-///     with the <c>auth_req_id</c>. Client then retrieves tokens from the token endpoint.
+///     <strong>Ping Mode:</strong> Stores the authenticated request as poll mode does, then sends an
+///     HTTP POST notification via <see cref="INotificationDeliveryService"/> to the client's
+///     <c>client_notification_endpoint</c> carrying the <c>auth_req_id</c>. The tokens are minted at
+///     the token endpoint when the client redeems, exactly as in poll mode.
 ///   </item>
 ///   <item>
 ///     <strong>Push Mode:</strong> Generates tokens via <see cref="ITokenRequestProcessor"/> and delivers
 ///     them directly via <see cref="INotificationDeliveryService"/> to the client's
-///     <c>client_notification_endpoint</c>. Tokens are removed from storage after successful delivery
-///     per CIBA specification section 10.3.1.
+///     <c>client_notification_endpoint</c>. This is the only mode where the tokens exist before the
+///     client asks for them, and the request is removed once they are delivered, because a push client
+///     never comes to the token endpoint. CIBA Core 1.0 does not require that removal - it says nothing
+///     about what the OP keeps - so it is this library's choice.
 ///   </item>
 /// </list>
 ///

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -8,12 +8,15 @@
 
 using System.Net;
 using System.Text.Json.Nodes;
+using Abblix.Jwt;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.E2E.TestHost.TestInfrastructure;
 using Abblix.Oidc.Server.E2E.Tests.Model;
 using Abblix.Oidc.Server.E2E.Tests.TestInfrastructure;
 using Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Interfaces;
+using Abblix.Oidc.Server.Endpoints.Token.Interfaces;
+using Abblix.Oidc.Server.Features.BackChannelAuthentication;
 using Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
@@ -186,8 +189,119 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.NotNull(discovery.BackChannelAuthenticationEndpoint);
     }
 
+    [Fact]
+    public async Task A_push_client_is_delivered_its_tokens_at_the_notification_endpoint()
+    {
+        // Push is the one mode whose delivery path is entirely different: the tokens are minted when the
+        // host completes and posted to the client, which never comes to the token endpoint at all. Nothing
+        // outside unit tests watched that path, so a token that is minted and not delivered - or delivered
+        // to the wrong place, or without the token that proves the notification came from here - looked the
+        // same as success.
+        var deliveries = new NotificationRecorder();
+        await using var host = CreateCibaHost(deliveries);
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+        var ciba = await RegisterPushCibaClientAsync(client, discovery);
+
+        var authRequestId = await InitiateAsync(client, discovery, ciba, RequestedDetails, NotificationToken);
+        await CompleteAsync(host, authRequestId, RequestedDetails);
+
+        var delivery = Assert.Single(deliveries.Received);
+        Assert.Equal(NotificationEndpoint, delivery.Endpoint);
+
+        // The notification token is what tells the client this POST is the answer to its own request rather
+        // than an unsolicited one, so a delivery carrying the tokens without it is not a delivery.
+        Assert.Equal(NotificationToken, delivery.BearerToken);
+
+        var payload = delivery.Payload;
+        Assert.Equal(authRequestId, payload["auth_req_id"]!.GetValue<string>());
+        Assert.False(string.IsNullOrEmpty(payload["access_token"]?.GetValue<string>()));
+    }
+
+    [Fact]
+    public async Task The_narrowing_a_host_performs_at_completion_reaches_the_pushed_token()
+    {
+        // A push client cannot be asked to check what it was granted - it never redeems anything, it just
+        // receives a token. So an end user who approved one of two entries is only honoured if the
+        // narrowing survives every step between the completion call and the bytes on the wire. Asserting
+        // it in storage would prove the host wrote it down, which is the half that was never in doubt.
+        var deliveries = new NotificationRecorder();
+        await using var host = CreateCibaHost(deliveries);
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+        var ciba = await RegisterPushCibaClientAsync(client, discovery);
+
+        var authRequestId = await InitiateAsync(client, discovery, ciba, BothDetails, NotificationToken);
+        await CompleteAsync(host, authRequestId, ApprovedDetail);
+
+        var delivered = Assert.Single(deliveries.Received);
+        var granted = ReadAuthorizationDetails(delivered.Payload["access_token"]!.GetValue<string>());
+
+        var entry = Assert.Single(granted);
+        Assert.Equal(TestConstants.PaymentInitiationType, entry!["type"]!.GetValue<string>());
+
+        // The action is what separates the two entries, so it is what proves the refused one was dropped
+        // rather than that the array merely came out the right length.
+        Assert.Equal("status", entry["actions"]![0]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task A_push_grant_the_per_type_validator_refuses_delivers_nothing()
+    {
+        // The per-type gate for push exists because a push client is never judged at the token endpoint,
+        // where the other two modes are. A gate that refuses and delivers anyway, or that lets a grant the
+        // validator rejected through, is invisible to a unit test whose fixture could not be delivered to
+        // in the first place. Here a token either arrives or it does not.
+        //
+        // The narrowing is one a host got WRONG rather than a malicious one: the entry keeps the type it
+        // asked for and loses the amount, which is the shape the type comparison structurally cannot see
+        // and the reason the per-type validator is asked at all.
+        var deliveries = new NotificationRecorder();
+        await using var host = CreateCibaHost(deliveries);
+        var client = CreateClientFor(host);
+        var discovery = await FetchDiscoveryAsync(client);
+        var ciba = await RegisterPushCibaClientAsync(client, discovery);
+
+        var authRequestId = await InitiateAsync(client, discovery, ciba, RequestedDetails, NotificationToken);
+        await CompleteAsync(host, authRequestId, DetailWithoutAmount);
+
+        Assert.Empty(deliveries.Received);
+
+        // And the request does not sit there afterwards. A push client never polls, so a refused request
+        // left in storage is an orphan nobody reads until it expires.
+        using var scope = host.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IBackChannelRequestStorage>();
+        Assert.Null(await storage.TryGetAsync(authRequestId));
+    }
+
     /// <summary>The identifier the client passes to name the end-user to be contacted.</summary>
     private const string LoginHint = "e2e-subject";
+
+    /// <summary>
+    /// Where a push client is told to deliver. Absolute and https because dynamic registration requires it;
+    /// nothing resolves this name, since the recorder below stands in for the transport.
+    /// </summary>
+    private static readonly Uri NotificationEndpoint = new("https://client.e2e.invalid/ciba-push");
+
+    /// <summary>The value the client sends at initiation and expects back on the notification.</summary>
+    private const string NotificationToken = "e2e-client-notification-token";
+
+    private const string RequestedDetails =
+        """[{"type":"payment_initiation","actions":["initiate"],"instructedAmount":{"currency":"EUR","amount":"500.00"}}]""";
+
+    private const string BothDetails =
+        """[{"type":"payment_initiation","actions":["initiate"],"instructedAmount":{"currency":"EUR","amount":"500.00"}},{"type":"payment_initiation","actions":["status"],"instructedAmount":{"currency":"EUR","amount":"10.00"}}]""";
+
+    /// <summary>The second of <see cref="BothDetails"/> alone: the end user approved the cheaper one.</summary>
+    private const string ApprovedDetail =
+        """[{"type":"payment_initiation","actions":["status"],"instructedAmount":{"currency":"EUR","amount":"10.00"}}]""";
+
+    /// <summary>
+    /// A narrowing of <see cref="RequestedDetails"/> that keeps the type and drops the amount, which is what
+    /// <c>PaymentInitiationValidator</c> refuses.
+    /// </summary>
+    private const string DetailWithoutAmount =
+        """[{"type":"payment_initiation","actions":["initiate"]}]""";
 
     private sealed record CibaClient(string ClientId, string ClientSecret);
 
@@ -226,20 +340,41 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
     /// Drives a well-formed backchannel authentication request and returns the issued auth_req_id, asserting
     /// the request was accepted so that a later assertion cannot pass against a flow that never started.
     /// </summary>
-    private static async Task<string> InitiateAsync(
+    private static Task<string> InitiateAsync(
         HttpClient client, DiscoveryDocument discovery, CibaClient ciba)
+        => InitiateAsync(client, discovery, ciba, authorizationDetails: null, notificationToken: null);
+
+    /// <summary>
+    /// Starts a backchannel authentication carrying authorization_details and the notification token a push
+    /// client must present back, asserting acceptance so a later assertion cannot pass against a flow that
+    /// never started.
+    /// </summary>
+    private static async Task<string> InitiateAsync(
+        HttpClient client,
+        DiscoveryDocument discovery,
+        CibaClient ciba,
+        string? authorizationDetails,
+        string? notificationToken)
     {
-        var response = await FormPostHelpers.PostFormAsync(
-            client,
-            discovery.BackChannelAuthenticationEndpoint!,
-            new Dictionary<string, string>
+        var form = new Dictionary<string, string>
             {
                 [CibaParameters.Scope] = Scopes.OpenId,
                 [CibaParameters.LoginHint] = LoginHint,
                 [CibaParameters.BindingMessage] = "e2e-binding",
                 [ClientRequest.Parameters.ClientId] = ciba.ClientId,
                 [ClientRequest.Parameters.ClientSecret] = ciba.ClientSecret,
-            });
+            };
+
+        // Omitted rather than sent empty: a poll client has no notification endpoint to be told about, and
+        // an empty authorization_details is not the same request as one that carries none.
+        if (notificationToken is not null)
+            form[CibaParameters.ClientNotificationToken] = notificationToken;
+
+        if (authorizationDetails is not null)
+            form[CibaParameters.AuthorizationDetails] = authorizationDetails;
+
+        var response = await FormPostHelpers.PostFormAsync(
+            client, discovery.BackChannelAuthenticationEndpoint!, form);
 
         var body = await ReadJsonAsync(response);
         Assert.True(response.IsSuccessStatusCode,
@@ -276,6 +411,28 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
                 services.Replace(ServiceDescriptor
                     .Scoped<IUserDeviceAuthenticationHandler, ReachableUserDeviceHandler>())));
 
+    /// <summary>
+    /// Builds the CIBA host with the notification transport pointed at <paramref name="recorder"/>, so what
+    /// the server posts to a push client can be read back.
+    /// </summary>
+    /// <remarks>
+    /// The recorder replaces the client's PRIMARY handler, which is where the SSRF validation of a
+    /// client-supplied endpoint lives - so these tests say nothing about that validation, and the endpoint
+    /// they register is never resolved. Chaining an outer handler instead would leave the validation in
+    /// front of an address no test host can own.
+    /// </remarks>
+    private WebApplicationFactory<Program> CreateCibaHost(NotificationRecorder recorder)
+        => Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+            {
+                services.Replace(ServiceDescriptor
+                    .Scoped<IUserDeviceAuthenticationHandler, ReachableUserDeviceHandler>());
+
+                services
+                    .AddHttpClient(BackChannelNotificationTransport.HttpClientName)
+                    .ConfigurePrimaryHttpMessageHandler(() => recorder);
+            }));
+
     private static HttpClient CreateClientFor(WebApplicationFactory<Program> host)
         => host.CreateClient(new WebApplicationFactoryClientOptions
         {
@@ -285,6 +442,106 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
 
     private static async Task<JsonObject> ReadJsonAsync(HttpResponseMessage response) =>
         JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+
+    /// <summary>
+    /// Registers a CIBA client in PUSH mode, with the notification endpoint the recorder answers on and the
+    /// authorization-detail type the host has a validator for.
+    /// </summary>
+    private static async Task<CibaClient> RegisterPushCibaClientAsync(
+        HttpClient client, DiscoveryDocument discovery)
+    {
+        var registered = await RegisterClientAsync(client, discovery, new JsonObject
+        {
+            [RegistrationMembers.ClientName] = $"ciba-push-{Guid.NewGuid():N}",
+            [RegistrationMembers.ResponseTypes] = new JsonArray(),
+            [RegistrationMembers.GrantTypes] = new JsonArray(GrantTypes.Ciba),
+            [RegistrationMembers.TokenEndpointAuthMethod] = ClientAuthenticationMethods.ClientSecretPost,
+            [RegistrationMembers.BackChannelTokenDeliveryMode] = BackchannelTokenDeliveryModes.Push,
+            [RegistrationMembers.BackChannelClientNotificationEndpoint] = NotificationEndpoint.AbsoluteUri,
+            [RegistrationMembers.AuthorizationDetailsTypes] =
+                new JsonArray(TestConstants.PaymentInitiationType),
+        });
+
+        return new CibaClient(
+            registered[RegistrationResponse.ClientId]!.GetValue<string>(),
+            registered[RegistrationResponse.ClientSecret]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Does what an integrator does when the end user answers on their device: reads the stored request,
+    /// puts the session and the grant the user actually approved on it, marks it authenticated and hands it
+    /// to the completion handler. Nothing in the library drives this - the answer arrives from outside.
+    /// </summary>
+    /// <param name="grantedDetails">
+    /// The authorization_details the end user approved, which is how a partial answer is expressed: the
+    /// grant's context is what will be issued, and replacing it is the only place that answer exists.
+    /// </param>
+    private static async Task CompleteAsync(
+        WebApplicationFactory<Program> host, string authenticationRequestId, string grantedDetails)
+    {
+        using var scope = host.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IBackChannelRequestStorage>();
+
+        var stored = await storage.TryGetAsync(authenticationRequestId);
+        Assert.NotNull(stored);
+
+        var session = new AuthSession(
+            Subject: LoginHint,
+            SessionId: Guid.NewGuid().ToString("N"),
+            AuthenticationTime: scope.ServiceProvider.GetRequiredService<TimeProvider>().GetUtcNow(),
+            IdentityProvider: "e2e-test");
+
+        var granted = stored.AuthorizedGrant.Context with
+        {
+            AuthorizationDetails = JsonNode.Parse(grantedDetails)!.AsArray(),
+        };
+
+        var completed = stored with { AuthorizedGrant = new AuthorizedGrant(session, granted) };
+        completed.Status = BackChannelAuthenticationStatus.Authenticated;
+
+        await scope.ServiceProvider
+            .GetRequiredService<IAuthenticationCompletionHandler>()
+            .CompleteAsync(authenticationRequestId, completed, TimeSpan.FromMinutes(5));
+    }
+
+    private static JsonArray ReadAuthorizationDetails(string accessToken)
+        => DecodeJwtPayload(accessToken)[IanaClaimTypes.AuthorizationDetails]!.AsArray();
+
+    /// <summary>What the server posted to a push or ping client's notification endpoint.</summary>
+    private sealed record RecordedNotification(Uri Endpoint, string? BearerToken, JsonObject Payload);
+
+    /// <summary>
+    /// Stands in for the client's notification endpoint. It answers 200 to every POST and keeps what
+    /// arrived, which is the whole point: a push client's tokens exist nowhere else once delivery succeeds.
+    /// </summary>
+    private sealed class NotificationRecorder : HttpMessageHandler
+    {
+        private readonly List<RecordedNotification> _received = [];
+
+        public IReadOnlyList<RecordedNotification> Received
+        {
+            get
+            {
+                lock (_received) return _received.ToArray();
+            }
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? new JsonObject()
+                : JsonNode.Parse(await request.Content.ReadAsStringAsync(cancellationToken))!.AsObject();
+
+            lock (_received)
+            {
+                _received.Add(new RecordedNotification(
+                    request.RequestUri!, request.Headers.Authorization?.Parameter, body));
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
 
     /// <summary>
     /// Test double for the integrator-supplied device interaction. It reports that the user was reached and

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -210,12 +210,28 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.Equal(NotificationEndpoint, delivery.Endpoint);
 
         // The notification token is what tells the client this POST is the answer to its own request rather
-        // than an unsolicited one, so a delivery carrying the tokens without it is not a delivery.
+        // than an unsolicited one, so a delivery carrying the tokens without it is not a delivery. The
+        // scheme is asserted beside it because CIBA Core 1.0 section 10.3.1 names Bearer, and a token in
+        // the right header under the wrong scheme is what a client's own middleware would reject.
+        Assert.Equal("Bearer", delivery.AuthorizationScheme);
         Assert.Equal(NotificationToken, delivery.BearerToken);
 
+        // Every member the client is issued, not just the one that proves something arrived. Each of these
+        // can be dropped from the payload on its own, and an assertion only on access_token sees none of it.
         var payload = delivery.Payload;
         Assert.Equal(authRequestId, payload["auth_req_id"]!.GetValue<string>());
         Assert.False(string.IsNullOrEmpty(payload["access_token"]?.GetValue<string>()));
+        Assert.False(string.IsNullOrEmpty(payload["id_token"]?.GetValue<string>()));
+        Assert.Equal(TokenTypes.Bearer, payload["token_type"]!.GetValue<string>());
+        Assert.True(payload["expires_in"]!.GetValue<int>() > 0);
+
+        // And the request is gone. CIBA Core 1.0 section 10.3.1 has a push client's request removed once
+        // the tokens are delivered, and a push client never polls - so one left behind is an authenticated
+        // grant nobody reads until it expires. Without this line the removal, and the whole branch that
+        // decides between it and the retry path, is unmeasured.
+        using var scope = host.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IBackChannelRequestStorage>();
+        Assert.Null(await storage.TryGetAsync(authRequestId));
     }
 
     [Fact]
@@ -263,6 +279,13 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         var ciba = await RegisterPushCibaClientAsync(client, discovery);
 
         var authRequestId = await InitiateAsync(client, discovery, ciba, RequestedDetails, NotificationToken);
+
+        // What the request ASKED for has to be on it, or the rest of this test passes for a reason it does
+        // not name: with nothing requested, the type comparison one step earlier refuses first, removes the
+        // request and delivers nothing - the identical observable state, reached without the per-type
+        // validator ever being asked.
+        await AssertTheRequestCarriesWhatWasAskedFor(host, authRequestId);
+
         await CompleteAsync(host, authRequestId, DetailWithoutAmount);
 
         Assert.Empty(deliveries.Received);
@@ -365,8 +388,9 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
                 [ClientRequest.Parameters.ClientSecret] = ciba.ClientSecret,
             };
 
-        // Omitted rather than sent empty: a poll client has no notification endpoint to be told about, and
-        // an empty authorization_details is not the same request as one that carries none.
+        // Omitted rather than sent empty, because that is what a client that wants neither actually
+        // sends. The server does not distinguish the two - the processor stores an empty array either
+        // way - but a request the poll tests share should not carry parameters they never used.
         if (notificationToken is not null)
             form[CibaParameters.ClientNotificationToken] = notificationToken;
 
@@ -416,10 +440,11 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
     /// the server posts to a push client can be read back.
     /// </summary>
     /// <remarks>
-    /// The recorder replaces the client's PRIMARY handler, which is where the SSRF validation of a
-    /// client-supplied endpoint lives - so these tests say nothing about that validation, and the endpoint
-    /// they register is never resolved. Chaining an outer handler instead would leave the validation in
-    /// front of an address no test host can own.
+    /// The recorder replaces the client's PRIMARY handler. That is where the address validation of a
+    /// client-supplied endpoint lives, together with the transport it wraps - which also refuses
+    /// redirects, default credentials and automatic decompression. So these tests say nothing about any
+    /// of that, and the endpoint they register is never resolved. Chaining an outer handler instead
+    /// would leave the validation standing in front of an address no test host can own.
     /// </remarks>
     private WebApplicationFactory<Program> CreateCibaHost(NotificationRecorder recorder)
         => Factory.WithWebHostBuilder(builder =>
@@ -444,8 +469,8 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
 
     /// <summary>
-    /// Registers a CIBA client in PUSH mode, with the notification endpoint the recorder answers on and the
-    /// authorization-detail type the host has a validator for.
+    /// Registers a CIBA client in PUSH mode, with the notification endpoint the recorder captures POSTs
+    /// to and the authorization-detail type the host has a validator for.
     /// </summary>
     private static async Task<CibaClient> RegisterPushCibaClientAsync(
         HttpClient client, DiscoveryDocument discovery)
@@ -476,6 +501,21 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
     /// The authorization_details the end user approved, which is how a partial answer is expressed: the
     /// grant's context is what will be issued, and replacing it is the only place that answer exists.
     /// </param>
+    /// <summary>
+    /// Reads back what the request ASKED for, so a test about the per-type validator cannot be
+    /// satisfied by the type comparison that runs before it.
+    /// </summary>
+    private static async Task AssertTheRequestCarriesWhatWasAskedFor(
+        WebApplicationFactory<Program> host, string authenticationRequestId)
+    {
+        using var scope = host.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IBackChannelRequestStorage>();
+
+        var stored = await storage.TryGetAsync(authenticationRequestId);
+        Assert.NotNull(stored);
+        Assert.NotEmpty(stored.RequestedAuthorizationDetails ?? []);
+    }
+
     private static async Task CompleteAsync(
         WebApplicationFactory<Program> host, string authenticationRequestId, string grantedDetails)
     {
@@ -508,7 +548,8 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         => DecodeJwtPayload(accessToken)[IanaClaimTypes.AuthorizationDetails]!.AsArray();
 
     /// <summary>What the server posted to a push or ping client's notification endpoint.</summary>
-    private sealed record RecordedNotification(Uri Endpoint, string? BearerToken, JsonObject Payload);
+    private sealed record RecordedNotification(
+        Uri Endpoint, string? AuthorizationScheme, string? BearerToken, JsonObject Payload);
 
     /// <summary>
     /// Stands in for the client's notification endpoint. It answers 200 to every POST and keeps what
@@ -536,7 +577,10 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
             lock (_received)
             {
                 _received.Add(new RecordedNotification(
-                    request.RequestUri!, request.Headers.Authorization?.Parameter, body));
+                    request.RequestUri!,
+                    request.Headers.Authorization?.Scheme,
+                    request.Headers.Authorization?.Parameter,
+                    body));
             }
 
             return new HttpResponseMessage(HttpStatusCode.OK);

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -225,10 +225,16 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.Equal(TokenTypes.Bearer, payload["token_type"]!.GetValue<string>());
         Assert.True(payload["expires_in"]!.GetValue<int>() > 0);
 
-        // And the request is gone. CIBA Core 1.0 section 10.3.1 has a push client's request removed once
-        // the tokens are delivered, and a push client never polls - so one left behind is an authenticated
-        // grant nobody reads until it expires. Without this line the removal, and the whole branch that
-        // decides between it and the retry path, is unmeasured.
+        // And the request is gone. That removal is this library's choice rather than a requirement -
+        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that a
+        // push client never polls, so one left behind is an authenticated grant nobody reads until it
+        // expires.
+        //
+        // Both arms of the delivery branch are already pinned by AuthenticationCompletionHandlerTests,
+        // through a mock's call count. What this line adds is the same fact at the level a client sees,
+        // which is the level where a removal that stops happening actually costs something. It does not
+        // pin the branch: hoisting the removal above the if, so it runs whether or not delivery
+        // succeeded, leaves every test in this file green and only the unit test red.
         using var scope = host.Services.CreateScope();
         var storage = scope.ServiceProvider.GetRequiredService<IBackChannelRequestStorage>();
         Assert.Null(await storage.TryGetAsync(authRequestId));
@@ -280,10 +286,14 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
 
         var authRequestId = await InitiateAsync(client, discovery, ciba, RequestedDetails, NotificationToken);
 
-        // What the request ASKED for has to be on it, or the rest of this test passes for a reason it does
-        // not name: with nothing requested, the type comparison one step earlier refuses first, removes the
-        // request and delivers nothing - the identical observable state, reached without the per-type
-        // validator ever being asked.
+        // What the request ASKED for has to be on it. With nothing requested, the type comparison one
+        // step earlier refuses first, removes the request and delivers nothing - the identical observable
+        // state, reached without the per-type validator ever being asked, and this rules that out.
+        //
+        // It rules out only that. The same comparison also refuses a granted type absent from a non-empty
+        // baseline, and no assertion here separates the two refusals: they differ in the log line and in
+        // nothing a client can see. The narrowing below keeps the type it asked for, so the comparison
+        // has no reason to fire - but that is an argument, not a measurement.
         await AssertTheRequestCarriesWhatWasAskedFor(host, authRequestId);
 
         await CompleteAsync(host, authRequestId, DetailWithoutAmount);
@@ -493,17 +503,8 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
     }
 
     /// <summary>
-    /// Does what an integrator does when the end user answers on their device: reads the stored request,
-    /// puts the session and the grant the user actually approved on it, marks it authenticated and hands it
-    /// to the completion handler. Nothing in the library drives this - the answer arrives from outside.
-    /// </summary>
-    /// <param name="grantedDetails">
-    /// The authorization_details the end user approved, which is how a partial answer is expressed: the
-    /// grant's context is what will be issued, and replacing it is the only place that answer exists.
-    /// </param>
-    /// <summary>
-    /// Reads back what the request ASKED for, so a test about the per-type validator cannot be
-    /// satisfied by the type comparison that runs before it.
+    /// Reads back what the request ASKED for, which rules out one of the two ways the comparison that runs
+    /// before the per-type validator can refuse: an empty requested baseline.
     /// </summary>
     private static async Task AssertTheRequestCarriesWhatWasAskedFor(
         WebApplicationFactory<Program> host, string authenticationRequestId)
@@ -516,6 +517,15 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.NotEmpty(stored.RequestedAuthorizationDetails ?? []);
     }
 
+    /// <summary>
+    /// Does what an integrator does when the end user answers on their device: reads the stored request,
+    /// puts the session and the grant the user actually approved on it, marks it authenticated and hands it
+    /// to the completion handler. Nothing in the library drives this - the answer arrives from outside.
+    /// </summary>
+    /// <param name="grantedDetails">
+    /// The authorization_details the end user approved, which is how a partial answer is expressed: the
+    /// grant's context is what will be issued, and replacing it is the only place that answer exists.
+    /// </param>
     private static async Task CompleteAsync(
         WebApplicationFactory<Program> host, string authenticationRequestId, string grantedDetails)
     {

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -226,9 +226,9 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.True(payload["expires_in"]!.GetValue<int>() > 0);
 
         // And the request is gone. That removal is this library's choice rather than a requirement -
-        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that a
-        // push client never polls, so one left behind is an authenticated grant nobody reads until it
-        // expires.
+        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that push
+        // never writes back: a record left behind is the PRE-completion one, which a host can complete
+        // again, delivering what the end user did not approve.
         //
         // Both arms of the delivery branch are already pinned by AuthenticationCompletionHandlerTests,
         // through a mock's call count. What this line adds is the same fact at the level a client sees,

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/BackChannelAuthenticationGrantHandlerTests.cs
@@ -764,7 +764,7 @@ public class BackChannelAuthenticationGrantHandlerTests
 
     /// <summary>
     /// Verifies that in ping mode, the authenticated request is removed from storage on retrieval.
-    /// The auth_req_id is single-use (CIBA Core 1.0 Section 7.3), so a notified client cannot replay
+    /// The auth_req_id is single-use (CIBA Core 1.0 Section 10.1.1), so a notified client cannot replay
     /// it to mint fresh tokens; ping consumes the entry exactly like poll.
     /// </summary>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -361,9 +361,16 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// Verifies that when push delivery fails, the authenticated request is retained in storage
-    /// rather than removed. Push clients cannot poll, so discarding the grant on a failed delivery
-    /// would silently lose tokens the client never received; the request is kept until it expires.
+    /// Verifies that when push delivery fails, the stored record is left alone rather than removed.
+    /// </summary>
+    /// <remarks>
+    /// It is not the authenticated request. Push never writes back - the status and the narrowed grant
+    /// were set on the in-memory object - so what stays is the PRE-completion record: Pending, carrying
+    /// what the client asked for, and carrying the session from initiation.
+    ///
+    /// Nor does keeping it save any tokens: the ones just minted are dropped with the lambda that made
+    /// them, and nothing retries. It is kept so a host can see the request existed, and because a host can
+    /// complete it again - which is a hazard rather than a recovery, and is issue 451.
     /// </summary>
     [Fact]
     public async Task CompleteAuthenticationAsync_PushMode_DeliveryFails_RetainsRequest()
@@ -414,11 +421,12 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// Verifies that when token generation fails in push mode, the error status is updated in storage
-    /// and no token delivery is attempted.
+    /// Verifies that when token generation fails in push mode, the request is REMOVED and no delivery is
+    /// attempted. Not marked denied: a push client never polls, so a status it will never read is an
+    /// orphan waiting out its expiry.
     /// </summary>
     [Fact]
-    public async Task CompleteAuthenticationAsync_PushMode_TokenGenerationFails_UpdatesStatus()
+    public async Task CompleteAuthenticationAsync_PushMode_TokenGenerationFails_RemovesRequest()
     {
         // Arrange
         var authSession = new AuthSession(UserId, "session_123", DateTimeOffset.UtcNow, "backchannel");
@@ -459,11 +467,61 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// Verifies that when push mode is configured but the client notification endpoint is missing,
-    /// the system treats it as a configuration error and updates the request status to Denied.
+    /// The push half of the same misconfiguration, which had no test while the one below carried its
+    /// name: push REMOVES the request rather than marking it Denied.
     /// </summary>
+    /// <remarks>
+    /// A push client never comes to the token endpoint, so a status it will never read is an orphan
+    /// sitting in storage until it expires. Removing is the only outcome that leaves nothing behind, and
+    /// the difference from ping is the whole reason push overrides the refusal.
+    /// </remarks>
     [Fact]
-    public async Task CompleteAuthenticationAsync_PushMode_MissingEndpoint_SetsStatusToDenied()
+    public async Task CompleteAuthenticationAsync_PushMode_MissingEndpoint_RemovesRequest()
+    {
+        var authSession = new AuthSession(UserId, "session_123", DateTimeOffset.UtcNow, "backchannel");
+        var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
+        var request = new BackChannelAuthenticationRequest(
+            new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
+        {
+            Status = BackChannelAuthenticationStatus.Authenticated,
+            ClientNotificationEndpoint = null,
+            ClientNotificationToken = NotificationToken,
+        };
+
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Push,
+        };
+
+        _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(request);
+
+        await CreatePushModeHandler().CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
+
+        _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
+
+        // The half that separates this from ping, and the reason the override exists.
+        _storage.Verify(
+            s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>()),
+            Times.Never);
+
+        // Nothing is minted or delivered for a client that cannot be reached.
+        _tokenRequestProcessor.Verify(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()), Times.Never);
+        _notificationService.Verify(
+            s => s.SendAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<IBackChannelNotificationRequest>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that when the client notification endpoint is missing, PING mode treats it as a
+    /// configuration error and marks the request Denied.
+    /// </summary>
+    /// <remarks>
+    /// Ping, not push, which the handler this builds has always been - the name said otherwise for long
+    /// enough that push's own missing-endpoint path had no test at all. Push removes instead of denying,
+    /// and the test below it is that one.
+    /// </remarks>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_PingMode_MissingEndpoint_SetsStatusToDenied()
     {
         // Arrange
         var authSession = new AuthSession(UserId, "session_123", DateTimeOffset.UtcNow, "backchannel");

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -467,17 +467,16 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// The push half of the same misconfiguration: push REMOVES the request rather than marking it Denied.
+    /// Push REMOVES a misconfigured request rather than marking it Denied, and this holds the ENDPOINT
+    /// clause of the check.
     /// </summary>
     /// <remarks>
-    /// The configuration check has TWO clauses - no endpoint, or no token - and a test can only hold the
-    /// one its fixture leaves out. <c>WhenNotConfiguredForDelivery_RemovesTheRequest</c> below drops the
-    /// token; this one drops the endpoint. Delete either and a build that checks only the surviving clause
-    /// still passes, which is the whole reason both exist.
+    /// The guard is two clauses, so it takes two fixtures: this one supplies the token and omits the
+    /// endpoint, <c>PushMode_MissingToken_RemovesRequest</c> does the reverse. Blinding either clause
+    /// kills exactly one of them.
     ///
-    /// The outcome they share: a push client never comes to the token endpoint, so a status it will never
-    /// read is an orphan sitting in storage until it expires. Removing leaves nothing behind, and that
-    /// difference from ping is why push overrides the refusal.
+    /// Why removal: a push client never comes to the token endpoint, so a status it will never read is an
+    /// orphan sitting in storage until it expires.
     /// </remarks>
     [Fact]
     public async Task CompleteAuthenticationAsync_PushMode_MissingEndpoint_RemovesRequest()
@@ -516,12 +515,52 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
+    /// The other clause: the endpoint is registered and the token is not, which push must also refuse.
+    /// </summary>
+    /// <remarks>
+    /// Without this, blinding the token half of the guard kills only a PING test - push would carry a
+    /// divergent check that drops the token and ship green.
+    /// </remarks>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_PushMode_MissingToken_RemovesRequest()
+    {
+        var authSession = new AuthSession(UserId, "session_123", DateTimeOffset.UtcNow, "backchannel");
+        var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
+        var request = new BackChannelAuthenticationRequest(
+            new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
+        {
+            Status = BackChannelAuthenticationStatus.Authenticated,
+            ClientNotificationEndpoint = new Uri("https://client.example/ciba"),
+            ClientNotificationToken = null,
+        };
+
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Push,
+        };
+
+        _storage.Setup(s => s.TryRemoveAsync(AuthReqId)).ReturnsAsync(request);
+
+        await CreatePushModeHandler().CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
+
+        _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
+        _storage.Verify(
+            s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>()),
+            Times.Never);
+
+        _tokenRequestProcessor.Verify(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()), Times.Never);
+        _notificationService.Verify(
+            s => s.SendAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<IBackChannelNotificationRequest>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Verifies that when the client notification endpoint is missing, PING mode treats it as a
     /// configuration error and marks the request Denied.
     /// </summary>
     /// <remarks>
     /// Ping, not push, which the handler this builds has always been; the name said otherwise. Push
-    /// removes instead of denying, and the test below it is push's endpoint clause.
+    /// removes instead of denying: the two tests above are its clauses.
     /// </remarks>
     [Fact]
     public async Task CompleteAuthenticationAsync_PingMode_MissingEndpoint_SetsStatusToDenied()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -467,13 +467,17 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// The push half of the same misconfiguration, which had no test while the one below carried its
-    /// name: push REMOVES the request rather than marking it Denied.
+    /// The push half of the same misconfiguration: push REMOVES the request rather than marking it Denied.
     /// </summary>
     /// <remarks>
-    /// A push client never comes to the token endpoint, so a status it will never read is an orphan
-    /// sitting in storage until it expires. Removing is the only outcome that leaves nothing behind, and
-    /// the difference from ping is the whole reason push overrides the refusal.
+    /// The configuration check has TWO clauses - no endpoint, or no token - and a test can only hold the
+    /// one its fixture leaves out. <c>WhenNotConfiguredForDelivery_RemovesTheRequest</c> below drops the
+    /// token; this one drops the endpoint. Delete either and a build that checks only the surviving clause
+    /// still passes, which is the whole reason both exist.
+    ///
+    /// The outcome they share: a push client never comes to the token endpoint, so a status it will never
+    /// read is an orphan sitting in storage until it expires. Removing leaves nothing behind, and that
+    /// difference from ping is why push overrides the refusal.
     /// </remarks>
     [Fact]
     public async Task CompleteAuthenticationAsync_PushMode_MissingEndpoint_RemovesRequest()
@@ -516,9 +520,8 @@ public class AuthenticationCompletionHandlerTests
     /// configuration error and marks the request Denied.
     /// </summary>
     /// <remarks>
-    /// Ping, not push, which the handler this builds has always been - the name said otherwise for long
-    /// enough that push's own missing-endpoint path had no test at all. Push removes instead of denying,
-    /// and the test below it is that one.
+    /// Ping, not push, which the handler this builds has always been; the name said otherwise. Push
+    /// removes instead of denying, and the test below it is push's endpoint clause.
     /// </remarks>
     [Fact]
     public async Task CompleteAuthenticationAsync_PingMode_MissingEndpoint_SetsStatusToDenied()
@@ -535,7 +538,7 @@ public class AuthenticationCompletionHandlerTests
 
         var clientInfo = new ClientInfo(ClientId)
         {
-            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Push,
+            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Ping,
         };
 
         _storage.Setup(s => s.UpdateAsync(AuthReqId, It.IsAny<BackChannelAuthenticationRequest>(), _expiresIn))

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessorTests.cs
@@ -24,8 +24,8 @@ namespace Abblix.Oidc.Server.UnitTests.Features.BackChannelAuthentication.GrantP
 
 /// <summary>
 /// Verifies that CIBA ping mode consumes the <c>auth_req_id</c> on token retrieval. CIBA Core 1.0
-/// Section 7.3 states the <c>auth_req_id</c> can be used only once; Section 10.1.1 defines the
-/// token response identically for poll and ping. Ping therefore must remove the grant from storage
+/// Section 10.1.1 says "Once redeemed for a successful token response, the auth_req_id value that
+/// was used is no longer valid", and defines the token response identically for poll and ping. Ping therefore must remove the grant from storage
 /// on first successful retrieval, exactly like poll, so a notified client cannot replay the same
 /// <c>auth_req_id</c> to mint fresh tokens until expiry.
 /// </summary>


### PR DESCRIPTION
Closes #428.

## What was uncovered

`BackChannelAuthenticationTests` drove the poll delivery mode only, and carried no `authorization_details` at all. Two things that ship had no end-to-end test.

Push is the mode whose whole delivery path is different: the tokens are minted when the host completes and posted to the client's notification endpoint, and the client never comes to the token endpoint. A token minted and not delivered, delivered to the wrong place, or delivered without the notification token that tells the client this POST answers its own request, all looked the same as success.

The per-type gate for push is the sharper gap. It exists because a push client is never judged at the token endpoint where poll and ping are, and it lives entirely on unit tests. Those tests are sound - the fixture that could not fail was fixed in #426, and its remark now documents the trap - but a unit test asserts that a processor was not called. End to end, a token either arrives at the client or it does not.

## The tests

Three end-to-end, and four in the completion-handler unit class: two push clauses of the notification-configuration guard, and two renames of tests whose names named the wrong mode.

They assert what reached the endpoint, and two of them read the storage back afterwards, because for a push client the endpoint is the only place the tokens exist and the storage is where a request that should be gone would linger.

- The tokens arrive at the registered endpoint, carrying the `auth_req_id` and the notification token the client sent at initiation.
- A completion that approves one of two requested entries delivers an access token carrying only that one. The assertion is on the ACTION, which is what separates the two entries, rather than on the array's length.
- A narrowing the per-type validator refuses delivers nothing, and leaves no request in storage. A push client never polls, so a refused request left behind is an orphan nobody reads until it expires.

The narrowing the third test uses is one a host got WRONG rather than a malicious one: the entry keeps the type it asked for and loses its amount. That is the shape the type comparison structurally cannot see, and the whole reason the per-type validator is asked.

## Evidence

Six mutations, each shown to BUILD with 0 errors before any count was read, and each killing exactly the test that covers it:

| mutation | tests failed |
|---|---|
| mint the tokens and never post them | 2 - both tests that assert something arrived |
| issue what the client ASKED for instead of what the host granted | 1 - the narrowing test only |
| make the per-type gate's answer never match | 1 - the refusal test only |
| drop the removal after a successful delivery | 1 here, 2 solution-wide - `AuthenticationCompletionHandlerTests` already holds both arms |
| drop every payload member past `access_token` | 1 - the delivery test only |
| request no `authorization_details`, so an earlier check refuses instead | 1 - the refusal test only |

The first killing two is right: both tests assert an arrival, and the refusal test asserts an absence, so skipping delivery cannot break it.

The last three survived the first version of these tests, which is why the assertions they need are there now. The delivery test read only that something arrived; the refusal test could not tell its own cause from a refusal one step earlier.

Two things these tests still do not pin, written down rather than left to be discovered. Hoisting the removal above the delivery branch, so it runs whether or not delivery succeeded, leaves every test here green and is caught only by the unit test. And the refusal test rules out one of the two ways the earlier type comparison can refuse - an empty requested baseline - not the other, because the two refusals differ in a log line and in nothing a client can see.

A constant-folded `if (false)` was the first attempt at two of these and raised `CS0162`; a length comparison that cannot be negative raised `S3981` from the Sonar analyser. Under `TreatWarningsAsErrors` both are failed builds rather than failing tests, so every mutation above was shown to build with zero errors before its count was read.

E2E project 193 passed, 0 failed on the restored tree.

## A citation this branch removed rather than added to

Comments across `PushModeCompletionHandler` and `IUserDeviceAuthenticationHandler` attributed the removal of a delivered push request to CIBA Core 1.0 section 10.3.1. That section is 4770 characters about what the OP delivers, and it contains no occurrence of remove, delete or storage; the one sentence about a redeemed identifier ceasing to be usable is in 10.1.1 and is about validity. Most of them predate this branch and one was added by it, and all are corrected here.

No count is given because two instruments disagreed on it - a comment wrapping across `///` markers is one attribution or two depending on how wide a window the sweep joins. Read the sweep as "every site the joined-comment pattern reaches in these two files, with a populated control proving the pattern fires", not as a number.

The behaviour is right and the reason was already written beside the invention - a push client never polls, so a request left behind is an orphan - so the reason stands on its own now.

The two attributions to that section that are true were left alone: it does have the outcome travel through the notification endpoint, and it does authenticate that POST with a bearer token whose value is the `client_notification_token`.

Reading it also turned up a conformance gap the tests came one line short of catching, filed as #437: section 10.3.1 makes `urn:openid:params:jwt:claim:auth_req_id` and `rt_hash` a MUST in push mode, and neither claim exists anywhere in the source.

## One thing the tests deliberately do not cover

The recorder that stands in for the client replaces the notification transport's PRIMARY handler. That is where the address validation of a client-supplied endpoint lives, together with the transport it wraps, which also refuses redirects, default credentials and automatic decompression. So these say nothing about any of that, and the endpoint they register is never resolved. Chaining an outer handler instead would leave the validation standing in front of an address no test host can own. Noted in the code where the host is built, so the next reader does not mistake the coverage for wider than it is.

