### PR TITLE
Refuse a CAEP event the interoperability profile says must carry reason_admin

### DIFF
--- a/src/Abblix.SecurityEvents.CAEP/CaepEventPayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepEventPayload.cs
@@ -61,10 +61,16 @@ public abstract record CaepEventPayload : IEventPayload
     /// <remarks>
     /// Optional to CAEP 1.0, and required of a TRANSMITTER by the CAEP Interoperability Profile 1.0: each
     /// of the three use cases in its Section 3 demands a non-empty object here. The property stays
-    /// nullable because the two documents disagree and the receive side follows the base specification -
-    /// CAEP 1.0 Section 3.1.1 positively requires an empty <c>session-revoked</c> payload to be accepted.
-    /// A deployment claiming the profile registers <see cref="CaepInteropProfilePolicy"/>, which refuses
-    /// the event rather than the type.
+    /// nullable because the base specification permits its absence - Section 2 makes the common claims
+    /// optional and Section 3.1.1 defines no event-specific claim for <c>session-revoked</c> - so an
+    /// empty payload is well-formed and a receiver must be able to hold one. A deployment claiming the
+    /// profile registers <see cref="CaepInteropProfilePolicy"/>, which refuses the event rather than the
+    /// type.
+    /// <para>
+    /// One rule here is the base specification's rather than the profile's: "The object MUST contain one
+    /// or more key/value pairs" (CAEP 1.0 Section 2). An empty object is wrong wherever it appears, with
+    /// or without the profile.
+    /// </para>
     /// </remarks>
     [JsonPropertyName(CaepClaimNames.ReasonAdmin)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Abblix.SecurityEvents.CAEP/CaepEventPayload.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepEventPayload.cs
@@ -58,6 +58,14 @@ public abstract record CaepEventPayload : IEventPayload
     /// OPTIONAL. The administrative message for logging and auditing, keyed by BCP 47 language
     /// tag (CAEP 1.0 Section 2).
     /// </summary>
+    /// <remarks>
+    /// Optional to CAEP 1.0, and required of a TRANSMITTER by the CAEP Interoperability Profile 1.0: each
+    /// of the three use cases in its Section 3 demands a non-empty object here. The property stays
+    /// nullable because the two documents disagree and the receive side follows the base specification -
+    /// CAEP 1.0 Section 3.1.1 positively requires an empty <c>session-revoked</c> payload to be accepted.
+    /// A deployment claiming the profile registers <see cref="CaepInteropProfilePolicy"/>, which refuses
+    /// the event rather than the type.
+    /// </remarks>
     [JsonPropertyName(CaepClaimNames.ReasonAdmin)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyDictionary<string, string>? ReasonAdmin { get; init; }

--- a/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
@@ -42,13 +42,43 @@ namespace Abblix.SecurityEvents.CAEP;
 /// </param>
 public sealed class CaepInteropProfilePolicy(params string[] claimedUseCases) : IEventPayloadPolicy
 {
-    private readonly HashSet<string> _claimed = claimedUseCases is { Length: > 0 }
-        ? [.. claimedUseCases]
-        : [
-            CaepEventTypes.SessionRevoked,
-            CaepEventTypes.CredentialChange,
-            CaepEventTypes.DeviceComplianceChange,
-        ];
+    /// <summary>The event types the profile's Section 3 defines use cases for, and the only claimable
+    /// values.</summary>
+    private static readonly string[] UseCases =
+    [
+        CaepEventTypes.SessionRevoked,
+        CaepEventTypes.CredentialChange,
+        CaepEventTypes.DeviceComplianceChange,
+    ];
+
+    private readonly HashSet<string> _claimed = Claimed(claimedUseCases);
+
+    /// <summary>
+    /// The claimed set, refusing at construction anything the profile does not define.
+    /// </summary>
+    /// <remarks>
+    /// An unrecognised value would otherwise leave a policy that is registered, resolvable, consulted on
+    /// every event and refuses nothing - which is the state this class exists to prevent, reached by a
+    /// typo or by the profile's own prose, where the use cases are named <c>session-revoked</c> rather
+    /// than by their event type URI. Silence in the permissive direction is the one failure a deployment
+    /// cannot notice, so it is answered at startup, where an issuer is answered two files away.
+    /// </remarks>
+    private static HashSet<string> Claimed(string[] claimedUseCases)
+    {
+        if (claimedUseCases is not { Length: > 0 })
+            return [.. UseCases];
+
+        if (claimedUseCases.FirstOrDefault(claimed => !UseCases.Contains(claimed, StringComparer.Ordinal))
+            is { } unknown)
+        {
+            throw new ArgumentException(
+                $"'{unknown}' is not a use case of the CAEP Interoperability Profile 1.0. Its Section 3 "
+                + $"defines three, by event type: {string.Join(", ", UseCases)}.",
+                nameof(claimedUseCases));
+        }
+
+        return [.. claimedUseCases];
+    }
 
     /// <summary>
     /// Claims all three use cases.
@@ -74,7 +104,10 @@ public sealed class CaepInteropProfilePolicy(params string[] claimedUseCases) : 
         {
             true => null,
 
-            false => $"'{CaepClaimNames.ReasonAdmin}' is absent or empty on '{eventType}'. The CAEP "
+            // Stated as what the member is NOT, rather than as a guess at which way it failed. Absent, an
+            // empty object, and a string where an object belongs are one verdict here, and enumerating
+            // them would send a host debugging a relay to grep upstream for a member that is right there.
+            false => $"'{CaepClaimNames.ReasonAdmin}' is not a non-empty object on '{eventType}'. The CAEP "
                 + "Interoperability Profile 1.0 Section 3 requires a transmitter to populate it with a "
                 + "non-empty object on every use case it claims, and CAEP 1.0 Section 2 requires the "
                 + "object to carry one or more key/value pairs wherever it appears at all.",

--- a/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
@@ -5,59 +5,110 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Text.Json.Nodes;
 using Abblix.SecurityEvents.Events;
 
 namespace Abblix.SecurityEvents.CAEP;
 
 /// <summary>
 /// What the CAEP Interoperability Profile 1.0 demands of a TRANSMITTER's payload, on top of what CAEP 1.0
-/// permits: each of the profile's three use cases requires <c>reason_admin</c> to carry a non-empty object.
+/// permits: each of its three use cases requires <c>reason_admin</c> to carry a non-empty object.
 /// </summary>
 /// <remarks>
-/// Section 3 opens "An implementation conforming to this profile MUST support at least one of the following
-/// use cases", so there is no way to claim the profile without meeting this on some event. Section 3.1 says
-/// "The reason_admin field of the event MUST be populated with a non-empty object"; Sections 3.2 and 3.3
-/// name the actor outright, "Transmitters MUST populate this value with a non-empty object".
+/// Section 3.1 says "The reason_admin field of the event MUST be populated with a non-empty object";
+/// Sections 3.2 and 3.3 name the actor outright, "Transmitters MUST populate this value with a non-empty
+/// object". The obligation is the transmitter's alone - neither document asks a receiver to reject an
+/// event without it.
 /// <para>
-/// The obligation is the transmitter's alone. Nothing anywhere requires a receiver to reject an event
-/// without the member, and CAEP 1.0 Section 3.1.1 positively requires an empty <c>session-revoked</c>
-/// payload to be accepted - which is why <see cref="CaepEventPayload.ReasonAdmin"/> stays optional and this
-/// lives beside the type rather than on it.
+/// CAEP 1.0 leaves the member optional - Section 2, "The following claims are optional unless otherwise
+/// specified in the event definition" - and defines no event-specific claim for <c>session-revoked</c>
+/// (Section 3.1.1), so an empty payload is well-formed under the base specification and the property stays
+/// nullable. What CAEP 1.0 does say about the member once it appears is "The object MUST contain one or
+/// more key/value pairs", so an EMPTY object is outside the base specification too and this policy is not
+/// the only thing that would be wrong to emit it.
 /// </para>
 /// <para>
-/// Registering it is how a deployment claims the profile. A host that does not is emitting CAEP 1.0 events,
-/// which is a smaller claim and a valid one.
+/// Registering it is how a deployment claims the profile. A host that does not is emitting CAEP 1.0
+/// events, which is a smaller claim and a valid one.
 /// </para>
 /// </remarks>
-public sealed class CaepInteropProfilePolicy : IEventPayloadPolicy
+/// <param name="claimedUseCases">
+/// The use cases this deployment claims, by event type; empty claims all three. The profile's Section 1
+/// says "Support for all use cases listed herein is not required in order to be considered compliant with
+/// this profile. An implementation can choose specific use cases to support", so a deployment conforming
+/// through one of them may still emit the others as plain CAEP 1.0 events. Naming the claimed ones is how
+/// it keeps that freedom, and the default is deliberately the strict reading: a transmitter that has not
+/// thought about it is better refused than quietly non-conformant.
+/// </param>
+public sealed class CaepInteropProfilePolicy(params string[] claimedUseCases) : IEventPayloadPolicy
 {
+    private readonly HashSet<string> _claimed = claimedUseCases is { Length: > 0 }
+        ? [.. claimedUseCases]
+        : [
+            CaepEventTypes.SessionRevoked,
+            CaepEventTypes.CredentialChange,
+            CaepEventTypes.DeviceComplianceChange,
+        ];
+
+    /// <summary>
+    /// Claims all three use cases.
+    /// </summary>
+    /// <remarks>
+    /// Spelled out rather than left to the parameter's default, because a container cannot satisfy a
+    /// <c>params</c> array: without this, the natural registration
+    /// <c>AddSingleton&lt;IEventPayloadPolicy, CaepInteropProfilePolicy&gt;()</c> compiles and then fails
+    /// when the policy is first resolved.
+    /// </remarks>
+    public CaepInteropProfilePolicy()
+        : this([])
+    {
+    }
+
     /// <inheritdoc />
     public string? RefusalOf(string eventType, IEventPayload? payload)
     {
-        if (!RequiresReasonAdmin(eventType))
+        if (!_claimed.Contains(eventType))
             return null;
 
-        // Stated as what must be PRESENT, so every way of failing it - no payload, a payload of another
-        // vocabulary, an absent member, an empty object - is refused by one condition rather than by a list
-        // of absences that is always short by one. The empty object is the case a presence check misses:
-        // "reason_admin": {} deserializes to a non-null empty dictionary and is emitted as written.
-        return payload is CaepEventPayload { ReasonAdmin.Count: > 0 }
-            ? null
-            : $"The CAEP Interoperability Profile 1.0 requires a transmitter to populate '"
-              + $"{CaepClaimNames.ReasonAdmin}' with a non-empty object on '{eventType}', and this event "
-              + "carries none. Populate it, or do not register this policy if the deployment claims CAEP "
-              + "1.0 rather than the interoperability profile.";
+        return PopulatedReasonAdmin(payload) switch
+        {
+            true => null,
+
+            false => $"'{CaepClaimNames.ReasonAdmin}' is absent or empty on '{eventType}'. The CAEP "
+                + "Interoperability Profile 1.0 Section 3 requires a transmitter to populate it with a "
+                + "non-empty object on every use case it claims, and CAEP 1.0 Section 2 requires the "
+                + "object to carry one or more key/value pairs wherever it appears at all.",
+
+            // The honest third answer, and it earns a message of its own: refusing a payload with "it
+            // carries none" would be a statement about contents this policy never read.
+            null => $"A payload of type '{payload?.GetType().Name}' cannot be read for "
+                + $"'{CaepClaimNames.ReasonAdmin}', so this transmitter cannot show that '{eventType}' "
+                + "meets the CAEP Interoperability Profile 1.0. Build the event with the payload types "
+                + "this package defines, or supply a policy that understands this one.",
+        };
     }
 
     /// <summary>
-    /// The three use cases of the profile's Section 3. CAEP 1.0 defines more event types, and the profile
-    /// makes no demand of them, so they pass.
+    /// Whether the payload carries a populated <c>reason_admin</c>, or null when this policy cannot tell.
     /// </summary>
-    private static bool RequiresReasonAdmin(string eventType) => eventType switch
+    /// <remarks>
+    /// Stated as what must be PRESENT, so no payload, an absent member and an empty object are all refused
+    /// by one condition rather than by a list of absences that is always short by one. The empty object is
+    /// the case a presence check misses: <c>"reason_admin": {}</c> deserializes to a non-null dictionary
+    /// and is emitted as written.
+    /// <para>
+    /// The question is about the WIRE member rather than about a .NET type, which is why the relayed shape
+    /// is read too: an event that arrived as raw JSON and is re-dispatched is conformant whenever its own
+    /// <c>reason_admin</c> is populated, and judging it by its C# class would refuse it while asserting
+    /// something about contents nobody looked at.
+    /// </para>
+    /// </remarks>
+    private static bool? PopulatedReasonAdmin(IEventPayload? payload) => payload switch
     {
-        CaepEventTypes.SessionRevoked => true,
-        CaepEventTypes.CredentialChange => true,
-        CaepEventTypes.DeviceComplianceChange => true,
-        _ => false,
+        null => false,
+        CaepEventPayload caep => caep.ReasonAdmin is { Count: > 0 },
+        UnknownEventPayload { Json: var json } =>
+            json[CaepClaimNames.ReasonAdmin] is JsonObject { Count: > 0 },
+        _ => null,
     };
 }

--- a/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
@@ -1,0 +1,63 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using Abblix.SecurityEvents.Events;
+
+namespace Abblix.SecurityEvents.CAEP;
+
+/// <summary>
+/// What the CAEP Interoperability Profile 1.0 demands of a TRANSMITTER's payload, on top of what CAEP 1.0
+/// permits: each of the profile's three use cases requires <c>reason_admin</c> to carry a non-empty object.
+/// </summary>
+/// <remarks>
+/// Section 3 opens "An implementation conforming to this profile MUST support at least one of the following
+/// use cases", so there is no way to claim the profile without meeting this on some event. Section 3.1 says
+/// "The reason_admin field of the event MUST be populated with a non-empty object"; Sections 3.2 and 3.3
+/// name the actor outright, "Transmitters MUST populate this value with a non-empty object".
+/// <para>
+/// The obligation is the transmitter's alone. Nothing anywhere requires a receiver to reject an event
+/// without the member, and CAEP 1.0 Section 3.1.1 positively requires an empty <c>session-revoked</c>
+/// payload to be accepted - which is why <see cref="CaepEventPayload.ReasonAdmin"/> stays optional and this
+/// lives beside the type rather than on it.
+/// </para>
+/// <para>
+/// Registering it is how a deployment claims the profile. A host that does not is emitting CAEP 1.0 events,
+/// which is a smaller claim and a valid one.
+/// </para>
+/// </remarks>
+public sealed class CaepInteropProfilePolicy : IEventPayloadPolicy
+{
+    /// <inheritdoc />
+    public string? RefusalOf(string eventType, IEventPayload? payload)
+    {
+        if (!RequiresReasonAdmin(eventType))
+            return null;
+
+        // Stated as what must be PRESENT, so every way of failing it - no payload, a payload of another
+        // vocabulary, an absent member, an empty object - is refused by one condition rather than by a list
+        // of absences that is always short by one. The empty object is the case a presence check misses:
+        // "reason_admin": {} deserializes to a non-null empty dictionary and is emitted as written.
+        return payload is CaepEventPayload { ReasonAdmin.Count: > 0 }
+            ? null
+            : $"The CAEP Interoperability Profile 1.0 requires a transmitter to populate '"
+              + $"{CaepClaimNames.ReasonAdmin}' with a non-empty object on '{eventType}', and this event "
+              + "carries none. Populate it, or do not register this policy if the deployment claims CAEP "
+              + "1.0 rather than the interoperability profile.";
+    }
+
+    /// <summary>
+    /// The three use cases of the profile's Section 3. CAEP 1.0 defines more event types, and the profile
+    /// makes no demand of them, so they pass.
+    /// </summary>
+    private static bool RequiresReasonAdmin(string eventType) => eventType switch
+    {
+        CaepEventTypes.SessionRevoked => true,
+        CaepEventTypes.CredentialChange => true,
+        CaepEventTypes.DeviceComplianceChange => true,
+        _ => false,
+    };
+}

--- a/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
+++ b/src/Abblix.SecurityEvents.CAEP/CaepInteropProfilePolicy.cs
@@ -68,12 +68,19 @@ public sealed class CaepInteropProfilePolicy(params string[] claimedUseCases) : 
         if (claimedUseCases is not { Length: > 0 })
             return [.. UseCases];
 
-        if (claimedUseCases.FirstOrDefault(claimed => !UseCases.Contains(claimed, StringComparer.Ordinal))
-            is { } unknown)
+        // By INDEX, because the offending element can itself be null - a JSON array carrying a null, or
+        // a missing configuration key read straight into the array - and a search returning the element
+        // has no way to tell "found a null" from "found nothing". That sentinel collision is what let a
+        // null through the first version of this guard, taking any real typo behind it along.
+        var unknown = Array.FindIndex(
+            claimedUseCases,
+            claimed => !UseCases.Contains(claimed, StringComparer.Ordinal));
+
+        if (unknown >= 0)
         {
             throw new ArgumentException(
-                $"'{unknown}' is not a use case of the CAEP Interoperability Profile 1.0. Its Section 3 "
-                + $"defines three, by event type: {string.Join(", ", UseCases)}.",
+                $"'{claimedUseCases[unknown] ?? "<null>"}' is not a use case of the CAEP Interoperability "
+                + $"Profile 1.0. Its Section 3 defines three, by event type: {string.Join(", ", UseCases)}.",
                 nameof(claimedUseCases));
         }
 

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -56,6 +56,24 @@ await dispatcher.DispatchAsync(new SecurityEventDescriptor
 });
 ```
 
+## Claiming the interoperability profile
+
+`reason_admin` is optional in CAEP 1.0 and required of a transmitter by the CAEP Interoperability Profile
+1.0: each of the three use cases in its Section 3 demands a non-empty object. The type cannot carry that
+rule, because the receive side follows the base specification, which requires an empty `session-revoked`
+payload to be accepted.
+
+So the rule is a policy a deployment registers, and registering it is how the deployment claims the
+profile:
+
+```csharp
+services.AddSingleton<IEventPayloadPolicy, CaepInteropProfilePolicy>();
+```
+
+The dispatcher then refuses `session-revoked`, `credential-change` and `device-compliance-change` without
+the member, before anything is minted, and says which event and what is missing. A host that registers
+nothing emits CAEP 1.0 events, which is a smaller claim and a valid one.
+
 ## Part of the Abblix product family
 
 The events themselves travel over the [Abblix.SharedSignals](https://www.nuget.org/packages/Abblix.SharedSignals) transmitter and receiver; the sibling dictionary for account risk incidents is [Abblix.SecurityEvents.RISC](https://www.nuget.org/packages/Abblix.SecurityEvents.RISC), and both compose on one registry.

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -85,8 +85,15 @@ services.AddSingleton<IEventPayloadPolicy>(
 ```
 
 One rule the policy applies is the base specification's rather than the profile's: `reason_admin`, once
-present, "MUST contain one or more key/value pairs" (CAEP 1.0 Section 2). An empty object is wrong with or
-without the profile.
+present, "MUST contain one or more key/value pairs" (CAEP 1.0 Section 2). It applies it only inside the
+use cases you claim, though - an unclaimed event carrying an empty object still goes out, because the
+policy is a statement about the profile and not a validator for CAEP 1.0.
+
+Two things the policy does not reach. Naming a use case the profile does not define is refused when the
+policy is built, because a value it does not recognise would otherwise leave it registered, consulted and
+refusing nothing. And `DispatchToStreamAsync` is not judged at all: it carries the framework's own
+verification and stream-updated signals, and its callers write state before dispatching, so a refusal
+there would fault mid-operation.
 
 ## Part of the Abblix product family
 

--- a/src/Abblix.SecurityEvents.CAEP/README.md
+++ b/src/Abblix.SecurityEvents.CAEP/README.md
@@ -60,8 +60,9 @@ await dispatcher.DispatchAsync(new SecurityEventDescriptor
 
 `reason_admin` is optional in CAEP 1.0 and required of a transmitter by the CAEP Interoperability Profile
 1.0: each of the three use cases in its Section 3 demands a non-empty object. The type cannot carry that
-rule, because the receive side follows the base specification, which requires an empty `session-revoked`
-payload to be accepted.
+rule, because the base specification permits the member's absence - Section 2 makes the common claims
+optional, Section 3.1.1 defines none of its own for `session-revoked` - so an empty payload is well-formed
+and a receiver has to be able to hold one.
 
 So the rule is a policy a deployment registers, and registering it is how the deployment claims the
 profile:
@@ -70,9 +71,22 @@ profile:
 services.AddSingleton<IEventPayloadPolicy, CaepInteropProfilePolicy>();
 ```
 
-The dispatcher then refuses `session-revoked`, `credential-change` and `device-compliance-change` without
-the member, before anything is minted, and says which event and what is missing. A host that registers
-nothing emits CAEP 1.0 events, which is a smaller claim and a valid one.
+The dispatcher then refuses the three events unless the member is populated, before anything is minted,
+and says which event and what is missing. A host that registers nothing emits CAEP 1.0 events, which is a
+smaller claim and a valid one.
+
+The profile lets you claim fewer than three: "Support for all use cases listed herein is not required in
+order to be considered compliant with this profile. An implementation can choose specific use cases to
+support." Name the ones you claim and the others go out as plain CAEP 1.0 events:
+
+```csharp
+services.AddSingleton<IEventPayloadPolicy>(
+    new CaepInteropProfilePolicy(CaepEventTypes.CredentialChange));
+```
+
+One rule the policy applies is the base specification's rather than the profile's: `reason_admin`, once
+present, "MUST contain one or more key/value pairs" (CAEP 1.0 Section 2). An empty object is wrong with or
+without the profile.
 
 ## Part of the Abblix product family
 

--- a/src/Abblix.SecurityEvents/Events/IEventPayloadPolicy.cs
+++ b/src/Abblix.SecurityEvents/Events/IEventPayloadPolicy.cs
@@ -1,0 +1,38 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+namespace Abblix.SecurityEvents.Events;
+
+/// <summary>
+/// What a deployment refuses to emit. An event vocabulary's base specification says what a payload MAY
+/// carry; a profile a deployment claims can demand more of the same payload, and this is where that extra
+/// demand is stated.
+/// </summary>
+/// <remarks>
+/// It lives here, in the assembly every event vocabulary and every transmitter references, because the two
+/// sides of the question are in packages that do not reference each other: the rule belongs to the
+/// vocabulary that defines the payload, and the moment it must be asked belongs to the transmitter.
+/// <para>
+/// A policy speaks about the payload alone, so it is consulted ONCE per event rather than once per stream:
+/// the payload is the same for every receiver, and a per-stream answer would emit to some and withhold
+/// from others by iteration order.
+/// </para>
+/// <para>
+/// Registering one is how a deployment CLAIMS a profile. Nothing is registered by default, so a
+/// transmitter that claims nothing keeps emitting whatever its host builds.
+/// </para>
+/// </remarks>
+public interface IEventPayloadPolicy
+{
+    /// <summary>
+    /// Why this deployment will not emit the event, or null when it will.
+    /// </summary>
+    /// <param name="eventType">The event type URI the payload is carried under.</param>
+    /// <param name="payload">The payload the application built; null for an event that carries none.</param>
+    /// <returns>An operator-facing sentence naming what is missing, or null to let the event go.</returns>
+    string? RefusalOf(string eventType, IEventPayload? payload);
+}

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
@@ -135,8 +135,13 @@ public sealed partial class EventDispatcher(
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(descriptor);
-        RefuseIfOutsidePolicy(descriptor);
 
+        // Deliberately unjudged. This door carries the framework's OWN signals - verification and
+        // stream-updated - minted by this library from payloads a host never built, and reached through a
+        // receiver's request: a refusal here would fire after the throttle or the status has already been
+        // written, turning a receiver's verification request into a fault mid-operation and breaking the
+        // very profile a policy was registered to claim. A policy is about what the HOST asks this
+        // transmitter to emit, and that is DispatchAsync.
         return MintAndEnqueueAsync(stream, descriptor, asStatusAnnouncement, cancellationToken);
     }
 
@@ -145,13 +150,13 @@ public sealed partial class EventDispatcher(
     /// </summary>
     /// <remarks>
     /// Asked once per event rather than once per stream: the payload is identical for every receiver, so a
-    /// per-stream answer would emit to some and withhold from others by iteration order. Asked on both
-    /// entry points, because the direct one skips every other check and would otherwise be the hole.
+    /// per-stream answer would emit to some and withhold from others by iteration order. Asked on this
+    /// entry point alone - <see cref="DispatchToStreamAsync"/> says why it is not.
     /// <para>
     /// It throws rather than dropping the event with a log line, and the choice is not a preference. A
     /// dropped <c>session-revoked</c> is a revocation that never happens, which is a worse outcome than a
-    /// non-conformant event; and the caller is the application code that built the payload, so the throw
-    /// reaches whoever can fix it. Nothing throws unless the host registered a policy.
+    /// non-conformant event; and on this path the caller is the application code that built the payload,
+    /// so the throw reaches whoever can fix it. Nothing throws unless the host registered a policy.
     /// </para>
     /// </remarks>
     /// <exception cref="InvalidOperationException">The policy refused the event.</exception>

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
@@ -7,6 +7,7 @@
 
 using Abblix.SecurityEvents;
 using Abblix.SecurityEvents.Abstractions;
+using Abblix.SecurityEvents.Events;
 using Abblix.SecurityEvents.Subjects;
 using Abblix.SharedSignals.Model;
 
@@ -33,6 +34,11 @@ namespace Abblix.SharedSignals.Transmitter;
 /// </param>
 /// <param name="clock">Supplies "iat"; null takes the system clock.</param>
 /// <param name="logger">Records the streams a fan-out could not reach.</param>
+/// <param name="payloadPolicy">
+/// What this deployment refuses to emit, over and above what the event vocabulary permits - how a
+/// deployment claims a profile such as the CAEP Interoperability Profile. Null emits whatever the host
+/// builds, which is what a transmitter claiming no profile does.
+/// </param>
 public sealed partial class EventDispatcher(
     ILogger<EventDispatcher> logger,
     IStreamStore streams,
@@ -40,6 +46,7 @@ public sealed partial class EventDispatcher(
     ISecurityEventTokenSigner signer,
     string issuer,
     IEventSharingPolicy? sharingPolicy = null,
+    IEventPayloadPolicy? payloadPolicy = null,
     TimeProvider? clock = null)
 {
     private readonly string _issuer = !string.IsNullOrEmpty(issuer)
@@ -58,6 +65,7 @@ public sealed partial class EventDispatcher(
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
+        RefuseIfOutsidePolicy(descriptor);
 
         var reached = 0;
         foreach (var stream in await streams.ListAllAsync(cancellationToken))
@@ -127,8 +135,32 @@ public sealed partial class EventDispatcher(
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(descriptor);
+        RefuseIfOutsidePolicy(descriptor);
 
         return MintAndEnqueueAsync(stream, descriptor, asStatusAnnouncement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Refuses an event this deployment has undertaken not to emit, before anything is minted.
+    /// </summary>
+    /// <remarks>
+    /// Asked once per event rather than once per stream: the payload is identical for every receiver, so a
+    /// per-stream answer would emit to some and withhold from others by iteration order. Asked on both
+    /// entry points, because the direct one skips every other check and would otherwise be the hole.
+    /// <para>
+    /// It throws rather than dropping the event with a log line, and the choice is not a preference. A
+    /// dropped <c>session-revoked</c> is a revocation that never happens, which is a worse outcome than a
+    /// non-conformant event; and the caller is the application code that built the payload, so the throw
+    /// reaches whoever can fix it. Nothing throws unless the host registered a policy.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The policy refused the event.</exception>
+    private void RefuseIfOutsidePolicy(SecurityEventDescriptor descriptor)
+    {
+        if (payloadPolicy?.RefusalOf(descriptor.EventType, descriptor.Payload) is { } refusal)
+        {
+            throw new InvalidOperationException(refusal);
+        }
     }
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
+++ b/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
@@ -33,6 +33,10 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Abblix.SharedSignals\Abblix.SharedSignals.csproj" />
+
+        <!-- The CAEP profile policy and the dispatcher that consults it ship in packages that do not
+             reference each other, so only a test holding both can prove the pair actually runs. -->
+        <ProjectReference Include="..\..\src\Abblix.SecurityEvents.CAEP\Abblix.SecurityEvents.CAEP.csproj" />
     </ItemGroup>
 
 

--- a/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
@@ -273,15 +273,27 @@ public sealed class CaepInteropProfileDispatchTests
     /// <c>reason_admin</c> - a statement about contents nothing had read. The pair is the point: same
     /// class, opposite verdicts, decided by the member.
     /// </remarks>
+    /// <remarks>
+    /// The empty-object row is its own, and it is what holds the relayed arm's NON-EMPTY half: with only
+    /// an absent member and a populated one, weakening <c>is JsonObject { Count: &gt; 0 }</c> to
+    /// <c>is JsonObject</c> leaves the whole suite green, because the typed arm's holder cannot see the
+    /// relayed one.
+    /// </remarks>
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ARelayedPayload_IsJudgedByItsJson(bool populated)
+    [InlineData(RelayedMember.Populated)]
+    [InlineData(RelayedMember.Absent)]
+    [InlineData(RelayedMember.EmptyObject)]
+    public async Task ARelayedPayload_IsJudgedByItsJson(RelayedMember member)
     {
+        var populated = member is RelayedMember.Populated;
         var json = new JsonObject();
         if (populated)
         {
             json[CaepClaimNames.ReasonAdmin] = new JsonObject { ["en"] = "Landspeed policy violation" };
+        }
+        else if (member is RelayedMember.EmptyObject)
+        {
+            json[CaepClaimNames.ReasonAdmin] = new JsonObject();
         }
 
         var (dispatcher, outbox, _) = await CreateAsync(
@@ -391,6 +403,19 @@ public sealed class CaepInteropProfileDispatchTests
             // ANSWERED rather than refused.
             Assert.Equal(0, await dispatcher.DispatchAsync(descriptor, Cancellation));
         }
+    }
+
+    /// <summary>What a relayed payload's <c>reason_admin</c> looks like on the wire.</summary>
+    public enum RelayedMember
+    {
+        /// <summary>A non-empty object, which is what the profile asks a transmitter for.</summary>
+        Populated,
+
+        /// <summary>No member at all.</summary>
+        Absent,
+
+        /// <summary>The member present and empty, which CAEP 1.0 Section 2 refuses on its own.</summary>
+        EmptyObject,
     }
 
     private static CancellationToken Cancellation => TestContext.Current.CancellationToken;

--- a/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
@@ -1,0 +1,272 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using Abblix.Jwt;
+using Abblix.SecurityEvents;
+using Abblix.SecurityEvents.Abstractions;
+using Abblix.SecurityEvents.CAEP;
+using Abblix.SecurityEvents.Events;
+using Abblix.SecurityEvents.Subjects;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Model.Delivery;
+using Abblix.SharedSignals.Transmitter;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Abblix.SharedSignals.UnitTests;
+
+/// <summary>
+/// The CAEP Interoperability Profile's demand on a transmitter, driven through the dispatcher with the
+/// real policy rather than a stand-in, because the two live in packages that do not reference each other.
+/// </summary>
+/// <remarks>
+/// Section 3 of the profile opens "An implementation conforming to this profile MUST support at least one
+/// of the following use cases", and each of the three demands the same member: 3.1 "The reason_admin field
+/// of the event MUST be populated with a non-empty object", 3.2 and 3.3 "Transmitters MUST populate this
+/// value with a non-empty object". All three land on the TRANSMITTER; nothing obliges a receiver to reject
+/// an event without it, which is why the payload type stays permissive.
+/// </remarks>
+public sealed class CaepInteropProfileDispatchTests
+{
+    private const string Issuer = "https://tr.example.com";
+
+    /// <summary>
+    /// Each of the three use cases, because a policy that recognised only <c>session-revoked</c> would
+    /// pass a suite written for the event the specification happens to name first.
+    /// </summary>
+    [Theory]
+    [InlineData(CaepEventTypes.SessionRevoked)]
+    [InlineData(CaepEventTypes.CredentialChange)]
+    [InlineData(CaepEventTypes.DeviceComplianceChange)]
+    public async Task AnEventWithNoReasonAdmin_IsRefused(string eventType)
+    {
+        var (dispatcher, outbox, _) = await CreateAsync(eventType, new CaepInteropProfilePolicy());
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DispatchAsync(Descriptor(eventType, PayloadFor(eventType)), Cancellation));
+
+        Assert.Contains(eventType, refusal.Message);
+        Assert.Contains("reason_admin", refusal.Message);
+        Assert.Empty(await outbox.PendingAsync("s-1", null, Cancellation));
+    }
+
+    /// <summary>
+    /// An empty object is its own row. <c>{}</c> deserializes to a non-null empty dictionary and is emitted
+    /// as <c>"reason_admin": {}</c>, so a check testing only for absence would let it through - and the
+    /// specification says non-empty, not present.
+    /// </summary>
+    [Fact]
+    public async Task AnEventWhoseReasonAdminIsEmpty_IsRefused()
+    {
+        var (dispatcher, _, _) = await CreateAsync(CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DispatchAsync(
+                Descriptor(
+                    CaepEventTypes.SessionRevoked,
+                    new SessionRevokedPayload { ReasonAdmin = new Dictionary<string, string>() }),
+                Cancellation));
+
+        Assert.Contains("reason_admin", refusal.Message);
+    }
+
+    [Fact]
+    public async Task AnEventCarryingReasonAdmin_IsDispatched()
+    {
+        var (dispatcher, outbox, _) = await CreateAsync(CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+
+        var reached = await dispatcher.DispatchAsync(
+            Descriptor(
+                CaepEventTypes.SessionRevoked,
+                new SessionRevokedPayload
+                {
+                    ReasonAdmin = new Dictionary<string, string> { ["en"] = "Landspeed policy violation" },
+                }),
+            Cancellation);
+
+        Assert.Equal(1, reached);
+        Assert.Single(await outbox.PendingAsync("s-1", null, Cancellation));
+    }
+
+    /// <summary>
+    /// The control that keeps every existing deployment working: the profile is a claim a deployment makes,
+    /// not a fact about the library, so a host that registered no policy dispatches what it always did.
+    /// </summary>
+    /// <remarks>
+    /// Without this row, making the check unconditional would satisfy every other row here and break each
+    /// transmitter that never claimed the profile.
+    /// </remarks>
+    [Fact]
+    public async Task WithNoPolicyRegistered_TheSameEventIsDispatched()
+    {
+        var (dispatcher, outbox, _) = await CreateAsync(CaepEventTypes.SessionRevoked, payloadPolicy: null);
+
+        var reached = await dispatcher.DispatchAsync(
+            Descriptor(CaepEventTypes.SessionRevoked, new SessionRevokedPayload()), Cancellation);
+
+        Assert.Equal(1, reached);
+        Assert.Single(await outbox.PendingAsync("s-1", null, Cancellation));
+    }
+
+    /// <summary>
+    /// An event type the profile says nothing about is dispatched with the policy on. The profile's Section
+    /// 3 names three use cases; CAEP 1.0 defines more, and the rule belongs to the three.
+    /// </summary>
+    [Fact]
+    public async Task AnEventTypeOutsideTheProfilesUseCases_IsUntouched()
+    {
+        var (dispatcher, outbox, _) = await CreateAsync(
+            CaepEventTypes.SessionEstablished, new CaepInteropProfilePolicy());
+
+        var reached = await dispatcher.DispatchAsync(
+            Descriptor(CaepEventTypes.SessionEstablished, new SessionEstablishedPayload()), Cancellation);
+
+        Assert.Equal(1, reached);
+        Assert.Single(await outbox.PendingAsync("s-1", null, Cancellation));
+    }
+
+    /// <summary>
+    /// The stream-verification path takes its own method, which skips status, delivered types, subject
+    /// coverage and the sharing policy alike - so it is where a check placed on the fan-out alone would
+    /// have a hole.
+    /// </summary>
+    [Fact]
+    public async Task TheDirectPath_IsRefusedToo()
+    {
+        var (dispatcher, _, stream) = await CreateAsync(
+            CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DispatchToStreamAsync(
+                stream,
+                Descriptor(CaepEventTypes.SessionRevoked, new SessionRevokedPayload()),
+                asStatusAnnouncement: false,
+                cancellationToken: Cancellation));
+    }
+
+    /// <summary>
+    /// The policy reaches the dispatcher the container builds, which is the only dispatcher a real
+    /// deployment ever holds.
+    /// </summary>
+    /// <remarks>
+    /// Every row above constructs the dispatcher by hand, so all of them would pass over a policy the
+    /// container never injects - a registration nobody resolves reads exactly like a working feature. This
+    /// row resolves it the way a host does, and its twin asserts the optional dependency stays optional:
+    /// a container with nothing registered must still produce a dispatcher.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ThePolicyRegisteredInTheContainer_ReachesTheDispatcher(bool claimsTheProfile)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSecurityEvents(options => options.SigningKeySource = _ => Task.FromResult<JsonWebKey>(
+            JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)));
+        services.AddSharedSignalsTransmitter(new SharedSignalsTransmitterOptions
+        {
+            Issuer = Issuer,
+            EventsSupported = [CaepEventTypes.SessionRevoked],
+            PollEndpointFactory = streamId => new Uri($"{Issuer}/ssf/poll/{streamId}"),
+        });
+
+        if (claimsTheProfile)
+        {
+            services.AddSingleton<IEventPayloadPolicy, CaepInteropProfilePolicy>();
+        }
+
+        await using var provider = services.BuildServiceProvider();
+        var dispatcher = provider.GetRequiredService<EventDispatcher>();
+        var descriptor = Descriptor(CaepEventTypes.SessionRevoked, new SessionRevokedPayload());
+
+        if (claimsTheProfile)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.DispatchAsync(descriptor, Cancellation));
+        }
+        else
+        {
+            // No stream is subscribed here, so zero is the honest answer - and the point is that it
+            // ANSWERED rather than refused.
+            Assert.Equal(0, await dispatcher.DispatchAsync(descriptor, Cancellation));
+        }
+    }
+
+    private static CancellationToken Cancellation => TestContext.Current.CancellationToken;
+
+    private static IEventPayload PayloadFor(string eventType) => eventType switch
+    {
+        CaepEventTypes.SessionRevoked => new SessionRevokedPayload(),
+        CaepEventTypes.CredentialChange => new CredentialChangePayload
+        {
+            // The profile's other two demands on this event, and the compiler already holds them: 3.2 names
+            // change_type and credential_type, and both are `required`. reason_admin is the one of the three
+            // nothing holds, which is the whole of this issue.
+            CredentialType = CredentialChangePayload.CredentialTypes.Password,
+            ChangeType = CredentialChangePayload.ChangeTypes.Revoke,
+        },
+        CaepEventTypes.DeviceComplianceChange => new DeviceComplianceChangePayload
+        {
+            PreviousStatus = DeviceComplianceChangePayload.ComplianceStatuses.Compliant,
+            CurrentStatus = DeviceComplianceChangePayload.ComplianceStatuses.NotCompliant,
+        },
+        _ => throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "No payload for this row."),
+    };
+
+    private static SecurityEventDescriptor Descriptor(string eventType, IEventPayload payload) => new()
+    {
+        EventType = eventType,
+        Subject = new EmailSubject("jdoe@example.com"),
+        Payload = payload,
+    };
+
+    private static async Task<(EventDispatcher Dispatcher, InMemoryEventOutbox Outbox, StreamState Stream)>
+        CreateAsync(string eventType, IEventPayloadPolicy? payloadPolicy)
+    {
+        var subject = new EmailSubject("jdoe@example.com");
+        var store = new InMemoryStreamStore();
+        var stream = new StreamState
+        {
+            ReceiverId = "receiver-a",
+            Status = StreamStatuses.Enabled,
+            SubjectsMode = StreamSubjectsMode.None,
+            AddedSubjects = [new StreamSubject(subject, Verified: true)],
+            RemovedSubjects = [],
+            Configuration = new StreamConfiguration
+            {
+                StreamId = "s-1",
+                Issuer = Issuer,
+                Audiences = ["https://receiver.example.com/s-1"],
+                EventsDelivered = [eventType],
+                Delivery = new PollDeliveryMethod(new Uri("https://tr.example.com/poll/s-1")),
+            },
+        };
+
+        Assert.True(await store.TryCreateAsync(stream, Cancellation));
+
+        var outbox = new InMemoryEventOutbox();
+        return (
+            new EventDispatcher(
+                NullLogger<EventDispatcher>.Instance,
+                store,
+                outbox,
+                new StubSigner(),
+                Issuer,
+                payloadPolicy: payloadPolicy),
+            outbox,
+            stream);
+    }
+
+    private sealed class StubSigner : ISecurityEventTokenSigner
+    {
+        public Task<string> SignAsync(SecurityEventToken token, CancellationToken cancellationToken = default)
+            => Task.FromResult($"signed.{token.JwtId}");
+    }
+}

--- a/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
@@ -96,7 +96,7 @@ public sealed class CaepInteropProfileDispatchTests
         var (dispatcher, outbox, _) = await CreateAsync(
             CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
             () => dispatcher.DispatchAsync(
                 new SecurityEventDescriptor
                 {
@@ -105,6 +105,10 @@ public sealed class CaepInteropProfileDispatchTests
                 },
                 Cancellation));
 
+        // The distinguishing phrase. Without it the row passes when the null arm is deleted and the event
+        // falls through to "a payload of type '' cannot be read" - a sentence naming a type that is not
+        // there, for an event that simply carries nothing.
+        Assert.Contains("not a non-empty object", refusal.Message);
         Assert.Empty(await outbox.PendingAsync("s-1", null, Cancellation));
     }
 
@@ -147,14 +151,37 @@ public sealed class CaepInteropProfileDispatchTests
     /// by a typo or by the profile's own prose, which names its use cases <c>session-revoked</c> rather
     /// than by event type URI. That value is the row.
     /// </remarks>
+    [Theory]
+    [InlineData("session-revoked")]
+    [InlineData("sesion-revoked")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AClaimedUseCaseTheProfileDoesNotDefine_IsRefusedAtConstruction(string? claimed)
+    {
+        // The array is what a configuration binder produces, so a null element is a shape a host reaches
+        // without writing one: a JSON array carrying a null, or a missing key read into the array. It sat
+        // in the first position deliberately - a search that returns the offending ELEMENT cannot tell a
+        // null it found from nothing at all, so a null here used to silence the guard for everything
+        // after it.
+        var refusal = Assert.Throws<ArgumentException>(
+            () => new CaepInteropProfilePolicy(claimed!, "sesion-change"));
+
+        // The value, not merely the list of valid ones - which the same message prints, so asserting a
+        // valid URI passes with the offending value dropped from the sentence entirely.
+        Assert.Contains(claimed is null ? "<null>" : $"'{claimed}'", refusal.Message);
+    }
+
+    /// <summary>
+    /// A null ahead of a real typo does not swallow it: the FIRST value the profile does not define is
+    /// the one named.
+    /// </summary>
     [Fact]
-    public void AClaimedUseCaseTheProfileDoesNotDefine_IsRefusedAtConstruction()
+    public void ANullAheadOfATypo_DoesNotSwallowIt()
     {
         var refusal = Assert.Throws<ArgumentException>(
-            () => new CaepInteropProfilePolicy("session-revoked"));
+            () => new CaepInteropProfilePolicy(null!, "sesion-revoked"));
 
-        Assert.Contains("session-revoked", refusal.Message);
-        Assert.Contains(CaepEventTypes.SessionRevoked, refusal.Message);
+        Assert.Contains("<null>", refusal.Message);
     }
 
     [Fact]

--- a/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
@@ -54,7 +54,11 @@ public sealed class CaepInteropProfileDispatchTests
             () => dispatcher.DispatchAsync(Descriptor(eventType, PayloadFor(eventType)), Cancellation));
 
         Assert.Contains(eventType, refusal.Message);
-        Assert.Contains("reason_admin", refusal.Message);
+
+        // The distinguishing phrase, not merely the member's name: the "cannot be read" refusal carries
+        // the event type and the member too, so a row asserting those alone passes when a CAEP payload
+        // falls through to the wrong arm.
+        Assert.Contains("not a non-empty object", refusal.Message);
         Assert.Empty(await outbox.PendingAsync("s-1", null, Cancellation));
     }
 
@@ -75,7 +79,82 @@ public sealed class CaepInteropProfileDispatchTests
                     new SessionRevokedPayload { ReasonAdmin = new Dictionary<string, string>() }),
                 Cancellation));
 
-        Assert.Contains("reason_admin", refusal.Message);
+        Assert.Contains("not a non-empty object", refusal.Message);
+    }
+
+    /// <summary>
+    /// An event carrying no payload at all is refused, which is the shape the issue was filed on.
+    /// </summary>
+    /// <remarks>
+    /// <c>SecurityEventDescriptor.Payload</c> is nullable and the builder has a branch for it, so a host
+    /// emitting <c>session-revoked</c> with nothing attached is emitting exactly the non-conformant event
+    /// this policy exists to stop - and every other refusing row here passes a payload.
+    /// </remarks>
+    [Fact]
+    public async Task AnEventWithNoPayloadAtAll_IsRefused()
+    {
+        var (dispatcher, outbox, _) = await CreateAsync(
+            CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DispatchAsync(
+                new SecurityEventDescriptor
+                {
+                    EventType = CaepEventTypes.SessionRevoked,
+                    Subject = new EmailSubject("jdoe@example.com"),
+                },
+                Cancellation));
+
+        Assert.Empty(await outbox.PendingAsync("s-1", null, Cancellation));
+    }
+
+    /// <summary>
+    /// A member that is present and non-empty but not an object is refused for what it IS, not for being
+    /// absent.
+    /// </summary>
+    /// <remarks>
+    /// Reachable only through the relayed arm, since a wrongly typed member on a typed payload fails at
+    /// deserialization. Saying "absent or empty" of a member sitting right there sends a host debugging
+    /// its relay upstream to look for something that is not missing.
+    /// </remarks>
+    [Theory]
+    [InlineData("\"a message\"")]
+    [InlineData("[\"en\"]")]
+    [InlineData("0")]
+    public async Task ARelayedMemberOfTheWrongKind_IsRefusedForWhatItIs(string rawValue)
+    {
+        var json = new JsonObject
+        {
+            [CaepClaimNames.ReasonAdmin] = JsonNode.Parse(rawValue),
+        };
+        var (dispatcher, _, _) = await CreateAsync(
+            CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DispatchAsync(
+                Descriptor(CaepEventTypes.SessionRevoked, new UnknownEventPayload(json)), Cancellation));
+
+        Assert.Contains("not a non-empty object", refusal.Message);
+        Assert.DoesNotContain("absent", refusal.Message);
+    }
+
+    /// <summary>
+    /// A claimed use case the profile does not define is refused at construction, not at dispatch.
+    /// </summary>
+    /// <remarks>
+    /// Left unchecked, it would produce a policy that is registered, resolvable, consulted on every event
+    /// and refuses nothing - the quietly non-conformant transmitter this class exists to prevent, reached
+    /// by a typo or by the profile's own prose, which names its use cases <c>session-revoked</c> rather
+    /// than by event type URI. That value is the row.
+    /// </remarks>
+    [Fact]
+    public void AClaimedUseCaseTheProfileDoesNotDefine_IsRefusedAtConstruction()
+    {
+        var refusal = Assert.Throws<ArgumentException>(
+            () => new CaepInteropProfilePolicy("session-revoked"));
+
+        Assert.Contains("session-revoked", refusal.Message);
+        Assert.Contains(CaepEventTypes.SessionRevoked, refusal.Message);
     }
 
     [Fact]

--- a/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
@@ -5,6 +5,7 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.SecurityEvents;
 using Abblix.SecurityEvents.Abstractions;
@@ -133,22 +134,109 @@ public sealed class CaepInteropProfileDispatchTests
     }
 
     /// <summary>
-    /// The stream-verification path takes its own method, which skips status, delivered types, subject
-    /// coverage and the sharing policy alike - so it is where a check placed on the fan-out alone would
-    /// have a hole.
+    /// The framework's own door is not judged, and that is a decision rather than an oversight.
     /// </summary>
+    /// <remarks>
+    /// It carries verification and stream-updated events, minted by this library and reached through a
+    /// receiver's own request. Its callers write state first - the verification throttle, the stream
+    /// status - so a refusal there would fire mid-operation and turn a conformant receiver's verification
+    /// request into a fault, breaking the very profile the policy was registered to claim. A policy speaks
+    /// about what the HOST asks this transmitter to emit.
+    /// </remarks>
     [Fact]
-    public async Task TheDirectPath_IsRefusedToo()
+    public async Task TheFrameworksOwnDoor_IsNotJudged()
     {
-        var (dispatcher, _, stream) = await CreateAsync(
+        var (dispatcher, outbox, stream) = await CreateAsync(
             CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => dispatcher.DispatchToStreamAsync(
-                stream,
-                Descriptor(CaepEventTypes.SessionRevoked, new SessionRevokedPayload()),
-                asStatusAnnouncement: false,
-                cancellationToken: Cancellation));
+        await dispatcher.DispatchToStreamAsync(
+            stream,
+            Descriptor(CaepEventTypes.SessionRevoked, new SessionRevokedPayload()),
+            asStatusAnnouncement: false,
+            cancellationToken: Cancellation);
+
+        Assert.Single(await outbox.PendingAsync("s-1", null, Cancellation));
+    }
+
+    /// <summary>
+    /// A relayed event is judged by what its JSON carries, not by which C# class holds it.
+    /// </summary>
+    /// <remarks>
+    /// An event of an unregistered type arrives as raw JSON and can be re-dispatched. Judging it by its
+    /// class would refuse a fully conformant event while telling its owner it carries no
+    /// <c>reason_admin</c> - a statement about contents nothing had read. The pair is the point: same
+    /// class, opposite verdicts, decided by the member.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ARelayedPayload_IsJudgedByItsJson(bool populated)
+    {
+        var json = new JsonObject();
+        if (populated)
+        {
+            json[CaepClaimNames.ReasonAdmin] = new JsonObject { ["en"] = "Landspeed policy violation" };
+        }
+
+        var (dispatcher, outbox, _) = await CreateAsync(
+            CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+        var descriptor = Descriptor(CaepEventTypes.SessionRevoked, new UnknownEventPayload(json));
+
+        if (populated)
+        {
+            Assert.Equal(1, await dispatcher.DispatchAsync(descriptor, Cancellation));
+            Assert.Single(await outbox.PendingAsync("s-1", null, Cancellation));
+        }
+        else
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.DispatchAsync(descriptor, Cancellation));
+        }
+    }
+
+    /// <summary>
+    /// A payload this policy cannot read is refused, and told so in those words.
+    /// </summary>
+    /// <remarks>
+    /// The third answer, and it needs its own message. Saying "this event carries none" of a payload
+    /// nothing read is a false statement about contents, and it sends a host looking for a member that may
+    /// well be there.
+    /// </remarks>
+    [Fact]
+    public async Task APayloadThisPolicyCannotRead_IsRefusedInThoseWords()
+    {
+        var (dispatcher, _, _) = await CreateAsync(
+            CaepEventTypes.SessionRevoked, new CaepInteropProfilePolicy());
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.DispatchAsync(
+                Descriptor(CaepEventTypes.SessionRevoked, new HostsOwnPayload()), Cancellation));
+
+        Assert.Contains("cannot be read", refusal.Message);
+        Assert.Contains(nameof(HostsOwnPayload), refusal.Message);
+    }
+
+    /// <summary>
+    /// A deployment claiming one use case may still emit the others as plain CAEP 1.0 events.
+    /// </summary>
+    /// <remarks>
+    /// The profile's Section 1 says so outright: "Support for all use cases listed herein is not required
+    /// in order to be considered compliant with this profile. An implementation can choose specific use
+    /// cases to support." Enforcing all three on a deployment that claimed one refuses an event both
+    /// documents permit, and the only escape would have been to drop enforcement on the claimed one too.
+    /// </remarks>
+    [Fact]
+    public async Task AnUnclaimedUseCase_IsLeftToCaep10()
+    {
+        var (dispatcher, outbox, _) = await CreateAsync(
+            CaepEventTypes.SessionRevoked,
+            new CaepInteropProfilePolicy(CaepEventTypes.CredentialChange));
+
+        var reached = await dispatcher.DispatchAsync(
+            Descriptor(CaepEventTypes.SessionRevoked, new SessionRevokedPayload()), Cancellation);
+
+        Assert.Equal(1, reached);
+        Assert.Single(await outbox.PendingAsync("s-1", null, Cancellation));
     }
 
     /// <summary>
@@ -206,9 +294,9 @@ public sealed class CaepInteropProfileDispatchTests
         CaepEventTypes.SessionRevoked => new SessionRevokedPayload(),
         CaepEventTypes.CredentialChange => new CredentialChangePayload
         {
-            // The profile's other two demands on this event, and the compiler already holds them: 3.2 names
-            // change_type and credential_type, and both are `required`. reason_admin is the one of the three
-            // nothing holds, which is the whole of this issue.
+            // Required by CAEP 1.0 Section 3.3.1, which is why the compiler holds them. The profile
+            // says something weaker about the pair - "Transmitters MAY generate any allowable value of
+            // this field" - and something stronger about reason_admin, which is the member nothing held.
             CredentialType = CredentialChangePayload.CredentialTypes.Password,
             ChangeType = CredentialChangePayload.ChangeTypes.Revoke,
         },
@@ -263,6 +351,9 @@ public sealed class CaepInteropProfileDispatchTests
             outbox,
             stream);
     }
+
+    /// <summary>A payload of the host's own, which this policy has no way to read.</summary>
+    private sealed class HostsOwnPayload : IEventPayload;
 
     private sealed class StubSigner : ISecurityEventTokenSigner
     {


### PR DESCRIPTION
Closes #445.

## What the profile demands, read at source

From the draft-01 source in `openid/sharedsignals`, not from a summary of it. Section 3 opens:

> An implementation conforming to this profile MUST support at least one of the following use cases.

And every one of the three demands the same member. Section 3.1:

> The `reason_admin` field of the event MUST be populated with a non-empty object.

Sections 3.2 and 3.3 name the actor outright:

> `reason_admin` : Transmitters MUST populate this value with a non-empty object

`EventDispatcher` never inspects a payload - it filters by stream status, delivered types, subject coverage and the sharing policy, then mints - so an Abblix transmitter emitted `session-revoked` with an empty statement and failed 3.1, with nothing said at build time or at dispatch.

One rule the policy applies belongs to CAEP 1.0 rather than to the profile: `reason_admin`, once present, "MUST contain one or more key/value pairs" (Section 2). An empty object is outside the base specification too.

## Why the rule cannot go on the type

CAEP 1.0 Section 2 makes the common claims optional and Section 3.1.1 defines no event-specific claim for `session-revoked`, so an empty payload is well-formed under the base specification and a receiver has to be able to hold one. A contract test pins that, and it is right. Making the property `required` would break the receive side.

## The shape

`Abblix.SharedSignals` does not reference `Abblix.SecurityEvents.CAEP`; they are siblings over `Abblix.SecurityEvents`. So the dispatcher cannot name `CaepEventPayload`, and the rule arrives through an abstraction both see.

`IEventPayloadPolicy` lives in the core for exactly that reason: the rule belongs to the vocabulary that defines the payload, and the moment it must be asked belongs to the transmitter. `CaepInteropProfilePolicy` implements it, and registering the class is how a deployment CLAIMS the profile:

```csharp
services.AddSingleton<IEventPayloadPolicy, CaepInteropProfilePolicy>();
```

It follows the shape already in this dispatcher for the sharing policy of SSF Section 9.2 - an optional dependency, null by default - rather than introducing a second one. The CAEP package gains no dependency: it defines the class, the host registers it, exactly as for `IEventSharingPolicy`.

**The profile lets a deployment claim fewer than three use cases**, and says so outright in Section 1: "Support for all use cases listed herein is not required in order to be considered compliant with this profile. An implementation can choose specific use cases to support." So the policy takes the claimed ones and leaves the rest to CAEP 1.0. The default is all three, deliberately: a transmitter that has not thought about it is better refused than quietly non-conformant.

**It judges the wire member, not the C# class.** An event of an unregistered type arrives as raw JSON and can be re-dispatched; judging it by its type would refuse a fully conformant relay. A payload the policy genuinely cannot read - a host's own `IEventPayload` - is refused too, and told exactly that, because "this event carries none" would be a statement about contents nothing had read.

## Where it runs, and where it deliberately does not

Once per event, before the fan-out. The payload is identical for every receiver, so a per-stream answer would emit to some and withhold from others by iteration order.

`DispatchToStreamAsync` is NOT judged. It carries the framework's own signals - verification and stream-updated - minted here from payloads no host built and reached through a receiver's request, and its callers write state first: a refusal would fire after the verification throttle or the stream status had been written, turning a conformant receiver's verification request into a fault and breaking the profile the policy exists to claim.

That leaves the issue's request to "name the stream" unanswerable, and it is: there is no stream at that point. The refusal names the event type and the member.

## Throw, and why it was not asked

The issue leaves this open between a throw and a dropped event with a log line. Two things already settled here decide it. `StreamManagementService.RefusalOf` throws for the reason it states - "silent is a refusal dressed as an acceptance, which is the one shape a caller cannot detect". And a dropped `session-revoked` is a revocation that never happens: between a non-conformant event and no event at all, the security failure is the second. On the path that is judged, the caller is the application code that built the payload.

Nothing throws unless the deployment registered the policy.

## Evidence

CI is green on this head, and the mutations below were each built rather than run under `--no-build`, with the printed `Error(s)` count read before any test result.

- Weakening the criterion from non-empty to merely present is caught by the row written for the empty object - `{}` deserializes to a non-null dictionary and is emitted as written, so that row is the only one separating the two readings.
- Dropping the condition entirely, so any CAEP payload passes, is caught by the three use-case rows, the empty-object row and the container row.
- Accepting any string as a claimed use case is caught by the theory over four claimed values, including the null one; restoring the old "absent or empty" wording is caught by the three wrong-JSON-kind rows.
- Deleting the `null => false` arm is caught by the no-payload row, which asserts the distinguishing phrase for exactly that reason.
- Weakening the RELAYED arm alone - accepting any object rather than a populated one - survived until a review measured it, because the theory over relayed payloads carried an absent member and a populated one and nothing between. It now names the three shapes a member takes on the wire, and the empty object is the row that goes red.

One attempted mutation did not build, and its `Error(s)` count was read before any test number: removing the call to the check leaves the private method unused, which the analyser refuses under `S1144`. `--no-build` after it would have reported the previous binary as green.

The controls, which assert what the change must not alter - they cannot literally run against `develop`, since they name a constructor parameter it does not have: a host that registered no policy dispatches what it always did; a CAEP event carrying the member goes out; an event type outside the claimed use cases is untouched; the framework's own door is unjudged.

Two rows resolve the dispatcher from a real container rather than constructing it, because every other row builds it by hand and would pass over a policy the container never injects - a registration nobody resolves reads exactly like a working feature. That pair earned its place immediately: it is what caught that a container cannot satisfy a `params` array, so `AddSingleton<IEventPayloadPolicy, CaepInteropProfilePolicy>()` - the registration this README shows - compiled and then failed on first resolve.

Measured on the state this branch would merge to, with `develop` merged in rather than inferred from two green branches.

## What a second review changed

Two failures of the same kind, both silent in the permissive direction. The policy took any string as a claimed use case, so a typo - or the short name the profile's own prose uses, `session-revoked` rather than the event type URI - left it registered, resolvable, consulted on every event and refusing nothing: the quietly non-conformant transmitter this class exists to prevent. It is refused when the policy is built, with the value in the message.

And the relayed arm answered "absent or empty" for a member present and non-empty but not an object. The contents had been read, and the sentence mischaracterised them - which sends a host debugging a relay upstream to look for something that is not missing.

Two refusal rows also asserted only the member's name, which the cannot-be-read message carries too, so neither could name its own cause; and the shape this issue was filed on - an event with no payload at all - had no row anywhere.

## What the first review changed

Four sentences attributed to CAEP 1.0 Section 3.1.1 a requirement that an empty `session-revoked` payload "be accepted". That section's only MUST is about `event_timestamp`, and the word "accept" occurs zero times in the document - a permission promoted to a demand because a demand argues better for a decision already made. One grep settles it, and the same reading turned up the non-empty rule the base specification does carry.

The refusal tested a C# class and then asserted something about contents; the framework's own door was judged and would have faulted mid-operation; the policy enforced three use cases where the profile permits claiming one; and a test comment called `change_type` and `credential_type` "the profile's other two demands" where the profile says "Transmitters MAY generate any allowable value of this field" - what makes them `required` is CAEP 1.0 Section 3.3.1.

## Stacking

#466 has landed and `develop` is merged in, so the suite quoted above ran on the state this branch merges to rather than being inferred from two green branches.
