### PR TITLE
Answer a management refusal with an RFC 6750 challenge

### DIFF
--- a/src/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
+++ b/src/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
@@ -56,7 +56,7 @@ public static class WwwAuthenticateBuilder
     public static string BuildDPoPChallenge(OidcError error, string? realm, IEnumerable<string> algs)
         // RFC 6750 §3.1 applies to the DPoP line too: an unauthenticated request gets a bare
         // challenge advertising the scheme, without error attributes. "algs" is DPoP's own parameter
-        // (RFC 9449 §7.1) and is passed through the same grammar as the rest - the figure there prints
+        // (RFC 9449 Section 7.1) and is passed through the same grammar as the rest - the figure there prints
         // it as the FIRST parameter of a challenge with no realm, where the separator is a space.
         => error is MissingAuthenticationError
             ? WwwAuthenticate.Challenge(

--- a/src/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
+++ b/src/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
@@ -54,19 +54,21 @@ public static class WwwAuthenticateBuilder
     /// JWS algorithms the AS accepts on a proof.
     /// </summary>
     public static string BuildDPoPChallenge(OidcError error, string? realm, IEnumerable<string> algs)
-    {
         // RFC 6750 §3.1 applies to the DPoP line too: an unauthenticated request gets a bare
-        // challenge advertising the scheme, without error attributes.
-        var challenge = error is MissingAuthenticationError
-            ? WwwAuthenticate.Challenge(TokenTypes.DPoP, realm)
-            : WwwAuthenticate.Challenge(TokenTypes.DPoP, realm, error.Error, error.ErrorDescription);
-
-        // "algs" is DPoP's own parameter (RFC 9449 Section 7.1) rather than part of the shared grammar,
-        // so it is appended here, quoted as the grammar quotes every other parameter.
-        return algs.ToArray() is { Length: > 0 } names
-            ? $"{challenge}, algs=\"{string.Join(' ', names)}\""
-            : challenge;
-    }
+        // challenge advertising the scheme, without error attributes. "algs" is DPoP's own parameter
+        // (RFC 9449 §7.1) and is passed through the same grammar as the rest - the figure there prints
+        // it as the FIRST parameter of a challenge with no realm, where the separator is a space.
+        => error is MissingAuthenticationError
+            ? WwwAuthenticate.Challenge(
+                TokenTypes.DPoP,
+                ("realm", realm),
+                ("algs", string.Join(' ', algs)))
+            : WwwAuthenticate.Challenge(
+                TokenTypes.DPoP,
+                ("realm", realm),
+                ("error", error.Error),
+                ("error_description", error.ErrorDescription),
+                ("algs", string.Join(' ', algs)));
 
     /// <summary>
     /// Builds the full set of <c>WWW-Authenticate</c> challenge lines for an error

--- a/src/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
+++ b/src/Abblix.Oidc.Server/Common/WwwAuthenticateBuilder.cs
@@ -6,7 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-using System.Text;
+using Abblix.Utils;
 using Abblix.Oidc.Server.Common.Constants;
 
 namespace Abblix.Oidc.Server.Common;
@@ -35,20 +35,11 @@ public static class WwwAuthenticateBuilder
     /// dual-scheme responses where the Bearer line is informational.
     /// </summary>
     public static string BuildBearerChallenge(OidcError error, string? realm, bool includeError = true)
-    {
-        var challenge = new Challenge(TokenTypes.Bearer);
-        challenge.Append("realm", realm);
-
         // RFC 6750 §3.1: when the request carried no authentication information at all, the
         // challenge must stay bare - no error code or description, just the scheme (and realm).
-        if (includeError && error is not MissingAuthenticationError)
-        {
-            challenge.Append("error", error.Error);
-            challenge.Append("error_description", error.ErrorDescription);
-        }
-
-        return challenge.ToString();
-    }
+        => includeError && error is not MissingAuthenticationError
+            ? WwwAuthenticate.Challenge(TokenTypes.Bearer, realm, error.Error, error.ErrorDescription)
+            : WwwAuthenticate.Challenge(TokenTypes.Bearer, realm);
 
     /// <summary>
     /// Builds a <c>WWW-Authenticate: Basic</c> challenge per RFC 7617 §2 for client-authentication
@@ -56,11 +47,7 @@ public static class WwwAuthenticateBuilder
     /// the Basic scheme defines no error attributes, so the error itself stays in the JSON body.
     /// </summary>
     public static string BuildBasicChallenge(string? realm)
-    {
-        var challenge = new Challenge(TokenTypes.Basic);
-        challenge.Append("realm", realm);
-        return challenge.ToString();
-    }
+        => WwwAuthenticate.Challenge(TokenTypes.Basic, realm);
 
     /// <summary>
     /// Builds a <c>WWW-Authenticate: DPoP</c> challenge per RFC 9449 §7.1, advertising the
@@ -68,19 +55,17 @@ public static class WwwAuthenticateBuilder
     /// </summary>
     public static string BuildDPoPChallenge(OidcError error, string? realm, IEnumerable<string> algs)
     {
-        var challenge = new Challenge(TokenTypes.DPoP);
-        challenge.Append("realm", realm);
-
         // RFC 6750 §3.1 applies to the DPoP line too: an unauthenticated request gets a bare
         // challenge advertising the scheme, without error attributes.
-        if (error is not MissingAuthenticationError)
-        {
-            challenge.Append("error", error.Error);
-            challenge.Append("error_description", error.ErrorDescription);
-        }
+        var challenge = error is MissingAuthenticationError
+            ? WwwAuthenticate.Challenge(TokenTypes.DPoP, realm)
+            : WwwAuthenticate.Challenge(TokenTypes.DPoP, realm, error.Error, error.ErrorDescription);
 
-        challenge.Append("algs", string.Join(' ', algs));
-        return challenge.ToString();
+        // "algs" is DPoP's own parameter (RFC 9449 Section 7.1) rather than part of the shared grammar,
+        // so it is appended here, quoted as the grammar quotes every other parameter.
+        return algs.ToArray() is { Length: > 0 } names
+            ? $"{challenge}, algs=\"{string.Join(' ', names)}\""
+            : challenge;
     }
 
     /// <summary>
@@ -100,43 +85,5 @@ public static class WwwAuthenticateBuilder
 
         var bearer = BuildBearerChallenge(error, realm, includeError: false);
         return [dpop, bearer];
-    }
-
-    /// <summary>
-    /// Accumulates a single <c>WWW-Authenticate</c> challenge value as
-    /// <c>scheme name1="v1", name2="v2", ...</c>. Owns the comma-vs-space delimiter logic so
-    /// callers stay declarative - they just append name/value pairs and skip empties.
-    /// </summary>
-    private sealed class Challenge(string scheme)
-    {
-        private readonly StringBuilder _builder = new(scheme);
-        private bool _first = true;
-
-        public void Append(string name, string? value)
-        {
-            if (string.IsNullOrEmpty(value))
-                return;
-
-            _builder
-                .Append(_first ? " " : ", ")
-                .Append(name)
-                .Append("=\"");
-
-            // RFC 7235 §2.2 / RFC 9110 §5.6.4: inside a quoted-string each `"` MUST be
-            // backslash-escaped, and `\` itself MUST be doubled. Anything else (CR/LF
-            // and other control bytes) is rejected upstream - mutating values silently
-            // would obscure malformed inputs.
-            foreach (var c in value)
-            {
-                if (c is '"' or '\\')
-                    _builder.Append('\\');
-                _builder.Append(c);
-            }
-
-            _builder.Append('"');
-            _first = false;
-        }
-
-        public override string ToString() => _builder.ToString();
     }
 }

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -386,8 +386,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// </para>
     /// <para>
     /// The third, <c>invalid_request</c> with 400, IS decided here and is not emitted: a request missing
-    /// its <c>stream_id</c> is answered with a bare <c>Results.BadRequest()</c> a few methods below. That
-    /// is a separate gap from this one and is not closed by this method.
+    /// its <c>stream_id</c> is answered with a bare <c>Results.BadRequest()</c> by
+    /// <see cref="DeleteStreamAsync"/> and <see cref="GetStatusAsync"/>. That is a separate gap from
+    /// this one and is not closed by this method.
     /// </para>
     /// <para>
     /// The realm is the transmitter's issuer, which is the one name a receiver already holds for this

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Abblix.SharedSignals.Model.Delivery;
 using Abblix.SharedSignals.Receiver;
 using Abblix.SharedSignals.Receiver.SecurityEvent;
 using Abblix.SharedSignals.Transmitter;
+using Abblix.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -194,7 +195,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.CreateStreamAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     /// <summary>
     /// One route, two reads: with "stream_id" the single configuration, without it the list -
@@ -209,7 +210,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     {
         if (ReceiverIdOf(http) is not { } receiverId)
         {
-            return Results.Unauthorized();
+            return Unauthenticated(http);
         }
 
         return streamId is null
@@ -224,7 +225,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.UpdateStreamAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     private static async Task<IResult> ReplaceStreamAsync(
         HttpContext http,
@@ -233,7 +234,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.ReplaceStreamAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     private static async Task<IResult> DeleteStreamAsync(
         HttpContext http,
@@ -243,7 +244,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     {
         if (ReceiverIdOf(http) is not { } receiverId)
         {
-            return Results.Unauthorized();
+            return Unauthenticated(http);
         }
 
         // "The DELETE request MUST include the 'stream_id'" per SSF 1.0 Section 8.1.1.5 -
@@ -261,7 +262,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     {
         if (ReceiverIdOf(http) is not { } receiverId)
         {
-            return Results.Unauthorized();
+            return Unauthenticated(http);
         }
 
         // The status read has no list fallback: "stream_id" is its REQUIRED parameter
@@ -278,7 +279,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.UpdateStreamStatusAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     private static async Task<IResult> AddSubjectAsync(
         HttpContext http,
@@ -287,7 +288,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.AddSubjectAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     private static async Task<IResult> RemoveSubjectAsync(
         HttpContext http,
@@ -296,7 +297,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.RemoveSubjectAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     private static async Task<IResult> RequestVerificationAsync(
         HttpContext http,
@@ -305,7 +306,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         CancellationToken cancellationToken)
         => ReceiverIdOf(http) is { } receiverId
             ? Render(await service.RequestVerificationAsync(receiverId, request, cancellationToken))
-            : Results.Unauthorized();
+            : Unauthenticated(http);
 
     private static async Task<IResult> PollAsync(
         HttpContext http,
@@ -317,7 +318,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     {
         if (ReceiverIdOf(http) is not { } receiverId)
         {
-            return Results.Unauthorized();
+            return Unauthenticated(http);
         }
 
         return await store.FindAsync(receiverId, streamId, cancellationToken) is { } stream
@@ -366,6 +367,53 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
             },
             DefaultSubjects = options.DefaultSubjectsValue,
         };
+    }
+
+    /// <summary>
+    /// The answer to a management request that named no receiver: 401 with a bare Bearer challenge.
+    /// </summary>
+    /// <remarks>
+    /// Bare, and deliberately so. Every refusal on this surface has the same cause - nothing identified
+    /// the caller - which is what RFC 6750 Section 3.1 describes as a request that "lacks any
+    /// authentication information", and for which it says the resource server "SHOULD NOT include an
+    /// error code or other error information". A caller that presented nothing has nothing to correct.
+    /// <para>
+    /// The other two codes that section defines belong to whoever validates the token, which is the host:
+    /// <c>invalid_token</c> when a presented token is expired or malformed, and <c>insufficient_scope</c>
+    /// with 403 when it is valid but too narrow. This package never sees a token - it reads whatever
+    /// identity the host's authentication left behind, through
+    /// <see cref="SharedSignalsEndpointOptions.ReceiverIdSelector"/>.
+    /// </para>
+    /// <para>
+    /// The realm is the transmitter's issuer, which is the one name a receiver already holds for this
+    /// protection space and the one it used to find these endpoints.
+    /// </para>
+    /// </remarks>
+    private static IResult Unauthenticated(HttpContext http)
+    {
+        var issuer = http.RequestServices.GetService<SharedSignalsTransmitterOptions>()?.Issuer;
+        return new BareChallengeResult(WwwAuthenticate.Challenge(BearerScheme, issuer));
+    }
+
+    /// <summary>
+    /// The scheme this surface advertises. Not a claim that the host authenticates with bearer tokens -
+    /// it is what the CAEP Interoperability Profile Section 2.4.3 requires a receiver to use, so it is
+    /// what a receiver reading the challenge is prepared to act on.
+    /// </summary>
+    private const string BearerScheme = "Bearer";
+
+    /// <summary>
+    /// A 401 carrying one <c>WWW-Authenticate</c> line and no body. Written by hand because
+    /// <c>Results.Unauthorized()</c> emits no headers, and the header is the whole point.
+    /// </summary>
+    private sealed class BareChallengeResult(string challenge) : IResult
+    {
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            httpContext.Response.Headers.WWWAuthenticate = challenge;
+            return Task.CompletedTask;
+        }
     }
 
     private static string? ReceiverIdOf(HttpContext context)

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -378,11 +378,16 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// authentication information", and for which it says the resource server "SHOULD NOT include an
     /// error code or other error information". A caller that presented nothing has nothing to correct.
     /// <para>
-    /// The other two codes that section defines belong to whoever validates the token, which is the host:
-    /// <c>invalid_token</c> when a presented token is expired or malformed, and <c>insufficient_scope</c>
-    /// with 403 when it is valid but too narrow. This package never sees a token - it reads whatever
-    /// identity the host's authentication left behind, through
+    /// That section defines three codes and this method answers none of them. Two belong to whoever
+    /// validates the token, which is the host: <c>invalid_token</c> when a presented token is expired or
+    /// malformed, and <c>insufficient_scope</c> with 403 when it is valid but too narrow. This package
+    /// never sees a token - it reads whatever identity the host's authentication left behind, through
     /// <see cref="SharedSignalsEndpointOptions.ReceiverIdSelector"/>.
+    /// </para>
+    /// <para>
+    /// The third, <c>invalid_request</c> with 400, IS decided here and is not emitted: a request missing
+    /// its <c>stream_id</c> is answered with a bare <c>Results.BadRequest()</c> a few methods below. That
+    /// is a separate gap from this one and is not closed by this method.
     /// </para>
     /// <para>
     /// The realm is the transmitter's issuer, which is the one name a receiver already holds for this
@@ -396,9 +401,14 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     }
 
     /// <summary>
-    /// The scheme this surface advertises. Not a claim that the host authenticates with bearer tokens -
-    /// it is what the CAEP Interoperability Profile Section 2.4.3 requires a receiver to use, so it is
-    /// what a receiver reading the challenge is prepared to act on.
+    /// The scheme this surface advertises. Not a claim about how the host authenticates - it is what the
+    /// CAEP Interoperability Profile Section 2.7.2 obliges a transmitter to accept: "MUST accept access
+    /// tokens in the HTTP header as in Section 2.1 of OAuth 2.0 Bearer Token Usage [RFC6750]". So it is
+    /// the scheme a receiver reading this challenge is prepared to act on.
+    /// <para>
+    /// Section 2.4.3 is the neighbouring requirement and does NOT carry this: it says a receiver "MUST
+    /// use OAuth 2.0 [RFC6749]", which is the framework and fixes no token type.
+    /// </para>
     /// </summary>
     private const string BearerScheme = "Bearer";
 

--- a/src/Abblix.Utils/WwwAuthenticate.cs
+++ b/src/Abblix.Utils/WwwAuthenticate.cs
@@ -32,7 +32,7 @@ public static class WwwAuthenticate
     /// yet has nothing to correct, and naming an error would describe a failure that did not happen.
     /// </remarks>
     public static string Challenge(string scheme, string? realm = null)
-        => Build(scheme, realm, null, null);
+        => Challenge(scheme, ("realm", realm));
 
     /// <summary>
     /// A challenge naming why the credentials that WERE presented did not suffice.
@@ -42,16 +42,25 @@ public static class WwwAuthenticate
     /// <param name="error">The error code, from whatever vocabulary the scheme defines.</param>
     /// <param name="errorDescription">Human-readable detail, omitted when null or empty.</param>
     public static string Challenge(string scheme, string? realm, string error, string? errorDescription)
-        => Build(scheme, realm, error, errorDescription);
+        => Challenge(scheme, ("realm", realm), ("error", error), ("error_description", errorDescription));
 
-    private static string Build(string scheme, string? realm, string? error, string? errorDescription)
+    /// <summary>
+    /// A challenge carrying whatever parameters the scheme defines, in the order given.
+    /// </summary>
+    /// <remarks>
+    /// Every scheme-specific parameter goes through here rather than being appended to the result, so
+    /// that one place decides the delimiter and the escaping. Appending by hand loses both: the first
+    /// parameter follows the scheme with a SPACE and the rest with a comma - RFC 9449 Section 7.1 Figure
+    /// 15 prints <c>DPoP algs="ES256 PS256"</c>, a challenge whose only parameter is its own - and a
+    /// value carrying a quotation mark has to be escaped or it ends the string early.
+    /// </remarks>
+    public static string Challenge(string scheme, params (string Name, string? Value)[] parameters)
     {
         var builder = new StringBuilder(scheme);
         var first = true;
 
-        Append("realm", realm);
-        Append("error", error);
-        Append("error_description", errorDescription);
+        foreach (var (name, value) in parameters)
+            Append(name, value);
 
         return builder.ToString();
 

--- a/src/Abblix.Utils/WwwAuthenticate.cs
+++ b/src/Abblix.Utils/WwwAuthenticate.cs
@@ -1,0 +1,80 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Text;
+
+namespace Abblix.Utils;
+
+/// <summary>
+/// Builds <c>WWW-Authenticate</c> challenge values: the HTTP grammar, not any one protocol's
+/// vocabulary of errors.
+/// </summary>
+/// <remarks>
+/// Two packages emit these headers for two different error vocabularies - an authorization server
+/// answering with OpenID Connect errors, and a Shared Signals transmitter answering with the three
+/// RFC 6750 codes - and they cannot share a type that names either. What they do share is the quoted-string
+/// grammar and the rule about when a challenge stays bare, which is what lives here.
+/// </remarks>
+public static class WwwAuthenticate
+{
+    /// <summary>
+    /// A challenge advertising <paramref name="scheme"/> and nothing else beyond the realm.
+    /// </summary>
+    /// <remarks>
+    /// This is the form RFC 6750 Section 3.1 requires when the request carried no credentials at all:
+    /// "If the request lacks any authentication information (e.g., the client was unaware that
+    /// authentication is necessary or attempted using an unsupported authentication method), the resource
+    /// server SHOULD NOT include an error code or other error information." A caller that has not tried
+    /// yet has nothing to correct, and naming an error would describe a failure that did not happen.
+    /// </remarks>
+    public static string Challenge(string scheme, string? realm = null)
+        => Build(scheme, realm, null, null);
+
+    /// <summary>
+    /// A challenge naming why the credentials that WERE presented did not suffice.
+    /// </summary>
+    /// <param name="scheme">The authentication scheme, such as <c>Bearer</c>.</param>
+    /// <param name="realm">The protection space, omitted when null or empty.</param>
+    /// <param name="error">The error code, from whatever vocabulary the scheme defines.</param>
+    /// <param name="errorDescription">Human-readable detail, omitted when null or empty.</param>
+    public static string Challenge(string scheme, string? realm, string error, string? errorDescription)
+        => Build(scheme, realm, error, errorDescription);
+
+    private static string Build(string scheme, string? realm, string? error, string? errorDescription)
+    {
+        var builder = new StringBuilder(scheme);
+        var first = true;
+
+        Append("realm", realm);
+        Append("error", error);
+        Append("error_description", errorDescription);
+
+        return builder.ToString();
+
+        void Append(string name, string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            builder.Append(first ? " " : ", ").Append(name).Append("=\"");
+
+            // RFC 9110 Section 5.6.4: inside a quoted-string each `"` must be backslash-escaped and `\`
+            // itself doubled. Anything else - control bytes, CR and LF - is rejected upstream rather than
+            // mangled here, because silently mutating a value hides where the malformed input came from.
+            foreach (var c in value)
+            {
+                if (c is '"' or '\\')
+                    builder.Append('\\');
+
+                builder.Append(c);
+            }
+
+            builder.Append('"');
+            first = false;
+        }
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/WwwAuthenticateBuilderTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/WwwAuthenticateBuilderTests.cs
@@ -75,6 +75,51 @@ public class WwwAuthenticateBuilderTests
             WwwAuthenticateBuilder.BuildDPoPChallenge(missingAuthentication, Realm, DPoPAlgs));
     }
 
+    /// <summary>
+    /// RFC 9449 Section 7.1, Figure 15, verbatim: "HTTP 401 Response to a Protected Resource Request
+    /// without Authentication" prints <c>WWW-Authenticate: DPoP algs="ES256 PS256"</c>.
+    /// </summary>
+    /// <remarks>
+    /// The point of the figure is the SEPARATOR. With no realm, <c>algs</c> is the challenge's first
+    /// parameter and follows the scheme with a space; a comma there is not a challenge under RFC 9110's
+    /// grammar, and a parser reads the scheme as parameterless and then chokes on the rest. Every other
+    /// row in this class passes a non-empty realm, so none of them can see it.
+    /// </remarks>
+    [Fact]
+    public void BuildDPoPChallenge_WithoutRealm_MatchesTheSpecificationFigure()
+        => Assert.Equal(
+            "DPoP algs=\"ES256 PS256\"",
+            WwwAuthenticateBuilder.BuildDPoPChallenge(
+                new MissingAuthenticationError("No access token provided"),
+                realm: null,
+                ["ES256", "PS256"]));
+
+    /// <summary>
+    /// An <c>algs</c> value carrying a quotation mark has to be escaped like any other parameter, or it
+    /// ends the quoted string early and the rest of the header is read as something else.
+    /// </summary>
+    /// <remarks>
+    /// The parameter is an unconstrained sequence on a public method of a published package, so what a
+    /// caller puts in it is not this library's choice.
+    /// </remarks>
+    [Fact]
+    public void BuildDPoPChallenge_AlgsCarryingSpecials_AreEscaped()
+        => Assert.Equal(
+            "DPoP realm=\"r\", algs=\"a\\\"b\"",
+            WwwAuthenticateBuilder.BuildDPoPChallenge(
+                new MissingAuthenticationError("No access token provided"), "r", ["a\"b"]));
+
+    /// <summary>
+    /// No algorithms leaves the parameter out rather than emitting <c>algs=""</c>, which advertises a
+    /// scheme that accepts nothing.
+    /// </summary>
+    [Fact]
+    public void BuildDPoPChallenge_NoAlgs_OmitsTheParameter()
+        => Assert.Equal(
+            "DPoP realm=\"r\"",
+            WwwAuthenticateBuilder.BuildDPoPChallenge(
+                new MissingAuthenticationError("No access token provided"), "r", []));
+
     [Fact]
     public void BuildBasicChallenge_WithRealm_EmitsRealmOnly()
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Common/WwwAuthenticateBuilderTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Common/WwwAuthenticateBuilderTests.cs
@@ -82,8 +82,13 @@ public class WwwAuthenticateBuilderTests
     /// <remarks>
     /// The point of the figure is the SEPARATOR. With no realm, <c>algs</c> is the challenge's first
     /// parameter and follows the scheme with a space; a comma there is not a challenge under RFC 9110's
-    /// grammar, and a parser reads the scheme as parameterless and then chokes on the rest. Every other
-    /// row in this class passes a non-empty realm, so none of them can see it.
+    /// grammar, and a parser reads the scheme as parameterless and then chokes on the rest.
+    /// <para>
+    /// The rest of this class guards that separator well - breaking it alone kills twelve of these
+    /// fifteen rows, most of them because the realm is what comes first. What none of them can see is a
+    /// parameter that BYPASSES the builder, which is what <c>algs</c> did: these three rows are the only
+    /// thing in the solution that catches it, measured.
+    /// </para>
     /// </remarks>
     [Fact]
     public void BuildDPoPChallenge_WithoutRealm_MatchesTheSpecificationFigure()

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -1,0 +1,144 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Net;
+using System.Net.Http.Json;
+using Abblix.Jwt;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.MinimalApi;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Abblix.SharedSignals.E2E.Tests;
+
+/// <summary>
+/// What a receiver is told when a Stream Management request names nobody.
+/// </summary>
+/// <remarks>
+/// The CAEP Interoperability Profile 1.0 Section 2.7.2 requires errors "as per Section 3.1 of [RFC6750]",
+/// and a bare 401 with an empty body satisfies neither the profile nor a receiver: it carries no challenge
+/// naming a scheme, so a client library has nothing to retry with and nothing to log.
+/// </remarks>
+public sealed class ManagementRefusalTests
+{
+    private const string Issuer = "https://transmitter.example";
+    private const string SomeEvent = "https://tenant.example.com/events/membership-changed";
+
+    /// <summary>
+    /// Every route on the management surface refuses the same way, because they refuse for the same
+    /// reason. Driving all of them rather than one keeps a route that grows its own refusal visible.
+    /// </summary>
+    /// <remarks>
+    /// Only reached with a body that binds. A malformed one is refused by the framework as 400 before any
+    /// of this package's code runs, so an unidentified caller who also sends bad JSON learns nothing
+    /// about authentication - true, and outside what this endpoint decides.
+    /// </remarks>
+    [Theory]
+    [InlineData("GET", "/ssf/stream")]
+    [InlineData("POST", "/ssf/stream")]
+    [InlineData("PATCH", "/ssf/stream")]
+    [InlineData("PUT", "/ssf/stream")]
+    [InlineData("DELETE", "/ssf/stream")]
+    [InlineData("GET", "/ssf/status")]
+    [InlineData("POST", "/ssf/status")]
+    [InlineData("POST", "/ssf/subjects:add")]
+    [InlineData("POST", "/ssf/subjects:remove")]
+    [InlineData("POST", "/ssf/verify")]
+    public async Task AnUnidentifiedCaller_GetsAChallengeRatherThanABare401(string method, string route)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await StartAsync();
+
+        // A body every bodied route will BIND. Those routes carry required members, and a body missing
+        // them is refused as malformed by the framework's binder before the handler runs at all - which
+        // is a 400 with no challenge, and a different question from this one.
+        using var request = new HttpRequestMessage(new HttpMethod(method), route)
+        {
+            Content = JsonContent.Create(new
+            {
+                stream_id = "stream-1",
+                status = "enabled",
+                subject = new { format = "opaque", id = "subject-1" },
+            }),
+        };
+
+        using var response = await host.GetTestClient().SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        var challenge = Assert.Single(response.Headers.WwwAuthenticate);
+        Assert.Equal("Bearer", challenge.Scheme);
+        Assert.Equal($"realm=\"{Issuer}\"", challenge.Parameter);
+    }
+
+    /// <summary>
+    /// RFC 6750 Section 3.1 on a request that presented nothing: the resource server "SHOULD NOT include
+    /// an error code or other error information". A caller that has not tried has nothing to correct, and
+    /// an error code would describe a failure that did not happen.
+    /// </summary>
+    [Fact]
+    public async Task TheChallenge_NamesNoError()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await StartAsync();
+
+        using var response = await host.GetTestClient().GetAsync("/ssf/stream", cancellationToken);
+
+        var challenge = Assert.Single(response.Headers.WwwAuthenticate);
+        Assert.DoesNotContain("error", challenge.Parameter!);
+    }
+
+    /// <summary>
+    /// The control. A host whose selector answers gets served, so the challenge above is the refusal
+    /// rather than the endpoint being unreachable in this fixture.
+    /// </summary>
+    [Fact]
+    public async Task AnIdentifiedCaller_IsServed()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await StartAsync(_ => "receiver-1");
+
+        using var response = await host.GetTestClient().GetAsync("/ssf/stream", cancellationToken);
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Empty(response.Headers.WwwAuthenticate);
+    }
+
+    private static async Task<WebApplication> StartAsync(Func<HttpContext, string?>? receiverId = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddSecurityEvents(o =>
+            o.SigningKeySource = _ => Task.FromResult<JsonWebKey>(
+                JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)));
+
+        builder.Services.AddSharedSignalsTransmitter(new SharedSignalsTransmitterOptions
+        {
+            Issuer = Issuer,
+            EventsSupported = [SomeEvent],
+            JwksUri = new Uri($"{Issuer}/jwks"),
+        });
+
+        builder.Services.AddSingleton(new SharedSignalsEndpointOptions
+        {
+            ReceiverIdSelector = receiverId ?? (_ => null),
+        });
+
+        var app = builder.Build();
+        app.MapSharedSignalsTransmitterEndpoints();
+        await app.StartAsync();
+        return app;
+    }
+}

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -25,9 +25,16 @@ namespace Abblix.SharedSignals.E2E.Tests;
 /// What a receiver is told when a Stream Management request names nobody.
 /// </summary>
 /// <remarks>
-/// The CAEP Interoperability Profile 1.0 Section 2.7.2 requires errors "as per Section 3.1 of [RFC6750]",
-/// and a bare 401 with an empty body satisfies neither the profile nor a receiver: it carries no challenge
-/// naming a scheme, so a client library has nothing to retry with and nothing to log.
+/// A bare 401 with an empty body carries no challenge naming a scheme, so a client library has nothing to
+/// retry with and nothing to log.
+/// <para>
+/// The CAEP Interoperability Profile Section 2.7.2 does require errors "as per Section 3.1 of [RFC6750]",
+/// but that MUST hangs on a condition this case does not meet: "If the access token is not sufficient for
+/// the requested action". Here no token was presented at all - this package never sees one - so the
+/// answer comes from RFC 6750 Section 3.1 directly, which covers a request that "lacks any authentication
+/// information" and says the challenge stays bare. The profile's clause is what governs the SCOPE split,
+/// which is a different change.
+/// </para>
 /// </remarks>
 public sealed class ManagementRefusalTests
 {
@@ -35,8 +42,10 @@ public sealed class ManagementRefusalTests
     private const string SomeEvent = "https://tenant.example.com/events/membership-changed";
 
     /// <summary>
-    /// Every route on the management surface refuses the same way, because they refuse for the same
-    /// reason. Driving all of them rather than one keeps a route that grows its own refusal visible.
+    /// Every route under this prefix refuses the same way, because they refuse for the same reason.
+    /// Driving all ELEVEN rather than a sample keeps a route that grows its own refusal visible - poll is
+    /// the one that is delivery rather than management, and leaving it out let a revert of that one site
+    /// alone survive the whole suite.
     /// </summary>
     /// <remarks>
     /// Only reached with a body that binds. A malformed one is refused by the framework as 400 before any
@@ -54,6 +63,7 @@ public sealed class ManagementRefusalTests
     [InlineData("POST", "/ssf/subjects:add")]
     [InlineData("POST", "/ssf/subjects:remove")]
     [InlineData("POST", "/ssf/verify")]
+    [InlineData("POST", "/ssf/poll/stream-1")]
     public async Task AnUnidentifiedCaller_GetsAChallengeRatherThanABare401(string method, string route)
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Abblix.Utils.UnitTests/WwwAuthenticateTests.cs
+++ b/tests/Abblix.Utils.UnitTests/WwwAuthenticateTests.cs
@@ -1,0 +1,83 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using Xunit;
+
+namespace Abblix.Utils.UnitTests;
+
+/// <summary>
+/// The <c>WWW-Authenticate</c> grammar, which two packages under two licences now share.
+/// </summary>
+/// <remarks>
+/// The quoting is the part worth pinning. A realm or description carrying a quotation mark or a backslash
+/// produces a header that a client parses into something else entirely, and the failure surfaces at the
+/// client as a malformed challenge rather than here as a bad string.
+/// </remarks>
+public class WwwAuthenticateTests
+{
+    [Fact]
+    public void Challenge_SchemeAlone_IsJustTheScheme()
+        => Assert.Equal("Bearer", WwwAuthenticate.Challenge("Bearer"));
+
+    /// <summary>
+    /// The form RFC 6750 Section 3.1 requires of a request that presented no credentials: the scheme and
+    /// the realm, and nothing a caller could mistake for a diagnosis of what it did wrong.
+    /// </summary>
+    [Fact]
+    public void Challenge_WithRealm_CarriesNoErrorAttributes()
+    {
+        var challenge = WwwAuthenticate.Challenge("Bearer", "https://transmitter.example");
+
+        Assert.Equal("Bearer realm=\"https://transmitter.example\"", challenge);
+        Assert.DoesNotContain("error", challenge);
+    }
+
+    [Fact]
+    public void Challenge_WithError_NamesItAfterTheRealm()
+        => Assert.Equal(
+            "Bearer realm=\"r\", error=\"invalid_token\", error_description=\"expired\"",
+            WwwAuthenticate.Challenge("Bearer", "r", "invalid_token", "expired"));
+
+    /// <summary>
+    /// An absent realm leaves the error first rather than emitting an empty parameter, so the delimiter
+    /// logic has to notice which parameter is actually first.
+    /// </summary>
+    [Fact]
+    public void Challenge_WithoutRealm_StartsAtTheError()
+        => Assert.Equal(
+            "Bearer error=\"insufficient_scope\"",
+            WwwAuthenticate.Challenge("Bearer", null, "insufficient_scope", null));
+
+    /// <summary>
+    /// RFC 9110 Section 5.6.4: inside a quoted-string a quotation mark is backslash-escaped and a
+    /// backslash is doubled. Without this a value carrying either one closes the string early and the
+    /// rest of the header is read as something else.
+    /// </summary>
+    [Theory]
+    [InlineData("a\"b", "a\\\"b")]
+    [InlineData("a\\b", "a\\\\b")]
+    [InlineData("\"", "\\\"")]
+    [InlineData("back\\slash and \"quote\"", "back\\\\slash and \\\"quote\\\"")]
+    public void Challenge_EscapesQuotedStringSpecials(string realm, string expected)
+        => Assert.Equal($"Bearer realm=\"{expected}\"", WwwAuthenticate.Challenge("Bearer", realm));
+
+    /// <summary>
+    /// An empty value is omitted rather than emitted as <c>name=""</c>, which would be a parameter the
+    /// caller has to interpret and cannot.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Challenge_EmptyRealm_IsOmitted(string? realm)
+        => Assert.Equal("Bearer", WwwAuthenticate.Challenge("Bearer", realm));
+
+    [Fact]
+    public void Challenge_EmptyDescription_LeavesTheErrorAlone()
+        => Assert.Equal(
+            "Bearer error=\"invalid_token\"",
+            WwwAuthenticate.Challenge("Bearer", null, "invalid_token", ""));
+}


### PR DESCRIPTION
Closes #444.

## What a receiver got

Every refusal on the Stream Management API was `Results.Unauthorized()` - a 401 with an empty body and no headers. Eleven call sites, one shape. A receiver got a status code and nothing to act on: no scheme to retry with, nothing to log, and no way to separate an authentication problem from anything else that answers 401.

CAEP Interoperability Profile 1.0 Section 2.7.2: `If the access token is not sufficient for the requested action, the Resource Server MUST return errors as per Section 3.1 of [RFC6750]`.

## What it answers now

All eleven sites refuse for one reason - `ReceiverIdOf` found nobody, so nothing identified the caller. That is the case RFC 6750 Section 3.1 describes directly:

> If the request lacks any authentication information (e.g., the client was unaware that authentication is necessary or attempted using an unsupported authentication method), the resource server SHOULD NOT include an error code or other error information.

So the challenge is bare: `WWW-Authenticate: Bearer realm="<issuer>"`, and no error attribute. A caller that presented nothing has nothing to correct, and naming an error would describe a failure that did not happen.

The realm is the transmitter's issuer - the one name a receiver already holds for this protection space, and the one it used to find these endpoints.

## What is deliberately not here

Section 3.1's other two codes belong to whoever validates the token, which is the host. `invalid_token` needs a token to have been presented and rejected; `insufficient_scope` with 403 needs a scope decision. This package never sees a token - it reads whatever identity the host's authentication left behind, through `SharedSignalsEndpointOptions.ReceiverIdSelector`. The scope half is #443.

One thing a reader would otherwise wonder about: a request whose body the framework's binder rejects is answered 400 before any of this package's code runs, so an unidentified caller who also sends malformed JSON still learns nothing about authentication. True, and not something this endpoint decides.

## The licence boundary, and what moved because of it

`Abblix.Oidc.Server.Common.WwwAuthenticateBuilder` already knew this grammar and could not be reached: it is `LicenseRef-Abblix-EULA` and `Abblix.SharedSignals` is Apache-2.0.

What moved to `Abblix.Utils` is the HTTP grammar only - the quoted-string escaping from RFC 9110 Section 5.6.4, the delimiter logic, and the rule that an empty value is omitted rather than emitted as `name=""`. Not any error vocabulary: one caller speaks OpenID Connect errors and the other speaks RFC 6750's three, and a shared type naming either would be wrong for the other.

The commercial builder now delegates and keeps its surface unchanged - `BuildBearerChallenge`, `BuildBasicChallenge`, `BuildDPoPChallenge`, `BuildChallenges` all still take `OidcError`, and `algs` stays with DPoP, since RFC 9449 Section 7.1 is the only place it belongs.

## Evidence

`Abblix.Utils.UnitTests` 305 passed (294 before). `Abblix.SharedSignals.E2E.Tests` 24 passed (11 before), the eleventh route added after a review found that reverting it alone survived the suite. `Abblix.Oidc.Server.UnitTests` 2897 passed - 2894 before, plus the three rows below. The delegation itself is behaviour-preserving, and the suite is not what says so: an oracle comparing develop's builder against this head over 115,640 inputs reports zero differences, and it is not a blind instrument - stripping the escaping produces 82,481.

The mutation that matters: making the challenge name `invalid_token` - the plausible wrong answer, and the one a reader might "fix" it to - turns 12 tests red, one of them the row named for exactly that. The grammar's escaping is pinned by its own rows, since a realm carrying a quotation mark produces a header a client parses into something else.

Two attempted mutations did NOT build, and their counts were read before any test number: reverting to `Results.Unauthorized()` leaves the result type and the scheme constant unused, which the analyser refuses under its own error code. `--no-build` after either would have reported the previous binary as green.

## What a review changed

The `algs` parameter of the DPoP challenge was rewritten by hand during the move and lost both rules the grammar owns: it hardcoded a comma where RFC 9449 Section 7.1 Figure 15 prints `DPoP algs="ES256 PS256"` with a space, and it interpolated the value raw so a quotation mark ended the string early. The specification's own figure is what refuted it, and running it cost nothing. Three rows pin it now, and they are the only thing in the solution that catches a parameter bypassing the builder.

Three statements went with it: CAEP 2.7.2's MUST quoted without the condition it hangs on, a count of Section 3.1's codes that said two where there are three, and a citation of CAEP 2.4.3 - which requires OAuth 2.0 and fixes no token type - for the Bearer scheme that 2.7.2 obliges.
