### PR TITLE
Say at most one, because exactly one is not what the redemption protocol keeps

### DIFF
--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -115,9 +115,11 @@ public class DeviceAuthorizationStorage(
     /// token requests cannot both claim the same device code.
     /// </para>
     /// <para>
-    /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>
-    /// which implements a lock-based protocol ensuring exactly one thread successfully removes the value
-    /// even in concurrent scenarios. After successful removal, cleans up the user code mapping.
+    /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>,
+    /// whose lock-based protocol lets AT MOST one caller remove the device code - never two, which is the
+    /// half that matters here. Not exactly one: a removal can end with no caller told it won, and the code
+    /// is then gone with nobody holding it. See issue 435. After a successful removal, cleans up the user
+    /// code mapping.
     /// </para>
     /// </remarks>
     /// <param name="deviceCode">The device code identifying the authorization request to remove.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -70,7 +70,7 @@ public class AuthorizationCodeService(
 	public async Task<Result<AuthorizedGrant, OidcError>> RemoveAuthorizationCodeAsync(string authorizationCode)
 	{
 		// removeOnRetrieval: true performs an atomic get-and-remove, so two concurrent redemptions
-		// of the same code cannot both observe the grant - exactly one wins the claim; every other
+		// of the same code cannot both observe the grant - at most one wins the claim; every other
 		// caller finds the code already gone and is rejected.
 		var grant = await storage.GetAsync<AuthorizedGrant>(
 			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -49,7 +49,7 @@ public interface IAuthorizationCodeService
     /// Atomically removes an authorization code from storage and returns the grant it held, in a
     /// single get-and-remove operation. This is how a code is claimed for redemption: it enforces
     /// the single-use guarantee against a race between two simultaneous redemptions of the same
-    /// code (RFC 6749 §4.1.2) - exactly one caller wins and receives the grant, every other caller
+    /// code (RFC 6749 §4.1.2) - at most one caller receives the grant, never two, and every other caller
     /// finds the code already gone and receives an <c>invalid_grant</c> failure.
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -97,10 +97,13 @@ public static class DistributedCacheExtensions
 	///   <item><term>Step 2:</term> Delegate to <see cref="TryRemoveAsync"/> for atomic removal</item>
 	/// </list>
 	/// <para>
-	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
-	/// lock token survives (last-write-wins) will return the value. Other threads detect the lock mismatch
-	/// and return null. This ensures exactly one thread retrieves the value, even though individual cache
-	/// operations are not atomic.
+	/// <strong>What it guarantees, and what it does not:</strong> in a race, only the caller whose lock
+	/// token survives last-write-wins returns the value; the others detect the mismatch and return null.
+	/// AT MOST one caller ever retrieves it, never two. NOT exactly one: a caller can remove the value and
+	/// then find a later caller's lock in place, in which case the value is gone and neither caller is told
+	/// it took it. Nothing observes that from inside a call - the losing caller cannot tell whether anybody
+	/// else won - so it is not reported, only documented. Issue 435 carries the fix, which needs an
+	/// indivisible take this interface does not expose.
 	/// </para>
 	/// <para>
 	/// <strong>Lock timeout:</strong> Locks auto-expire after the specified timeout (default 5 seconds)
@@ -163,7 +166,9 @@ public static class DistributedCacheExtensions
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
 	/// lock token survives (last-write-wins) will return true. Other threads detect the lock mismatch
-	/// and return false. This ensures exactly one thread successfully removes the value.
+	/// and return false. So AT MOST one caller ever removes the value, never two - but not exactly one: a
+	/// caller that removes it and then finds a later caller's lock in place reports a loss over a value
+	/// that is already gone, and so does the other. Issue 435 carries the fix.
 	/// </para>
 	/// <para>
 	/// <strong>Use Case:</strong> This method is useful when you need to atomically remove a value without


### PR DESCRIPTION
Closes #433. The fix is #435, on the 3.0 milestone; this stops four comments promising a guarantee the code does not give.

## What they promised

`DistributedCacheExtensions.TryRemoveAsync` has an interleaving in which the value is removed and every caller is told it lost.

- A writes its lock token
- B writes its own, overwriting A's
- A reads the value, finds it present, and removes it
- A reads the lock back, finds B's token, and reports a loss
- B reads the value, finds nothing, and reports a loss

The authorization is destroyed with nothing issued from it and nothing left to retry against. Four comments said this cannot happen: "ensures exactly one thread retrieves the value", "This ensures exactly one thread successfully removes the value", "exactly one caller wins and receives the grant", "exactly one wins the claim".

They now say **at most** one, which is what the protocol keeps and is the half that matters - never two token sets for one code - and say what is given up instead.

## Why this reports nothing

The first attempt at this branch added a callback on the losing path and logged it. It cannot work, and the reason is worth writing down so nobody rebuilds it.

The losing caller cannot tell whether anybody else won. From its vantage, "another caller took the value" and "nobody did" are the same observation: it removed the value and found a foreign lock token. Which of the two happened is decided by whether the other caller's existence check runs before or after that removal, and that happens after this one has already returned.

Measured rather than argued: two concurrent callers that both read the value before either removes it produce **one winner and one loss report**. That is the ordinary race the lock exists to resolve, and for the device flow two in-flight polls is the normal shape rather than an unusual one, so the line would fire constantly while claiming an authorization was destroyed. A detector that cries wolf is worse than no detector.

A second arm made it worse: `survivingLockToken == null` is the lock's own TTL elapsing, not a race at all, so a lone caller with no competitor would have fired a message asserting a second caller that never existed.

## What is left alone, and why

`ProcessLocalDeliveryLease` also says "exactly one wins", and it means it: the claim is replaced through `ConcurrentDictionary.TryUpdate`, a compare-and-swap. That is precisely the primitive this protocol does not have, which is what #435 is about.

## Evidence

Unit project 2892 passed, 0 failed. `Abblix.Utils` 284 passed, 0 failed. Comments only - no behaviour changed, and none was expected to.

The reproduction of the underlying defect is a deterministic test in a comment on #433, which stays red until #435 lands.
