### PR TITLE
Refuse an RSA signing key below the size RFC 7518 requires

### DIFF
--- a/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -48,16 +48,20 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 	/// <inheritdoc />
 	public byte[] EncryptKey(JsonWebTokenHeader header, RsaJsonWebKey rsaKey, byte[] keyToEncrypt)
 	{
-		using var rsa = rsaKey.ToRsa();
-
-		// Validate minimum key size per RFC 7518 Section 4
+		// Measured from the modulus, NOT from RSA.KeySize, which reports the imported octet count: a
+		// modulus left-padded to twice its size reads as twice its strength, and RFC 7518 Section 6.3.1.1
+		// warns that implementations emit the extra octet. Checked before the import, which is where the
+		// distinction is lost.
 		const int minimumKeySize = 2048;
-		if (rsa.KeySize < minimumKeySize)
+		var bits = rsaKey.ModulusBitLength();
+		if (bits < minimumKeySize)
 		{
 			throw new InvalidOperationException(
 				$"RSA key size must be at least {minimumKeySize} bits for {algorithm} per RFC 7518 Section 4. " +
-				$"Current key size: {rsa.KeySize} bits.");
+				$"The modulus is {bits} bits.");
 		}
+
+		using var rsa = rsaKey.ToRsa();
 
 		// Allocate buffer for encrypted output - RSA encryption output is always the key size in bytes
 		var encryptedKey = new byte[rsa.KeySize / 8];

--- a/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -52,7 +52,7 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 		// modulus left-padded to twice its size reads as twice its strength, and RFC 7518 Section 6.3.1.1
 		// warns that implementations emit the extra octet. Checked before the import, which is where the
 		// distinction is lost.
-		const int minimumKeySize = 2048;
+		const int minimumKeySize = JsonWebKeyExtensions.MinimumRsaKeyBits;
 		var bits = rsaKey.ModulusBitLength();
 		if (bits < minimumKeySize)
 		{

--- a/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -57,8 +57,8 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 		if (bits < minimumKeySize)
 		{
 			throw new InvalidOperationException(
-				$"RSA key size must be at least {minimumKeySize} bits for {algorithm} per RFC 7518 Section 4. " +
-				$"The modulus is {bits} bits.");
+				$"The key (kid={rsaKey.KeyId}) has a {bits}-bit modulus. {algorithm} requires at least " +
+				$"{minimumKeySize} bits per RFC 7518 {JsonWebKeyExtensions.RsaSectionFor(algorithm)}.");
 		}
 
 		using var rsa = rsaKey.ToRsa();

--- a/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -81,15 +81,24 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 		return encryptedKey;
 	}
 
+	/// <summary>
+	/// The RFC 3447 section bounding the plaintext for the padding in hand. NOT RFC 7518, which states no
+	/// such limit anywhere - Section 4 is two sentences about what JWE does with a CEK, and 4.2 and 4.3
+	/// both defer to RFC 3447 for the operation itself.
+	/// </summary>
+	private string PlaintextLimitSection => _padding == RSAEncryptionPadding.Pkcs1
+		? "RFC 3447 Section 7.2.1"
+		: "RFC 3447 Section 7.1.1";
+
 	private CryptographicException DiagnosticException(byte[] keyToEncrypt, RSA rsa)
 	{
 		// Calculate theoretical maximum CEK size for diagnostics
 		var keySizeBytes = rsa.KeySize / 8;
 
-		// Per RFC 7518 Section 4:
-		// - RSA1_5: key_size - 11 bytes
-		// - RSA-OAEP (SHA-1): key_size - 42 bytes (2 * hash_length + 2)
-		// - RSA-OAEP-256 (SHA-256): key_size - 66 bytes (2 * hash_length + 2)
+		// The limits come from RFC 3447, which RFC 7518 defers to for both padding schemes:
+		// - RSA1_5: k - 11 octets (Section 7.2.1)
+		// - RSA-OAEP with SHA-1: k - 2*20 - 2 = k - 42 (Section 7.1.1)
+		// - RSA-OAEP with SHA-256: k - 2*32 - 2 = k - 66 (Section 7.1.1)
 		var maxContentEncryptionKeySize = algorithm switch
 		{
 			EncryptionAlgorithms.KeyManagement.Rsa1_5 => keySizeBytes - 11,
@@ -101,12 +110,11 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 		// Log diagnostic information before throwing
 		LogEncryptionFailed(algorithm, rsa.KeySize, keyToEncrypt.Length, maxContentEncryptionKeySize);
 
-		// Encryption failed - provide detailed error message per RFC 7518 Section 4
 		return new CryptographicException(
 			$"Failed to encrypt Content Encryption Key using {algorithm} with {rsa.KeySize}-bit RSA key. " +
 			$"CEK size: {keyToEncrypt.Length} bytes, theoretical maximum: {maxContentEncryptionKeySize} bytes. " +
-			$"The CEK may be too large for the RSA key size per RFC 7518 Section 4, which limits the maximum " +
-			$"plaintext size based on the key size and padding overhead.");
+			$"The CEK may be too large: {PlaintextLimitSection} bounds the plaintext by the modulus size " +
+			"less the padding overhead.");
 	}
 
 	/// <inheritdoc />

--- a/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -49,9 +49,9 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 	public byte[] EncryptKey(JsonWebTokenHeader header, RsaJsonWebKey rsaKey, byte[] keyToEncrypt)
 	{
 		// Measured from the modulus, NOT from RSA.KeySize, which reports the imported octet count: a
-		// modulus left-padded to twice its size reads as twice its strength, and RFC 7518 Section 6.3.1.1
-		// warns that implementations emit the extra octet. Checked before the import, which is where the
-		// distinction is lost.
+		// modulus left-padded to twice its size reads as twice its strength. Checked before the import,
+		// which is where the distinction is lost. See ModulusBitLength for why padding on that scale is
+		// not the benign one-octet quirk the specification records.
 		const int minimumKeySize = JsonWebKeyExtensions.MinimumRsaKeyBits;
 		var bits = rsaKey.ModulusBitLength();
 		if (bits < minimumKeySize)

--- a/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
+++ b/src/Abblix.Jwt/Encryption/RsaKeyEncryptor.cs
@@ -48,10 +48,10 @@ internal sealed partial class RsaKeyEncryptor(ILogger<RsaKeyEncryptor> logger, s
 	/// <inheritdoc />
 	public byte[] EncryptKey(JsonWebTokenHeader header, RsaJsonWebKey rsaKey, byte[] keyToEncrypt)
 	{
-		// Measured from the modulus, NOT from RSA.KeySize, which reports the imported octet count: a
-		// modulus left-padded to twice its size reads as twice its strength. Checked before the import,
-		// which is where the distinction is lost. See ModulusBitLength for why padding on that scale is
-		// not the benign one-octet quirk the specification records.
+		// Measured from the modulus, NOT from RSA.KeySize, whose answer for a padded modulus depends on
+		// the platform's importer. Checked before the import, which is what introduces that dependence.
+		// See ModulusBitLength, both for the platform split and for why padding on that scale is not the
+		// benign one-octet quirk the specification records.
 		const int minimumKeySize = JsonWebKeyExtensions.MinimumRsaKeyBits;
 		var bits = rsaKey.ModulusBitLength();
 		if (bits < minimumKeySize)

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -182,10 +182,31 @@ public static class JsonWebKeyExtensions
 	}
 
 	/// <summary>
-	/// The smallest RSA modulus RFC 7518 permits, for signing (Section 3.3 and Section 3.5) and for key
-	/// encryption (Section 4) alike. One number, so the sites that enforce it cannot drift apart.
+	/// The smallest RSA modulus RFC 7518 permits. Four sections state it in the same words, one per
+	/// family: Section 3.3 and Section 3.5 for signing, Section 4.2 and Section 4.3 for key encryption.
+	/// One number here, so the sites that enforce it cannot drift apart.
 	/// </summary>
 	public const int MinimumRsaKeyBits = 2048;
+
+	/// <summary>
+	/// The RFC 7518 section that carries the key-size requirement for <paramref name="algorithm"/>.
+	/// </summary>
+	/// <remarks>
+	/// A refusal has to send the operator to the paragraph that refused them. Sections 3 and 4 are
+	/// container headings and state no size requirement at all, so citing either leaves the reader
+	/// looking at a table of algorithm names and no MUST - which reads as the library inventing the rule.
+	/// </remarks>
+	/// <exception cref="ArgumentException">The algorithm is not one this library enforces a floor for.</exception>
+	public static string RsaSectionFor(string algorithm) => algorithm switch
+	{
+		SigningAlgorithms.RS256 or SigningAlgorithms.RS384 or SigningAlgorithms.RS512 => "Section 3.3",
+		SigningAlgorithms.PS256 or SigningAlgorithms.PS384 or SigningAlgorithms.PS512 => "Section 3.5",
+		EncryptionAlgorithms.KeyManagement.Rsa1_5 => "Section 4.2",
+		EncryptionAlgorithms.KeyManagement.RsaOaep or EncryptionAlgorithms.KeyManagement.RsaOaep256
+			=> "Section 4.3",
+		_ => throw new ArgumentException(
+			$"No RSA key-size section is known for {algorithm}.", nameof(algorithm)),
+	};
 
 	/// <summary>
 	/// The real bit length of the key's modulus, ignoring any leading zero octets.
@@ -199,8 +220,8 @@ public static class JsonWebKeyExtensions
 	/// <c>RSA.KeySize</c> passes on a key half the strength it claims, and the forgery arrives later from
 	/// whoever factored the real modulus.
 	/// <para>
-	/// Measured from the leading octet's own highest set bit rather than from the octet count, so a key
-	/// whose modulus simply begins below 0x80 is not mistaken for a smaller one.
+	/// The leading octet contributes only the bits from its own highest set bit down, which is what makes
+	/// this the modulus's true length rather than a rounded-up octet count.
 	/// </para>
 	/// </remarks>
 	public static int ModulusBitLength(this RsaJsonWebKey key)

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -202,13 +202,16 @@ public static class JsonWebKeyExtensions
 		?? throw new ArgumentException($"No RSA key-size section is known for {algorithm}.", nameof(algorithm));
 
 	/// <summary>
-	/// The same citation, for use INSIDE a refusal message.
+	/// The WHOLE citation phrase, ready to drop into a refusal message - "per RFC 7518 Section 3.3", or
+	/// "for RSA signatures" when the algorithm has no section of its own.
 	/// </summary>
 	/// <remarks>
-	/// An unknown algorithm here must not replace the refusal the operator was about to read with a
-	/// complaint about the citation, so this yields a section-free phrase instead of throwing and the
-	/// sentence still names the key, the size and the floor. Reachable: an RSA key carrying no
-	/// <c>alg</c> resolves to <c>SigningAlgorithms.None</c>, which has no floor of its own.
+	/// Two differences from <see cref="RsaSectionFor"/>, and both matter at a call site. This one never
+	/// throws, because an unknown algorithm must not replace the refusal the operator was about to read
+	/// with a complaint about the citation - and it is reachable, since an RSA key carrying no
+	/// <c>alg</c> resolves to <c>SigningAlgorithms.None</c>. And this one carries the words "per RFC
+	/// 7518" itself, where <see cref="RsaSectionFor"/> returns the bare section and leaves them to the
+	/// caller. Interpolate this one into a sentence that writes them too and the message says them twice.
 	/// </remarks>
 	public static string RsaSectionForOrNothing(string algorithm)
 		=> SectionOrNull(algorithm) is { } section ? $"per RFC 7518 {section}" : "for RSA signatures";

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -182,6 +182,12 @@ public static class JsonWebKeyExtensions
 	}
 
 	/// <summary>
+	/// The smallest RSA modulus RFC 7518 permits, for signing (Section 3.3 and Section 3.5) and for key
+	/// encryption (Section 4) alike. One number, so the sites that enforce it cannot drift apart.
+	/// </summary>
+	public const int MinimumRsaKeyBits = 2048;
+
+	/// <summary>
 	/// The real bit length of the key's modulus, ignoring any leading zero octets.
 	/// </summary>
 	/// <remarks>

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -182,9 +182,10 @@ public static class JsonWebKeyExtensions
 	}
 
 	/// <summary>
-	/// The smallest RSA modulus RFC 7518 permits. Four sections state it in the same words, one per
-	/// family: Section 3.3 and Section 3.5 for signing, Section 4.2 and Section 4.3 for key encryption.
-	/// One number here, so the sites that enforce it cannot drift apart.
+	/// The smallest RSA modulus RFC 7518 permits. Four sections state it, one per family: Section 3.3
+	/// and Section 3.5 for signing, Section 4.2 and Section 4.3 for key encryption. Almost the same
+	/// words - 3.3 and 4.3 govern several algorithms and say "these", 3.5 and 4.2 govern one and say
+	/// "this". One number here, so the sites that enforce it cannot drift apart.
 	/// </summary>
 	public const int MinimumRsaKeyBits = 2048;
 
@@ -197,15 +198,29 @@ public static class JsonWebKeyExtensions
 	/// looking at a table of algorithm names and no MUST - which reads as the library inventing the rule.
 	/// </remarks>
 	/// <exception cref="ArgumentException">The algorithm is not one this library enforces a floor for.</exception>
-	public static string RsaSectionFor(string algorithm) => algorithm switch
+	public static string RsaSectionFor(string algorithm) => SectionOrNull(algorithm)
+		?? throw new ArgumentException($"No RSA key-size section is known for {algorithm}.", nameof(algorithm));
+
+	/// <summary>
+	/// The same citation, for use INSIDE a refusal message.
+	/// </summary>
+	/// <remarks>
+	/// An unknown algorithm here must not replace the refusal the operator was about to read with a
+	/// complaint about the citation, so this yields a section-free phrase instead of throwing and the
+	/// sentence still names the key, the size and the floor. Reachable: an RSA key carrying no
+	/// <c>alg</c> resolves to <c>SigningAlgorithms.None</c>, which has no floor of its own.
+	/// </remarks>
+	public static string RsaSectionForOrNothing(string algorithm)
+		=> SectionOrNull(algorithm) is { } section ? $"per RFC 7518 {section}" : "for RSA signatures";
+
+	private static string? SectionOrNull(string algorithm) => algorithm switch
 	{
 		SigningAlgorithms.RS256 or SigningAlgorithms.RS384 or SigningAlgorithms.RS512 => "Section 3.3",
 		SigningAlgorithms.PS256 or SigningAlgorithms.PS384 or SigningAlgorithms.PS512 => "Section 3.5",
 		EncryptionAlgorithms.KeyManagement.Rsa1_5 => "Section 4.2",
 		EncryptionAlgorithms.KeyManagement.RsaOaep or EncryptionAlgorithms.KeyManagement.RsaOaep256
 			=> "Section 4.3",
-		_ => throw new ArgumentException(
-			$"No RSA key-size section is known for {algorithm}.", nameof(algorithm)),
+		_ => null,
 	};
 
 	/// <summary>
@@ -213,12 +228,17 @@ public static class JsonWebKeyExtensions
 	/// </summary>
 	/// <remarks>
 	/// <c>RSA.KeySize</c> is not this number. It reports the length of the octets that were IMPORTED, so a
-	/// modulus left-padded to twice its size reports twice its strength - and a peer supplying one is not
-	/// necessarily attacking: RFC 7518 Section 2 requires the minimal encoding ("The octet sequence MUST
-	/// utilize the minimum number of octets needed to represent the value"), while Section 6.3.1.1 warns
-	/// that implementations emit the extra octet anyway. So a size check written against
+	/// modulus left-padded to twice its size reports twice its strength: a size check written against
 	/// <c>RSA.KeySize</c> passes on a key half the strength it claims, and the forgery arrives later from
 	/// whoever factored the real modulus.
+	/// <para>
+	/// RFC 7518 Section 2 requires the minimal encoding - "The octet sequence MUST utilize the minimum
+	/// number of octets needed to represent the value" - which is what this measurement follows. Padding
+	/// far enough to matter is NOT something a library does by accident: the one benign quirk the
+	/// specification records is a single extra zero octet (Section 6.3.1.1, "returning 257 octets for a
+	/// 2048-bit key"), and one octet moves neither check in either direction. Sixty-four of them is a
+	/// malformed or hostile JWKS entry.
+	/// </para>
 	/// <para>
 	/// The leading octet contributes only the bits from its own highest set bit down, which is what makes
 	/// this the modulus's true length rather than a rounded-up octet count.

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -230,10 +230,17 @@ public static class JsonWebKeyExtensions
 	/// The real bit length of the key's modulus, ignoring any leading zero octets.
 	/// </summary>
 	/// <remarks>
-	/// <c>RSA.KeySize</c> is not this number. It reports the length of the octets that were IMPORTED, so a
-	/// modulus left-padded to twice its size reports twice its strength: a size check written against
-	/// <c>RSA.KeySize</c> passes on a key half the strength it claims, and the forgery arrives later from
+	/// <c>RSA.KeySize</c> is not this number, and how far it differs depends on the platform. It reports
+	/// the key as the importer built it: Windows CNG keeps a left-padded modulus at its padded length and
+	/// reports twice the real strength, while Linux (OpenSSL) strips the leading zeros and reports the
+	/// true one. So a size check written against that property refuses a downgraded key on one operating
+	/// system and admits it on another - which is a worse failure than either, because the deployment
+	/// that admits it looks identical to the one that does not, and the forgery arrives later from
 	/// whoever factored the real modulus.
+	/// <para>
+	/// Measuring the modulus itself removes the platform from the question. It is also never larger than
+	/// <c>RSA.KeySize</c>, so switching to it can only add refusals, never remove one.
+	/// </para>
 	/// <para>
 	/// RFC 7518 Section 2 requires the minimal encoding - "The octet sequence MUST utilize the minimum
 	/// number of octets needed to represent the value" - which is what this measurement follows. Padding

--- a/src/Abblix.Jwt/JsonWebKeyExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebKeyExtensions.cs
@@ -182,6 +182,42 @@ public static class JsonWebKeyExtensions
 	}
 
 	/// <summary>
+	/// The real bit length of the key's modulus, ignoring any leading zero octets.
+	/// </summary>
+	/// <remarks>
+	/// <c>RSA.KeySize</c> is not this number. It reports the length of the octets that were IMPORTED, so a
+	/// modulus left-padded to twice its size reports twice its strength - and a peer supplying one is not
+	/// necessarily attacking: RFC 7518 Section 2 requires the minimal encoding ("The octet sequence MUST
+	/// utilize the minimum number of octets needed to represent the value"), while Section 6.3.1.1 warns
+	/// that implementations emit the extra octet anyway. So a size check written against
+	/// <c>RSA.KeySize</c> passes on a key half the strength it claims, and the forgery arrives later from
+	/// whoever factored the real modulus.
+	/// <para>
+	/// Measured from the leading octet's own highest set bit rather than from the octet count, so a key
+	/// whose modulus simply begins below 0x80 is not mistaken for a smaller one.
+	/// </para>
+	/// </remarks>
+	public static int ModulusBitLength(this RsaJsonWebKey key)
+	{
+		var modulus = key.Modulus;
+		if (modulus is null)
+			return 0;
+
+		var first = 0;
+		while (first < modulus.Length && modulus[first] == 0)
+			first++;
+
+		if (first == modulus.Length)
+			return 0;
+
+		var bitsInLeadingOctet = 8;
+		for (var mask = 0x80; mask != 0 && (modulus[first] & mask) == 0; mask >>= 1)
+			bitsInLeadingOctet--;
+
+		return (modulus.Length - first - 1) * 8 + bitsInLeadingOctet;
+	}
+
+	/// <summary>
 	/// Converts an RsaJsonWebKey to RSAParameters, which represent the key parameters used in RSA cryptographic operations.
 	/// </summary>
 	/// <param name="key">The RsaJsonWebKey to be converted.</param>

--- a/src/Abblix.Jwt/JsonWebKeyFactory.cs
+++ b/src/Abblix.Jwt/JsonWebKeyFactory.cs
@@ -20,9 +20,14 @@ public static class JsonWebKeyFactory
     /// Creates an RSA JsonWebKey with a specified algorithm.
     /// </summary>
     /// <param name="usage">The intended usage of the key, typically 'sig' for signing or 'enc' for encryption.</param>
-    /// <param name="algorithm">The signing or encryption algorithm. Key size is determined automatically based on the algorithm.</param>
-    /// <param name="keySize">The size of the RSA key in bits. If null, determined by algorithm (defaults to 2048).</param>
+    /// <param name="algorithm">The signing or encryption algorithm the key declares. It does not affect
+    /// the key size.</param>
+    /// <param name="keySize">The size of the RSA key in bits, 2048 by default, which is also the smallest
+    /// this library will mint.</param>
     /// <returns>A <see cref="RsaJsonWebKey"/> configured for the specified algorithm.</returns>
+    /// <exception cref="ArgumentException">The usage is neither signing nor encryption, or
+    /// <paramref name="keySize"/> is below <see cref="JsonWebKeyExtensions.MinimumRsaKeyBits"/> - a size
+    /// this library would refuse to sign or encrypt with, so it does not produce one either.</exception>
     public static RsaJsonWebKey CreateRsa(string usage, string? algorithm = null, int keySize = 2048)
     {
         if (usage is not (PublicKeyUsages.Signature or PublicKeyUsages.Encryption))

--- a/src/Abblix.Jwt/JsonWebKeyFactory.cs
+++ b/src/Abblix.Jwt/JsonWebKeyFactory.cs
@@ -33,6 +33,15 @@ public static class JsonWebKeyFactory
                 nameof(usage));
         }
 
+        if (keySize < JsonWebKeyExtensions.MinimumRsaKeyBits)
+        {
+            throw new ArgumentException(
+                $"An RSA key of {keySize} bits cannot be used for JOSE: RFC 7518 requires at least " +
+                $"{JsonWebKeyExtensions.MinimumRsaKeyBits}, and this library refuses to sign or encrypt " +
+                "with anything smaller. Raise the configured key size.",
+                nameof(keySize));
+        }
+
         using var rsa = RSA.Create();
         rsa.KeySize = keySize;
         var parameters = rsa.ExportParameters(true);

--- a/src/Abblix.Jwt/Signing/CompositeSigner.cs
+++ b/src/Abblix.Jwt/Signing/CompositeSigner.cs
@@ -27,9 +27,10 @@ internal sealed class CompositeSigner(IEnumerable<IDataSigner> backends) : IData
         CancellationToken cancellationToken)
     {
         // The floor RFC 7518 sets on an RSA key belongs to the DEPLOYMENT's keys, not to one backend's
-        // code path. RsaSigner enforces it for what it signs in process; a key whose private half lives
-        // with a custodian never reaches that class, so without this the same deployment mints RS256 over
-        // an undersized modulus through the external backend while refusing to verify its own output.
+        // code path. RsaSigner enforces it for what it SIGNS in process, and a key whose private half
+        // lives with a custodian never reaches that class for signing - it does reach it for every
+        // verification, which is local. So without this the same deployment mints RS256 over an
+        // undersized modulus through the external backend and then refuses to verify its own output.
         //
         // Measured from the modulus rather than from RSA.KeySize, which reports the imported octet count -
         // an external key is public-only and its modulus is all there is to read.
@@ -38,7 +39,8 @@ internal sealed class CompositeSigner(IEnumerable<IDataSigner> backends) : IData
             throw new ArgumentException(
                 $"The signing key (kid={key.KeyId}) has a {bits}-bit modulus. {algorithm} requires at " +
                 $"least {JsonWebKeyExtensions.MinimumRsaKeyBits} bits per RFC 7518 " +
-                $"{JsonWebKeyExtensions.RsaSectionFor(algorithm)}, and this deployment would not be able " +
+                $"{JsonWebKeyExtensions.RsaSectionForOrNothing(algorithm)}, and this deployment would " +
+                "not be able " +
                 "to verify what it signed with this key.",
                 nameof(key));
         }

--- a/src/Abblix.Jwt/Signing/CompositeSigner.cs
+++ b/src/Abblix.Jwt/Signing/CompositeSigner.cs
@@ -35,10 +35,12 @@ internal sealed class CompositeSigner(IEnumerable<IDataSigner> backends) : IData
         // an external key is public-only and its modulus is all there is to read.
         if (key is RsaJsonWebKey rsaKey && rsaKey.ModulusBitLength() is var bits and < JsonWebKeyExtensions.MinimumRsaKeyBits)
         {
-            throw new InvalidOperationException(
-                $"The signing key (kid={key.KeyId}) has a {bits}-bit modulus. RFC 7518 requires at least " +
-                $"{JsonWebKeyExtensions.MinimumRsaKeyBits} bits for RSA signatures, and this deployment " +
-                "would not be able to verify what it signed with this key.");
+            throw new ArgumentException(
+                $"The signing key (kid={key.KeyId}) has a {bits}-bit modulus. {algorithm} requires at " +
+                $"least {JsonWebKeyExtensions.MinimumRsaKeyBits} bits per RFC 7518 " +
+                $"{JsonWebKeyExtensions.RsaSectionFor(algorithm)}, and this deployment would not be able " +
+                "to verify what it signed with this key.",
+                nameof(key));
         }
 
         var owner = backends.FirstOrDefault(backend => backend.CanSign(key));

--- a/src/Abblix.Jwt/Signing/CompositeSigner.cs
+++ b/src/Abblix.Jwt/Signing/CompositeSigner.cs
@@ -26,6 +26,21 @@ internal sealed class CompositeSigner(IEnumerable<IDataSigner> backends) : IData
         byte[] data,
         CancellationToken cancellationToken)
     {
+        // The floor RFC 7518 sets on an RSA key belongs to the DEPLOYMENT's keys, not to one backend's
+        // code path. RsaSigner enforces it for what it signs in process; a key whose private half lives
+        // with a custodian never reaches that class, so without this the same deployment mints RS256 over
+        // an undersized modulus through the external backend while refusing to verify its own output.
+        //
+        // Measured from the modulus rather than from RSA.KeySize, which reports the imported octet count -
+        // an external key is public-only and its modulus is all there is to read.
+        if (key is RsaJsonWebKey rsaKey && rsaKey.ModulusBitLength() is var bits and < JsonWebKeyExtensions.MinimumRsaKeyBits)
+        {
+            throw new InvalidOperationException(
+                $"The signing key (kid={key.KeyId}) has a {bits}-bit modulus. RFC 7518 requires at least " +
+                $"{JsonWebKeyExtensions.MinimumRsaKeyBits} bits for RSA signatures, and this deployment " +
+                "would not be able to verify what it signed with this key.");
+        }
+
         var owner = backends.FirstOrDefault(backend => backend.CanSign(key));
         if (owner == null)
         {

--- a/src/Abblix.Jwt/Signing/CompositeSigner.cs
+++ b/src/Abblix.Jwt/Signing/CompositeSigner.cs
@@ -38,10 +38,9 @@ internal sealed class CompositeSigner(IEnumerable<IDataSigner> backends) : IData
         {
             throw new ArgumentException(
                 $"The signing key (kid={key.KeyId}) has a {bits}-bit modulus. {algorithm} requires at " +
-                $"least {JsonWebKeyExtensions.MinimumRsaKeyBits} bits per RFC 7518 " +
+                $"least {JsonWebKeyExtensions.MinimumRsaKeyBits} bits " +
                 $"{JsonWebKeyExtensions.RsaSectionForOrNothing(algorithm)}, and this deployment would " +
-                "not be able " +
-                "to verify what it signed with this key.",
+                "not be able to verify what it signed with this key.",
                 nameof(key));
         }
 

--- a/src/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/src/Abblix.Jwt/Signing/RsaSigner.cs
@@ -22,7 +22,12 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	/// RS256/RS384/RS512: "A key of size 2048 bits or larger MUST be used with these algorithms." Section
 	/// 3.5, for PS256/PS384/PS512, says it of the singular: "with this algorithm."
 	/// </summary>
-	private const int MinimumKeySizeBits = 2048;
+	/// <remarks>
+	/// Enforced here AND at the signing seam, because they are different doors. This one is the contract
+	/// of the byte-level algorithm and the one its own tests drive. The seam's is the one a key held by an
+	/// external custodian passes through, and such a key never reaches this class at all.
+	/// </remarks>
+	private const int MinimumKeySizeBits = JsonWebKeyExtensions.MinimumRsaKeyBits;
 
 	/// <summary>
 	/// The section that governs the algorithm in hand, so a refusal sends the reader to the paragraph that

--- a/src/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/src/Abblix.Jwt/Signing/RsaSigner.cs
@@ -40,9 +40,9 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	/// <inheritdoc />
 	public byte[] Sign(RsaJsonWebKey rsaKey, byte[] data)
 	{
-		// Measured from the modulus, NOT from RSA.KeySize, which reports the imported octet count and so
-		// reads a padded modulus as twice its strength. Checked before the import, because the import is
-		// where the distinction is lost.
+		// Measured from the modulus, NOT from RSA.KeySize, whose answer for a padded modulus depends on
+		// the platform's importer - see ModulusBitLength. Checked before the import, which is what makes
+		// the answer platform-dependent in the first place.
 		//
 		// Nothing upstream chooses the key - it arrives from whatever the host registered - so without
 		// this a deployment mints RS256 over a 1024-bit modulus and every peer accepts it, because the

--- a/src/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/src/Abblix.Jwt/Signing/RsaSigner.cs
@@ -29,14 +29,6 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	/// </remarks>
 	private const int MinimumKeySizeBits = JsonWebKeyExtensions.MinimumRsaKeyBits;
 
-	/// <summary>
-	/// The section that governs the algorithm in hand, so a refusal sends the reader to the paragraph that
-	/// refused them rather than to both and neither.
-	/// </summary>
-	private string GoverningSection => _parameters.padding == RSASignaturePadding.Pkcs1
-		? "Section 3.3"
-		: "Section 3.5";
-
 	private readonly (HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) _parameters = GetAlgorithmParameters(algorithm);
 
 	/// <inheritdoc />
@@ -55,8 +47,9 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 		var bits = rsaKey.ModulusBitLength();
 		if (bits < MinimumKeySizeBits)
 			throw new ArgumentException(
-				$"{algorithm} requires an RSA key of at least {MinimumKeySizeBits} bits per RFC 7518 " +
-				$"{GoverningSection}; the modulus is {bits} bits.",
+				$"The signing key (kid={rsaKey.KeyId}) has a {bits}-bit modulus. {algorithm} requires at " +
+				$"least {MinimumKeySizeBits} bits per RFC 7518 " +
+				$"{JsonWebKeyExtensions.RsaSectionFor(algorithm)}.",
 				nameof(rsaKey));
 
 		using var rsa = rsaKey.ToRsa();

--- a/src/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/src/Abblix.Jwt/Signing/RsaSigner.cs
@@ -17,6 +17,12 @@ namespace Abblix.Jwt.Signing;
 /// </summary>
 internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonWebKey>
 {
+	/// <summary>
+	/// "A key of size 2048 bits or larger MUST be used with these algorithms" - RFC 7518 section 3.3 for the
+	/// PKCS#1 v1.5 family and section 3.5 for PSS, in those words in both.
+	/// </summary>
+	private const int MinimumKeySizeBits = 2048;
+
 	private readonly (HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) _parameters = GetAlgorithmParameters(algorithm);
 
 	/// <inheritdoc />
@@ -26,6 +32,19 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	public byte[] Sign(RsaJsonWebKey rsaKey, byte[] data)
 	{
 		using var rsa = rsaKey.ToRsa();
+
+		// Both families this class implements carry the same floor in the sections its summary already
+		// cites: "A key of size 2048 bits or larger MUST be used with these algorithms" (RFC 7518 Section
+		// 3.3 for RS256/384/512, Section 3.5 for PS256/384/512). Nothing upstream chooses the key - it
+		// arrives from whatever the host registered - so without this a deployment mints RS256 over a
+		// 1024-bit modulus and every peer accepts it, because the header says RS256 and the signature
+		// verifies.
+		if (rsa.KeySize < MinimumKeySizeBits)
+			throw new ArgumentException(
+				$"{algorithm} requires an RSA key of at least {MinimumKeySizeBits} bits per RFC 7518 " +
+				$"section 3.3 and section 3.5; got {rsa.KeySize} bits.",
+				nameof(rsaKey));
+
 		return rsa.SignData(data, _parameters.hashAlgorithm, _parameters.padding);
 	}
 
@@ -33,6 +52,15 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	public bool Verify(RsaJsonWebKey rsaKey, byte[] data, byte[] signature)
 	{
 		using var rsa = rsaKey.ToRsa();
+
+		// RFC 7518 section 3.3 and section 3.5: a key below the floor cannot carry the algorithm's nominal strength,
+		// so refuse without verifying - otherwise a peer downgrades this deployment simply by publishing
+		// a weak key in its JWKS, and the header still reads RS256. Same shape as HmacSigner, which
+		// returns false rather than throwing on the verifying side: an undersized key from somebody else
+		// is a signature that does not check out, not a fault in the caller.
+		if (rsa.KeySize < MinimumKeySizeBits)
+			return false;
+
 		return rsa.VerifyData(data, signature, _parameters.hashAlgorithm, _parameters.padding);
 	}
 

--- a/src/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/src/Abblix.Jwt/Signing/RsaSigner.cs
@@ -18,10 +18,19 @@ namespace Abblix.Jwt.Signing;
 internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonWebKey>
 {
 	/// <summary>
-	/// "A key of size 2048 bits or larger MUST be used with these algorithms" - RFC 7518 section 3.3 for the
-	/// PKCS#1 v1.5 family and section 3.5 for PSS, in those words in both.
+	/// RFC 7518 requires the same floor of both families this class implements. Section 3.3, for
+	/// RS256/RS384/RS512: "A key of size 2048 bits or larger MUST be used with these algorithms." Section
+	/// 3.5, for PS256/PS384/PS512, says it of the singular: "with this algorithm."
 	/// </summary>
 	private const int MinimumKeySizeBits = 2048;
+
+	/// <summary>
+	/// The section that governs the algorithm in hand, so a refusal sends the reader to the paragraph that
+	/// refused them rather than to both and neither.
+	/// </summary>
+	private string GoverningSection => _parameters.padding == RSASignaturePadding.Pkcs1
+		? "Section 3.3"
+		: "Section 3.5";
 
 	private readonly (HashAlgorithmName hashAlgorithm, RSASignaturePadding padding) _parameters = GetAlgorithmParameters(algorithm);
 
@@ -31,36 +40,39 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	/// <inheritdoc />
 	public byte[] Sign(RsaJsonWebKey rsaKey, byte[] data)
 	{
-		using var rsa = rsaKey.ToRsa();
-
-		// Both families this class implements carry the same floor in the sections its summary already
-		// cites: "A key of size 2048 bits or larger MUST be used with these algorithms" (RFC 7518 Section
-		// 3.3 for RS256/384/512, Section 3.5 for PS256/384/512). Nothing upstream chooses the key - it
-		// arrives from whatever the host registered - so without this a deployment mints RS256 over a
-		// 1024-bit modulus and every peer accepts it, because the header says RS256 and the signature
-		// verifies.
-		if (rsa.KeySize < MinimumKeySizeBits)
+		// Measured from the modulus, NOT from RSA.KeySize, which reports the imported octet count and so
+		// reads a padded modulus as twice its strength. Checked before the import, because the import is
+		// where the distinction is lost.
+		//
+		// Nothing upstream chooses the key - it arrives from whatever the host registered - so without
+		// this a deployment mints RS256 over a 1024-bit modulus and every peer accepts it, because the
+		// header says RS256 and the signature verifies.
+		var bits = rsaKey.ModulusBitLength();
+		if (bits < MinimumKeySizeBits)
 			throw new ArgumentException(
 				$"{algorithm} requires an RSA key of at least {MinimumKeySizeBits} bits per RFC 7518 " +
-				$"section 3.3 and section 3.5; got {rsa.KeySize} bits.",
+				$"{GoverningSection}; the modulus is {bits} bits.",
 				nameof(rsaKey));
 
+		using var rsa = rsaKey.ToRsa();
 		return rsa.SignData(data, _parameters.hashAlgorithm, _parameters.padding);
 	}
 
 	/// <inheritdoc />
 	public bool Verify(RsaJsonWebKey rsaKey, byte[] data, byte[] signature)
 	{
-		using var rsa = rsaKey.ToRsa();
-
-		// RFC 7518 section 3.3 and section 3.5: a key below the floor cannot carry the algorithm's nominal strength,
-		// so refuse without verifying - otherwise a peer downgrades this deployment simply by publishing
-		// a weak key in its JWKS, and the header still reads RS256. Same shape as HmacSigner, which
-		// returns false rather than throwing on the verifying side: an undersized key from somebody else
-		// is a signature that does not check out, not a fault in the caller.
-		if (rsa.KeySize < MinimumKeySizeBits)
+		// A key below the floor cannot carry the algorithm's nominal strength, so refuse without verifying -
+		// otherwise a peer downgrades this deployment simply by publishing a weak key in its JWKS, and the
+		// header still reads RS256. Same shape as HmacSigner, which returns false rather than throwing on
+		// the verifying side: an undersized key from somebody else is a signature that does not check out,
+		// not a fault in the caller.
+		//
+		// Measured from the modulus for the reason ModulusBitLength gives: padding a weak modulus out to a
+		// respectable octet count is exactly how this check would otherwise be walked past.
+		if (rsaKey.ModulusBitLength() < MinimumKeySizeBits)
 			return false;
 
+		using var rsa = rsaKey.ToRsa();
 		return rsa.VerifyData(data, signature, _parameters.hashAlgorithm, _parameters.padding);
 	}
 

--- a/src/Abblix.Jwt/Signing/RsaSigner.cs
+++ b/src/Abblix.Jwt/Signing/RsaSigner.cs
@@ -23,9 +23,12 @@ internal sealed class RsaSigner(string algorithm) : ISignatureAlgorithm<RsaJsonW
 	/// 3.5, for PS256/PS384/PS512, says it of the singular: "with this algorithm."
 	/// </summary>
 	/// <remarks>
-	/// Enforced here AND at the signing seam, because they are different doors. This one is the contract
-	/// of the byte-level algorithm and the one its own tests drive. The seam's is the one a key held by an
-	/// external custodian passes through, and such a key never reaches this class at all.
+	/// Enforced here AND at the signing seam, because they are different doors and neither covers the
+	/// other. A key whose private half lives with a custodian never reaches this class FOR SIGNING - the
+	/// seam is what refuses it there. It reaches this class for every VERIFICATION, because verification
+	/// is always local: the validator resolves the keyed algorithm by key type and never consults the
+	/// seam. So the floor below runs in both directions, and deleting it would leave a custodian
+	/// deployment with nothing refusing an undersized key published in a peer's JWKS.
 	/// </remarks>
 	private const int MinimumKeySizeBits = JsonWebKeyExtensions.MinimumRsaKeyBits;
 

--- a/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
@@ -22,9 +22,9 @@ namespace Abblix.Jwt.UnitTests;
 /// passes would open the configuration most deployments run.
 ///
 /// What this door adds: a key whose private half lives with an external custodian is public-only, so
-/// <c>RsaSigner</c> never sees it - the composite routes it to the custodian backend instead. Without the
-/// floor here, such a deployment signs RS256 over an undersized modulus and then refuses to verify its own
-/// output, because verification is always local and always goes through <c>RsaSigner</c>.
+/// <c>RsaSigner</c> never sees it FOR SIGNING - the composite routes it to the custodian backend instead.
+/// It does see that key for every VERIFICATION, which is always local. So without the floor here, such a
+/// deployment signs RS256 over an undersized modulus and then refuses to verify its own output.
 /// </remarks>
 public class CompositeSignerKeyFloorTests
 {
@@ -48,6 +48,12 @@ public class CompositeSignerKeyFloorTests
 
         Assert.Contains(BelowTheFloor.ToString(), error.Message);
         Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
+
+        // The COMPOSED sentence, not the pieces. Two functions can each return something correct and
+        // still produce a message that says "per RFC 7518" twice, which is exactly what happened: the
+        // citation phrase carries those words and the sentence around it once wrote them as well.
+        Assert.Contains("per RFC 7518 Section 3.3", error.Message);
+        Assert.DoesNotContain("per RFC 7518 per", error.Message);
 
         // The refusal has to happen BEFORE the custodian is asked, or a hardware module has already
         // performed the operation this deployment cannot verify.
@@ -91,6 +97,11 @@ public class CompositeSignerKeyFloorTests
 
         Assert.Contains(BelowTheFloor.ToString(), error.Message);
         Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
+
+        // The arm with no section of its own has to read as a sentence too.
+        Assert.Contains("for RSA signatures", error.Message);
+        Assert.DoesNotContain("per RFC 7518 per", error.Message);
+
         Assert.False(custodian.WasAsked);
     }
 

--- a/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
@@ -1,0 +1,110 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Security.Cryptography;
+using Abblix.Jwt.Signing;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// The RSA key-size floor is a property of the deployment's keys, so it has to hold at the seam every
+/// signing path crosses - not only inside the algorithm that signs in process.
+/// </summary>
+/// <remarks>
+/// A key whose private half lives with an external custodian is public-only, so <c>RsaSigner</c> never
+/// sees it: the composite routes it to the custodian backend instead. Without the floor at the seam, such
+/// a deployment signs RS256 over an undersized modulus and then refuses to verify its own output, because
+/// verification is always local and always goes through <c>RsaSigner</c>.
+/// </remarks>
+public class CompositeSignerKeyFloorTests
+{
+    private static readonly byte[] SampleData = "the quick brown fox"u8.ToArray();
+
+    /// <summary>
+    /// An undersized key that every RSA signing algorithm can still use, for the reason
+    /// <see cref="RsaSignerTests"/> gives: PSS with SHA-512 cannot sign with 1024 bits at all.
+    /// </summary>
+    private const int BelowTheFloor = 1536;
+
+    [Fact]
+    public async Task SignAsync_AnExternalKeyBelowTheFloor_IsRefusedAtTheSeam()
+    {
+        var custodian = new RecordingCustodian();
+        var composite = new CompositeSigner([new ExternalKeys.ExternalKeySigner(custodian)]);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => composite.SignAsync(PublicOnlyKey(BelowTheFloor), SigningAlgorithms.RS256, SampleData,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains(BelowTheFloor.ToString(), error.Message);
+        Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
+
+        // The refusal has to happen BEFORE the custodian is asked, or a hardware module has already
+        // performed the operation this deployment cannot verify.
+        Assert.False(custodian.WasAsked);
+    }
+
+    /// <summary>
+    /// The control. Without it, a seam that refused every external key would pass the test above.
+    /// </summary>
+    [Fact]
+    public async Task SignAsync_AnExternalKeyAtTheFloor_ReachesTheCustodian()
+    {
+        var custodian = new RecordingCustodian();
+        var composite = new CompositeSigner([new ExternalKeys.ExternalKeySigner(custodian)]);
+
+        var signature = await composite.SignAsync(
+            PublicOnlyKey(JsonWebKeyExtensions.MinimumRsaKeyBits), SigningAlgorithms.RS256, SampleData,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(custodian.WasAsked);
+        Assert.NotEmpty(signature);
+    }
+
+    private static RsaJsonWebKey PublicOnlyKey(int bits)
+    {
+        using var rsa = RSA.Create(bits);
+        var parameters = rsa.ExportParameters(false);
+
+        return new RsaJsonWebKey
+        {
+            KeyId = "custodian-handle",
+            Usage = PublicKeyUsages.Signature,
+            Algorithm = SigningAlgorithms.RS256,
+            Modulus = parameters.Modulus,
+            Exponent = parameters.Exponent,
+        };
+    }
+
+    private sealed class RecordingCustodian : ExternalKeys.IKeyCustodian
+    {
+        public bool WasAsked { get; private set; }
+
+        public Task<byte[]> SignAsync(
+            string keyId, string algorithm, byte[] data, CancellationToken cancellationToken)
+        {
+            WasAsked = true;
+            return Task.FromResult(new byte[] { 1, 2, 3 });
+        }
+
+        // The rest of the seam, which these tests do not exercise: a custodian that never answers them is
+        // still a custodian for the purpose of asking whether signing was reached.
+        public Task<byte[]?> UnwrapKeyAsync(
+            string keyId, string algorithm, JsonWebTokenHeader header, byte[] encryptedKey,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<byte[]> AgreeKeyAsync(
+            string keyId, string algorithm, JsonWebKey ephemeralPublicKey, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<KeyVersion> GetKeyVersionsAsync(
+            string keyName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
@@ -98,9 +98,10 @@ public class CompositeSignerKeyFloorTests
         Assert.Contains(BelowTheFloor.ToString(), error.Message);
         Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
 
-        // The arm with no section of its own has to read as a sentence too.
-        Assert.Contains("for RSA signatures", error.Message);
-        Assert.DoesNotContain("per RFC 7518 per", error.Message);
+        // The arm with no section of its own has to read as a sentence too - stated positively, because
+        // the negative form cannot fail here: this arm never begins with "per", so a doubled prefix
+        // upstream leaves it green while breaking the other one.
+        Assert.Contains("bits for RSA signatures", error.Message);
 
         Assert.False(custodian.WasAsked);
     }

--- a/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
@@ -71,6 +71,29 @@ public class CompositeSignerKeyFloorTests
         Assert.NotEmpty(signature);
     }
 
+    /// <summary>
+    /// An RSA key carrying no <c>alg</c> resolves to <c>SigningAlgorithms.None</c>, which has no floor
+    /// section of its own. The seam must still refuse it for its SIZE, and say so.
+    /// </summary>
+    /// <remarks>
+    /// Building the citation by a method that throws on an unknown algorithm would replace this refusal
+    /// with a complaint about the citation, on the one path where the operator most needs the size.
+    /// </remarks>
+    [Fact]
+    public async Task SignAsync_AnUndersizedKeyWithNoAlgorithm_IsStillRefusedForItsSize()
+    {
+        var custodian = new RecordingCustodian();
+        var composite = new CompositeSigner([new ExternalKeys.ExternalKeySigner(custodian)]);
+
+        var error = await Assert.ThrowsAsync<ArgumentException>(
+            () => composite.SignAsync(PublicOnlyKey(BelowTheFloor), SigningAlgorithms.None, SampleData,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains(BelowTheFloor.ToString(), error.Message);
+        Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
+        Assert.False(custodian.WasAsked);
+    }
+
     private static RsaJsonWebKey PublicOnlyKey(int bits)
     {
         using var rsa = RSA.Create(bits);

--- a/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/CompositeSignerKeyFloorTests.cs
@@ -12,14 +12,19 @@ using Xunit;
 namespace Abblix.Jwt.UnitTests;
 
 /// <summary>
-/// The RSA key-size floor is a property of the deployment's keys, so it has to hold at the seam every
-/// signing path crosses - not only inside the algorithm that signs in process.
+/// The RSA key-size floor is a property of the deployment's keys, so it holds at BOTH doors into
+/// signing - neither of which is always present.
 /// </summary>
 /// <remarks>
-/// A key whose private half lives with an external custodian is public-only, so <c>RsaSigner</c> never
-/// sees it: the composite routes it to the custodian backend instead. Without the floor at the seam, such
-/// a deployment signs RS256 over an undersized modulus and then refuses to verify its own output, because
-/// verification is always local and always goes through <c>RsaSigner</c>.
+/// <c>CompositeSigner</c> is registered only when a custodian is wired; a deployment with nothing but
+/// <c>AddJsonWebTokens()</c> resolves <c>IDataSigner</c> to <c>LocalKeySigner</c> and this class does not
+/// exist in it. So neither guard is redundant, and deleting the one in <c>RsaSigner</c> because this test
+/// passes would open the configuration most deployments run.
+///
+/// What this door adds: a key whose private half lives with an external custodian is public-only, so
+/// <c>RsaSigner</c> never sees it - the composite routes it to the custodian backend instead. Without the
+/// floor here, such a deployment signs RS256 over an undersized modulus and then refuses to verify its own
+/// output, because verification is always local and always goes through <c>RsaSigner</c>.
 /// </remarks>
 public class CompositeSignerKeyFloorTests
 {
@@ -37,7 +42,7 @@ public class CompositeSignerKeyFloorTests
         var custodian = new RecordingCustodian();
         var composite = new CompositeSigner([new ExternalKeys.ExternalKeySigner(custodian)]);
 
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+        var error = await Assert.ThrowsAsync<ArgumentException>(
             () => composite.SignAsync(PublicOnlyKey(BelowTheFloor), SigningAlgorithms.RS256, SampleData,
                 TestContext.Current.CancellationToken));
 

--- a/tests/Abblix.Jwt.UnitTests/InMemoryKeyRingTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/InMemoryKeyRingTests.cs
@@ -25,9 +25,10 @@ public class InMemoryKeyRingTests
         RotateEvery = TimeSpan.FromDays(30),
         KeepRetiredFor = TimeSpan.FromDays(7),
 
-        // The smallest RSA size the platform will generate. These tests care about which keys are offered and
-        // in what order, never about the strength of one, and a larger modulus only costs seconds per mint.
-        RsaKeySize = 512,
+        // These tests care about which keys are offered and in what order, never about the strength of
+        // one. The floor is what the factory will mint, so a smaller size is refused where it is created
+        // rather than at the first signature.
+        RsaKeySize = JsonWebKeyExtensions.MinimumRsaKeyBits,
     };
 
     private static InMemoryKeyRing CreateRing(TimeProvider timeProvider, LocalKeys? policy = null)

--- a/tests/Abblix.Jwt.UnitTests/RsaKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaKeyFloorTests.cs
@@ -1,0 +1,155 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Security.Cryptography;
+using System.Text.Json.Nodes;
+using Abblix.Jwt.Encryption;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// The 2048-bit floor and the citation that explains it, at the sites where nothing else measures them.
+/// </summary>
+/// <remarks>
+/// Every test here was written because a mutation survived the suite. The section a refusal cites could
+/// be swapped between families, the whole encryption-side floor could be deleted, and a modulus of all
+/// zero octets could be measured any way at all - each of those passed 607 of 607.
+/// </remarks>
+public class RsaKeyFloorTests
+{
+    /// <summary>
+    /// RFC 7518 states the floor four times, once per family, and never in the container headings 3
+    /// and 4. An operator sent to a heading finds a table of algorithm names and no MUST, which reads
+    /// as the library having invented the rule.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.RS256, "Section 3.3")]
+    [InlineData(SigningAlgorithms.RS384, "Section 3.3")]
+    [InlineData(SigningAlgorithms.RS512, "Section 3.3")]
+    [InlineData(SigningAlgorithms.PS256, "Section 3.5")]
+    [InlineData(SigningAlgorithms.PS384, "Section 3.5")]
+    [InlineData(SigningAlgorithms.PS512, "Section 3.5")]
+    [InlineData(EncryptionAlgorithms.KeyManagement.Rsa1_5, "Section 4.2")]
+    [InlineData(EncryptionAlgorithms.KeyManagement.RsaOaep, "Section 4.3")]
+    [InlineData(EncryptionAlgorithms.KeyManagement.RsaOaep256, "Section 4.3")]
+    public void RsaSectionFor_NamesTheSectionThatCarriesTheRequirement(string algorithm, string expected)
+        => Assert.Equal(expected, JsonWebKeyExtensions.RsaSectionFor(algorithm));
+
+    [Fact]
+    public void RsaSectionFor_AnAlgorithmWithNoFloor_Refuses()
+        => Assert.Throws<ArgumentException>(
+            () => JsonWebKeyExtensions.RsaSectionFor(SigningAlgorithms.ES256));
+
+    /// <summary>
+    /// The encryption-side floor. Deleting it outright used to pass the whole suite.
+    /// </summary>
+    [Fact]
+    public void EncryptKey_AKeyBelowTheFloor_IsRefused()
+    {
+        var encryptor = new RsaKeyEncryptor(
+            NullLogger<RsaKeyEncryptor>.Instance, EncryptionAlgorithms.KeyManagement.RsaOaep256);
+
+        var error = Assert.Throws<InvalidOperationException>(
+            () => encryptor.EncryptKey(HeaderFor(EncryptionAlgorithms.KeyManagement.RsaOaep256),
+                PublicOnlyKey(1024), new byte[32]));
+
+        Assert.Contains("1024", error.Message);
+        Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
+
+        // The half a swapped citation would break: RSA-OAEP-256 is governed by Section 4.3, and an
+        // operator who opens Section 4 instead finds nothing that refuses anything.
+        Assert.Contains("Section 4.3", error.Message);
+    }
+
+    /// <summary>
+    /// The control. Without it an encryptor that refused every key would pass the test above.
+    /// </summary>
+    [Fact]
+    public void EncryptKey_AKeyAtTheFloor_Encrypts()
+    {
+        var encryptor = new RsaKeyEncryptor(
+            NullLogger<RsaKeyEncryptor>.Instance, EncryptionAlgorithms.KeyManagement.RsaOaep256);
+
+        var encrypted = encryptor.EncryptKey(
+            HeaderFor(EncryptionAlgorithms.KeyManagement.RsaOaep256),
+            PublicOnlyKey(JsonWebKeyExtensions.MinimumRsaKeyBits),
+            new byte[32]);
+
+        Assert.Equal(JsonWebKeyExtensions.MinimumRsaKeyBits / 8, encrypted.Length);
+    }
+
+    /// <summary>
+    /// A modulus carrying no value at all measures zero, so it fails the floor rather than sliding
+    /// past a check written as "not obviously too small".
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(new byte[0])]
+    [InlineData(new byte[] { 0 })]
+    [InlineData(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 })]
+    public void ModulusBitLength_NothingToMeasure_IsZero(byte[]? modulus)
+        => Assert.Equal(0, new RsaJsonWebKey { Modulus = modulus }.ModulusBitLength());
+
+    /// <summary>
+    /// The leading octet contributes only from its own highest set bit, so a modulus that happens to
+    /// begin below 0x80 measures shorter than its octet count - which is its true length.
+    /// </summary>
+    [Theory]
+    [InlineData(new byte[] { 0x01 }, 1)]
+    [InlineData(new byte[] { 0x80 }, 8)]
+    [InlineData(new byte[] { 0xFF }, 8)]
+    [InlineData(new byte[] { 0x00, 0x80 }, 8)]
+    [InlineData(new byte[] { 0x01, 0x00 }, 9)]
+    public void ModulusBitLength_MeasuresFromTheHighestSetBit(byte[] modulus, int expected)
+        => Assert.Equal(expected, new RsaJsonWebKey { Modulus = modulus }.ModulusBitLength());
+
+    /// <summary>
+    /// Minting is where a configured key size becomes a key, so it is where a size this library will
+    /// later refuse to sign with has to be refused - not at the token endpoint, on first use.
+    /// </summary>
+    [Fact]
+    public void CreateRsa_BelowTheFloor_Refuses()
+    {
+        var error = Assert.Throws<ArgumentException>(
+            () => JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256, 1024));
+
+        Assert.Contains("1024", error.Message);
+        Assert.Contains(JsonWebKeyExtensions.MinimumRsaKeyBits.ToString(), error.Message);
+    }
+
+    [Fact]
+    public void CreateRsa_AtTheFloor_Mints()
+    {
+        var key = JsonWebKeyFactory.CreateRsa(
+            PublicKeyUsages.Signature, SigningAlgorithms.RS256, JsonWebKeyExtensions.MinimumRsaKeyBits);
+
+        Assert.Equal(JsonWebKeyExtensions.MinimumRsaKeyBits, key.ModulusBitLength());
+    }
+
+    private static JsonWebTokenHeader HeaderFor(string algorithm)
+        => new(new JsonObject())
+        {
+            Algorithm = algorithm,
+            EncryptionAlgorithm = EncryptionAlgorithms.ContentEncryption.Aes256Gcm,
+        };
+
+    private static RsaJsonWebKey PublicOnlyKey(int bits)
+    {
+        using var rsa = RSA.Create(bits);
+        var parameters = rsa.ExportParameters(false);
+
+        return new RsaJsonWebKey
+        {
+            KeyId = "floor-test",
+            Usage = PublicKeyUsages.Encryption,
+            Modulus = parameters.Modulus,
+            Exponent = parameters.Exponent,
+        };
+    }
+}

--- a/tests/Abblix.Jwt.UnitTests/RsaKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaKeyFloorTests.cs
@@ -47,6 +47,18 @@ public class RsaKeyFloorTests
             () => JsonWebKeyExtensions.RsaSectionFor(SigningAlgorithms.ES256));
 
     /// <summary>
+    /// The message-building form must never throw, because it is called while composing a refusal: an
+    /// unknown algorithm there would replace the size refusal the operator was about to read.
+    /// </summary>
+    [Theory]
+    [InlineData(SigningAlgorithms.RS256, "per RFC 7518 Section 3.3")]
+    [InlineData(SigningAlgorithms.PS512, "per RFC 7518 Section 3.5")]
+    [InlineData(SigningAlgorithms.None, "for RSA signatures")]
+    [InlineData(SigningAlgorithms.ES256, "for RSA signatures")]
+    public void RsaSectionForOrNothing_NeverThrows(string algorithm, string expected)
+        => Assert.Equal(expected, JsonWebKeyExtensions.RsaSectionForOrNothing(algorithm));
+
+    /// <summary>
     /// The encryption-side floor. Deleting it outright used to pass the whole suite.
     /// </summary>
     [Fact]
@@ -111,8 +123,14 @@ public class RsaKeyFloorTests
 
     /// <summary>
     /// Minting is where a configured key size becomes a key, so it is where a size this library will
-    /// later refuse to sign with has to be refused - not at the token endpoint, on first use.
+    /// later refuse to sign with has to be refused.
     /// </summary>
+    /// <remarks>
+    /// How early that lands still depends on the ring. <c>KeyRing</c> mints on its first refresh, inside
+    /// the hosted service, so the process stops at startup. <c>InMemoryKeyRing</c> mints lazily by
+    /// design, so a misconfigured host reaches this refusal on its first JWKS or token request instead.
+    /// Closing that difference means validating the configured size at startup, which is its own change.
+    /// </remarks>
     [Fact]
     public void CreateRsa_BelowTheFloor_Refuses()
     {

--- a/tests/Abblix.Jwt.UnitTests/RsaKeyFloorTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaKeyFloorTests.cs
@@ -17,9 +17,10 @@ namespace Abblix.Jwt.UnitTests;
 /// The 2048-bit floor and the citation that explains it, at the sites where nothing else measures them.
 /// </summary>
 /// <remarks>
-/// Every test here was written because a mutation survived the suite. The section a refusal cites could
+/// Every test here was written because a mutation survived the suite: the section a refusal cites could
 /// be swapped between families, the whole encryption-side floor could be deleted, and a modulus of all
-/// zero octets could be measured any way at all - each of those passed 607 of 607.
+/// zero octets could be measured any way at all, each with nothing going red. No pass count is given,
+/// because it was a mid-branch one and a figure that no longer reproduces reads as evidence.
 /// </remarks>
 public class RsaKeyFloorTests
 {

--- a/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
@@ -90,9 +90,10 @@ public class RsaSignerTests
         Assert.Contains("2048", error.Message);
         Assert.Contains(BelowTheFloor.ToString(), error.Message);
 
-        // Which key, out of however many the deployment holds, and which paragraph refused it.
+        // Which key, out of however many the deployment holds. The SECTION is asserted against
+        // hardcoded strings in RsaKeyFloorTests instead - computing it here from the mapping under test
+        // would prove only that the message carries whatever that mapping returns.
         Assert.Contains("undersized", error.Message);
-        Assert.Contains(JsonWebKeyExtensions.RsaSectionFor(algorithm), error.Message);
     }
 
     /// <summary>
@@ -101,10 +102,11 @@ public class RsaSignerTests
     /// reports the octets that were imported rather than the value they encode.
     /// </summary>
     /// <remarks>
-    /// Not an exotic attack. RFC 7518 Section 2 requires the minimal encoding, and Section 6.3.1.1 warns
-    /// that implementations emit the extra octet anyway - so the malformed modulus arrives without malice,
-    /// and the forgery arrives later from whoever factored the real one. Only the public half is supplied,
-    /// which is exactly what a peer publishes in its JWKS.
+    /// The padding here is not the benign quirk RFC 7518 records: Section 6.3.1.1 describes a single
+    /// extra zero octet, which moves no check at all. A modulus padded to twice its length is a malformed
+    /// or hostile JWKS entry, and it is cheap to publish - only the public half is needed, which is
+    /// exactly what a peer publishes. The forgery arrives later, from whoever factored the real
+    /// modulus.
     /// </remarks>
     [Theory]
     [MemberData(nameof(Algorithms))]

--- a/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
@@ -66,6 +66,47 @@ public class RsaSignerTests
     }
 
     /// <summary>
+    /// A weak key whose modulus is padded out to a respectable octet count must still be refused. This is
+    /// the case a size check written against <c>RSA.KeySize</c> walks straight past, because that property
+    /// reports the octets that were imported rather than the value they encode.
+    /// </summary>
+    /// <remarks>
+    /// Not an exotic attack. RFC 7518 Section 2 requires the minimal encoding, and Section 6.3.1.1 warns
+    /// that implementations emit the extra octet anyway - so the malformed modulus arrives without malice,
+    /// and the forgery arrives later from whoever factored the real one. Only the public half is supplied,
+    /// which is exactly what a peer publishes in its JWKS.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(Algorithms))]
+    public void Verify_APaddedModulusHidingAWeakKey_IsStillRefused(string algorithm)
+    {
+        using var weak = System.Security.Cryptography.RSA.Create(BelowTheFloor);
+        var parameters = weak.ExportParameters(false);
+
+        // Left-padded to the octet count of a 2048-bit key, which is what RSA.KeySize would then report.
+        var padded = new byte[2048 / 8];
+        parameters.Modulus!.CopyTo(padded, padded.Length - parameters.Modulus.Length);
+
+        var key = new RsaJsonWebKey
+        {
+            KeyId = "padded",
+            Usage = PublicKeyUsages.Signature,
+            Algorithm = algorithm,
+            Modulus = padded,
+            Exponent = parameters.Exponent,
+        };
+
+        // The signature is genuinely correct for that key, so what the test measures is the refusal.
+        using var privateKey = System.Security.Cryptography.RSA.Create();
+        privateKey.ImportParameters(weak.ExportParameters(true));
+        var signature = privateKey.SignData(SampleData, HashOf(algorithm), PaddingOf(algorithm));
+
+        Assert.Equal(2048, key.ToRsa().KeySize);
+        Assert.Equal(BelowTheFloor, key.ModulusBitLength());
+        Assert.False(new RsaSigner(algorithm).Verify(key, SampleData, signature));
+    }
+
+    /// <summary>
     /// The control. Without it, a signer that refused everything would pass the test above.
     /// </summary>
     [Theory]
@@ -95,19 +136,20 @@ public class RsaSignerTests
         // Produced outside the guarded path, because signing through it would throw - which is the
         // point: the only way an undersized signature reaches this deployment is from somewhere else.
         using var rsa = key.ToRsa();
-        var parameters = algorithm switch
-        {
-            SigningAlgorithms.RS256 or SigningAlgorithms.PS256 => System.Security.Cryptography.HashAlgorithmName.SHA256,
-            SigningAlgorithms.RS384 or SigningAlgorithms.PS384 => System.Security.Cryptography.HashAlgorithmName.SHA384,
-            _ => System.Security.Cryptography.HashAlgorithmName.SHA512,
-        };
-
-        var padding = algorithm.StartsWith("PS", StringComparison.Ordinal)
-            ? System.Security.Cryptography.RSASignaturePadding.Pss
-            : System.Security.Cryptography.RSASignaturePadding.Pkcs1;
-
-        var signature = rsa.SignData(SampleData, parameters, padding);
+        var signature = rsa.SignData(SampleData, HashOf(algorithm), PaddingOf(algorithm));
 
         Assert.False(new RsaSigner(algorithm).Verify(key, SampleData, signature));
     }
+
+    private static System.Security.Cryptography.HashAlgorithmName HashOf(string algorithm) => algorithm switch
+    {
+        SigningAlgorithms.RS256 or SigningAlgorithms.PS256 => System.Security.Cryptography.HashAlgorithmName.SHA256,
+        SigningAlgorithms.RS384 or SigningAlgorithms.PS384 => System.Security.Cryptography.HashAlgorithmName.SHA384,
+        _ => System.Security.Cryptography.HashAlgorithmName.SHA512,
+    };
+
+    private static System.Security.Cryptography.RSASignaturePadding PaddingOf(string algorithm)
+        => algorithm.StartsWith("PS", StringComparison.Ordinal)
+            ? System.Security.Cryptography.RSASignaturePadding.Pss
+            : System.Security.Cryptography.RSASignaturePadding.Pkcs1;
 }

--- a/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
@@ -37,6 +37,32 @@ public class RsaSignerTests
     private const int BelowTheFloor = 1536;
 
     /// <summary>
+    /// An undersized key with its private half, built here rather than through
+    /// <see cref="JsonWebKeyFactory"/>, which refuses to mint one at all - a size this library will not
+    /// sign with is not a size it should produce either.
+    /// </summary>
+    private static RsaJsonWebKey UndersizedKey(string algorithm)
+    {
+        using var rsa = System.Security.Cryptography.RSA.Create(BelowTheFloor);
+        var parameters = rsa.ExportParameters(true);
+
+        return new RsaJsonWebKey
+        {
+            KeyId = "undersized",
+            Algorithm = algorithm,
+            Usage = PublicKeyUsages.Signature,
+            Exponent = parameters.Exponent,
+            Modulus = parameters.Modulus,
+            PrivateExponent = parameters.D,
+            FirstPrimeFactor = parameters.P,
+            SecondPrimeFactor = parameters.Q,
+            FirstFactorCrtExponent = parameters.DP,
+            SecondFactorCrtExponent = parameters.DQ,
+            FirstCrtCoefficient = parameters.InverseQ,
+        };
+    }
+
+    /// <summary>
     /// Every algorithm this signer implements, since the floor is the same in both families and a
     /// guard written for one of them is the shape that silently leaves the other open.
     /// </summary>
@@ -55,7 +81,7 @@ public class RsaSignerTests
     public void Sign_KeyBelowTheFloor_IsRefused(string algorithm)
     {
         var signer = new RsaSigner(algorithm);
-        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, algorithm, keySize: BelowTheFloor);
+        var key = UndersizedKey(algorithm);
 
         var error = Assert.Throws<ArgumentException>(() => signer.Sign(key, SampleData));
 
@@ -63,6 +89,10 @@ public class RsaSignerTests
         // only that something was refused.
         Assert.Contains("2048", error.Message);
         Assert.Contains(BelowTheFloor.ToString(), error.Message);
+
+        // Which key, out of however many the deployment holds, and which paragraph refused it.
+        Assert.Contains("undersized", error.Message);
+        Assert.Contains(JsonWebKeyExtensions.RsaSectionFor(algorithm), error.Message);
     }
 
     /// <summary>
@@ -131,7 +161,7 @@ public class RsaSignerTests
     [MemberData(nameof(Algorithms))]
     public void Verify_KeyBelowTheFloor_IsRefusedWithoutChecking(string algorithm)
     {
-        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, algorithm, keySize: BelowTheFloor);
+        var key = UndersizedKey(algorithm);
 
         // Produced outside the guarded path, because signing through it would throw - which is the
         // point: the only way an undersized signature reaches this deployment is from somewhere else.

--- a/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
@@ -1,0 +1,113 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using Abblix.Jwt.Signing;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="RsaSigner"/> covering the minimum-key-size contract of RFC 7518:
+/// "A key of size 2048 bits or larger MUST be used with these algorithms", stated in those words in
+/// section 3.3 for RS256/RS384/RS512 and in section 3.5 for PS256/PS384/PS512.
+/// </summary>
+/// <remarks>
+/// Both directions, matching <see cref="HmacSigner"/>, which carries the same shape for its own floor:
+/// signing throws, because an undersized key is the caller's own mistake and the caller is this
+/// deployment; verifying returns false, because an undersized key from a peer is a signature that does
+/// not check out rather than a fault to raise.
+/// </remarks>
+public class RsaSignerTests
+{
+    private static readonly byte[] SampleData = "the quick brown fox"u8.ToArray();
+
+    /// <summary>
+    /// An undersized key that every algorithm here can still USE, which 1024 bits is not: PSS with
+    /// SHA-512 needs two hash outputs plus two bytes inside the modulus, so a 1024-bit key cannot
+    /// produce a PS512 signature at all and the arrangement fails before the guard is reached.
+    /// </summary>
+    /// <remarks>
+    /// The stronger fixture anyway. 1024 bits is obviously weak; 1536 is a size a deployment might
+    /// plausibly be holding, and it is the floor that has to refuse it rather than the arithmetic.
+    /// </remarks>
+    private const int BelowTheFloor = 1536;
+
+    /// <summary>
+    /// Every algorithm this signer implements, since the floor is the same in both families and a
+    /// guard written for one of them is the shape that silently leaves the other open.
+    /// </summary>
+    public static TheoryData<string> Algorithms =>
+    [
+        SigningAlgorithms.RS256,
+        SigningAlgorithms.RS384,
+        SigningAlgorithms.RS512,
+        SigningAlgorithms.PS256,
+        SigningAlgorithms.PS384,
+        SigningAlgorithms.PS512,
+    ];
+
+    [Theory]
+    [MemberData(nameof(Algorithms))]
+    public void Sign_KeyBelowTheFloor_IsRefused(string algorithm)
+    {
+        var signer = new RsaSigner(algorithm);
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, algorithm, keySize: BelowTheFloor);
+
+        var error = Assert.Throws<ArgumentException>(() => signer.Sign(key, SampleData));
+
+        // The message has to name the floor and what was supplied, or an operator reading it learns
+        // only that something was refused.
+        Assert.Contains("2048", error.Message);
+        Assert.Contains(BelowTheFloor.ToString(), error.Message);
+    }
+
+    /// <summary>
+    /// The control. Without it, a signer that refused everything would pass the test above.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Algorithms))]
+    public void Sign_KeyAtTheFloor_Signs(string algorithm)
+    {
+        var signer = new RsaSigner(algorithm);
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, algorithm, keySize: 2048);
+
+        var signature = signer.Sign(key, SampleData);
+
+        Assert.NotEmpty(signature);
+        Assert.True(signer.Verify(key, SampleData, signature));
+    }
+
+    /// <summary>
+    /// A peer publishing an undersized key in its JWKS must not be able to have a signature accepted,
+    /// whatever the header says. Verified against a signature that is genuinely correct for that key,
+    /// so what the test measures is the refusal and not a mismatch.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Algorithms))]
+    public void Verify_KeyBelowTheFloor_IsRefusedWithoutChecking(string algorithm)
+    {
+        var key = JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, algorithm, keySize: BelowTheFloor);
+
+        // Produced outside the guarded path, because signing through it would throw - which is the
+        // point: the only way an undersized signature reaches this deployment is from somewhere else.
+        using var rsa = key.ToRsa();
+        var parameters = algorithm switch
+        {
+            SigningAlgorithms.RS256 or SigningAlgorithms.PS256 => System.Security.Cryptography.HashAlgorithmName.SHA256,
+            SigningAlgorithms.RS384 or SigningAlgorithms.PS384 => System.Security.Cryptography.HashAlgorithmName.SHA384,
+            _ => System.Security.Cryptography.HashAlgorithmName.SHA512,
+        };
+
+        var padding = algorithm.StartsWith("PS", StringComparison.Ordinal)
+            ? System.Security.Cryptography.RSASignaturePadding.Pss
+            : System.Security.Cryptography.RSASignaturePadding.Pkcs1;
+
+        var signature = rsa.SignData(SampleData, parameters, padding);
+
+        Assert.False(new RsaSigner(algorithm).Verify(key, SampleData, signature));
+    }
+}

--- a/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/RsaSignerTests.cs
@@ -105,8 +105,18 @@ public class RsaSignerTests
     /// The padding here is not the benign quirk RFC 7518 records: Section 6.3.1.1 describes a single
     /// extra zero octet, which moves no check at all. A modulus padded to twice its length is a malformed
     /// or hostile JWKS entry, and it is cheap to publish - only the public half is needed, which is
-    /// exactly what a peer publishes. The forgery arrives later, from whoever factored the real
-    /// modulus.
+    /// exactly what a peer publishes. The forgery arrives later, from whoever factored the real modulus.
+    /// <para>
+    /// Whether <c>RSA.KeySize</c> is fooled by it depends on the PLATFORM, which is the strongest reason
+    /// not to measure with it. Windows CNG keeps the padding and reports 2048 for the key below; Linux
+    /// (OpenSSL) strips the leading zeros on import and reports 1536, so the same size check refuses on
+    /// one operating system and admits on the other. That difference was invisible until CI ran the
+    /// suite on Linux, because every local run and every review of this branch was on Windows.
+    /// </para>
+    /// <para>
+    /// The assertions below are therefore the platform-independent ones: the modulus measures what it
+    /// really is, that measurement never exceeds what the import reports, and the signature is refused.
+    /// </para>
     /// </remarks>
     [Theory]
     [MemberData(nameof(Algorithms))]
@@ -133,9 +143,15 @@ public class RsaSignerTests
         privateKey.ImportParameters(weak.ExportParameters(true));
         var signature = privateKey.SignData(SampleData, HashOf(algorithm), PaddingOf(algorithm));
 
-        Assert.Equal(2048, key.ToRsa().KeySize);
         Assert.Equal(BelowTheFloor, key.ModulusBitLength());
         Assert.False(new RsaSigner(algorithm).Verify(key, SampleData, signature));
+
+        // The safety property, which holds on every platform and is what makes the change incapable of
+        // ADMITTING a key the old check refused: the measured modulus never exceeds what the import
+        // reports. Where the import keeps the padding, it is strictly smaller, and that gap is the
+        // vulnerability.
+        using var imported = key.ToRsa();
+        Assert.True(key.ModulusBitLength() <= imported.KeySize);
     }
 
     /// <summary>


### PR DESCRIPTION
A deployment could sign RS256 over an undersized RSA key, and the check that was supposed to stop it measured the wrong thing.

## The measurement

`RSA.KeySize` reports the length of the octets that were IMPORTED, not the length of the value they encode. A 1024-bit modulus left-padded to 256 octets imports as `KeySize = 2048`, so a floor written against that property passes a key half the strength it claims. Proven directly: `reported KeySize=2048, real=1024, Verify accepted=True`.

`JsonWebKeyExtensions.ModulusBitLength()` measures the modulus itself, from its leading octet's own highest set bit. It is never larger than `RSA.KeySize`, so the change can only add refusals, and a well-formed modulus of nominal size always has its top bit set, so no legitimate key loses. Verified against `BigInteger.GetBitLength()` over 2000 random inputs plus every named edge case.

RFC 7518 Section 2 requires the minimal encoding, which is what this follows. The one benign quirk the specification records is a single extra zero octet (Section 6.3.1.1, "returning 257 octets for a 2048-bit key"), and one octet moves no check in either direction. Padding on the scale that defeats a size check is a malformed or hostile JWKS entry.

## Where the floor now stands

Three doors, and none of them covers the others:

- `RsaSigner` for what it signs and verifies in process. Verification is ALWAYS here - the validator resolves the keyed algorithm by key type - so this is the only refusal a custodian deployment has on the verify side.
- `CompositeSigner`, the seam a key whose private half lives with an external custodian crosses. Such a key never reaches `RsaSigner` for signing, so without this the deployment mints RS256 over an undersized modulus and then refuses to verify its own output. The composite is registered only when a custodian is wired: a default `AddJsonWebTokens()` resolves `IDataSigner` to `LocalKeySigner`, so neither guard is redundant.
- `RsaKeyEncryptor` for key wrapping, whose own floor was reading `RSA.KeySize` too.

And one refusal earlier: `JsonWebKeyFactory.CreateRsa` no longer mints below the floor. Without it a host setting `RsaKeySize` under 2048 got a library that minted a key it would then refuse to sign with.

## The citation

RFC 7518 states the floor four times, once per family, and never in the container headings 3 and 4. An operator sent to Section 4 finds a table of `alg` values and no MUST, which reads as the library having invented the rule. `RsaSectionFor` answers this once for all nine algorithms the library serves, so the signing and encryption refusals cannot drift. A message-building variant yields a section-free phrase rather than throwing, because an RSA key carrying no `alg` resolves to `None`, and a complaint about the citation must not replace the size refusal an operator was about to read.

Both refusals now name the key id, the algorithm, the measured size and the floor, and both throw `ArgumentException` - the same condition no longer produces two exception types depending on whether a custodian happens to be wired.

## Evidence

`Abblix.Jwt.UnitTests` 635 passed, 0 failed, 0 not run. No before-figure is given: three sources in this branch's own history disagree on it, and a contested number reads as precision. `Abblix.Oidc.Server.UnitTests` 2892, E2E 190, Azure 51, Vault 71 - all green.

| what is held | mutation that kills it | rows that die |
|---|---|---|
| the verify-side floor | delete the two-line guard in `Verify` | 12 |
| the sign-side floor | delete the guard in `Sign` | 6 |
| the seam's floor | delete the guard in `CompositeSigner` | 2 |
| the minting floor | delete the guard in `CreateRsa` | 1 |
| the measurement itself | `modulus.Length * 8` | 11 |
| the cited section | swap Section 3.3 and Section 3.5 | 9 |
| the encryption floor | delete the guard in `EncryptKey` | 1 |

Each mutation was confirmed to BUILD before its count was read, and every count above was measured at the current head rather than carried forward - the section row alone has moved three times as rows were added. Two probes during review were refused by SonarAnalyzer under `S927` and `S2699` rather than by the compiler, which a `grep "error CS"` would have called clean while `--no-build` measured the previous binary.

Two rows are worth naming. The padded-modulus verify test was suspected vacuous and is not: it is one of the twelve that die with the `Verify` floor, which also proves the exposure was live. And the section rows are asserted against hardcoded strings rather than against the mapping under test, because an expectation computed by that mapping inherits any mutation of it - measured, the computed form leaves all six green.

## Related

`RsaSigner.Verify` refuses silently, which is #452. The remaining public surface - `MinimumRsaKeyBits`, `RsaSectionFor`, `ModulusBitLength`, and `CreateRsa` now throwing below the floor - belongs in the release notes.

## One defect the fixes introduced

Round 3 moved the citation into a helper that carries the words "per RFC 7518" itself, while the seam's message already wrote them - so every ordinary custodian refusal read `per RFC 7518 per RFC 7518 Section 3.3`. The arm the helper was invented for, an RSA key with no `alg`, was the only one that came out clean.

Nothing measured it, because the tests asserted the two numbers and the helper's return in isolation. Both seam tests now read the COMPOSED sentence, and re-planting the doubled prefix turns one of them red. A message assembled from individually correct pieces is its own thing to check.
