### PR TITLE
Serialize redemptions of one key within the process, and say what a win actually requires

### DIFF
--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -116,11 +116,11 @@ public class DeviceAuthorizationStorage(
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>
-    /// which serializes redemptions of one device code in-process, so at most one caller ever removes it
-    /// and the rest are told it was not there. What that does not give is a winner for every removal: a
-    /// lock expiring mid-protocol loses the code with one caller on one node, and a second node loses it
-    /// without the expiry. The extension's own remarks carry both and name the store primitive that closes
-    /// them. After successful removal, cleans up the user code mapping.
+    /// which serializes redemptions of one device code in-process, so at most one caller ever removes it.
+    /// What that does NOT give is a winner for every removal - the code can be consumed with nobody told
+    /// they took it, and that needs neither a second caller nor a second node. The extension's own remarks
+    /// carry the condition and name the store primitive that closes it. After a successful removal, cleans
+    /// up the user code mapping.
     /// </para>
     /// </remarks>
     /// <param name="deviceCode">The device code identifying the authorization request to remove.</param>
@@ -129,7 +129,12 @@ public class DeviceAuthorizationStorage(
     /// A task that completes when the operation finishes, containing true when this caller removed the
     /// request AND still held the claim afterwards. False otherwise, which is wider than "another caller
     /// won or it was never there": the code can be consumed and the caller still told false, when the lock
-    /// guarding the removal expires mid-protocol. The extension's remarks carry the full condition.
+    /// guarding the removal expires mid-protocol. The extension's remarks carry that condition.
+    /// <para>
+    /// They cannot cover the cleanup below them, which is this method's own call: if removing the user-code
+    /// index throws, the device code is already consumed and the caller gets the exception instead of true,
+    /// so no tokens are issued for a code that can never be presented again. Tracked as issue 453.
+    /// </para>
     /// </returns>
     public async Task<bool> TryRemoveAsync(string deviceCode, string userCode)
     {

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -116,11 +116,11 @@ public class DeviceAuthorizationStorage(
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>
-    /// which serializes redemptions of one device code in-process: where one process touches the code,
-    /// exactly one caller removes it and the rest are told it was not there. Across processes the protocol
-    /// gives at most one, never two, and a deployment that needs more than that supplies its own storage -
-    /// the extension's own remarks name the primitive to reach for. After successful removal, cleans up
-    /// the user code mapping.
+    /// which serializes redemptions of one device code in-process, so at most one caller ever removes it
+    /// and the rest are told it was not there. What that does not give is a winner for every removal: a
+    /// lock expiring mid-protocol loses the code with one caller on one node, and a second node loses it
+    /// without the expiry. The extension's own remarks carry both and name the store primitive that closes
+    /// them. After successful removal, cleans up the user code mapping.
     /// </para>
     /// </remarks>
     /// <param name="deviceCode">The device code identifying the authorization request to remove.</param>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -117,7 +117,7 @@ public class DeviceAuthorizationStorage(
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>
     /// which admits at most one caller through its lock-token protocol, and serializes redemptions of one
-    /// device code in-process so that a removal has a winner at all.
+    /// device code in-process, which closes the one way a removal loses its winner to a competitor.
     /// What that does NOT give is a winner for every removal - the code can be consumed with nobody told
     /// they took it, and that needs neither a second caller nor a second node. The extension's own remarks
     /// carry the condition and name the store primitive that closes it. After a successful removal, cleans

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -116,7 +116,8 @@ public class DeviceAuthorizationStorage(
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>
-    /// which serializes redemptions of one device code in-process, so at most one caller ever removes it.
+    /// which admits at most one caller through its lock-token protocol, and serializes redemptions of one
+    /// device code in-process so that a removal has a winner at all.
     /// What that does NOT give is a winner for every removal - the code can be consumed with nobody told
     /// they took it, and that needs neither a second caller nor a second node. The extension's own remarks
     /// carry the condition and name the store primitive that closes it. After a successful removal, cleans

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -126,8 +126,10 @@ public class DeviceAuthorizationStorage(
     /// <param name="deviceCode">The device code identifying the authorization request to remove.</param>
     /// <param name="userCode">The user code for cleaning up the secondary index mapping.</param>
     /// <returns>
-    /// A task that completes when the operation finishes, containing true if the request was successfully
-    /// removed by this thread; false if another thread won the race or the device code didn't exist.
+    /// A task that completes when the operation finishes, containing true when this caller removed the
+    /// request AND still held the claim afterwards. False otherwise, which is wider than "another caller
+    /// won or it was never there": the code can be consumed and the caller still told false, when the lock
+    /// guarding the removal expires mid-protocol. The extension's remarks carry the full condition.
     /// </returns>
     public async Task<bool> TryRemoveAsync(string deviceCode, string userCode)
     {

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -34,7 +34,7 @@ public class DeviceAuthorizationStorage(
     {
         // Persist the absolute expiry so a regularly-polling client cannot extend the code: the token
         // endpoint derives the remaining cache TTL from this fixed instant instead of resetting the full
-        // lifetime on every poll (RFC 8628 §3.2)
+        // lifetime on every poll (RFC 8628 section 3.2)
         request.ExpiresAt = timeProvider.GetUtcNow() + expiresIn;
 
         var cacheOptions = new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = expiresIn };
@@ -78,7 +78,7 @@ public class DeviceAuthorizationStorage(
     public Task UpdateAsync(string deviceCode, DeviceAuthorizationRequest request, TimeSpan expiresIn)
     {
         // Apply the caller-computed remaining lifetime as the cache TTL. The caller derives it once from the
-        // record's fixed ExpiresAt (RFC 8628 §3.2) and gates on expiry first, so polling cannot extend the
+        // record's fixed ExpiresAt (RFC 8628 section 3.2) and gates on expiry first, so polling cannot extend the
         // code and the TTL here is always positive - no second clock read that could race the expiry boundary
         return cache.SetAsync(
             keyFactory.DeviceAuthorizationRequestKey(deviceCode),

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -116,8 +116,11 @@ public class DeviceAuthorizationStorage(
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>
-    /// which implements a lock-based protocol ensuring exactly one thread successfully removes the value
-    /// even in concurrent scenarios. After successful removal, cleans up the user code mapping.
+    /// which serializes redemptions of one device code in-process: where one process touches the code,
+    /// exactly one caller removes it and the rest are told it was not there. Across processes the protocol
+    /// gives at most one, never two, and a deployment that needs more than that supplies its own storage -
+    /// the extension's own remarks name the primitive to reach for. After successful removal, cleans up
+    /// the user code mapping.
     /// </para>
     /// </remarks>
     /// <param name="deviceCode">The device code identifying the authorization request to remove.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -70,8 +70,8 @@ public class AuthorizationCodeService(
 	public async Task<Result<AuthorizedGrant, OidcError>> RemoveAuthorizationCodeAsync(string authorizationCode)
 	{
 		// removeOnRetrieval: true performs an atomic get-and-remove, so two concurrent redemptions
-		// of the same code cannot both observe the grant - in one process exactly one wins the claim,
-		// across processes at most one and never two; every other
+		// of the same code cannot both observe the grant - at most one wins the claim, never two, though
+		// a lock expiring mid-protocol can leave the code consumed with nobody holding it; every other
 		// caller finds the code already gone and is rejected.
 		var grant = await storage.GetAsync<AuthorizedGrant>(
 			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);

--- a/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -70,7 +70,8 @@ public class AuthorizationCodeService(
 	public async Task<Result<AuthorizedGrant, OidcError>> RemoveAuthorizationCodeAsync(string authorizationCode)
 	{
 		// removeOnRetrieval: true performs an atomic get-and-remove, so two concurrent redemptions
-		// of the same code cannot both observe the grant - exactly one wins the claim; every other
+		// of the same code cannot both observe the grant - in one process exactly one wins the claim,
+		// across processes at most one and never two; every other
 		// caller finds the code already gone and is rejected.
 		var grant = await storage.GetAsync<AuthorizedGrant>(
 			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);

--- a/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -69,10 +69,10 @@ public class AuthorizationCodeService(
 	/// <inheritdoc />
 	public async Task<Result<AuthorizedGrant, OidcError>> RemoveAuthorizationCodeAsync(string authorizationCode)
 	{
-		// removeOnRetrieval: true performs an atomic get-and-remove, so two concurrent redemptions
-		// of the same code cannot both observe the grant - at most one wins the claim, never two, though
-		// a lock expiring mid-protocol can leave the code consumed with nobody holding it; every other
-		// caller finds the code already gone and is rejected.
+		// removeOnRetrieval: true claims the code, and every caller that finds it gone is rejected.
+		// What the claim does NOT give: a removal can end with nobody holding the grant, when the claim
+		// expires mid-protocol; and two callers can both hold it, because the value is read before the
+		// claim is taken and the reuse decorator writes the grant back at this same key. Issue 454.
 		var grant = await storage.GetAsync<AuthorizedGrant>(
 			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);
 

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -49,9 +49,15 @@ public interface IAuthorizationCodeService
     /// Atomically removes an authorization code from storage and returns the grant it held, in a
     /// single get-and-remove operation. This is how a code is claimed for redemption: it enforces
     /// the single-use guarantee against a race between two simultaneous redemptions of the same
-    /// code (RFC 6749 section 4.1.2) - at most one caller ever receives the grant, never two, though a
-    /// removal can still end with nobody receiving it, and every other caller
-    /// finds the code already gone and receives an <c>invalid_grant</c> failure.
+    /// code (RFC 6749 section 4.1.2) - every other caller finds the code already gone and receives an
+    /// <c>invalid_grant</c> failure.
+    /// <para>
+    /// Two exceptions, and neither needs a second node. A removal can end with NOBODY receiving the
+    /// grant, when the claim guarding it expires mid-protocol. And two callers CAN both receive it, when
+    /// one of them redeems while the other writes the grant back at the same key - the second is handed
+    /// what it read before the claim, not what it removed, so the reuse check sees no issued tokens and
+    /// mints a second set. That is issue 454, and it is why this sentence no longer says "never two".
+    /// </para>
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>
     /// <returns>

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -49,8 +49,8 @@ public interface IAuthorizationCodeService
     /// Atomically removes an authorization code from storage and returns the grant it held, in a
     /// single get-and-remove operation. This is how a code is claimed for redemption: it enforces
     /// the single-use guarantee against a race between two simultaneous redemptions of the same
-    /// code (RFC 6749 §4.1.2) - where one process touches the code exactly one caller receives the grant,
-    /// across processes at most one and never two, and every other caller
+    /// code (RFC 6749 section 4.1.2) - at most one caller ever receives the grant, never two, though a
+    /// removal can still end with nobody receiving it, and every other caller
     /// finds the code already gone and receives an <c>invalid_grant</c> failure.
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -53,7 +53,8 @@ public interface IAuthorizationCodeService
     /// <c>invalid_grant</c> failure.
     /// <para>
     /// Two exceptions, and neither needs a second node. A removal can end with NOBODY receiving the
-    /// grant, when the claim guarding it expires mid-protocol. And two callers CAN both receive it, when
+    /// grant - an expiring claim is one way there and a store fault after the removal is another. And two
+    /// callers CAN both receive it, when
     /// one of them redeems while the other writes the grant back at the same key - the second is handed
     /// what it read before the claim, not what it removed, so the reuse check sees no issued tokens and
     /// mints a second set. That is issue 454, and it is why this sentence no longer says "never two".

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -49,7 +49,8 @@ public interface IAuthorizationCodeService
     /// Atomically removes an authorization code from storage and returns the grant it held, in a
     /// single get-and-remove operation. This is how a code is claimed for redemption: it enforces
     /// the single-use guarantee against a race between two simultaneous redemptions of the same
-    /// code (RFC 6749 §4.1.2) - exactly one caller wins and receives the grant, every other caller
+    /// code (RFC 6749 §4.1.2) - where one process touches the code exactly one caller receives the grant,
+    /// across processes at most one and never two, and every other caller
     /// finds the code already gone and receives an <c>invalid_grant</c> failure.
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -55,9 +55,11 @@ public interface IAuthorizationCodeService
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>
     /// <returns>
-    /// The grant on success when this caller won the claim; an <c>invalid_grant</c>
-    /// <see cref="OidcError"/> when the code is absent - already claimed by a concurrent request,
-    /// already consumed, expired, or never issued.
+    /// The grant when this caller won the claim; an <c>invalid_grant</c> <see cref="OidcError"/>
+    /// otherwise. Otherwise is wider than the obvious list - a concurrent request, an earlier
+    /// consumption, an expiry, a code never issued - because the claim can also CONSUME the code and
+    /// still refuse, when the lock guarding it expires mid-protocol. So a refusal does not prove another
+    /// request took it, and looking for one is how that case is missed.
     /// </returns>
     /// <remarks>
     /// A successfully claimed grant whose <c>IssuedTokens</c> is non-empty indicates the code was

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -34,6 +34,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Abblix.Utils.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -268,9 +268,13 @@ public static class DistributedCacheExtensions
 	/// many exist, while these are keyed by the code being redeemed, so a table that never forgets would
 	/// grow by one entry for every authorization the deployment ever issues.
 	/// </remarks>
-	private static readonly Dictionary<string, GateEntry> Gates = new(StringComparer.Ordinal);
+	/// <remarks>
+	/// Internal rather than private so the test that proves it is emptied can name it and be carried
+	/// through a rename by the compiler. Read-only from outside this class either way.
+	/// </remarks>
+	internal static readonly Dictionary<string, GateEntry> Gates = new(StringComparer.Ordinal);
 
-	private sealed class GateEntry
+	internal sealed class GateEntry
 	{
 		public readonly SemaphoreSlim Gate = new(1, 1);
 		public int Waiters;

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -99,10 +99,10 @@ public static class DistributedCacheExtensions
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
 	/// lock token survives (last-write-wins) will return the value. Other threads detect the lock mismatch
-	/// and return null. So where one process touches the key, exactly one caller retrieves the value, even
-	/// though the individual cache operations are not atomic - and across processes, at most one. The
-	/// difference, and what to do about it, is under <see cref="TryRemoveAsync"/>, which this delegates to
-	/// and which carries the guarantee.
+	/// and return null. AT MOST one caller ever retrieves the value, never two - and the mechanism that
+	/// picks the winner is not the same on one node as on several. Both, and what a value can be lost to
+	/// even with a single caller, are under <see cref="TryRemoveAsync"/>, which this delegates to and
+	/// which carries the guarantee.
 	/// </para>
 	/// <para>
 	/// <strong>Lock timeout:</strong> Locks auto-expire after the specified timeout (default 5 seconds)
@@ -165,8 +165,9 @@ public static class DistributedCacheExtensions
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
 	/// lock token survives (last-write-wins) will return true. Other threads detect the lock mismatch
-	/// and return false. What that leaves is spelled out below, because it is not the same answer on one
-	/// node as on several.
+	/// and return false. In one process that branch is unreachable - callers on a key are serialized, so
+	/// nobody else writes that lock and every caller's own token survives - and the winner is picked by
+	/// the value-existence check instead. What that leaves is spelled out below.
 	/// </para>
 	/// <para>
 	/// <strong>Use Case:</strong> This method is useful when you need to atomically remove a value without
@@ -175,18 +176,26 @@ public static class DistributedCacheExtensions
 	/// not the request data itself.
 	/// </para>
 	/// <para>
-	/// <strong>What this guarantees:</strong> where ONE process touches the key, exactly one caller removes
-	/// the value and every other caller is told the key was not there. Callers of this method on the same
-	/// key are serialized in-process, so the protocol below never runs concurrently against itself. Note
-	/// the condition is the key's traffic, not the deployment: a second process redeeming the same key at
-	/// the same moment is outside this and lands in the paragraph below.
+	/// <strong>What this guarantees, always:</strong> AT MOST one caller removes the value. Never two,
+	/// wherever the traffic comes from. Callers on one key are serialized in-process, so the protocol below
+	/// never runs concurrently against itself here.
 	/// </para>
 	/// <para>
-	/// <strong>Across processes it guarantees only AT MOST one.</strong> Two nodes redeeming the same key
-	/// at the same moment can end with the value removed and neither told it took it, because the lock
-	/// protocol is assembled from <c>Get</c>, <c>Set</c> and <c>Remove</c> as three separate operations and
-	/// there is a window between any two of them. A take-once needs one indivisible read-modify-write, and
-	/// this interface exposes none: no compare-and-swap, no set-if-absent, no delete-returning-value.
+	/// <strong>What it does NOT guarantee is that a removal has a winner</strong>, and the serialization
+	/// only closes one of the two ways to lose one. A caller reports a loss when the lock token it reads
+	/// back is not the one it wrote, and there are two ways for that: somebody overwrote it, which needs a
+	/// second caller and is what the serialization prevents within a process; or it EXPIRED, which needs
+	/// only time. The lock carries <paramref name="lockTimeout"/>, five seconds by default, and three cache
+	/// round trips sit between writing it and reading it back - so a stalled cache call, a garbage
+	/// collection pause or a starved thread pool is enough for ONE caller on ONE node to remove the value
+	/// and be told it did not.
+	/// </para>
+	/// <para>
+	/// <strong>Across processes the second way opens too.</strong> Two nodes redeeming the same key at the
+	/// same moment can end with the value removed and neither told it took it, because the lock protocol is
+	/// assembled from <c>Get</c>, <c>Set</c> and <c>Remove</c> as three separate operations and there is a
+	/// window between any two of them. A take-once needs one indivisible read-modify-write, and this
+	/// interface exposes none: no compare-and-swap, no set-if-absent, no delete-returning-value.
 	/// </para>
 	/// <para>
 	/// <strong>A deployment on several nodes that cannot afford that</strong> supplies its own storage and
@@ -219,8 +228,9 @@ public static class DistributedCacheExtensions
 	/// <param name="cancellationToken">Optional cancellation token to cancel the operation.</param>
 	/// <returns>
 	/// A task that completes when the operation finishes, containing true if the value was removed by this
-	/// caller; false if another caller took it, if the key did not exist, or - only across processes - if
-	/// the value was removed and no caller could be told it took it.
+	/// caller; false if another caller took it, if the key did not exist, or if the value was removed and
+	/// no caller could be told it took it - which needs a second node OR merely a lock that expired
+	/// mid-protocol, and so is reachable with one caller on one node.
 	/// </returns>
 	public static async Task<bool> TryRemoveAsync(
 		this IDistributedCache cache,

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -86,9 +86,9 @@ public static class DistributedCacheExtensions
 	}
 
 	/// <summary>
-	/// Atomically retrieves and removes a value from the distributed cache.
-	/// Uses a lock-based protocol to ensure atomic get-and-remove semantics even when the underlying
-	/// cache implementation doesn't support native atomic operations (e.g., Redis GETDEL).
+	/// Reads a value and then removes it under a lock, for a cache with no native primitive of its own.
+	/// This is NOT the equivalent of Redis GETDEL: the bytes returned are the ones read before the lock,
+	/// so two callers can be handed the same value. Read the remarks before relying on it.
 	/// </summary>
 	/// <remarks>
 	/// <para><strong>Atomicity Protocol:</strong></para>
@@ -123,9 +123,10 @@ public static class DistributedCacheExtensions
 	/// <param name="lockTimeout">Duration after which the lock expires, 5 seconds if null.</param>
 	/// <param name="cancellationToken">Optional cancellation token to cancel the operation.</param>
 	/// <returns>
-	/// A task that completes when the operation finishes, containing the retrieved value when this caller
-	/// removed it AND its own claim was still in the store afterwards. Null otherwise - which does NOT mean
-	/// somebody else took it. See <see cref="TryRemoveAsync"/>, whose remarks carry the condition; this
+	/// A task that completes when the operation finishes, containing the value READ BEFORE the removal
+	/// when this caller's own claim was still in the store afterwards - not necessarily the value it
+	/// removed, see the remarks and issue 454. Null otherwise, which does NOT mean somebody else took it:
+	/// see <see cref="TryRemoveAsync"/>, whose remarks carry the condition; this
 	/// method adds nothing to it beyond returning the value.
 	/// </returns>
 	public static async Task<byte[]?> TryGetAndRemoveAsync(
@@ -164,10 +165,11 @@ public static class DistributedCacheExtensions
 	/// <remarks>
 	/// <para><strong>Atomicity Protocol:</strong></para>
 	/// <list type="number">
-	///   <item><term>Step 1:</term> Write a unique lock token to fully-qualified lock key</item>
-	///   <item><term>Step 2:</term> Remove the value from cache</item>
-	///   <item><term>Step 3:</term> Read back the lock token and verify it matches ours</item>
-	///   <item><term>Step 4:</term> Clean up the lock key</item>
+	///   <item><term>Step 1:</term> Write a unique claim token to the fully-qualified lock key</item>
+	///   <item><term>Step 2:</term> Check the value is there at all, and give up early if it is not</item>
+	///   <item><term>Step 3:</term> Remove the value from cache</item>
+	///   <item><term>Step 4:</term> Read back the claim token and verify it is still ours</item>
+	///   <item><term>Step 5:</term> Clean up the lock key</item>
 	/// </list>
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> a caller reports the removal as its own only when its
@@ -356,7 +358,7 @@ public static class DistributedCacheExtensions
 		// The value must still exist at the moment we hold the lock. Without this check a caller whose lock
 		// window does not overlap a prior successful removal would still see its own token survive and wrongly
 		// report success - breaking exactly-once removal (two token requests both redeeming the same
-		// device_code or authorization code). RFC 6749 §4.1.2 forbids reusing an authorization code; for a
+		// device_code or authorization code). RFC 6749 section 4.1.2 forbids reusing an authorization code; for a
 		// device_code no RFC says so, and single use is this codebase's own rule. The documented contract is
 		// "false if ... the key didn't exist".
 		if (await cache.GetAsync(key, cancellationToken) == null)

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -186,39 +186,30 @@ public static class DistributedCacheExtensions
 	/// </para>
 	/// <para>
 	/// <strong>What the protocol decides:</strong> a caller is told it took the value only when the
-	/// protocol runs to the end AND finds its own lock token still in the store. Everything below follows
-	/// from that one sentence, which is why it is stated instead of a list of what cannot happen.
+	/// protocol runs to the end AND finds its own lock token still in the store.
 	/// </para>
 	/// <para>
-	/// <strong>At most one caller passes that check</strong>, and the lock token is what decides it, not
-	/// the in-process gate: eight callers on one key over two hundred rounds produce no round with two
-	/// winners either with the gate or without it. Passing the check is not the same as being handed the
-	/// value, though - <see cref="TryGetAndRemoveAsync"/> hands back what it read BEFORE the protocol, so
-	/// where something writes the key in between, two callers can pass and be handed the same bytes. That
-	/// is issue 454, and this class does not close it.
+	/// That is the whole contract, and it is deliberately not followed by a count of what can go wrong.
+	/// Such a list is not closable - the token can be overwritten, it can expire while a cache call
+	/// stalls, and the store calls after the removal can fail, and there is no argument that those are
+	/// all. What the tests carry instead, each dying when its fact stops holding:
+	/// <c>TryRemoveAsync_TheLockExpiresMidProtocol_OneCallerAloneLosesTheValue</c> for a removal with
+	/// nobody told, on one node with no competitor, and
+	/// <c>TryRemoveAsync_TheStoreFaultsAfterTheRemoval_TheValueIsGoneAndNobodyIsTold</c> for the same
+	/// outcome reached by a fault, where the caller gets an exception rather than an answer at all.
 	/// </para>
 	/// <para>
-	/// <strong>A removal may have NO winner, and the gate closes only one way of reaching that.</strong>
-	/// In the same measurement it took the no-winner rounds from eleven to zero, which is the
-	/// competitor-overwrite way. The other two survive it, so a single caller on a single node still
-	/// reaches a no-winner removal - <c>TryRemoveAsync_TheLockExpiresMidProtocol_OneCallerAloneLosesTheValue</c>
-	/// and <c>TryRemoveAsync_TheStoreFaultsAfterTheRemoval_TheValueIsGoneAndNobodyIsTold</c> are those two.
-	/// Worth knowing before moving the gate or dropping it: what would come back is a loss that needs a
-	/// competitor, not a loss of single use.
+	/// <strong>Two things the check does NOT give you.</strong> It does not make this a take-once: the
+	/// gate serializes callers within one process, so a competitor cannot overwrite another's token HERE,
+	/// and nothing about that survives a second node - see below. And passing it is not the same as being
+	/// handed the value, because <see cref="TryGetAndRemoveAsync"/> returns what it read BEFORE the
+	/// protocol; where something writes the key in between, two callers pass and are handed the same
+	/// bytes. That is issue 454, and this class does not close it.
 	/// </para>
 	/// <para>
-	/// <strong>The three ways the check is not passed.</strong>
-	/// State it that way round rather than listing the ways to lose, because that list is not closable:
-	/// the token can be overwritten, which needs a competitor and is what the serialization prevents here;
-	/// it can EXPIRE, which needs only time; and the two store calls that follow the removal can fail, in
-	/// which case the value is gone and the caller gets an exception rather than an answer at all. Only the
-	/// first of those three needs a second caller, so a single caller on a single node can lose a value -
-	/// <paramref name="lockTimeout"/> is five seconds by default, and a stalled cache call, a garbage
-	/// collection pause or a starved thread pool is enough.
-	/// </para>
-	/// <para>
-	/// <strong>Across processes the second way opens too.</strong> Two nodes redeeming the same key at the
-	/// same moment can end with the value removed and neither told it took it, because the lock protocol is
+	/// <strong>Across processes even the overwrite reopens.</strong> Two nodes redeeming the same key at
+	/// the same moment can end with the value removed and neither told it took it, because the lock
+	/// protocol is
 	/// assembled from <c>Get</c>, <c>Set</c> and <c>Remove</c> as three separate operations and there is a
 	/// window between any two of them. A take-once needs one indivisible read-modify-write, and this
 	/// interface exposes none: no compare-and-swap, no set-if-absent, no delete-returning-value.

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -164,10 +164,9 @@ public static class DistributedCacheExtensions
 	/// </list>
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
-	/// lock token survives (last-write-wins) will return true. Other threads detect the lock mismatch
-	/// and return false. In one process that branch is unreachable - callers on a key are serialized, so
-	/// nobody else writes that lock and every caller's own token survives - and the winner is picked by
-	/// the value-existence check instead. What that leaves is spelled out below.
+	/// lock token survives (last-write-wins) will return true. A caller whose token is not there returns
+	/// false - and in one process that is not because somebody overwrote it, since callers on a key are
+	/// serialized, but because it EXPIRED. What that leaves is spelled out below.
 	/// </para>
 	/// <para>
 	/// <strong>Use Case:</strong> This method is useful when you need to atomically remove a value without
@@ -181,14 +180,15 @@ public static class DistributedCacheExtensions
 	/// never runs concurrently against itself here.
 	/// </para>
 	/// <para>
-	/// <strong>What it does NOT guarantee is that a removal has a winner</strong>, and the serialization
-	/// only closes one of the two ways to lose one. A caller reports a loss when the lock token it reads
-	/// back is not the one it wrote, and there are two ways for that: somebody overwrote it, which needs a
-	/// second caller and is what the serialization prevents within a process; or it EXPIRED, which needs
-	/// only time. The lock carries <paramref name="lockTimeout"/>, five seconds by default, and three cache
-	/// round trips sit between writing it and reading it back - so a stalled cache call, a garbage
-	/// collection pause or a starved thread pool is enough for ONE caller on ONE node to remove the value
-	/// and be told it did not.
+	/// <strong>What it does NOT guarantee is that a removal has a winner.</strong> A caller is told it took
+	/// the value only when the protocol runs to the end AND finds its own lock token still in the store.
+	/// State it that way round rather than listing the ways to lose, because that list is not closable:
+	/// the token can be overwritten, which needs a competitor and is what the serialization prevents here;
+	/// it can EXPIRE, which needs only time; and the two store calls that follow the removal can fail, in
+	/// which case the value is gone and the caller gets an exception rather than an answer at all. Only the
+	/// first of those three needs a second caller, so a single caller on a single node can lose a value -
+	/// <paramref name="lockTimeout"/> is five seconds by default, and a stalled cache call, a garbage
+	/// collection pause or a starved thread pool is enough.
 	/// </para>
 	/// <para>
 	/// <strong>Across processes the second way opens too.</strong> Two nodes redeeming the same key at the
@@ -227,10 +227,11 @@ public static class DistributedCacheExtensions
 	/// <param name="lockTimeout">Duration after which the lock expires, 5 seconds if null.</param>
 	/// <param name="cancellationToken">Optional cancellation token to cancel the operation.</param>
 	/// <returns>
-	/// A task that completes when the operation finishes, containing true if the value was removed by this
-	/// caller; false if another caller took it, if the key did not exist, or if the value was removed and
-	/// no caller could be told it took it - which needs a second node OR merely a lock that expired
-	/// mid-protocol, and so is reachable with one caller on one node.
+	/// A task that completes when the operation finishes, containing true when the value was removed by
+	/// this caller AND its own lock token was still in the store afterwards. False otherwise - which covers
+	/// the key not being there, another caller having taken it, and the case where the value is gone and
+	/// nobody can be told they took it. That last one does not need a second node: see the remarks. A
+	/// store fault after the removal raises rather than returning, and loses the value the same way.
 	/// </returns>
 	public static async Task<bool> TryRemoveAsync(
 		this IDistributedCache cache,
@@ -242,9 +243,11 @@ public static class DistributedCacheExtensions
 		ArgumentNullException.ThrowIfNull(key);
 
 		// Redemptions of the SAME key are serialized within this process, so the protocol below never runs
-		// concurrently against itself here and the interleaving that loses a value cannot form. Callers on
-		// different keys never meet: the gate exists only while a call is in flight and is discarded with
-		// the last one out.
+		// concurrently against itself here and no caller can overwrite another's lock token. That is one of
+		// the three ways a value is lost with nobody told; the other two - an expiring lock and a store
+		// fault after the removal - need no competitor and are untouched by this. Callers on different keys
+		// never meet: the gate exists only while a call is in flight and is discarded with the last one
+		// out.
 		//
 		// This gate is taken HERE and not in TryGetAndRemoveAsync, which calls this method - gating both
 		// would deadlock a caller against itself on one key. That is safe: TryGetAndRemoveAsync discards

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -172,9 +172,11 @@ public static class DistributedCacheExtensions
 	/// not the request data itself.
 	/// </para>
 	/// <para>
-	/// <strong>What this guarantees:</strong> within ONE process, exactly one caller removes the value and
-	/// every other caller is told the key was not there. Callers of this method on the same key are
-	/// serialized, so the protocol below never runs concurrently against itself.
+	/// <strong>What this guarantees:</strong> where ONE process touches the key, exactly one caller removes
+	/// the value and every other caller is told the key was not there. Callers of this method on the same
+	/// key are serialized in-process, so the protocol below never runs concurrently against itself. Note
+	/// the condition is the key's traffic, not the deployment: a second process redeeming the same key at
+	/// the same moment is outside this and lands in the paragraph below.
 	/// </para>
 	/// <para>
 	/// <strong>Across processes it guarantees only AT MOST one.</strong> Two nodes redeeming the same key
@@ -184,16 +186,21 @@ public static class DistributedCacheExtensions
 	/// this interface exposes none: no compare-and-swap, no set-if-absent, no delete-returning-value.
 	/// </para>
 	/// <para>
-	/// <strong>A deployment on several nodes that cannot afford that</strong> supplies its own storage - the
-	/// interfaces above this one are public and replaceable - and reaches for the primitive its store
-	/// already has. Which primitive that is depends on the store, which is why it cannot live here:
+	/// <strong>A deployment on several nodes that cannot afford that</strong> supplies its own storage and
+	/// reaches for the primitive its store already has. No new API is needed for that:
+	/// <c>IDeviceAuthorizationStorage</c>, <c>IBackChannelRequestStorage</c> and <c>IEntityStorage</c> are
+	/// public and registered with <c>TryAddSingleton</c>, so a host's own registration wins. Which
+	/// primitive to reach for depends on the store, which is why it cannot be chosen here:
 	/// </para>
 	/// <list type="bullet">
 	///   <item>Redis 6.2 and later: <c>GETDEL key</c>, one command, which returns the value to exactly one
 	///   caller and deletes it. Earlier versions get the same effect from a two-line <c>EVAL</c> script,
-	///   since Redis runs a script indivisibly.</item>
+	///   since Redis runs a script indivisibly. Both are for a storage of your own: they read a STRING,
+	///   and the <c>IDistributedCache</c> implementation for Redis keeps each entry as a hash whose value
+	///   sits in a field, so pointed at these keys they answer <c>WRONGTYPE</c>.</item>
 	///   <item>PostgreSQL: <c>DELETE FROM ... WHERE key = $1 RETURNING value</c>. The row lock picks the
-	///   winner and the losing statement returns no rows.</item>
+	///   winner, and at the default isolation level the loser returns no rows; under REPEATABLE READ or
+	///   SERIALIZABLE it fails to serialize instead, which is the same answer through an exception.</item>
 	///   <item>SQL Server: <c>DELETE ... OUTPUT deleted.value</c>, the same shape.</item>
 	///   <item>Oracle: <c>DELETE ... RETURNING value INTO :out</c>. Oracle documents the RETURNING INTO
 	///   clause as belonging to DELETE among others, and for a DELETE it yields the pre-deletion value.</item>
@@ -252,6 +259,12 @@ public static class DistributedCacheExtensions
 	/// <summary>
 	/// One gate per key, alive only while a redemption of that key is in flight.
 	/// </summary>
+	/// <remarks>
+	/// Retired on the way out, unlike the per-stream gate in the security-event outbox, and the difference
+	/// is the key space rather than taste: a stream is a long-lived entity and its gates are bounded by how
+	/// many exist, while these are keyed by the code being redeemed, so a table that never forgets would
+	/// grow by one entry for every authorization the deployment ever issues.
+	/// </remarks>
 	private static readonly Dictionary<string, GateEntry> Gates = new(StringComparer.Ordinal);
 
 	private sealed class GateEntry
@@ -280,8 +293,10 @@ public static class DistributedCacheExtensions
 	{
 		lock (Gates)
 		{
+			// Loud rather than defensive: every return is paired with a rent that put the entry here, so a
+			// miss means the invariant is already broken and swallowing it hides whatever broke it.
 			if (!Gates.TryGetValue(key, out var entry))
-				return;
+				throw new InvalidOperationException($"No redemption gate is held for '{key}'.");
 
 			if (--entry.Waiters > 0)
 				return;

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -87,8 +87,10 @@ public static class DistributedCacheExtensions
 
 	/// <summary>
 	/// Reads a value and then removes it under a lock, for a cache with no native primitive of its own.
-	/// This is NOT the equivalent of Redis GETDEL: the bytes returned are the ones read before the lock,
-	/// so two callers can be handed the same value. Read the remarks before relying on it.
+	/// This is NOT the equivalent of Redis GETDEL: the bytes returned are the ones read BEFORE the lock,
+	/// so if anything writes the key between the read and the removal, this caller destroys that write and
+	/// is handed the earlier value. With nothing writing the key, exactly one caller is handed it. Read
+	/// the remarks before relying on it.
 	/// </summary>
 	/// <remarks>
 	/// <para><strong>Atomicity Protocol:</strong></para>
@@ -183,9 +185,15 @@ public static class DistributedCacheExtensions
 	/// not the request data itself.
 	/// </para>
 	/// <para>
-	/// <strong>What this guarantees, always:</strong> AT MOST one caller removes the value. Never two,
-	/// wherever the traffic comes from. Callers on one key are serialized in-process, so the protocol below
-	/// never runs concurrently against itself here.
+	/// <strong>AT MOST one caller removes the value, and the lock-token protocol is what gives that</strong>
+	/// - not the in-process gate. Measured: eight callers on one key over two hundred rounds produce no
+	/// round with two winners either with the gate or without it.
+	/// </para>
+	/// <para>
+	/// <strong>What the gate buys is that a removal HAS a winner.</strong> In the same measurement it took
+	/// the rounds with NO winner from eleven to zero. That is liveness rather than exclusivity, and it is
+	/// worth knowing before moving the gate or dropping it: single use does not depend on it, and the
+	/// defect it closes does.
 	/// </para>
 	/// <para>
 	/// <strong>What it does NOT guarantee is that a removal has a winner.</strong> A caller is told it took
@@ -258,9 +266,14 @@ public static class DistributedCacheExtensions
 		// out.
 		//
 		// This gate is taken HERE and not in TryGetAndRemoveAsync, which calls this method - gating both
-		// would deadlock a caller against itself on one key. That is safe: TryGetAndRemoveAsync discards
-		// the value it read whenever this returns false, so a caller that lost inside the gate hands back
-		// nothing.
+		// naively would deadlock a caller against itself on one key.
+		//
+		// That placement is NOT settled, and this comment is not a reason to leave it. It is fine for the
+		// caller that LOSES: TryGetAndRemoveAsync discards the value it read whenever this returns false.
+		// The caller that WINS is issue 454 - it was handed the value it read before this gate, which is
+		// not necessarily the value removed inside it. Bringing the read inside the serialized section is
+		// what closes the in-process half; the deadlock is an objection to the naive shape of that, not to
+		// the goal.
 		var gate = RentGate(key);
 		try
 		{

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -303,7 +303,9 @@ public static class DistributedCacheExtensions
 			// Loud rather than defensive: every return is paired with a rent that put the entry here, so a
 			// miss means the invariant is already broken and swallowing it hides whatever broke it.
 			if (!Gates.TryGetValue(key, out var entry))
-				throw new InvalidOperationException($"No redemption gate is held for '{key}'.");
+				throw new InvalidOperationException(
+					$"No redemption gate is held. {nameof(RentGate)} and {nameof(ReturnGate)} are paired, so "
+					+ "this cannot happen unless one of them was changed.");
 
 			if (--entry.Waiters > 0)
 				return;

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -99,8 +99,10 @@ public static class DistributedCacheExtensions
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
 	/// lock token survives (last-write-wins) will return the value. Other threads detect the lock mismatch
-	/// and return null. This ensures exactly one thread retrieves the value, even though individual cache
-	/// operations are not atomic.
+	/// and return null. So where one process touches the key, exactly one caller retrieves the value, even
+	/// though the individual cache operations are not atomic - and across processes, at most one. The
+	/// difference, and what to do about it, is under <see cref="TryRemoveAsync"/>, which this delegates to
+	/// and which carries the guarantee.
 	/// </para>
 	/// <para>
 	/// <strong>Lock timeout:</strong> Locks auto-expire after the specified timeout (default 5 seconds)
@@ -163,7 +165,8 @@ public static class DistributedCacheExtensions
 	/// <para>
 	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
 	/// lock token survives (last-write-wins) will return true. Other threads detect the lock mismatch
-	/// and return false. This ensures exactly one thread successfully removes the value.
+	/// and return false. What that leaves is spelled out below, because it is not the same answer on one
+	/// node as on several.
 	/// </para>
 	/// <para>
 	/// <strong>Use Case:</strong> This method is useful when you need to atomically remove a value without

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -87,10 +87,10 @@ public static class DistributedCacheExtensions
 
 	/// <summary>
 	/// Reads a value and then removes it under a lock, for a cache with no native primitive of its own.
-	/// This is NOT the equivalent of Redis GETDEL: the bytes returned are the ones read BEFORE the lock,
-	/// so if anything writes the key between the read and the removal, this caller destroys that write and
-	/// is handed the earlier value. With nothing writing the key, exactly one caller is handed it. Read
-	/// the remarks before relying on it.
+	/// This is NOT the equivalent of Redis GETDEL. The bytes returned are the ones read BEFORE the lock,
+	/// so anything writing the key in between is destroyed by this caller while it is handed the earlier
+	/// value - and that is only one of the ways the two differ. AT MOST one caller is handed the value
+	/// when nothing writes the key, and none may be. Read the remarks before relying on it.
 	/// </summary>
 	/// <remarks>
 	/// <para><strong>Atomicity Protocol:</strong></para>
@@ -185,19 +185,29 @@ public static class DistributedCacheExtensions
 	/// not the request data itself.
 	/// </para>
 	/// <para>
-	/// <strong>AT MOST one caller removes the value, and the lock-token protocol is what gives that</strong>
-	/// - not the in-process gate. Measured: eight callers on one key over two hundred rounds produce no
-	/// round with two winners either with the gate or without it.
+	/// <strong>What the protocol decides:</strong> a caller is told it took the value only when the
+	/// protocol runs to the end AND finds its own lock token still in the store. Everything below follows
+	/// from that one sentence, which is why it is stated instead of a list of what cannot happen.
 	/// </para>
 	/// <para>
-	/// <strong>What the gate buys is that a removal HAS a winner.</strong> In the same measurement it took
-	/// the rounds with NO winner from eleven to zero. That is liveness rather than exclusivity, and it is
-	/// worth knowing before moving the gate or dropping it: single use does not depend on it, and the
-	/// defect it closes does.
+	/// <strong>At most one caller passes that check</strong>, and the lock token is what decides it, not
+	/// the in-process gate: eight callers on one key over two hundred rounds produce no round with two
+	/// winners either with the gate or without it. Passing the check is not the same as being handed the
+	/// value, though - <see cref="TryGetAndRemoveAsync"/> hands back what it read BEFORE the protocol, so
+	/// where something writes the key in between, two callers can pass and be handed the same bytes. That
+	/// is issue 454, and this class does not close it.
 	/// </para>
 	/// <para>
-	/// <strong>What it does NOT guarantee is that a removal has a winner.</strong> A caller is told it took
-	/// the value only when the protocol runs to the end AND finds its own lock token still in the store.
+	/// <strong>A removal may have NO winner, and the gate closes only one way of reaching that.</strong>
+	/// In the same measurement it took the no-winner rounds from eleven to zero, which is the
+	/// competitor-overwrite way. The other two survive it, so a single caller on a single node still
+	/// reaches a no-winner removal - <c>TryRemoveAsync_TheLockExpiresMidProtocol_OneCallerAloneLosesTheValue</c>
+	/// and <c>TryRemoveAsync_TheStoreFaultsAfterTheRemoval_TheValueIsGoneAndNobodyIsTold</c> are those two.
+	/// Worth knowing before moving the gate or dropping it: what would come back is a loss that needs a
+	/// competitor, not a loss of single use.
+	/// </para>
+	/// <para>
+	/// <strong>The three ways the check is not passed.</strong>
 	/// State it that way round rather than listing the ways to lose, because that list is not closable:
 	/// the token can be overwritten, which needs a competitor and is what the serialization prevents here;
 	/// it can EXPIRE, which needs only time; and the two store calls that follow the removal can fail, in

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -172,6 +172,33 @@ public static class DistributedCacheExtensions
 	/// not the request data itself.
 	/// </para>
 	/// <para>
+	/// <strong>What this guarantees:</strong> within ONE process, exactly one caller removes the value and
+	/// every other caller is told the key was not there. Callers of this method on the same key are
+	/// serialized, so the protocol below never runs concurrently against itself.
+	/// </para>
+	/// <para>
+	/// <strong>Across processes it guarantees only AT MOST one.</strong> Two nodes redeeming the same key
+	/// at the same moment can end with the value removed and neither told it took it, because the lock
+	/// protocol is assembled from <c>Get</c>, <c>Set</c> and <c>Remove</c> as three separate operations and
+	/// there is a window between any two of them. A take-once needs one indivisible read-modify-write, and
+	/// this interface exposes none: no compare-and-swap, no set-if-absent, no delete-returning-value.
+	/// </para>
+	/// <para>
+	/// <strong>A deployment on several nodes that cannot afford that</strong> supplies its own storage - the
+	/// interfaces above this one are public and replaceable - and reaches for the primitive its store
+	/// already has. Which primitive that is depends on the store, which is why it cannot live here:
+	/// </para>
+	/// <list type="bullet">
+	///   <item>Redis 6.2 and later: <c>GETDEL key</c>, one command, which returns the value to exactly one
+	///   caller and deletes it. Earlier versions get the same effect from a two-line <c>EVAL</c> script,
+	///   since Redis runs a script indivisibly.</item>
+	///   <item>PostgreSQL: <c>DELETE FROM ... WHERE key = $1 RETURNING value</c>. The row lock picks the
+	///   winner and the losing statement returns no rows.</item>
+	///   <item>SQL Server: <c>DELETE ... OUTPUT deleted.value</c>, the same shape.</item>
+	///   <item>Oracle: <c>DELETE ... RETURNING value INTO :out</c>. Oracle documents the RETURNING INTO
+	///   clause as belonging to DELETE among others, and for a DELETE it yields the pre-deletion value.</item>
+	/// </list>
+	/// <para>
 	/// <strong>Lock timeout:</strong> Locks auto-expire after the specified timeout (default 5 seconds)
 	/// to prevent orphaned locks if a process crashes between writing the lock token and cleaning it up.
 	/// </para>
@@ -181,8 +208,9 @@ public static class DistributedCacheExtensions
 	/// <param name="lockTimeout">Duration after which the lock expires, 5 seconds if null.</param>
 	/// <param name="cancellationToken">Optional cancellation token to cancel the operation.</param>
 	/// <returns>
-	/// A task that completes when the operation finishes, containing true if the value was successfully
-	/// removed by this thread; false if another thread won the race or the key didn't exist.
+	/// A task that completes when the operation finishes, containing true if the value was removed by this
+	/// caller; false if another caller took it, if the key did not exist, or - only across processes - if
+	/// the value was removed and no caller could be told it took it.
 	/// </returns>
 	public static async Task<bool> TryRemoveAsync(
 		this IDistributedCache cache,
@@ -193,6 +221,84 @@ public static class DistributedCacheExtensions
 		ArgumentNullException.ThrowIfNull(cache);
 		ArgumentNullException.ThrowIfNull(key);
 
+		// Redemptions of the SAME key are serialized within this process, so the protocol below never runs
+		// concurrently against itself here and the interleaving that loses a value cannot form. Callers on
+		// different keys never meet: the gate exists only while a call is in flight and is discarded with
+		// the last one out.
+		//
+		// This gate is taken HERE and not in TryGetAndRemoveAsync, which calls this method - gating both
+		// would deadlock a caller against itself on one key. That is safe: TryGetAndRemoveAsync discards
+		// the value it read whenever this returns false, so a caller that lost inside the gate hands back
+		// nothing.
+		var gate = RentGate(key);
+		try
+		{
+			await gate.WaitAsync(cancellationToken);
+			try
+			{
+				return await RemoveUnderGateAsync(cache, key, lockTimeout, cancellationToken);
+			}
+			finally
+			{
+				gate.Release();
+			}
+		}
+		finally
+		{
+			ReturnGate(key);
+		}
+	}
+
+	/// <summary>
+	/// One gate per key, alive only while a redemption of that key is in flight.
+	/// </summary>
+	private static readonly Dictionary<string, GateEntry> Gates = new(StringComparer.Ordinal);
+
+	private sealed class GateEntry
+	{
+		public readonly SemaphoreSlim Gate = new(1, 1);
+		public int Waiters;
+	}
+
+	private static SemaphoreSlim RentGate(string key)
+	{
+		lock (Gates)
+		{
+			if (!Gates.TryGetValue(key, out var entry))
+			{
+				entry = new GateEntry();
+				Gates[key] = entry;
+			}
+
+			// Incremented before the caller waits, so nobody else can retire this gate underneath it.
+			entry.Waiters++;
+			return entry.Gate;
+		}
+	}
+
+	private static void ReturnGate(string key)
+	{
+		lock (Gates)
+		{
+			if (!Gates.TryGetValue(key, out var entry))
+				return;
+
+			if (--entry.Waiters > 0)
+				return;
+
+			// The last caller out retires the gate, which is what keeps the table the size of the traffic
+			// in flight rather than the size of every key ever redeemed.
+			Gates.Remove(key);
+			entry.Gate.Dispose();
+		}
+	}
+
+	private static async Task<bool> RemoveUnderGateAsync(
+		IDistributedCache cache,
+		string key,
+		TimeSpan? lockTimeout,
+		CancellationToken cancellationToken)
+	{
 		// Use fully qualified type name to avoid collisions with application keys
 		var lockKey = $"{nameof(Abblix)}.{nameof(Utils)}.{nameof(DistributedCacheExtensions)}:{nameof(TryRemoveAsync)}:{key}";
 

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -120,8 +120,10 @@ public static class DistributedCacheExtensions
 	/// <param name="lockTimeout">Duration after which the lock expires, 5 seconds if null.</param>
 	/// <param name="cancellationToken">Optional cancellation token to cancel the operation.</param>
 	/// <returns>
-	/// A task that completes when the operation finishes, containing the retrieved value if found and
-	/// successfully removed; otherwise, null if the value was not found or another thread won the race.
+	/// A task that completes when the operation finishes, containing the retrieved value when this caller
+	/// removed it AND its own claim was still in the store afterwards. Null otherwise - which does NOT mean
+	/// somebody else took it. See <see cref="TryRemoveAsync"/>, whose remarks carry the condition; this
+	/// method adds nothing to it beyond returning the value.
 	/// </returns>
 	public static async Task<byte[]?> TryGetAndRemoveAsync(
 		this IDistributedCache cache,
@@ -141,11 +143,11 @@ public static class DistributedCacheExtensions
 
 		if (!await cache.TryRemoveAsync(key, lockTimeout, cancellationToken))
 		{
-			// Another thread's lock overwrote ours - they won the race
+			// Not necessarily somebody else: see TryRemoveAsync's remarks for what false covers.
 			return null;
 		}
 
-		// Our lock survived - we won the race, return the value
+		// The claim held, so this caller is the one entitled to the value.
 		return valueData;
 	}
 
@@ -366,11 +368,13 @@ public static class DistributedCacheExtensions
 		var survivingLockToken = await cache.GetAsync(lockKey, cancellationToken);
 		if (survivingLockToken == null || !ourLockToken.SequenceEqual(survivingLockToken))
 		{
-			// Another thread's lock overwrote ours - they won the race
+			// The claim is not ours any more. Do NOT read that as a competitor: it is equally the claim
+			// having EXPIRED, which one caller alone reaches, and the value is already gone either way.
 			return false;
 		}
 
-		// Our lock survived - we won the race, return the value
+		// The claim is still ours, which is the whole condition for reporting the removal as this
+		// caller's: nothing overwrote it and it did not expire.
 		await cache.RemoveAsync(lockKey, cancellationToken); // Cleanup lock
 		return true;
 	}

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -97,22 +97,25 @@ public static class DistributedCacheExtensions
 	///   <item><term>Step 2:</term> Delegate to <see cref="TryRemoveAsync"/> for atomic removal</item>
 	/// </list>
 	/// <para>
-	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
-	/// lock token survives (last-write-wins) will return the value. Other threads detect the lock mismatch
-	/// and return null. AT MOST one caller ever retrieves the value, never two - and the mechanism that
-	/// picks the winner is not the same on one node as on several. Both, and what a value can be lost to
-	/// even with a single caller, are under <see cref="TryRemoveAsync"/>, which this delegates to and
-	/// which carries the guarantee.
+	/// <strong>How it provides atomicity:</strong> the removal is delegated to
+	/// <see cref="TryRemoveAsync"/>, and the condition for reporting one is under that method.
 	/// </para>
 	/// <para>
-	/// <strong>Lock timeout:</strong> Locks auto-expire after the specified timeout (default 5 seconds)
-	/// to prevent orphaned locks if a process crashes between writing the lock token (step 2) and
-	/// cleaning it up (after step 4).
+	/// <strong>The value returned is the one read BEFORE that removal, not the one removed.</strong> The
+	/// read happens here and the removal happens inside the delegate, so anything that writes the key
+	/// between them is destroyed by this caller and handed to nobody, while this caller receives the
+	/// earlier bytes and is told it won. Nothing in this class closes that: a store whose own primitive
+	/// returns the removed value is what closes it, and issue 454 tracks the change.
 	/// </para>
 	/// <para>
-	/// <strong>Performance:</strong> This operation performs 5 cache operations (1 get + 4 from TryRemoveAsync),
-	/// so it has higher latency than native atomic operations. However, it works with any IDistributedCache
-	/// implementation.
+	/// <strong>Lock timeout:</strong> the claim auto-expires after the specified timeout (5 seconds by
+	/// default), so a process that crashes mid-protocol does not leave the key claimed forever. It also
+	/// means a caller slower than the timeout loses its own claim: see <see cref="TryRemoveAsync"/>.
+	/// </para>
+	/// <para>
+	/// <strong>Performance:</strong> up to six cache operations - one read here, and up to five inside
+	/// <see cref="TryRemoveAsync"/> - so it has higher latency than a store's own atomic primitive, and
+	/// works with any IDistributedCache in exchange.
 	/// </para>
 	/// </remarks>
 	/// <param name="cache">The distributed cache instance.</param>
@@ -147,7 +150,9 @@ public static class DistributedCacheExtensions
 			return null;
 		}
 
-		// The claim held, so this caller is the one entitled to the value.
+		// The claim held, so this caller is the one entitled to A value - but not necessarily to THIS
+		// one. These bytes were read before the gate, and what the protocol removed is whatever was at
+		// the key when it ran. See the remarks, and issue 454.
 		return valueData;
 	}
 
@@ -165,10 +170,9 @@ public static class DistributedCacheExtensions
 	///   <item><term>Step 4:</term> Clean up the lock key</item>
 	/// </list>
 	/// <para>
-	/// <strong>How it provides atomicity:</strong> In a race between multiple threads, only the thread whose
-	/// lock token survives (last-write-wins) will return true. A caller whose token is not there returns
-	/// false - and in one process that is not because somebody overwrote it, since callers on a key are
-	/// serialized, but because it EXPIRED. What that leaves is spelled out below.
+	/// <strong>How it provides atomicity:</strong> a caller reports the removal as its own only when its
+	/// own claim is still in the store at the end of the protocol. What that condition does and does not
+	/// buy is spelled out below.
 	/// </para>
 	/// <para>
 	/// <strong>Use Case:</strong> This method is useful when you need to atomically remove a value without

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -426,8 +426,8 @@ public class AuthorizationCodeServiceTests
     /// <summary>
     /// Verifies that RemoveAuthorizationCodeAsync performs an atomic get-and-remove
     /// (removeOnRetrieval: true) and returns the claimed grant. The atomic claim is what enforces
-    /// single-use against two concurrent redemptions of the same code - in one process, which is where
-    /// this test lives, exactly one caller wins.
+    /// single-use against two concurrent redemptions of the same code: at most one caller ever wins, and
+    /// here, where nothing competes and nothing expires, that one is this caller.
     /// </summary>
     [Fact]
     public async Task RemoveAuthorizationCodeAsync_ShouldGetAndRemoveAtomically()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -426,7 +426,8 @@ public class AuthorizationCodeServiceTests
     /// <summary>
     /// Verifies that RemoveAuthorizationCodeAsync performs an atomic get-and-remove
     /// (removeOnRetrieval: true) and returns the claimed grant. The atomic claim is what enforces
-    /// single-use against two concurrent redemptions of the same code - exactly one caller wins.
+    /// single-use against two concurrent redemptions of the same code - in one process, which is where
+    /// this test lives, exactly one caller wins.
     /// </summary>
     [Fact]
     public async Task RemoveAuthorizationCodeAsync_ShouldGetAndRemoveAtomically()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -426,8 +426,9 @@ public class AuthorizationCodeServiceTests
     /// <summary>
     /// Verifies that RemoveAuthorizationCodeAsync performs an atomic get-and-remove
     /// (removeOnRetrieval: true) and returns the claimed grant. The atomic claim is what enforces
-    /// single-use against two concurrent redemptions of the same code: at most one caller ever wins, and
-    /// here, where nothing competes and nothing expires, that one is this caller.
+    /// single-use against two concurrent redemptions of the same code. Here nothing competes, nothing
+    /// expires and nothing writes the grant back, so this caller wins - which is what the test measures,
+    /// and is narrower than what the claim gives in general. See issue 454.
     /// </summary>
     [Fact]
     public async Task RemoveAuthorizationCodeAsync_ShouldGetAndRemoveAtomically()

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -347,13 +347,16 @@ public class RedemptionSerializationTests
 	[Fact]
 	public async Task TryRemoveAsync_DifferentKeys_DoNotWaitOnEachOther()
 	{
-		var inner = CreateCache();
-		await inner.SetAsync("first", Encoding.UTF8.GetBytes("a"), TestContext.Current.CancellationToken);
-		await inner.SetAsync("second", Encoding.UTF8.GetBytes("b"), TestContext.Current.CancellationToken);
-		var cache = new ParkOnValueRead(inner, "first", "second");
+		var first = $"{Key}-first";
+		var second = $"{Key}-second";
 
-		var a = cache.TryRemoveAsync("first", cancellationToken: TestContext.Current.CancellationToken);
-		var b = cache.TryRemoveAsync("second", cancellationToken: TestContext.Current.CancellationToken);
+		var inner = CreateCache();
+		await inner.SetAsync(first, Encoding.UTF8.GetBytes("a"), TestContext.Current.CancellationToken);
+		await inner.SetAsync(second, Encoding.UTF8.GetBytes("b"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, first, second);
+
+		var a = cache.TryRemoveAsync(first, cancellationToken: TestContext.Current.CancellationToken);
+		var b = cache.TryRemoveAsync(second, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Both reach their read. Under a gate shared across keys the second would still be waiting.
 		await cache.WaitUntilParkedAsync(2);

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -20,9 +20,9 @@ namespace Abblix.Utils.UnitTests;
 /// <remarks>
 /// Serializing callers on a key stops one of them overwriting another's token, which is one of the three
 /// ways a value goes with nobody told. The tests below measure that serialization directly rather than
-/// trying to observe the absence of an interleaving - and then measure one of the ways it does NOT close,
-/// because a guarantee stated as a list of prevented causes is the shape that keeps turning out to be
-/// short by one.
+/// trying to observe the absence of an interleaving - and then measure the ways it does NOT close, one
+/// test each for an expiring claim and for a store fault after the removal, because a guarantee stated as
+/// a list of prevented causes is the shape that keeps turning out to be short by one.
 /// </remarks>
 public class RedemptionSerializationTests
 {

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -124,6 +124,159 @@ public class RedemptionSerializationTests
 	}
 
 	/// <summary>
+	/// A failure inside the guarded section must still release the lock, with somebody already queued
+	/// behind it - or that caller waits for a lock nobody will ever hand back.
+	/// </summary>
+	/// <remarks>
+	/// The queue is what makes this measurable. A failure with nobody waiting is invisible: the entry's
+	/// last share goes back, the entry is retired, and the next caller rents a fresh lock and walks
+	/// straight in whether or not the failed one released anything. Only a caller already waiting on THAT
+	/// lock can tell the difference.
+	/// </remarks>
+	[Fact]
+	public async Task TryRemoveAsync_TheProtocolThrowsWithACallerQueued_TheLockIsStillReleased()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkThenThrowOnValueRead(inner, Key);
+
+		// The first caller holds the lock and parks inside the guarded section.
+		var failing = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		await cache.WaitUntilParkedAsync(1);
+
+		// The second queues on the same lock, so the entry cannot be retired out from under it.
+		var queued = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		for (var i = 0; i < 50; i++) await Task.Yield();
+		Assert.Equal(1, cache.Parked);
+
+		// Resume the first, which now fails inside the section.
+		cache.ResumeNext();
+		await Assert.ThrowsAsync<InvalidOperationException>(() => failing);
+
+		// The queued caller must get in. Bounded, because without the release it would wait forever and a
+		// hanging test says nothing.
+		await cache.WaitUntilParkedAsync(1);
+		cache.ResumeNext();
+
+		var finished = await Task.WhenAny(
+			queued, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+
+		Assert.True(ReferenceEquals(finished, queued), "the lock was not released after the failure");
+		Assert.True(await queued);
+		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
+	}
+
+	/// <summary>
+	/// Cancellation while WAITING for the lock is the other half: the caller never acquired it, so it must
+	/// not release it, and it must still give back its share of the entry.
+	/// </summary>
+	/// <remarks>
+	/// Releasing a semaphore that was never taken raises its count, which is worse than a wedge: the next
+	/// two callers both get in and the interleaving this whole change exists to prevent forms again.
+	/// </remarks>
+	[Fact]
+	public async Task TryRemoveAsync_CancelledWhileWaiting_LeavesTheLockUsable()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, Key);
+
+		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		await cache.WaitUntilParkedAsync(1);
+
+		using var cancelled = new CancellationTokenSource();
+		var waiter = cache.TryRemoveAsync(Key, cancellationToken: cancelled.Token);
+		await cancelled.CancelAsync();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+
+		cache.ResumeNext();
+		Assert.True(await holder);
+
+		// If the cancelled waiter had over-released, two callers could now be inside at once. Drive the
+		// same arrangement again and require it to still serialize.
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("again"), TestContext.Current.CancellationToken);
+
+		var a = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		await cache.WaitUntilParkedAsync(1);
+		var b = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		for (var i = 0; i < 50; i++) await Task.Yield();
+
+		Assert.Equal(1, cache.Parked);
+
+		cache.ResumeNext();
+		Assert.True(await a);
+		await cache.WaitUntilParkedAsync(1);
+		cache.ResumeNext();
+		Assert.False(await b);
+	}
+
+	/// <summary>
+	/// Parks every read of <paramref name="gatedKey"/>, and makes the FIRST of them throw when resumed, so
+	/// the failure lands inside the guarded section with a caller already queued behind it.
+	/// </summary>
+	private sealed class ParkThenThrowOnValueRead(IDistributedCache inner, string gatedKey) : IDistributedCache
+	{
+		private readonly Queue<TaskCompletionSource> _parked = new();
+		private readonly Lock _sync = new();
+		private int _reads;
+
+		public int Parked
+		{
+			get
+			{
+				lock (_sync) return _parked.Count;
+			}
+		}
+
+		public async Task WaitUntilParkedAsync(int count)
+		{
+			for (var i = 0; i < 1000 && Parked < count; i++) await Task.Yield();
+			Assert.Equal(count, Parked);
+		}
+
+		public void ResumeNext()
+		{
+			TaskCompletionSource gate;
+			lock (_sync) gate = _parked.Dequeue();
+			gate.SetResult();
+		}
+
+		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+		{
+			if (key != gatedKey)
+				return await inner.GetAsync(key, token);
+
+			var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			lock (_sync) _parked.Enqueue(gate);
+			await gate.Task;
+
+			if (Interlocked.Increment(ref _reads) == 1)
+				throw new InvalidOperationException("the store failed mid-redemption");
+
+			return await inner.GetAsync(key, token);
+		}
+
+		public Task SetAsync(
+			string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+			=> inner.SetAsync(key, value, options, token);
+
+		public Task RemoveAsync(string key, CancellationToken token = default)
+			=> inner.RemoveAsync(key, token);
+
+		public Task RefreshAsync(string key, CancellationToken token = default)
+			=> inner.RefreshAsync(key, token);
+
+		public byte[]? Get(string key) => inner.Get(key);
+
+		public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+			=> inner.Set(key, value, options);
+
+		public void Remove(string key) => inner.Remove(key);
+
+		public void Refresh(string key) => inner.Refresh(key);
+	}
+
+	/// <summary>
 	/// Parks every read of one of <paramref name="gatedKeys"/> until the test resumes it. The lock keys the
 	/// protocol reads are deliberately not among them: parking those would suspend a caller somewhere the
 	/// property under test says nothing about.

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -193,6 +193,88 @@ public class RedemptionSerializationTests
 	}
 
 	/// <summary>
+	/// Serializing callers closes ONE of the two ways a redemption loses its value. This is the other one,
+	/// and it needs neither a second caller nor a second node.
+	/// </summary>
+	/// <remarks>
+	/// A caller reports a loss when the lock token it reads back is not the one it wrote. Somebody
+	/// overwriting it needs a competitor; the lock EXPIRING needs only time, and three cache round trips
+	/// sit between writing it and reading it back. So a stalled call, a collection pause or a starved
+	/// thread pool is enough - which is why the remarks say so rather than blaming a second node.
+	///
+	/// Driven with a delay rather than waited out: the point is the ordering, not the duration.
+	/// </remarks>
+	[Fact]
+	public async Task TryRemoveAsync_TheLockExpiresMidProtocol_OneCallerAloneLosesTheValue()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+
+		var cache = new SlowValueRead(inner, Key, TimeSpan.FromMilliseconds(200));
+
+		var won = await cache.TryRemoveAsync(
+			Key,
+			lockTimeout: TimeSpan.FromMilliseconds(50),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// Both halves, because either one alone reads as something else: a false with the value still
+		// there is an ordinary refusal, and a missing value with a true is a normal redemption.
+		Assert.False(won);
+		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
+	}
+
+	/// <summary>
+	/// The control for the test above. With the lock outliving the protocol, the same single caller wins,
+	/// so what that test measures is the expiry and not the delay.
+	/// </summary>
+	[Fact]
+	public async Task TryRemoveAsync_TheLockOutlivesTheProtocol_TheOneCallerWins()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+
+		var cache = new SlowValueRead(inner, Key, TimeSpan.FromMilliseconds(200));
+
+		var won = await cache.TryRemoveAsync(
+			Key,
+			lockTimeout: TimeSpan.FromSeconds(30),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.True(won);
+		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
+	}
+
+	/// <summary>
+	/// Passes everything through, delaying only the read of one key, which is how the protocol is made to
+	/// outlast its own lock without the test waiting out a real timeout.
+	/// </summary>
+	private sealed class SlowValueRead(IDistributedCache inner, string slowKey, TimeSpan delay) : IDistributedCache
+	{
+		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+		{
+			if (key == slowKey) await Task.Delay(delay, token);
+			return await inner.GetAsync(key, token);
+		}
+
+		public Task SetAsync(
+			string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+			=> inner.SetAsync(key, value, options, token);
+
+		public Task RemoveAsync(string key, CancellationToken token = default) => inner.RemoveAsync(key, token);
+
+		public Task RefreshAsync(string key, CancellationToken token = default) => inner.RefreshAsync(key, token);
+
+		public byte[]? Get(string key) => inner.Get(key);
+
+		public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+			=> inner.Set(key, value, options);
+
+		public void Remove(string key) => inner.Remove(key);
+
+		public void Refresh(string key) => inner.Refresh(key);
+	}
+
+	/// <summary>
 	/// Different keys must not wait on each other, or the gate would serialize the whole endpoint rather
 	/// than one redemption.
 	/// </summary>

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -13,14 +13,16 @@ using Microsoft.Extensions.Options;
 namespace Abblix.Utils.UnitTests;
 
 /// <summary>
-/// Covers the guarantee <see cref="DistributedCacheExtensions.TryRemoveAsync"/> gives within one process:
-/// exactly one caller removes the value, and it is never removed with nobody told they took it.
+/// Covers what <see cref="DistributedCacheExtensions.TryRemoveAsync"/> guarantees: at most one caller ever
+/// removes the value, and a caller is told it took the value only when its own lock token was still there
+/// afterwards.
 /// </summary>
 /// <remarks>
-/// The interleaving that loses a value needs two callers inside the protocol at once - one removing the
-/// value while the other has already overwritten the lock token. Serializing callers on the key makes that
-/// arrangement unreachable here, so the tests below measure the serialization directly rather than trying
-/// to observe the absence of an interleaving.
+/// Serializing callers on a key stops one of them overwriting another's token, which is one of the three
+/// ways a value goes with nobody told. The tests below measure that serialization directly rather than
+/// trying to observe the absence of an interleaving - and then measure one of the ways it does NOT close,
+/// because a guarantee stated as a list of prevented causes is the shape that keeps turning out to be
+/// short by one.
 /// </remarks>
 public class RedemptionSerializationTests
 {
@@ -110,8 +112,8 @@ public class RedemptionSerializationTests
 	}
 
 	/// <summary>
-	/// The outcome: a value that is gone was taken by somebody. This is the property issue 433 states, and
-	/// where one process touches the key it now holds.
+	/// The outcome the serialization buys: with no competitor able to overwrite a token, a value that is
+	/// gone was taken by somebody. Issue 433's property, for the one cause this closes.
 	/// </summary>
 	/// <remarks>
 	/// Driven rather than raced. Eight callers started at once measure the scheduler: the distributed
@@ -193,8 +195,8 @@ public class RedemptionSerializationTests
 	}
 
 	/// <summary>
-	/// Serializing callers closes ONE of the two ways a redemption loses its value. This is the other one,
-	/// and it needs neither a second caller nor a second node.
+	/// Serializing callers closes ONE of the three ways a redemption loses its value. This is a second one,
+	/// and it needs neither a competitor nor a second node.
 	/// </summary>
 	/// <remarks>
 	/// A caller reports a loss when the lock token it reads back is not the one it wrote. Somebody
@@ -261,6 +263,70 @@ public class RedemptionSerializationTests
 			=> inner.SetAsync(key, value, options, token);
 
 		public Task RemoveAsync(string key, CancellationToken token = default) => inner.RemoveAsync(key, token);
+
+		public Task RefreshAsync(string key, CancellationToken token = default) => inner.RefreshAsync(key, token);
+
+		public byte[]? Get(string key) => inner.Get(key);
+
+		public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+			=> inner.Set(key, value, options);
+
+		public void Remove(string key) => inner.Remove(key);
+
+		public void Refresh(string key) => inner.Refresh(key);
+	}
+
+	/// <summary>
+	/// The third way, and the one no amount of serialization or lock lifetime reaches: the removal
+	/// succeeds and a store call AFTER it fails.
+	/// </summary>
+	/// <remarks>
+	/// The protocol removes the value and then makes two more round trips to the same store - reading the
+	/// lock token back and cleaning it up. A fault in either leaves the value gone and the caller holding
+	/// an exception rather than an answer, so nothing anywhere reports a winner.
+	///
+	/// This is why the guarantee is stated as what must be TRUE for a win rather than as a list of ways to
+	/// lose: the list was short by this one for four review rounds.
+	/// </remarks>
+	[Fact]
+	public async Task TryRemoveAsync_TheStoreFaultsAfterTheRemoval_TheValueIsGoneAndNobodyIsTold()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+
+		var cache = new FaultAfterValueRemoval(inner, Key);
+
+		await Assert.ThrowsAsync<TimeoutException>(
+			() => cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken));
+
+		// The half that matters: the caller got no answer AND the value is gone. Either alone is ordinary -
+		// a fault before the removal loses nothing, and a false over a present value is a plain refusal.
+		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
+	}
+
+	/// <summary>
+	/// Passes everything through until the value is removed, then faults the next read - which is the lock
+	/// read-back, the first thing the protocol does once the value is already gone.
+	/// </summary>
+	private sealed class FaultAfterValueRemoval(IDistributedCache inner, string valueKey) : IDistributedCache
+	{
+		private bool _removed;
+
+		public async Task RemoveAsync(string key, CancellationToken token = default)
+		{
+			await inner.RemoveAsync(key, token);
+			if (key == valueKey) _removed = true;
+		}
+
+		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+		{
+			if (_removed) throw new TimeoutException("the store stopped answering after the removal");
+			return await inner.GetAsync(key, token);
+		}
+
+		public Task SetAsync(
+			string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+			=> inner.SetAsync(key, value, options, token);
 
 		public Task RefreshAsync(string key, CancellationToken token = default) => inner.RefreshAsync(key, token);
 

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -5,6 +5,7 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -24,10 +25,29 @@ namespace Abblix.Utils.UnitTests;
 /// </remarks>
 public class RedemptionSerializationTests
 {
-	private const string Key = "the-authorization";
+	/// <summary>
+	/// A key of its own per test instance. The gate table is static and lives for the process, so tests
+	/// sharing a key share a gate: one that fails while holding it leaves every later test on that key
+	/// waiting forever, and a hung test is reported as a smaller suite with nothing failing.
+	/// </summary>
+	private readonly string _key = $"the-authorization-{Guid.NewGuid():N}";
 
 	private static IDistributedCache CreateCache()
 		=> new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+	/// <summary>
+	/// Awaits a caller with a bound. A redemption that never answers must fail this suite rather than stop
+	/// it: a hung test takes the rest of its class with it, and the run then reports fewer tests and no
+	/// failures, which is indistinguishable from a pass.
+	/// </summary>
+	private static async Task<bool> AnsweredAsync(Task<bool> caller)
+	{
+		var finished = await Task.WhenAny(
+			caller, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+
+		Assert.True(ReferenceEquals(finished, caller), "the caller never answered");
+		return await caller;
+	}
 
 	/// <summary>
 	/// The control. Without it, a serialized second caller would be indistinguishable from a gate that
@@ -37,10 +57,10 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_OneCaller_TakesTheValue()
 	{
 		var cache = CreateCache();
-		await cache.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		await cache.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
 
-		Assert.True(await cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken));
-		Assert.Null(await cache.GetAsync(Key, TestContext.Current.CancellationToken));
+		Assert.True(await cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken));
+		Assert.Null(await cache.GetAsync(_key, TestContext.Current.CancellationToken));
 	}
 
 	/// <summary>
@@ -51,51 +71,117 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_SameKey_TheSecondCallerWaitsOutsideTheProtocol()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkOnValueRead(inner, Key);
+		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, _key);
 
 		// The first caller enters and parks at its read of the value, holding the key.
-		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var first = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
 		// The second is started and given every chance to get in.
-		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var second = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		for (var i = 0; i < 50; i++) await Task.Yield();
 
 		// It did not. One caller is inside the protocol, not two - which is the whole property.
 		Assert.Equal(1, cache.Parked);
 
 		cache.ResumeNext();
-		Assert.True(await first);
+		Assert.True(await AnsweredAsync(first));
 
 		await cache.WaitUntilParkedAsync(1);
 		cache.ResumeNext();
-		Assert.False(await second);
+		Assert.False(await AnsweredAsync(second));
 	}
 
 	/// <summary>
 	/// The outcome: a value that is gone was taken by somebody. This is the property issue 433 states, and
-	/// on a single node it now holds.
+	/// where one process touches the key it now holds.
 	/// </summary>
+	/// <remarks>
+	/// Driven rather than raced. Eight callers started at once measure the scheduler: the distributed
+	/// protocol already picks at most one winner in almost every arrangement, so a run with a winner says
+	/// nothing, and the arrangement with NO winner has to be built to be seen.
+	///
+	/// Here both callers are pointed at their read and then released one at a time. Serialized, the second
+	/// cannot reach its read while the first is inside, so the first wins and the second finds nothing.
+	/// Unserialized, both reach it, the first removes the value and reads back a lock token that is no
+	/// longer its own, and the second finds nothing - and nobody won.
+	/// </remarks>
 	[Fact]
-	public async Task TryRemoveAsync_ManyCallersOnOneKey_ExactlyOneTakesTheValue()
+	public async Task TryRemoveAsync_TwoCallersOnOneKey_SomebodyIsToldTheyTookIt()
 	{
-		var cache = CreateCache();
-		await cache.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var inner = CreateCache();
+		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, _key);
 
-		var callers = Enumerable
-			.Range(0, 8)
-			.Select(_ => Task.Run(
-				() => cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken),
-				TestContext.Current.CancellationToken))
-			.ToArray();
+		var first = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		await cache.WaitUntilParkedAsync(1);
+
+		var second = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+
+		// Give the second every chance to get in beside the first. Under a gate it does not; without one it
+		// does, and that is the arrangement in which the value is lost.
+		for (var i = 0; i < 50; i++) await Task.Yield();
+
+		// Release whatever is parked, one at a time, until both callers have answered. This is the same
+		// driver in both worlds, so the test is measuring the outcome and not the shape of the gate.
+		var callers = new[] { first, second };
+		var step = 0;
+		while (callers.Any(caller => !caller.IsCompleted))
+		{
+			// Bounded, because an unbounded driver turns a wrong answer into a hang - and a hung test is
+			// reported as a smaller suite with nothing failing, which reads exactly like a pass.
+			Assert.True(step++ < 10_000, "a caller never answered; the driver gave up rather than hang");
+
+			if (cache.Parked > 0)
+			{
+				cache.ResumeNext();
+			}
+
+			await Task.Yield();
+		}
 
 		var results = await Task.WhenAll(callers);
 
-		Assert.Null(await cache.GetAsync(Key, TestContext.Current.CancellationToken));
+		Assert.Null(await inner.GetAsync(_key, TestContext.Current.CancellationToken));
 
 		var winners = results.Count(won => won);
 		Assert.True(winners == 1, $"the value was removed and {winners} callers were told they took it");
+	}
+
+	/// <summary>
+	/// The table holds gates only while calls are in flight, which is what keeps it the size of the traffic
+	/// rather than of every authorization the deployment ever issued.
+	/// </summary>
+	[Fact]
+	public async Task TryRemoveAsync_AfterTheCallsFinish_NoGateIsLeftBehind()
+	{
+		var cache = CreateCache();
+
+		foreach (var key in new[] { "one", "two", "three" })
+		{
+			await cache.SetAsync(key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+			Assert.True(await cache.TryRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken));
+		}
+
+		Assert.Equal(0, LiveGateCount());
+	}
+
+	/// <summary>
+	/// Reads the private table the gates live in. Asserting on it directly is the only way to see a leak:
+	/// a table that never forgets behaves identically until the process runs out of memory.
+	/// </summary>
+	private static int LiveGateCount()
+	{
+		var field = typeof(DistributedCacheExtensions).GetField(
+			"Gates", BindingFlags.NonPublic | BindingFlags.Static);
+
+		Assert.NotNull(field);
+
+		var gates = field.GetValue(null);
+		Assert.NotNull(gates);
+
+		return (int)gates.GetType().GetProperty("Count")!.GetValue(gates)!;
 	}
 
 	/// <summary>
@@ -119,8 +205,8 @@ public class RedemptionSerializationTests
 		cache.ResumeNext();
 		cache.ResumeNext();
 
-		Assert.True(await a);
-		Assert.True(await b);
+		Assert.True(await AnsweredAsync(a));
+		Assert.True(await AnsweredAsync(b));
 	}
 
 	/// <summary>
@@ -137,15 +223,15 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_TheProtocolThrowsWithACallerQueued_TheLockIsStillReleased()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkThenThrowOnValueRead(inner, Key);
+		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkThenThrowOnValueRead(inner, _key);
 
 		// The first caller holds the lock and parks inside the guarded section.
-		var failing = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var failing = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
 		// The second queues on the same lock, so the entry cannot be retired out from under it.
-		var queued = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var queued = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		for (var i = 0; i < 50; i++) await Task.Yield();
 		Assert.Equal(1, cache.Parked);
 
@@ -162,8 +248,8 @@ public class RedemptionSerializationTests
 			queued, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
 		Assert.True(ReferenceEquals(finished, queued), "the lock was not released after the failure");
-		Assert.True(await queued);
-		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
+		Assert.True(await AnsweredAsync(queued));
+		Assert.Null(await inner.GetAsync(_key, TestContext.Current.CancellationToken));
 	}
 
 	/// <summary>
@@ -178,43 +264,43 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_CancelledWhileWaiting_LeavesTheLockUsable()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkOnValueRead(inner, Key);
+		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, _key);
 
-		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var holder = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
 		using var cancelled = new CancellationTokenSource();
-		var waiter = cache.TryRemoveAsync(Key, cancellationToken: cancelled.Token);
+		var waiter = cache.TryRemoveAsync(_key, cancellationToken: cancelled.Token);
 		await cancelled.CancelAsync();
 		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
 
 		cache.ResumeNext();
-		Assert.True(await holder);
+		Assert.True(await AnsweredAsync(holder));
 
 		// If the cancelled waiter had over-released, two callers could now be inside at once. Drive the
 		// same arrangement again and require it to still serialize.
-		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("again"), TestContext.Current.CancellationToken);
+		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("again"), TestContext.Current.CancellationToken);
 
-		var a = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var a = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
-		var b = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		var b = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
 		for (var i = 0; i < 50; i++) await Task.Yield();
 
 		Assert.Equal(1, cache.Parked);
 
 		cache.ResumeNext();
-		Assert.True(await a);
+		Assert.True(await AnsweredAsync(a));
 		await cache.WaitUntilParkedAsync(1);
 		cache.ResumeNext();
-		Assert.False(await b);
+		Assert.False(await AnsweredAsync(b));
 	}
 
 	/// <summary>
 	/// Parks every read of <paramref name="gatedKey"/>, and makes the FIRST of them throw when resumed, so
 	/// the failure lands inside the guarded section with a caller already queued behind it.
 	/// </summary>
-	private sealed class ParkThenThrowOnValueRead(IDistributedCache inner, string gatedKey) : IDistributedCache
+	private sealed class ParkThenThrowOnValueRead(IDistributedCache inner, string gated_key) : IDistributedCache
 	{
 		private readonly Queue<TaskCompletionSource> _parked = new();
 		private readonly Lock _sync = new();
@@ -243,7 +329,7 @@ public class RedemptionSerializationTests
 
 		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
 		{
-			if (key != gatedKey)
+			if (key != gated_key)
 				return await inner.GetAsync(key, token);
 
 			var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -13,9 +13,9 @@ using Microsoft.Extensions.Options;
 namespace Abblix.Utils.UnitTests;
 
 /// <summary>
-/// Covers what <see cref="DistributedCacheExtensions.TryRemoveAsync"/> guarantees: at most one caller ever
-/// removes the value, and a caller is told it took the value only when its own lock token was still there
-/// afterwards.
+/// Covers what <see cref="DistributedCacheExtensions.TryRemoveAsync"/> decides: a caller is told it took
+/// the value only when its own lock token is still in the store at the end of the protocol, and at most
+/// one caller passes that check.
 /// </summary>
 /// <remarks>
 /// Serializing callers on a key stops one of them overwriting another's token, which is one of the three

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -5,7 +5,6 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
-using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -30,7 +29,9 @@ public class RedemptionSerializationTests
 	/// sharing a key share a gate: one that fails while holding it leaves every later test on that key
 	/// waiting forever, and a hung test is reported as a smaller suite with nothing failing.
 	/// </summary>
-	private readonly string _key = $"the-authorization-{Guid.NewGuid():N}";
+	private readonly string _suffix = Guid.NewGuid().ToString("N");
+
+	private string Key => $"the-authorization-{_suffix}";
 
 	private static IDistributedCache CreateCache()
 		=> new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
@@ -57,10 +58,10 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_OneCaller_TakesTheValue()
 	{
 		var cache = CreateCache();
-		await cache.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		await cache.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
 
-		Assert.True(await cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken));
-		Assert.Null(await cache.GetAsync(_key, TestContext.Current.CancellationToken));
+		Assert.True(await cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken));
+		Assert.Null(await cache.GetAsync(Key, TestContext.Current.CancellationToken));
 	}
 
 	/// <summary>
@@ -71,15 +72,15 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_SameKey_TheSecondCallerWaitsOutsideTheProtocol()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkOnValueRead(inner, _key);
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, Key);
 
 		// The first caller enters and parks at its read of the value, holding the key.
-		var first = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
 		// The second is started and given every chance to get in.
-		var second = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		for (var i = 0; i < 50; i++) await Task.Yield();
 
 		// It did not. One caller is inside the protocol, not two - which is the whole property.
@@ -111,13 +112,13 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_TwoCallersOnOneKey_SomebodyIsToldTheyTookIt()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkOnValueRead(inner, _key);
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, Key);
 
-		var first = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
-		var second = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Give the second every chance to get in beside the first. Under a gate it does not; without one it
 		// does, and that is the arrangement in which the value is lost.
@@ -143,7 +144,7 @@ public class RedemptionSerializationTests
 
 		var results = await Task.WhenAll(callers);
 
-		Assert.Null(await inner.GetAsync(_key, TestContext.Current.CancellationToken));
+		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
 
 		var winners = results.Count(won => won);
 		Assert.True(winners == 1, $"the value was removed and {winners} callers were told they took it");
@@ -158,30 +159,29 @@ public class RedemptionSerializationTests
 	{
 		var cache = CreateCache();
 
-		foreach (var key in new[] { "one", "two", "three" })
+		foreach (var key in new[] { $"one-{_suffix}", $"two-{_suffix}", $"three-{_suffix}" })
 		{
 			await cache.SetAsync(key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
 			Assert.True(await cache.TryRemoveAsync(key, cancellationToken: TestContext.Current.CancellationToken));
 		}
 
-		Assert.Equal(0, LiveGateCount());
+		Assert.Equal(0, LiveGatesForThisTest());
 	}
 
 	/// <summary>
-	/// Reads the private table the gates live in. Asserting on it directly is the only way to see a leak:
-	/// a table that never forgets behaves identically until the process runs out of memory.
+	/// The table the locks live in. Asserting on it directly is the only way to see a leak: a table that
+	/// never forgets behaves identically until the process runs out of memory.
 	/// </summary>
-	private static int LiveGateCount()
+	/// <remarks>
+	/// Counted under its own lock, because other tests in this process redeem their own keys at the same
+	/// time - only THIS test's keys are asserted about, and a bare Count would race them.
+	/// </remarks>
+	private int LiveGatesForThisTest()
 	{
-		var field = typeof(DistributedCacheExtensions).GetField(
-			"Gates", BindingFlags.NonPublic | BindingFlags.Static);
-
-		Assert.NotNull(field);
-
-		var gates = field.GetValue(null);
-		Assert.NotNull(gates);
-
-		return (int)gates.GetType().GetProperty("Count")!.GetValue(gates)!;
+		lock (DistributedCacheExtensions.Gates)
+		{
+			return DistributedCacheExtensions.Gates.Keys.Count(key => key.Contains(_suffix, StringComparison.Ordinal));
+		}
 	}
 
 	/// <summary>
@@ -223,15 +223,15 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_TheProtocolThrowsWithACallerQueued_TheLockIsStillReleased()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkThenThrowOnValueRead(inner, _key);
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkThenThrowOnValueRead(inner, Key);
 
 		// The first caller holds the lock and parks inside the guarded section.
-		var failing = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var failing = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
 		// The second queues on the same lock, so the entry cannot be retired out from under it.
-		var queued = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var queued = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		for (var i = 0; i < 50; i++) await Task.Yield();
 		Assert.Equal(1, cache.Parked);
 
@@ -249,7 +249,7 @@ public class RedemptionSerializationTests
 
 		Assert.True(ReferenceEquals(finished, queued), "the lock was not released after the failure");
 		Assert.True(await AnsweredAsync(queued));
-		Assert.Null(await inner.GetAsync(_key, TestContext.Current.CancellationToken));
+		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
 	}
 
 	/// <summary>
@@ -264,14 +264,14 @@ public class RedemptionSerializationTests
 	public async Task TryRemoveAsync_CancelledWhileWaiting_LeavesTheLockUsable()
 	{
 		var inner = CreateCache();
-		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkOnValueRead(inner, _key);
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, Key);
 
-		var holder = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
 		using var cancelled = new CancellationTokenSource();
-		var waiter = cache.TryRemoveAsync(_key, cancellationToken: cancelled.Token);
+		var waiter = cache.TryRemoveAsync(Key, cancellationToken: cancelled.Token);
 		await cancelled.CancelAsync();
 		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
 
@@ -280,11 +280,11 @@ public class RedemptionSerializationTests
 
 		// If the cancelled waiter had over-released, two callers could now be inside at once. Drive the
 		// same arrangement again and require it to still serialize.
-		await inner.SetAsync(_key, Encoding.UTF8.GetBytes("again"), TestContext.Current.CancellationToken);
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("again"), TestContext.Current.CancellationToken);
 
-		var a = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var a = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
-		var b = cache.TryRemoveAsync(_key, cancellationToken: TestContext.Current.CancellationToken);
+		var b = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		for (var i = 0; i < 50; i++) await Task.Yield();
 
 		Assert.Equal(1, cache.Parked);
@@ -300,7 +300,7 @@ public class RedemptionSerializationTests
 	/// Parks every read of <paramref name="gatedKey"/>, and makes the FIRST of them throw when resumed, so
 	/// the failure lands inside the guarded section with a caller already queued behind it.
 	/// </summary>
-	private sealed class ParkThenThrowOnValueRead(IDistributedCache inner, string gated_key) : IDistributedCache
+	private sealed class ParkThenThrowOnValueRead(IDistributedCache inner, string gatedKey) : IDistributedCache
 	{
 		private readonly Queue<TaskCompletionSource> _parked = new();
 		private readonly Lock _sync = new();
@@ -329,7 +329,7 @@ public class RedemptionSerializationTests
 
 		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
 		{
-			if (key != gated_key)
+			if (key != gatedKey)
 				return await inner.GetAsync(key, token);
 
 			var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -14,8 +14,7 @@ namespace Abblix.Utils.UnitTests;
 
 /// <summary>
 /// Covers what <see cref="DistributedCacheExtensions.TryRemoveAsync"/> decides: a caller is told it took
-/// the value only when its own lock token is still in the store at the end of the protocol, and at most
-/// one caller passes that check.
+/// the value only when its own lock token is still in the store at the end of the protocol.
 /// </summary>
 /// <remarks>
 /// Serializing callers on a key stops one of them overwriting another's token, which is one of the three

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -37,6 +37,21 @@ public class RedemptionSerializationTests
 		=> new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
 
 	/// <summary>
+	/// Awaits a caller that must throw, with a bound. <c>Assert.ThrowsAsync</c> on its own waits forever
+	/// when the caller never answers, and a hung test does not fail the suite - it stops the runner, which
+	/// then prints no summary at all.
+	/// </summary>
+	private static async Task<TException> ThrewAsync<TException>(Task caller)
+		where TException : Exception
+	{
+		var finished = await Task.WhenAny(
+			caller, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+
+		Assert.True(ReferenceEquals(finished, caller), "the caller never answered");
+		return await Assert.ThrowsAnyAsync<TException>(() => caller);
+	}
+
+	/// <summary>
 	/// Awaits a caller with a bound. A redemption that never answers must fail this suite rather than stop
 	/// it: a hung test takes the rest of its class with it, and the run then reports fewer tests and no
 	/// failures, which is indistinguishable from a pass.
@@ -124,29 +139,22 @@ public class RedemptionSerializationTests
 		// does, and that is the arrangement in which the value is lost.
 		for (var i = 0; i < 50; i++) await Task.Yield();
 
-		// Release whatever is parked, one at a time, until both callers have answered. This is the same
-		// driver in both worlds, so the test is measuring the outcome and not the shape of the gate.
-		var callers = new[] { first, second };
-		var step = 0;
-		while (callers.Any(caller => !caller.IsCompleted))
-		{
-			// Bounded, because an unbounded driver turns a wrong answer into a hang - and a hung test is
-			// reported as a smaller suite with nothing failing, which reads exactly like a pass.
-			Assert.True(step++ < 10_000, "a caller never answered; the driver gave up rather than hang");
+		// Release the first and let it FINISH before releasing the second. Resuming both and yielding
+		// between them is not the same thing and does not build the arrangement: the second's read runs
+		// before the first's removal, so it finds the value still there, removes it itself and comes away
+		// holding the surviving token - one winner, by luck, in a build with no serialization at all.
+		cache.ResumeNext();
+		var firstWon = await AnsweredAsync(first);
 
-			if (cache.Parked > 0)
-			{
-				cache.ResumeNext();
-			}
-
-			await Task.Yield();
-		}
-
-		var results = await Task.WhenAll(callers);
+		// Serialized, the second only reaches its read now; unserialized it has been parked since before
+		// the first ran. Either way its gate is the next one out.
+		await cache.WaitUntilParkedAsync(1);
+		cache.ResumeNext();
+		var secondWon = await AnsweredAsync(second);
 
 		Assert.Null(await inner.GetAsync(Key, TestContext.Current.CancellationToken));
 
-		var winners = results.Count(won => won);
+		var winners = (firstWon ? 1 : 0) + (secondWon ? 1 : 0);
 		Assert.True(winners == 1, $"the value was removed and {winners} callers were told they took it");
 	}
 
@@ -237,7 +245,7 @@ public class RedemptionSerializationTests
 
 		// Resume the first, which now fails inside the section.
 		cache.ResumeNext();
-		await Assert.ThrowsAsync<InvalidOperationException>(() => failing);
+		await ThrewAsync<InvalidOperationException>(failing);
 
 		// The queued caller must get in. Bounded, because without the release it would wait forever and a
 		// hanging test says nothing.
@@ -273,7 +281,7 @@ public class RedemptionSerializationTests
 		using var cancelled = new CancellationTokenSource();
 		var waiter = cache.TryRemoveAsync(Key, cancellationToken: cancelled.Token);
 		await cancelled.CancelAsync();
-		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+		await ThrewAsync<OperationCanceledException>(waiter);
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(holder));

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -232,7 +232,13 @@ public class RedemptionSerializationTests
 	{
 		var inner = CreateCache();
 		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
-		var cache = new ParkThenThrowOnValueRead(inner, Key);
+		var cache = new ParkOnValueRead(inner, Key)
+		{
+			AfterResume = resumed =>
+			{
+				if (resumed == 1) throw new InvalidOperationException("the store failed mid-redemption");
+			},
+		};
 
 		// The first caller holds the lock and parks inside the guarded section.
 		var failing = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
@@ -305,82 +311,28 @@ public class RedemptionSerializationTests
 	}
 
 	/// <summary>
-	/// Parks every read of <paramref name="gatedKey"/>, and makes the FIRST of them throw when resumed, so
-	/// the failure lands inside the guarded section with a caller already queued behind it.
-	/// </summary>
-	private sealed class ParkThenThrowOnValueRead(IDistributedCache inner, string gatedKey) : IDistributedCache
-	{
-		private readonly Queue<TaskCompletionSource> _parked = new();
-		private readonly Lock _sync = new();
-		private int _reads;
-
-		public int Parked
-		{
-			get
-			{
-				lock (_sync) return _parked.Count;
-			}
-		}
-
-		public async Task WaitUntilParkedAsync(int count)
-		{
-			for (var i = 0; i < 1000 && Parked < count; i++) await Task.Yield();
-			Assert.Equal(count, Parked);
-		}
-
-		public void ResumeNext()
-		{
-			TaskCompletionSource gate;
-			lock (_sync) gate = _parked.Dequeue();
-			gate.SetResult();
-		}
-
-		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
-		{
-			if (key != gatedKey)
-				return await inner.GetAsync(key, token);
-
-			var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-			lock (_sync) _parked.Enqueue(gate);
-			await gate.Task;
-
-			if (Interlocked.Increment(ref _reads) == 1)
-				throw new InvalidOperationException("the store failed mid-redemption");
-
-			return await inner.GetAsync(key, token);
-		}
-
-		public Task SetAsync(
-			string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
-			=> inner.SetAsync(key, value, options, token);
-
-		public Task RemoveAsync(string key, CancellationToken token = default)
-			=> inner.RemoveAsync(key, token);
-
-		public Task RefreshAsync(string key, CancellationToken token = default)
-			=> inner.RefreshAsync(key, token);
-
-		public byte[]? Get(string key) => inner.Get(key);
-
-		public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
-			=> inner.Set(key, value, options);
-
-		public void Remove(string key) => inner.Remove(key);
-
-		public void Refresh(string key) => inner.Refresh(key);
-	}
-
-	/// <summary>
 	/// Parks every read of one of <paramref name="gatedKeys"/> until the test resumes it. The lock keys the
 	/// protocol reads are deliberately not among them: parking those would suspend a caller somewhere the
 	/// property under test says nothing about.
 	/// </summary>
+	/// <remarks>
+	/// One double rather than two. A second copy differing only in what happens after the read is resumed
+	/// is a copy that drifts: a fix to the parking, the counting or the resume order lands in one of them.
+	/// What varies is passed in.
+	/// </remarks>
 	private sealed class ParkOnValueRead(IDistributedCache inner, params string[] gatedKeys) : IDistributedCache
 	{
 		private readonly HashSet<string> _gated = [..gatedKeys];
-
 		private readonly Queue<TaskCompletionSource> _parked = new();
 		private readonly Lock _sync = new();
+		private int _resumedReads;
+
+		/// <summary>
+		/// Runs after a resumed read, before the value is fetched, so a test can make the store fail INSIDE
+		/// the guarded section rather than before it. The argument is how many reads have been resumed so
+		/// far, one-based, which is how a test says "only the first".
+		/// </summary>
+		public Action<int>? AfterResume { get; init; }
 
 		public int Parked
 		{
@@ -410,6 +362,8 @@ public class RedemptionSerializationTests
 				var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 				lock (_sync) _parked.Enqueue(gate);
 				await gate.Task;
+
+				AfterResume?.Invoke(Interlocked.Increment(ref _resumedReads));
 			}
 
 			return await inner.GetAsync(key, token);

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -1,0 +1,190 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Utils.UnitTests;
+
+/// <summary>
+/// Covers the guarantee <see cref="DistributedCacheExtensions.TryRemoveAsync"/> gives within one process:
+/// exactly one caller removes the value, and it is never removed with nobody told they took it.
+/// </summary>
+/// <remarks>
+/// The interleaving that loses a value needs two callers inside the protocol at once - one removing the
+/// value while the other has already overwritten the lock token. Serializing callers on the key makes that
+/// arrangement unreachable here, so the tests below measure the serialization directly rather than trying
+/// to observe the absence of an interleaving.
+/// </remarks>
+public class RedemptionSerializationTests
+{
+	private const string Key = "the-authorization";
+
+	private static IDistributedCache CreateCache()
+		=> new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+	/// <summary>
+	/// The control. Without it, a serialized second caller would be indistinguishable from a gate that
+	/// never lets anybody through.
+	/// </summary>
+	[Fact]
+	public async Task TryRemoveAsync_OneCaller_TakesTheValue()
+	{
+		var cache = CreateCache();
+		await cache.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+
+		Assert.True(await cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken));
+		Assert.Null(await cache.GetAsync(Key, TestContext.Current.CancellationToken));
+	}
+
+	/// <summary>
+	/// The mechanism: a second caller on the same key cannot enter the protocol while the first is inside
+	/// it. This is what makes the losing interleaving unconstructible rather than merely unlikely.
+	/// </summary>
+	[Fact]
+	public async Task TryRemoveAsync_SameKey_TheSecondCallerWaitsOutsideTheProtocol()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, Key);
+
+		// The first caller enters and parks at its read of the value, holding the key.
+		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		await cache.WaitUntilParkedAsync(1);
+
+		// The second is started and given every chance to get in.
+		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		for (var i = 0; i < 50; i++) await Task.Yield();
+
+		// It did not. One caller is inside the protocol, not two - which is the whole property.
+		Assert.Equal(1, cache.Parked);
+
+		cache.ResumeNext();
+		Assert.True(await first);
+
+		await cache.WaitUntilParkedAsync(1);
+		cache.ResumeNext();
+		Assert.False(await second);
+	}
+
+	/// <summary>
+	/// The outcome: a value that is gone was taken by somebody. This is the property issue 433 states, and
+	/// on a single node it now holds.
+	/// </summary>
+	[Fact]
+	public async Task TryRemoveAsync_ManyCallersOnOneKey_ExactlyOneTakesTheValue()
+	{
+		var cache = CreateCache();
+		await cache.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+
+		var callers = Enumerable
+			.Range(0, 8)
+			.Select(_ => Task.Run(
+				() => cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken),
+				TestContext.Current.CancellationToken))
+			.ToArray();
+
+		var results = await Task.WhenAll(callers);
+
+		Assert.Null(await cache.GetAsync(Key, TestContext.Current.CancellationToken));
+
+		var winners = results.Count(won => won);
+		Assert.True(winners == 1, $"the value was removed and {winners} callers were told they took it");
+	}
+
+	/// <summary>
+	/// Different keys must not wait on each other, or the gate would serialize the whole endpoint rather
+	/// than one redemption.
+	/// </summary>
+	[Fact]
+	public async Task TryRemoveAsync_DifferentKeys_DoNotWaitOnEachOther()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync("first", Encoding.UTF8.GetBytes("a"), TestContext.Current.CancellationToken);
+		await inner.SetAsync("second", Encoding.UTF8.GetBytes("b"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, "first", "second");
+
+		var a = cache.TryRemoveAsync("first", cancellationToken: TestContext.Current.CancellationToken);
+		var b = cache.TryRemoveAsync("second", cancellationToken: TestContext.Current.CancellationToken);
+
+		// Both reach their read. Under a gate shared across keys the second would still be waiting.
+		await cache.WaitUntilParkedAsync(2);
+
+		cache.ResumeNext();
+		cache.ResumeNext();
+
+		Assert.True(await a);
+		Assert.True(await b);
+	}
+
+	/// <summary>
+	/// Parks every read of one of <paramref name="gatedKeys"/> until the test resumes it. The lock keys the
+	/// protocol reads are deliberately not among them: parking those would suspend a caller somewhere the
+	/// property under test says nothing about.
+	/// </summary>
+	private sealed class ParkOnValueRead(IDistributedCache inner, params string[] gatedKeys) : IDistributedCache
+	{
+		private readonly HashSet<string> _gated = [..gatedKeys];
+
+		private readonly Queue<TaskCompletionSource> _parked = new();
+		private readonly Lock _sync = new();
+
+		public int Parked
+		{
+			get
+			{
+				lock (_sync) return _parked.Count;
+			}
+		}
+
+		public async Task WaitUntilParkedAsync(int count)
+		{
+			for (var i = 0; i < 1000 && Parked < count; i++) await Task.Yield();
+			Assert.Equal(count, Parked);
+		}
+
+		public void ResumeNext()
+		{
+			TaskCompletionSource gate;
+			lock (_sync) gate = _parked.Dequeue();
+			gate.SetResult();
+		}
+
+		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+		{
+			if (_gated.Contains(key))
+			{
+				var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+				lock (_sync) _parked.Enqueue(gate);
+				await gate.Task;
+			}
+
+			return await inner.GetAsync(key, token);
+		}
+
+		public Task SetAsync(
+			string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+			=> inner.SetAsync(key, value, options, token);
+
+		public Task RemoveAsync(string key, CancellationToken token = default)
+			=> inner.RemoveAsync(key, token);
+
+		public Task RefreshAsync(string key, CancellationToken token = default)
+			=> inner.RefreshAsync(key, token);
+
+		public byte[]? Get(string key) => inner.Get(key);
+
+		public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+			=> inner.Set(key, value, options);
+
+		public void Remove(string key) => inner.Remove(key);
+
+		public void Refresh(string key) => inner.Refresh(key);
+	}
+}


### PR DESCRIPTION
Closes #435.

**Does NOT close #433**, and that is the point of the last two rounds. #433's outcome - the value removed with nobody told they took it - stays reachable on a single node: an expiring lock reaches it, and so does a store fault after the removal. This branch closes one of the three causes, names the other two, and pins both with tests. #433 stays open for them.

## What could go wrong

`DistributedCacheExtensions.TryRemoveAsync` could remove the value and tell every caller it lost.

- A writes its lock token
- B writes its own, overwriting A's
- A reads the value, finds it present, and removes it
- A reads the lock back, finds B's token, and reports a loss
- B reads the value, finds nothing, and reports a loss

The authorization was destroyed with nothing issued from it and nothing left to retry against. To an operator it arrived as a device code or an authorization code reporting `expired` on a code the user had just approved.

## What closes it, and how far

That arrangement needs two callers inside the protocol at once - one removing the value while the other has already overwritten the lock token. A gate on the key keeps them apart, so within one process it cannot form.

**That closes one of three ways a redemption loses its value, and the remarks now state the guarantee the other way round.**

A caller is told it took the value only when the protocol runs to the end AND finds its own lock token still in the store. Said as a list of ways to lose instead, it was short by one for four rounds running: the token can be overwritten, which needs a competitor and is what this prevents; it can EXPIRE, which needs only time; and the two store calls that follow the removal can fail, leaving the value gone and the caller holding an exception rather than an answer.

Both of the causes this does not close are pinned by tests. An earlier version of this branch said "where one process touches the key, exactly one caller removes the value" in five places and in this body; it was refuted by construction, and so was the claim that the lock-mismatch branch is unreachable in one process - the expiring lock reaches exactly that branch.

This covers every deployment where a single process touches a given key, whatever store sits underneath: what matters is the number of processes, not the nature of the cache. It changes nothing across processes, and the `<remarks>` say so plainly rather than leaving a half-guarantee to be mistaken for a whole one.

Two details that are easy to get wrong and are written down beside the code:

The gate is taken in `TryRemoveAsync` and **not** in `TryGetAndRemoveAsync`, which calls it - gating both naively would deadlock a caller against itself on one key.

That placement is not settled, and the deadlock is an objection to the naive shape of the fix rather than a reason to leave it. It is fine for the caller that LOSES: `TryGetAndRemoveAsync` discards the value it read whenever the removal reports false. The caller that WINS is #454 - it is handed the value it read before the gate, which is not necessarily the value removed inside it, and with the reuse decorator writing the grant back at the same key two callers can both be handed the same pre-issuance bytes. Bringing the read inside the serialized section is what closes the in-process half.

The gate is per key and lives only while a call is in flight. Callers on different keys never meet, and the last caller out retires it, so the table is the size of the traffic in flight rather than of every key ever redeemed.

## Multi-node, in the remarks rather than in the code

A take-once needs one indivisible read-modify-write. `IDistributedCache` exposes `Get`, `Set`, `Refresh` and `Remove` - no compare-and-swap, no set-if-absent, no delete-returning-value - so nothing assembled from them is correct under concurrency, and no amount of extra checking changes that; it moves the window.

A deployment on several nodes that cannot afford the gap supplies its own storage: `IDeviceAuthorizationStorage`, `IBackChannelRequestStorage` and `IEntityStorage` are public and replaceable today, so this needs no new API. What it reaches for depends on the store, which is why the remarks name the primitives rather than the code choosing one:

- Redis 6.2 and later: `GETDEL key`, one command. Earlier versions get the same effect from a two-line `EVAL` script, since Redis runs a script indivisibly.
- PostgreSQL: `DELETE FROM ... WHERE key = $1 RETURNING value`. The row lock picks the winner and the losing statement returns no rows.
- SQL Server: `DELETE ... OUTPUT deleted.value`.
- Oracle: `DELETE ... RETURNING value INTO :out`.

## Evidence

Ten tests, each with the mutation that kills it and nothing else.

| test | what it holds | mutation that kills it |
|---|---|---|
| one caller takes the value | the control - a serialized second caller is distinguishable from a lock that lets nobody through | (survives everything, by design) |
| the second caller waits outside the protocol | the mechanism, measured directly rather than by observing the absence of an interleaving | a fresh lock per call |
| two callers driven through, somebody is told they took it | the outcome the serialization buys, which is #433's property for the ONE cause this closes | a fresh lock per call; a lock of two |
| different keys do not wait on each other | that the gate is per key and not one global lock | a single shared gate - and this is the ONLY test that catches that |
| a failure inside the section, with a caller queued behind it | the inner `finally` | deleting the inner `finally` |
| cancellation while waiting leaves the lock usable | that a caller which never acquired does not release | moving `Release` to the outer `finally`; moving `WaitAsync` inside it |
| no lock is left behind after the calls finish | the retirement, read off the table itself | `--entry.Waiters >= 0` |
| the lock expires mid-protocol, one caller alone loses the value | that serializing callers does NOT close this - it needs no competitor and no second node | (holds a cause open, not a mechanism) |
| the lock outlives the protocol, the one caller wins | the control for the row above; without it a version that always lost would pass it | (same) |
| the store faults after the removal, the value is gone and nobody is told | the third cause, which raises rather than answering | hoisting the value removal below the read-back; swallowing the read-back fault and returning false |

Each mutation was shown to build with 0 errors before its count was read, and each kills exactly the row it is against.

Two of these were written wrong first, which is the part worth recording.

The mutation for the serialization initially left `Release` without its `Wait` and threw `SemaphoreFullException`, reddening unrelated tests. That measures a broken semaphore, not the serialization.

And the failure test could not see what it claimed. A failure with nobody queued behind it gives the entry's last share back, retires it from the table, and the next caller rents a fresh lock and walks in whether or not the failed caller released anything - so deleting the inner `finally` left the test green. The queue is what makes the release observable, and the test now arranges one.

The outcome test was worse: eight callers started at once measured the scheduler, not the code. The distributed protocol already picks at most one winner in nearly every arrangement, so a run with a winner says nothing - the arrangement with NO winner has to be built to be seen. Against a deliberately unserialized build it caught the fault once in fifteen runs. It now drives two callers through the same parked-read seam the mechanism test uses and catches it every time, in a fraction of a second.

What turned that one-in-fifteen into a certainty was deleting a defensive branch: `ReturnGate` used to swallow a missing entry. That branch is unreachable under the invariant, and swallowing it let the unserialized build run cleanly instead of failing at the first return. It throws now.

Two instrument notes, both of which produced a false green here before being caught. `dotnet test --no-build` reported `total: 286, failed: 0` on a 291-test suite, because a hung test takes the rest of its class with it - the runner executable reports `Not Run` and is the one to read. And the tests shared one key while the lock table is static and process-wide, so a test failing while holding a lock left every later test on that key waiting forever; each test now has its own key, and every wait on a caller is bounded.

`Abblix.Utils` 294 passed, 0 failed, 0 not run. Unit project 2892 passed, 0 failed.

The mutation named against each row is the one it is aimed at; several kill more tests than that, which under-claims coverage rather than over-claiming it.




