### PR TITLE
Say that new streams cover nothing, because a conformant receiver will not

### DIFF
--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -33,6 +33,11 @@ builder.Services
         Issuer = "https://tr.example.com",
         EventsSupported = ["https://schemas.openid.net/secevent/caep/event-type/session-revoked"],
         JwksUri = new Uri("https://tr.example.com/.well-known/jwks.json"),
+
+        // A receiver following the CAEP Interoperability Profile adds no subjects, so a transmitter
+        // targeting that profile covers them all. Leave it out and new streams cover nothing until a
+        // subject is named - which the startup log says, because neither side would.
+        DefaultSubjectsMode = StreamSubjectsMode.All,
     });
 
 var app = builder.Build();

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
@@ -88,4 +88,34 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
             + "that the token is sufficient for the requested action, and Section 2.7.3 defines "
             + "ssf.read and ssf.manage as what sufficient means.")]
     private static partial void LogScopeCheckingDisabled(ILogger logger);
+
+    /// <summary>
+    /// A new stream covers no subject until the receiver names one, and a receiver following the profile
+    /// never will.
+    /// </summary>
+    /// <remarks>
+    /// The quietest of the set, and the reason it is worth saying out loud. Nothing is refused and nothing
+    /// is logged at delivery: the dispatcher matches no stream, answers zero, and a receiver that is doing
+    /// exactly what Section 2.4.4 tells it to do waits forever on a stream that reads as healthy on both
+    /// sides. There is no error on the wire and nothing in the stream status to distinguish it from a quiet
+    /// period.
+    /// <para>
+    /// A warning rather than a refusal, and the default is not flipped, because the two readings are both
+    /// defensible: covering nothing until a subject is named is what keeps a misconfigured stream from
+    /// leaking, and covering everything is what an interoperable transmitter does. The profile binds only
+    /// the receiver here - Section 2.3 imposes no mirror - so this is a deployment's choice, and the only
+    /// thing wrong with it was that it was made silently.
+    /// </para>
+    /// </remarks>
+    [LoggerMessage(
+        EventId = LogEvents.Transmitter.NoSubjectsIncludedByDefault,
+        Level = LogLevel.Warning,
+        Message = "New streams will cover no subject: "
+            + "SharedSignalsTransmitterOptions.DefaultSubjectsMode is None, so a stream delivers only to "
+            + "subjects added through the Add Subject API. The CAEP Interoperability Profile 1.0 Section "
+            + "2.4.4 tells a receiver to \"assume that all subjects are implicitly included in a Stream, "
+            + "without any Add Subject method invocations\", so a conformant receiver adds none and "
+            + "receives nothing, silently. Set DefaultSubjectsMode to All, or keep None knowing that this "
+            + "transmitter expects its receivers to name their subjects.")]
+    private static partial void LogNoSubjectsIncludedByDefault(ILogger logger);
 }

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
@@ -97,9 +97,14 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// The quietest of the set, and the reason it is worth saying out loud. Nothing is refused and nothing
     /// is logged at delivery: the dispatcher matches no stream, answers zero, and a receiver that is doing
     /// exactly what Section 2.4.4 tells it to do waits forever on a stream that reads as healthy on both
-    /// sides. What IS on the wire is the configuration document, which publishes
+    /// sides - and healthy is not a figure of speech. Stream Verification goes through the door that
+    /// bypasses subject coverage, so a receiver asking this transmitter to prove the stream works gets its
+    /// verification event and concludes the stream is live, while no real event will ever arrive.
+    /// <para>
+    /// What IS on the wire is the configuration document, which publishes
     /// <c>"default_subjects": "NONE"</c> (SSF 1.0 Section 7.1) - so the fact is discoverable, by a receiver
     /// that fetched the document and read a member the profile never told it to act on.
+    /// </para>
     /// <para>
     /// A warning rather than a refusal, and the default is not flipped, because the two readings are both
     /// defensible: covering nothing until a subject is named is what keeps a misconfigured stream from
@@ -118,8 +123,10 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
             + "without any Add Subject method invocations\", so a conformant receiver adds none and "
             + "receives nothing, silently. Set DefaultSubjectsMode to All, or keep None knowing that this "
             + "transmitter expects its receivers to name their subjects. Setting it reaches only streams "
-            + "created afterwards: a stream takes its mode at creation, so any stream already stored keeps "
-            + "covering nothing and must be deleted and created again - and this warning goes quiet as "
-            + "soon as the option changes, whether or not those streams were dealt with.")]
+            + "created afterwards, and this warning goes quiet as soon as the option changes - so whether "
+            + "any stream is left behind depends on where streams live: the in-memory store keeps none "
+            + "across the restart the change requires, a configured stream set re-scopes them from the "
+            + "declaration on the next reconcile, and a store that outlives the process keeps them at the "
+            + "mode they were created with.")]
     private static partial void LogNoSubjectsIncludedByDefault(ILogger logger);
 }

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
@@ -97,8 +97,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// The quietest of the set, and the reason it is worth saying out loud. Nothing is refused and nothing
     /// is logged at delivery: the dispatcher matches no stream, answers zero, and a receiver that is doing
     /// exactly what Section 2.4.4 tells it to do waits forever on a stream that reads as healthy on both
-    /// sides. There is no error on the wire and nothing in the stream status to distinguish it from a quiet
-    /// period.
+    /// sides. What IS on the wire is the configuration document, which publishes
+    /// <c>"default_subjects": "NONE"</c> (SSF 1.0 Section 7.1) - so the fact is discoverable, by a receiver
+    /// that fetched the document and read a member the profile never told it to act on.
     /// <para>
     /// A warning rather than a refusal, and the default is not flipped, because the two readings are both
     /// defensible: covering nothing until a subject is named is what keeps a misconfigured stream from
@@ -116,6 +117,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
             + "2.4.4 tells a receiver to \"assume that all subjects are implicitly included in a Stream, "
             + "without any Add Subject method invocations\", so a conformant receiver adds none and "
             + "receives nothing, silently. Set DefaultSubjectsMode to All, or keep None knowing that this "
-            + "transmitter expects its receivers to name their subjects.")]
+            + "transmitter expects its receivers to name their subjects. Setting it reaches only streams "
+            + "created afterwards: a stream takes its mode at creation, so any stream already stored keeps "
+            + "covering nothing and must be deleted and created again - and this warning goes quiet as "
+            + "soon as the option changes, whether or not those streams were dealt with.")]
     private static partial void LogNoSubjectsIncludedByDefault(ILogger logger);
 }

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -253,6 +253,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         if ((services.GetService<SharedSignalsEndpointOptions>() ?? DefaultEndpointOptions)
             .GrantedScopesSelector is null)
             LogScopeCheckingDisabled(logger);
+
+        if (options.DefaultSubjectsMode is StreamSubjectsMode.None)
+            LogNoSubjectsIncludedByDefault(logger);
     }
 
     private static bool IsOAuth(JsonObject scheme)

--- a/src/Abblix.SharedSignals/LogEvents.cs
+++ b/src/Abblix.SharedSignals/LogEvents.cs
@@ -55,5 +55,8 @@ public static class LogEvents
 
         /// <summary>No scope is checked on the management API, which the CAEP profile requires.</summary>
         public const int ScopeCheckingDisabled = Base + 11;
+
+        /// <summary>A new stream covers no subject, while a conformant receiver adds none.</summary>
+        public const int NoSubjectsIncludedByDefault = Base + 12;
     }
 }

--- a/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
@@ -37,6 +37,14 @@ public sealed record SharedSignalsTransmitterOptions
     /// default is <see cref="StreamSubjectsMode.None"/>: nothing flows until the receiver names
     /// its subjects, so a misconfigured stream leaks nothing.
     /// </summary>
+    /// <remarks>
+    /// A deployment targeting the CAEP Interoperability Profile 1.0 sets this to
+    /// <see cref="StreamSubjectsMode.All"/>. Its Section 2.4.4 tells a receiver to "assume that all
+    /// subjects are implicitly included in a Stream, without any Add Subject method invocations", so a
+    /// conformant receiver adds none - and against a transmitter covering nothing by default it receives
+    /// nothing, with no error on either side to say why. The profile binds only the receiver, so the
+    /// default is left where it is and said out loud at startup instead.
+    /// </remarks>
     public StreamSubjectsMode DefaultSubjectsMode { get; init; } = StreamSubjectsMode.None;
 
     /// <summary>

--- a/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
@@ -44,6 +44,12 @@ public sealed record SharedSignalsTransmitterOptions
     /// conformant receiver adds none - and against a transmitter covering nothing by default it receives
     /// nothing, with no error on either side to say why. The profile binds only the receiver, so the
     /// default is left where it is and said out loud at startup instead.
+    /// <para>
+    /// Changing it reaches only streams created afterwards. A stream takes its mode at creation, as
+    /// <see cref="StreamSubjectsMode"/> says, so a deployment that has already stored streams under
+    /// <see cref="StreamSubjectsMode.None"/> has to delete and recreate them - and the startup warning
+    /// stops the moment this option changes, whether or not that was done.
+    /// </para>
     /// </remarks>
     public StreamSubjectsMode DefaultSubjectsMode { get; init; } = StreamSubjectsMode.None;
 

--- a/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
@@ -45,10 +45,12 @@ public sealed record SharedSignalsTransmitterOptions
     /// nothing, with no error on either side to say why. The profile binds only the receiver, so the
     /// default is left where it is and said out loud at startup instead.
     /// <para>
-    /// Changing it reaches only streams created afterwards. A stream takes its mode at creation, as
-    /// <see cref="StreamSubjectsMode"/> says, so a deployment that has already stored streams under
-    /// <see cref="StreamSubjectsMode.None"/> has to delete and recreate them - and the startup warning
-    /// stops the moment this option changes, whether or not that was done.
+    /// Changing it reaches only streams created afterwards, because a stream takes its mode at creation -
+    /// which is what keeps a later change from silently re-scoping what a receiver already has. What is
+    /// left behind therefore depends on the store: the in-memory default keeps nothing across the restart
+    /// the change requires, a configured stream set writes the declared mode over every stream on the next
+    /// reconcile, and a store outliving the process keeps its streams at the mode they were created with.
+    /// The startup warning stops the moment this option changes, in all three.
     /// </para>
     /// </remarks>
     public StreamSubjectsMode DefaultSubjectsMode { get; init; } = StreamSubjectsMode.None;

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
@@ -99,8 +99,10 @@ public sealed class CaepProfileMetadataTests
     }
 
     /// <summary>
-    /// The control for both warnings. One that fires on every deployment is not a check, and one that
-    /// fires on the DEFAULT would fire on every deployment that configures nothing.
+    /// The control for the warnings that can be silenced by configuring something. One that fires on
+    /// every deployment regardless is not a check - and the subjects-mode warning DOES fire on the
+    /// shipped default, deliberately, which is why the arrange block below has to move that option to
+    /// stay green here.
     /// </summary>
     /// <remarks>
     /// Scoped to what this check looks at, and no count is given: the list grows, and a fixture that fires

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
@@ -126,8 +126,8 @@ public sealed class CaepProfileMetadataTests
     }
 
     /// <summary>
-    /// A transmitter whose new streams cover nothing is told so, because a receiver following the profile
-    /// will never populate one and neither side will say why.
+    /// A transmitter whose new streams would cover nothing is told so, because a receiver following the
+    /// profile will never populate one.
     /// </summary>
     /// <remarks>
     /// Section 2.4.4 tells the receiver to "assume that all subjects are implicitly included in a Stream,
@@ -135,9 +135,14 @@ public sealed class CaepProfileMetadataTests
     /// is not a clause a deployment violates - which is exactly why the default is left alone and the
     /// consequence is said out loud instead. The failure it prevents is the quietest kind: the dispatcher
     /// matches no stream, answers zero, and the receiver waits on a stream that reads as healthy.
+    /// <para>
+    /// The check reads the OPTION, which is what the name says: a declared stream set carries its own
+    /// <c>SubjectsMode</c> and this cannot see it, so a configured stream at <c>None</c> is warned about
+    /// by nothing.
+    /// </para>
     /// </remarks>
     [Fact]
-    public async Task ATransmitterWhoseStreamsCoverNoSubject_IsWarnedAtStartup()
+    public async Task ATransmitterWhoseNewStreamsWouldCoverNoSubject_IsWarnedAtStartup()
     {
         var recorder = new RecordingProvider();
 
@@ -266,9 +271,10 @@ public sealed class CaepProfileMetadataTests
                 JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)));
         builder.Services.AddSharedSignalsTransmitter(options);
 
-        // Scope checking is the third thing the startup check looks at, so a fixture asserting NO warning
-        // has to be inside the profile on that count too - otherwise it is asserting the absence of two
-        // warnings while a third fires, which is a criterion that stops meaning what its name says.
+        // Scope checking is one of the things the startup check looks at, so a fixture asserting NO
+        // warning has to be inside the profile on that count too - otherwise it is asserting the absence
+        // of the warnings it means while another fires, which is a criterion that stops meaning what its
+        // name says. No count, because the list grows and a count in a comment does not.
         if (checksScopes)
         {
             builder.Services.AddSingleton(new SharedSignalsEndpointOptions

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
@@ -103,12 +103,12 @@ public sealed class CaepProfileMetadataTests
     /// fires on the DEFAULT would fire on every deployment that configures nothing.
     /// </summary>
     /// <remarks>
-    /// Scoped to the three things this check looks at. A fixture that fires none of them is not thereby
-    /// conformant overall: the check speaks about what a host configured, and the profile has requirements
-    /// no configuration can be wrong about.
+    /// Scoped to what this check looks at, and no count is given: the list grows, and a fixture that fires
+    /// none of them is not thereby conformant overall - the check speaks about what a host configured, and
+    /// the profile has requirements no configuration can be wrong about.
     /// </remarks>
     [Fact]
-    public async Task AHostInsideTheProfileOnAllThree_IsNotWarned()
+    public async Task AHostInsideTheProfile_IsNotWarned()
     {
         var recorder = new RecordingProvider();
 
@@ -117,11 +117,33 @@ public sealed class CaepProfileMetadataTests
             {
                 JwksUri = new Uri($"{Issuer}/jwks"),
                 AuthorizationSchemes = [SchemeOf(SchemeUrns.OAuth2)],
+                DefaultSubjectsMode = StreamSubjectsMode.All,
             },
             recorder,
             checksScopes: true);
 
         Assert.Empty(recorder.Warnings);
+    }
+
+    /// <summary>
+    /// A transmitter whose new streams cover nothing is told so, because a receiver following the profile
+    /// will never populate one and neither side will say why.
+    /// </summary>
+    /// <remarks>
+    /// Section 2.4.4 tells the receiver to "assume that all subjects are implicitly included in a Stream,
+    /// without any Add Subject method invocations". Section 2.3 puts no mirror on the transmitter, so this
+    /// is not a clause a deployment violates - which is exactly why the default is left alone and the
+    /// consequence is said out loud instead. The failure it prevents is the quietest kind: the dispatcher
+    /// matches no stream, answers zero, and the receiver waits on a stream that reads as healthy.
+    /// </remarks>
+    [Fact]
+    public async Task ATransmitterWhoseStreamsCoverNoSubject_IsWarnedAtStartup()
+    {
+        var recorder = new RecordingProvider();
+
+        await using var host = await StartAsync(BaseOptions(), recorder);
+
+        Assert.Contains(recorder.Warnings, message => message.Contains("DefaultSubjectsMode"));
     }
 
     /// <summary>
@@ -154,6 +176,7 @@ public sealed class CaepProfileMetadataTests
             {
                 JwksUri = new Uri($"{Issuer}/jwks"),
                 AuthorizationSchemes = [],
+                DefaultSubjectsMode = StreamSubjectsMode.All,
             },
             recorder,
             checksScopes: true);

--- a/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
@@ -116,6 +116,36 @@ public class EventDispatcherTests
         Assert.True(minted.Events.TryGetPayload(MembershipChanged, out _));
     }
 
+    /// <summary>
+    /// A stream nobody added a subject to: everything under <c>All</c>, nothing under <c>None</c>.
+    /// </summary>
+    /// <remarks>
+    /// The pair is what a conformant receiver meets. The CAEP Interoperability Profile 1.0 Section 2.4.4
+    /// tells it to "assume that all subjects are implicitly included in a Stream, without any Add Subject
+    /// method invocations", so it adds none - and against a transmitter whose new streams cover nothing it
+    /// receives nothing, with no error on either side. Two rows rather than one because the row that
+    /// matters is the one that answers ZERO: a suite asserting only that <c>All</c> delivers would go on
+    /// passing if <c>None</c> quietly started delivering too.
+    /// </remarks>
+    [Theory]
+    [InlineData(StreamSubjectsMode.All, 1)]
+    [InlineData(StreamSubjectsMode.None, 0)]
+    public async Task AStreamWithNoAddedSubjects_DeliversByItsMode(StreamSubjectsMode mode, int expected)
+    {
+        var subject = new EmailSubject("jdoe@example.com");
+        var (dispatcher, outbox, _) = await CreateDispatcherAsync(
+            policy: null,
+            CreateStream("s-1", mode: mode));
+
+        var reached = await dispatcher.DispatchAsync(
+            Descriptor(subject), TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, reached);
+        Assert.Equal(
+            expected,
+            (await outbox.PendingAsync("s-1", null, TestContext.Current.CancellationToken)).Count);
+    }
+
     [Fact]
     public async Task Dispatch_SkipsWhatDoesNotMatch()
     {

--- a/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
@@ -123,9 +123,10 @@ public class EventDispatcherTests
     /// The pair is what a conformant receiver meets. The CAEP Interoperability Profile 1.0 Section 2.4.4
     /// tells it to "assume that all subjects are implicitly included in a Stream, without any Add Subject
     /// method invocations", so it adds none - and against a transmitter whose new streams cover nothing it
-    /// receives nothing, with no error on either side. Two rows rather than one because the row that
-    /// matters is the one that answers ZERO: a suite asserting only that <c>All</c> delivers would go on
-    /// passing if <c>None</c> quietly started delivering too.
+    /// receives nothing, with no error on either side. What each row uniquely holds is the EMPTY list on
+    /// its own side, measured rather than asserted: narrowing <c>None</c> to also cover a stream with no
+    /// added subjects kills this row alone out of the suite, and widening <c>All</c> to require a
+    /// non-empty removed list kills the other alone.
     /// </remarks>
     [Theory]
     [InlineData(StreamSubjectsMode.All, 1)]


### PR DESCRIPTION
Closes #447.

## What a conformant receiver observes

Nothing, and neither side says why.

CAEP Interoperability Profile 1.0 draft 01, Section 2.4.4:

> The Receiver MUST assume that all subjects are implicitly included in a Stream, without any Add Subject method invocations.

So a receiver following the profile adds no subjects. This transmitter's new streams cover only subjects that were added: `DefaultSubjectsMode` is `None` by default, `StreamManagementService` stamps it onto every stream the API creates, and `EventDispatcher.CoversSubject` then matches nothing. `DispatchAsync` answers zero, the events are dropped, and there is no error on the wire, nothing in the stream status, and nothing that tells this from a quiet period.

That is the worst shape a failure can take between two implementations that each believe they are conformant - and this library ships both roles.

## What is deliberately not done

The default is not flipped. Section 2.3 puts no mirror requirement on the transmitter, so the profile does not make `None` a violation, and covering nothing until a subject is named is what keeps a misconfigured stream from delivering to a receiver nobody meant it to reach. Flipping it would make an out-of-the-box transmitter disclose every subject's events to any receiver that can create a stream, on a package that also ships `IEventSharingPolicy` unset by default.

What was wrong was not the default. It was that a host could reach it without ever meeting the option.

So it is said at startup, which is what this codebase already does for the three other ways a deployment falls outside this profile: it is a working deployment and a choice the host is entitled to make, once it is making it knowingly. **If the flip is wanted anyway, it is a one-line change and a release note** - the argument above is why it is not taken silently.

## Evidence

CI is green on this head, and the mutations were built rather than run under `--no-build`.

- Firing the warning on `All` instead of `None` is caught three times over: by the new row that asserts the warning, and by both controls that assert no warning at all. Those two controls had to move inside the profile on this fourth count as part of the change, which is what a control is for.
- Narrowing `None` to also cover a stream with no added subjects is caught by that row and nothing else in the suite; widening `All` to require a non-empty removed list is caught by its twin and nothing else. Each row holds the empty list on its own side, which is what a conformant receiver actually produces.

The rows sit in `EventDispatcherTests`, where the decision is made, rather than beside the warning, which only announces it. The test that counted "all three" lost the count rather than gaining a fourth, because a count over a list that grows is the one thing in a name guaranteed to rot.

## What two reviews changed

The remedy the warning named - set the option to `All` - is true of one of the three shipped store shapes. The in-memory default keeps no stream across the restart the change requires; a configured stream set writes the declared mode over every stream on the next reconcile, so the edit is itself the re-scope and a delete would be undone by the next start. Only a store outliving the process keeps streams at the mode they were created with, and there the delete and create the instruction names are receiver-authenticated with no operator surface. What is true everywhere stays: the change reaches only new streams, and the warning goes quiet either way.

"Nothing on the wire" was false - the configuration document publishes `"default_subjects": "NONE"` unauthenticated, which is SSF 1.0 Section 7.1's member for exactly this fact. And "reads as healthy on both sides" was a figure of speech that did not need to be: Stream Verification goes through the door that bypasses subject coverage, so a receiver asking this transmitter to prove the stream works gets its verification event and concludes the stream is live.

A control's summary said a warning firing on the shipped default would fire on every deployment that configures nothing, as a reason such a warning is not a check. The one this change adds does exactly that, deliberately.
