### PR TITLE
Let a token declare that it carries one event statement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CI/CD configuration changes require admin review
-# Background: https://github.com/Abblix/Docs/blob/master/wiki/github-repository-security-setup.md
+# Background: the workspace's repository security setup guide.
 .github/workflows/  @kirill-abblix
 .github/scripts/    @kirill-abblix

--- a/.github/scripts/lint-no-cr-in-blobs.py
+++ b/.github/scripts/lint-no-cr-in-blobs.py
@@ -22,12 +22,12 @@ output - and both disagreed with reality on two committed PDFs, which are stored
 harmlessly. A check that flags files nobody can fix teaches people to wave it away, and that
 habit is what greets the true positive.
 
-WHERE THIS FILE COMES FROM. The copy under Abblix/Infrastructure at
-scripts/hooks/lint-no-cr-in-blobs.py is the one to edit; every other repository carries its
-own copy of it. pre-commit can pull a hook straight from another repository, but Oidc.Server
-is public and a contributor cloning it cannot reach a private hooks repository - and one
-repository guarded differently from the rest is worse than uniform copies. Change the
-canonical file, then copy it over the others in the same pass.
+WHERE THIS FILE COMES FROM. It is a copy. The canonical one lives in the workspace's shared
+hooks directory, and every repository carries its own copy of it. pre-commit can pull a hook
+straight from another repository, but this one is public and a contributor cloning it cannot
+reach a hooks repository they have no access to - and one repository guarded differently from
+the rest is worse than uniform copies. Change the canonical file, then copy it over the others
+in the same pass.
 
 A path may still declare a genuine need for CR by being marked `binary` or `-text` in
 .gitattributes. That is a FORM someone states deliberately, not a filename added to a list here.

--- a/.github/scripts/lint-no-split-doc-comments.py
+++ b/.github/scripts/lint-no-split-doc-comments.py
@@ -58,14 +58,26 @@ def split_blocks(path: pathlib.Path) -> list[tuple[int, int]]:
 
 def main() -> int:
     named = [pathlib.Path(a) for a in sys.argv[1:]]
-    paths = [p for p in named if p.suffix == ".cs" and p.is_file()] if named else tracked_sources()
+
+    # Filtered on BOTH routes, because the tracked list can name a file the working tree no longer has -
+    # deleted in a refactor and not yet staged - and reading it unguarded kills the walk on the first one,
+    # leaving every file after it unchecked under an exit code that means "found something".
+    readable = [p for p in (named or tracked_sources()) if p.suffix == ".cs" and p.is_file()]
 
     # A silence has to mean something was read. Given arguments that name no readable C# file - a
     # directory, a typo, a moved path - an exit of zero is an all-clear indistinguishable from a real
-    # one, which is the shape this whole family of checks exists to refuse.
-    if named and not paths:
-        print("None of the given paths is a readable .cs file, so nothing was checked.")
+    # one, which is the shape this whole family of checks exists to refuse. Named paths that are not
+    # readable are called out one by one rather than as a count, because the point is WHICH.
+    unreadable = [p for p in named if p not in readable]
+    for path in unreadable:
+        print(f"{path}: not a readable .cs file, so it was not checked.")
+
+    # Every named path, not merely one of them: nine unread out of ten is still an all-clear over nine
+    # files nobody looked at.
+    if unreadable:
         return 2
+
+    paths = readable
 
     failures = 0
     for path in paths:

--- a/.github/scripts/lint-no-split-doc-comments.py
+++ b/.github/scripts/lint-no-split-doc-comments.py
@@ -26,10 +26,26 @@ DOC_LINE = re.compile(r"^\s*///")
 SUMMARY_OPEN = re.compile(r"<summary\b")
 
 
+def repository_root() -> pathlib.Path:
+    located = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True)
+    return pathlib.Path(located.stdout.strip())
+
+
 def tracked_sources() -> list[pathlib.Path]:
+    """Every tracked ``.cs`` file in the working tree, from wherever this is run.
+
+    Two separate defaults are relative to the CURRENT directory here, and each needs its own flag.
+    ``:(top)`` anchors the PATTERN: without it the same command run from ``src/`` matches 1249 files
+    instead of 1762, and run from ``.github/scripts/`` matches none at all - an all-clear over a sweep
+    that read nothing, which is the one shape this family of checks exists to refuse. ``--full-name``
+    anchors the OUTPUT, without which the paths come back relative to the caller and cannot be read from
+    anywhere else. Anchoring one and not the other still moves the reach.
+    """
+    root = repository_root()
     listed = subprocess.run(
-        ["git", "ls-files", "*.cs"], capture_output=True, text=True, check=True)
-    return [pathlib.Path(line) for line in listed.stdout.splitlines() if line]
+        ["git", "ls-files", "--full-name", ":(top)*.cs"], capture_output=True, text=True, check=True)
+    return [root / line for line in listed.stdout.splitlines() if line]
 
 
 def split_blocks(path: pathlib.Path) -> list[tuple[int, int]]:
@@ -93,6 +109,9 @@ def main() -> int:
         print(f"\n{failures} split doc comment(s). Move each block to sit directly above its own member.")
         return 1
 
+    # The count is the only thing that distinguishes a clean sweep from a sweep that read a fraction of
+    # the tree, and the two print the same nothing otherwise.
+    print(f"{len(paths)} source(s) read; no split doc comments.")
     return 0
 
 

--- a/.github/scripts/lint-no-split-doc-comments.py
+++ b/.github/scripts/lint-no-split-doc-comments.py
@@ -57,12 +57,18 @@ def split_blocks(path: pathlib.Path) -> list[tuple[int, int]]:
 
 
 def main() -> int:
-    paths = [pathlib.Path(a) for a in sys.argv[1:]] or tracked_sources()
+    named = [pathlib.Path(a) for a in sys.argv[1:]]
+    paths = [p for p in named if p.suffix == ".cs" and p.is_file()] if named else tracked_sources()
+
+    # A silence has to mean something was read. Given arguments that name no readable C# file - a
+    # directory, a typo, a moved path - an exit of zero is an all-clear indistinguishable from a real
+    # one, which is the shape this whole family of checks exists to refuse.
+    if named and not paths:
+        print("None of the given paths is a readable .cs file, so nothing was checked.")
+        return 2
 
     failures = 0
     for path in paths:
-        if path.suffix != ".cs" or not path.is_file():
-            continue
 
         for start, summaries in split_blocks(path):
             failures += 1

--- a/.github/scripts/lint-no-split-doc-comments.py
+++ b/.github/scripts/lint-no-split-doc-comments.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Refuse a C# doc comment that documents two members at once.
+
+An edit that inserts a member between an existing ``</remarks>`` and the member it belonged to
+produces a single uninterrupted run of ``///`` lines carrying two ``<summary>`` blocks. The result is
+valid C#, the compiler has no diagnostic for it, and the build stays green under
+``TreatWarningsAsErrors`` - so the only thing that notices is a reader, and what they read is the
+summary of some other member.
+
+The signature is exact and needs no parser: one contiguous run of ``///`` lines with more than one
+``<summary>`` in it. A member carries one summary, so a second inside the same run means the run spans
+two members and the first one lost its own documentation.
+
+Usage: ``lint-no-split-doc-comments.py [path ...]``; with no argument it walks the working tree's
+tracked ``.cs`` files.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+DOC_LINE = re.compile(r"^\s*///")
+SUMMARY_OPEN = re.compile(r"<summary\b")
+
+
+def tracked_sources() -> list[pathlib.Path]:
+    listed = subprocess.run(
+        ["git", "ls-files", "*.cs"], capture_output=True, text=True, check=True)
+    return [pathlib.Path(line) for line in listed.stdout.splitlines() if line]
+
+
+def split_blocks(path: pathlib.Path) -> list[tuple[int, int]]:
+    """Every doc-comment run in the file carrying more than one summary, as (start, count)."""
+    lines = path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+    found: list[tuple[int, int]] = []
+
+    start = None
+    summaries = 0
+    for number, line in enumerate(lines, start=1):
+        if DOC_LINE.match(line):
+            if start is None:
+                start, summaries = number, 0
+            summaries += len(SUMMARY_OPEN.findall(line))
+            continue
+
+        if start is not None and summaries > 1:
+            found.append((start, summaries))
+        start, summaries = None, 0
+
+    if start is not None and summaries > 1:
+        found.append((start, summaries))
+
+    return found
+
+
+def main() -> int:
+    paths = [pathlib.Path(a) for a in sys.argv[1:]] or tracked_sources()
+
+    failures = 0
+    for path in paths:
+        if path.suffix != ".cs" or not path.is_file():
+            continue
+
+        for start, summaries in split_blocks(path):
+            failures += 1
+            print(
+                f"{path}:{start}: one doc comment carries {summaries} <summary> blocks, so it documents "
+                "more than one member - a member inserted above the one this text belongs to leaves that "
+                "member undocumented and heads the new one with somebody else's summary.")
+
+    if failures:
+        print(f"\n{failures} split doc comment(s). Move each block to sit directly above its own member.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks for GitHub Actions workflow safety.
+# Pre-commit hooks: workflow safety, committed-text hygiene and C# documentation.
 #
 # One-time setup per clone:
 #   pip install pre-commit
@@ -10,7 +10,7 @@
 # Bypass once (NOT recommended; CI re-runs the same checks):
 #   git commit --no-verify
 #
-# Rules and rationale: ../Docs/wiki/github-actions-security-checklist.md
+# Rules and rationale: the workspace's GitHub Actions security checklist.
 
 repos:
   - repo: https://github.com/rhysd/actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
         additional_dependencies: [pyyaml]
         files: ^\.github/(workflows/.*\.(yml|yaml)|scripts/lint-no-inline-secrets\.py)$
         pass_filenames: false
+      - id: no-split-doc-comments
+        name: "Block a doc comment that documents two members"
+        entry: python .github/scripts/lint-no-split-doc-comments.py
+        language: python
+        types: [c#]
       - id: no-cr-in-blobs
         name: "Block carriage returns in committed text"
         entry: python .github/scripts/lint-no-cr-in-blobs.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,9 @@
 # Run manually on all files:
 #   pre-commit run --all-files
 #
-# Bypass once (NOT recommended; CI re-runs the same checks):
+# Bypass once (NOT recommended, and not a safety net: CI re-runs actionlint and the inline-secrets
+# check, and nothing else here - the carriage-return and doc-comment hooks run in this clone or
+# nowhere):
 #   git commit --no-verify
 #
 # Rules and rationale: the workspace's GitHub Actions security checklist.

--- a/src/Abblix.SecurityEvents/SecurityEventTokenBuilder.cs
+++ b/src/Abblix.SecurityEvents/SecurityEventTokenBuilder.cs
@@ -56,9 +56,9 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
     /// deployment speaks. A profile may be tighter: the CAEP Interoperability Profile 1.0 says "The
     /// 'events' claim of the SET MUST contain only one event", and a deployment claiming it sets this.
     /// <para>
-    /// Refused at the second <see cref="WithEvent(string, JsonObject)"/> rather than at
-    /// <see cref="Build"/>, so the failure names the call that broke the rule instead of the one that
-    /// noticed.
+    /// Refused at the second statement - through either <see cref="WithEvent(string, JsonObject)"/> or
+    /// <see cref="WithEvent{TPayload}"/> - rather than at <see cref="Build"/>, so the failure names the
+    /// call that broke the rule instead of the one that noticed.
     /// </para>
     /// </remarks>
     public bool SingleEventStatement { get; init; }
@@ -226,6 +226,8 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
     /// A statement with the same event identifier was already added, or the payload serialized
     /// into something other than a JSON object, which RFC 8417 Section 2.2 requires the value to
     /// be.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A second statement was added while <see cref="SingleEventStatement"/> is set.</exception>
     public SecurityEventTokenBuilder WithEvent<TPayload>(
         string eventType,
         TPayload payload,
@@ -258,14 +260,21 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
     /// A second statement was added to a token declared to carry one.</exception>
     private SecurityEventTokenBuilder AddStatement(string eventType, JsonObject? payload)
     {
-        if (SingleEventStatement && _events.Count > 0)
+        // Read once and consumed by both the decision and the message, so the two cannot disagree about
+        // which statement is already there.
+        var present = _events.Count > 0 ? _events.First().Key : null;
+
+        // A repeat of the SAME identifier is RFC 8417 Section 2.2's rule, and the collection names that
+        // section when it refuses. Answering it here would point a caller at a profile with nothing to
+        // say about saying one thing twice.
+        if (SingleEventStatement && present is not null && present != eventType)
         {
             throw new InvalidOperationException(
-                $"This token carries a single event statement and already holds '{_events.Single().Key}', so "
+                $"This token carries a single event statement and already holds '{present}', so "
                 + $"'{eventType}' cannot be added. The CAEP Interoperability Profile 1.0 requires the "
-                + $"'{JwtClaimTypes.Events}' claim to contain only one event; clear "
-                + $"{nameof(SingleEventStatement)} to build the several-statement SET RFC 8417 Section 2 "
-                + "allows.");
+                + $"'{JwtClaimTypes.Events}' claim to contain only one event; build the token without "
+                + $"{nameof(SingleEventStatement)} for the several-statement SET RFC 8417 Section 2 "
+                + "allows - the property is init-only, so it is settled when the builder is constructed.");
         }
 
         _events.Add(eventType, payload);

--- a/src/Abblix.SecurityEvents/SecurityEventTokenBuilder.cs
+++ b/src/Abblix.SecurityEvents/SecurityEventTokenBuilder.cs
@@ -47,6 +47,22 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
             [IanaClaimTypes.SubId] = nameof(WithSubjectId),
         };
 
+    /// <summary>
+    /// Whether the token carries a single event statement, refusing a second where RFC 8417 would take it.
+    /// </summary>
+    /// <remarks>
+    /// RFC 8417 Section 2 lets one SET carry several statements about different aspects of one transition,
+    /// and that is what this builder does by default, because it builds SETs for whatever profiles the
+    /// deployment speaks. A profile may be tighter: the CAEP Interoperability Profile 1.0 says "The
+    /// 'events' claim of the SET MUST contain only one event", and a deployment claiming it sets this.
+    /// <para>
+    /// Refused at the second <see cref="WithEvent(string, JsonObject)"/> rather than at
+    /// <see cref="Build"/>, so the failure names the call that broke the rule instead of the one that
+    /// noticed.
+    /// </para>
+    /// </remarks>
+    public bool SingleEventStatement { get; init; }
+
     private readonly TimeProvider _clock = clock ?? TimeProvider.System;
     private readonly List<string> _audiences = [];
     private readonly EventsCollection _events = new();
@@ -190,11 +206,10 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
     /// <exception cref="ArgumentException">
     /// A statement with the same event identifier was already added (RFC 8417 Section 2.2).
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// A second statement was added while <see cref="SingleEventStatement"/> is set.</exception>
     public SecurityEventTokenBuilder WithEvent(string eventType, JsonObject? payload = null)
-    {
-        _events.Add(eventType, payload);
-        return this;
-    }
+        => AddStatement(eventType, payload);
 
     /// <summary>
     /// Adds an event statement whose payload is a typed model, serialized here so the caller
@@ -233,7 +248,27 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
                 nameof(payload));
         }
 
-        _events.Add(eventType, payloadObject);
+        return AddStatement(eventType, payloadObject);
+    }
+
+    /// <summary>
+    /// The one door to the "events" claim, so the count is decided in a single place.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// A second statement was added to a token declared to carry one.</exception>
+    private SecurityEventTokenBuilder AddStatement(string eventType, JsonObject? payload)
+    {
+        if (SingleEventStatement && _events.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"This token carries a single event statement and already holds '{_events.Single().Key}', so "
+                + $"'{eventType}' cannot be added. The CAEP Interoperability Profile 1.0 requires the "
+                + $"'{JwtClaimTypes.Events}' claim to contain only one event; clear "
+                + $"{nameof(SingleEventStatement)} to build the several-statement SET RFC 8417 Section 2 "
+                + "allows.");
+        }
+
+        _events.Add(eventType, payload);
         return this;
     }
 

--- a/src/Abblix.SecurityEvents/SecurityEventTokenBuilder.cs
+++ b/src/Abblix.SecurityEvents/SecurityEventTokenBuilder.cs
@@ -260,6 +260,13 @@ public sealed class SecurityEventTokenBuilder(TimeProvider? clock = null)
     /// A second statement was added to a token declared to carry one.</exception>
     private SecurityEventTokenBuilder AddStatement(string eventType, JsonObject? payload)
     {
+        // Judged before anything else, because an identifier that is not one is not a second statement:
+        // without this the profile guard answers a null or empty argument with "this token already holds
+        // another event", which names the wrong rule and offers a remedy that does not fix the call. The
+        // collection refuses the same input on its own terms, and this only moves the refusal in front of
+        // a guard that would otherwise reach it first.
+        ArgumentException.ThrowIfNullOrEmpty(eventType);
+
         // Read once and consumed by both the decision and the message, so the two cannot disagree about
         // which statement is already there.
         var present = _events.Count > 0 ? _events.First().Key : null;

--- a/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
@@ -59,12 +59,6 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection, SharedSi
     private readonly IDatabase _database = connection.GetDatabase();
 
     /// <summary>
-    /// Joins receiver and stream into the hash field. Both parts are escaped before the separator
-    /// joins them: the receiver id is whatever the host's authentication produced and may contain
-    /// anything, and a composite key that trusts its inputs' alphabet is ambiguous the day one input
-    /// widens - <c>("a|b", "c")</c> and <c>("a", "b|c")</c> address one field unescaped.
-    /// </summary>
-    /// <summary>
     /// The exact text a stored stream carries when its version is <paramref name="version"/>.
     /// </summary>
     /// <remarks>
@@ -90,6 +84,12 @@ public sealed class RedisStreamStore(IConnectionMultiplexer connection, SharedSi
     /// </remarks>
     private const string AnyVersionMarker = "\"version\":\"";
 
+    /// <summary>
+    /// Joins receiver and stream into the hash field. Both parts are escaped before the separator
+    /// joins them: the receiver id is whatever the host's authentication produced and may contain
+    /// anything, and a composite key that trusts its inputs' alphabet is ambiguous the day one input
+    /// widens - <c>("a|b", "c")</c> and <c>("a", "b|c")</c> address one field unescaped.
+    /// </summary>
     private static RedisValue FieldOf(string receiverId, string streamId)
         => $"{Uri.EscapeDataString(receiverId)}|{Uri.EscapeDataString(streamId)}";
 

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
@@ -159,7 +159,7 @@ public sealed partial class EventDispatcher(
         // across receivers is exactly the unintended-disclosure shape Section 4.1.8 warns about.
         var jwtId = Guid.NewGuid().ToString("N");
 
-        var builder = new SecurityEventTokenBuilder(clock)
+        var builder = new SecurityEventTokenBuilder(clock) { SingleEventStatement = true }
             .WithIssuer(_issuer)
             .WithJwtId(jwtId)
             .WithAudience([.. stream.Configuration.Audiences])

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
@@ -159,6 +159,13 @@ public sealed partial class EventDispatcher(
         // across receivers is exactly the unintended-disclosure shape Section 4.1.8 warns about.
         var jwtId = Guid.NewGuid().ToString("N");
 
+        // Declared rather than merely true, and no test can hold it: a descriptor carries one event type,
+        // a single required string, so nothing here can add a second statement and the constraint has no
+        // input that makes it speak. What it buys is the day somebody widens this method - the widening
+        // fails here instead of reaching a receiver as a SET the CAEP Interoperability Profile forbids,
+        // whose Section 2.8.1 requires the "events" claim to contain only one event. The same reasoning
+        // as the unreachable arm in StreamManagementService.AddressRefusalOf, and said out loud for the
+        // same reason: an unreachable guard nobody explained reads as one nobody finished.
         var builder = new SecurityEventTokenBuilder(clock) { SingleEventStatement = true }
             .WithIssuer(_issuer)
             .WithJwtId(jwtId)

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/PairwiseProtectedSubjectTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/PairwiseProtectedSubjectTests.cs
@@ -200,12 +200,6 @@ public class PairwiseProtectedSubjectTests(TestFactory factory) : TestBase(facto
     }
 
     /// <summary>
-    /// Builds an isolated host that enables pairwise identifiers, keeps the service tokens as signed JWS (so the test
-    /// can decode <c>sub</c>) and registers a pairwise client alongside the pre-seeded ones. The reversible pairwise
-    /// seal is keyed by the pairwise salt, so no service encryption key is needed. The shared default host stays
-    /// untouched.
-    /// </summary>
-    /// <summary>
     /// RFC 7662 Section 5 offers two ways to keep an introspection response from disclosing a user to an
     /// unintended party. Withholding the identifier is the one it calls simplest; the other is to "transmit
     /// user identifiers as opaque service-specific strings, potentially returning different identifiers to
@@ -237,6 +231,12 @@ public class PairwiseProtectedSubjectTests(TestFactory factory) : TestBase(facto
     }
 
 
+    /// <summary>
+    /// Builds an isolated host that enables pairwise identifiers, keeps the service tokens as signed JWS (so the test
+    /// can decode <c>sub</c>) and registers a pairwise client alongside the pre-seeded ones. The reversible pairwise
+    /// seal is keyed by the pairwise salt, so no service encryption key is needed. The shared default host stays
+    /// untouched.
+    /// </summary>
     private WebApplicationFactory<Program> CreateHost()
     {
         var secret = new ClientSecret

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
@@ -72,16 +72,32 @@ public class SecurityEventTokenBuilderTests
     }
 
     /// <summary>
-    /// Left unset, several statements are built, because that is what RFC 8417 Section 2 allows and this
-    /// package speaks whatever profile the deployment does.
+    /// An identifier that is not one is judged as an argument, not as a second statement.
     /// </summary>
     /// <remarks>
-    /// The explicit boundary of the change. Refusing the second statement outright turns five red rather
-    /// than this one - four of them pre-existing, including the fixture that rebuilds RFC 8417's own
-    /// two-statement figure - so this row is not what stands between the change and that mistake. It is
-    /// what says the permission is intended, in one place a reader can find, rather than inferred from a
-    /// fixture about something else.
+    /// Both guards would fire on this call and the wrong one used to answer: a caller whose event-type
+    /// variable came back null was told the token already holds another event, and sent to construct the
+    /// builder without the declaration - which swaps the message and does not fix the call. The collection
+    /// refuses the same input on its own terms whenever the declaration is unset, so the two paths
+    /// disagreed about what the fault was.
     /// </remarks>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AnIdentifierThatIsNotOne_IsRefusedAsAnArgument(string? eventType)
+    {
+        var builder = new SecurityEventTokenBuilder { SingleEventStatement = true }
+            .WithIssuer("https://issuer.example.com")
+            .WithJwtId("id-1")
+            .WithEvent("https://example.com/events/first");
+
+        // ThrowsAny, because null gives ArgumentNullException and empty gives ArgumentException, and which
+        // of the two arrives is not what this row is about.
+        var refusal = Assert.ThrowsAny<ArgumentException>(() => builder.WithEvent(eventType!));
+
+        Assert.Equal("eventType", refusal.ParamName);
+    }
+
     /// <summary>
     /// The same identifier twice is still RFC 8417 Section 2.2's rule, not the profile's, even on a token
     /// carrying one statement.
@@ -106,6 +122,16 @@ public class SecurityEventTokenBuilderTests
         Assert.Contains("2.2", refusal.Message);
     }
 
+    /// <summary>
+    /// Left unset, several statements are built, because that is what RFC 8417 Section 2 allows and this
+    /// package speaks whatever profile the deployment does.
+    /// </summary>
+    /// <remarks>
+    /// The explicit boundary of the change rather than the barrier: refusing the second statement outright
+    /// turns several other rows red too, including the fixture that rebuilds RFC 8417's own two-statement
+    /// figure. What this row adds is a place a reader can find the permission stated, rather than having
+    /// to infer it from a fixture about something else.
+    /// </remarks>
     [Fact]
     public void WithoutTheDeclaration_SeveralStatementsAreBuilt()
     {

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
@@ -10,6 +10,7 @@ using Abblix.Jwt;
 using Abblix.SecurityEvents.Abstractions;
 using Abblix.SecurityEvents.Subjects;
 using Microsoft.Extensions.Time.Testing;
+using Abblix.SecurityEvents.Events;
 using Xunit;
 
 namespace Abblix.SecurityEvents.UnitTests;
@@ -25,6 +26,72 @@ public class SecurityEventTokenBuilderTests
         .WithIssuer("https://issuer.example.com")
         .WithJwtId("id-1")
         .WithEvent("https://example.com/events/test");
+
+    /// <summary>
+    /// A token declared to carry one event statement refuses the second, at the call that adds it.
+    /// </summary>
+    /// <remarks>
+    /// The CAEP Interoperability Profile 1.0 says "The 'events' claim of the SET MUST contain only one
+    /// event", which is tighter than RFC 8417 Section 2 - and a host minting SETs outside the SSF
+    /// dispatch path had nothing to hold it to. The message names the statement already there, because
+    /// "you already have one" without saying which is the least useful thing a builder can answer.
+    /// </remarks>
+    [Fact]
+    public void ASecondStatementOnASingleEventToken_IsRefusedWhereItIsAdded()
+    {
+        var builder = new SecurityEventTokenBuilder { SingleEventStatement = true }
+            .WithIssuer("https://issuer.example.com")
+            .WithJwtId("id-1")
+            .WithEvent("https://example.com/events/first");
+
+        var refusal = Assert.Throws<InvalidOperationException>(
+            () => builder.WithEvent("https://example.com/events/second"));
+
+        Assert.Contains("https://example.com/events/first", refusal.Message);
+        Assert.Contains("https://example.com/events/second", refusal.Message);
+    }
+
+    /// <summary>
+    /// The typed overload is the same door, so it is refused the same way.
+    /// </summary>
+    /// <remarks>
+    /// Its own row because the two overloads reach the collection independently: the typed one serializes
+    /// first and then adds, so a guard placed on the untyped one alone would leave the door a host using
+    /// the profile's own payload types walks through.
+    /// </remarks>
+    [Fact]
+    public void ASecondStatementThroughTheTypedOverload_IsRefusedToo()
+    {
+        var builder = new SecurityEventTokenBuilder { SingleEventStatement = true }
+            .WithIssuer("https://issuer.example.com")
+            .WithJwtId("id-1")
+            .WithEvent("https://example.com/events/first");
+
+        Assert.Throws<InvalidOperationException>(
+            () => builder.WithEvent("https://example.com/events/second", new StubPayload()));
+    }
+
+    /// <summary>
+    /// Left unset, several statements are built, because that is what RFC 8417 Section 2 allows and this
+    /// package speaks whatever profile the deployment does.
+    /// </summary>
+    /// <remarks>
+    /// The control, and the boundary of the change: without it, refusing the second statement outright
+    /// would satisfy both rows above and break every deployment building a SET the base specification
+    /// permits.
+    /// </remarks>
+    [Fact]
+    public void WithoutTheDeclaration_SeveralStatementsAreBuilt()
+    {
+        var token = new SecurityEventTokenBuilder()
+            .WithIssuer("https://issuer.example.com")
+            .WithJwtId("id-1")
+            .WithEvent("https://example.com/events/first")
+            .WithEvent("https://example.com/events/second")
+            .Build();
+
+        Assert.Equal(2, token.Events!.Count);
+    }
 
     [Fact]
     public void Build_WithoutIssuer_Fails()
@@ -304,4 +371,7 @@ public class SecurityEventTokenBuilderTests
             return Task.FromResult(Result);
         }
     }
+
+    /// <summary>A payload of no particular vocabulary, for exercising the typed overload.</summary>
+    private sealed record StubPayload : IEventPayload;
 }

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenBuilderTests.cs
@@ -8,9 +8,9 @@
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
 using Abblix.SecurityEvents.Abstractions;
+using Abblix.SecurityEvents.Events;
 using Abblix.SecurityEvents.Subjects;
 using Microsoft.Extensions.Time.Testing;
-using Abblix.SecurityEvents.Events;
 using Xunit;
 
 namespace Abblix.SecurityEvents.UnitTests;
@@ -76,10 +76,36 @@ public class SecurityEventTokenBuilderTests
     /// package speaks whatever profile the deployment does.
     /// </summary>
     /// <remarks>
-    /// The control, and the boundary of the change: without it, refusing the second statement outright
-    /// would satisfy both rows above and break every deployment building a SET the base specification
-    /// permits.
+    /// The explicit boundary of the change. Refusing the second statement outright turns five red rather
+    /// than this one - four of them pre-existing, including the fixture that rebuilds RFC 8417's own
+    /// two-statement figure - so this row is not what stands between the change and that mistake. It is
+    /// what says the permission is intended, in one place a reader can find, rather than inferred from a
+    /// fixture about something else.
     /// </remarks>
+    /// <summary>
+    /// The same identifier twice is still RFC 8417 Section 2.2's rule, not the profile's, even on a token
+    /// carrying one statement.
+    /// </summary>
+    /// <remarks>
+    /// Two guards stand over one call and both would fire, so which answers decides what an operator is
+    /// told. Saying "this token carries one event" about a caller repeating one identifier points at a
+    /// profile that has nothing to say about saying the same thing twice, and hides the rule that does.
+    /// </remarks>
+    [Fact]
+    public void TheSameIdentifierTwiceOnASingleEventToken_IsTheDuplicateRule()
+    {
+        var builder = new SecurityEventTokenBuilder { SingleEventStatement = true }
+            .WithIssuer("https://issuer.example.com")
+            .WithJwtId("id-1")
+            .WithEvent("https://example.com/events/first");
+
+        var refusal = Assert.Throws<ArgumentException>(
+            () => builder.WithEvent("https://example.com/events/first"));
+
+        Assert.Contains("already present", refusal.Message);
+        Assert.Contains("2.2", refusal.Message);
+    }
+
     [Fact]
     public void WithoutTheDeclaration_SeveralStatementsAreBuilt()
     {

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
@@ -41,10 +41,6 @@ public class SharedSignalsServiceCollectionTests
         PollEndpointFactory = streamId => new Uri($"https://tr.example.com/ssf/poll/{streamId}"),
     };
 
-    /// <summary>
-    /// The Security Events core plus the two deployment-knowledge seams a real host wires with
-    /// keys - faked here, because these tests measure wiring, not cryptography.
-    /// </summary>
     /// <summary>A signer that keeps what it was handed, so a test can read what was minted.</summary>
     private sealed class RecordingSigner : ISecurityEventTokenSigner
     {
@@ -128,6 +124,10 @@ public class SharedSignalsServiceCollectionTests
         Assert.Equal(stream.Configuration.Issuer, minted.Issuer);
     }
 
+    /// <summary>
+    /// The Security Events core plus the two deployment-knowledge seams a real host wires with
+    /// keys - faked here, because these tests measure wiring, not cryptography.
+    /// </summary>
     private static IServiceCollection SecurityEventsBase()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
Closes #448.

## What the profile requires

CAEP Interoperability Profile 1.0 draft 01, Section 2.8.1, in full:

> The "events" claim of the SET MUST contain only one event.

That is tighter than RFC 8417 Section 2, which lets one SET carry several statements about different aspects of one transition, and the tighter rule was expressed nowhere.

## Where it held and where it did not

The SSF transmit path was already fine, and not by accident: `SecurityEventDescriptor.EventType` is a single `required string`, `MintAndEnqueueAsync` calls `WithEvent` once, and `DispatchToStreamAsync` funnels into the same method.

`SecurityEventTokenBuilder` is the seam a host uses when it mints SETs outside that path, and it took a second statement without complaint. `Build` checked only that the collection was not empty, and `EventsCollection.Add` refuses nothing about the COUNT - it refuses a null or empty identifier, a duplicate one, and a payload still attached to another JSON tree.

## Not refused by default

`Abblix.SecurityEvents` builds SETs for whatever profiles the deployment speaks. RFC 8417 permits several statements, so refusing them here would enforce one profile's rule on every consumer of the base specification. The token declares the constraint instead, and declaring it is how a deployment claims the profile:

```csharp
new SecurityEventTokenBuilder(clock) { SingleEventStatement = true }
```

Refused where the second statement is ADDED rather than at `Build`, so the failure names the call that broke the rule instead of the one that noticed. The message names the statement already present - "you already have one" without saying which is the least useful answer a builder can give.

Both overloads now reach the collection through one private door. The typed one serializes and adds on its own, so a guard on the untyped overload alone would have left open exactly the door a host using a profile's payload types walks through - that has its own row.

## The dispatch path declares it, and the mutation survives

`MintAndEnqueueAsync` sets it. Removing that leaves every suite green, and **that is the expected result rather than a gap**: a descriptor carries one event type, so nothing there can add a second statement, and no input can make the constraint speak. Its value is the day somebody widens that method - the widening then fails in the build or the suite instead of reaching a receiver as a SET the profile forbids.

This repository already carries that pattern with its reasoning written down, in `AddressRefusalOf`'s unreachable arm: "The arm is for the day somebody teaches that method a third delivery." The difference between unreachable-because-forgotten and unreachable-on-purpose is only whether it was said out loud.

## Evidence

CI is green on this head, and the mutations were built rather than run under `--no-build`.

- An off-by-one on the guard, so the second statement is taken and only a third refused, is caught once per overload - the typed one serializes and adds on its own, so a guard on the untyped door alone would have left it open.
- Dropping the declaration from the check so it applies unconditionally is caught by the control, which builds the several-statement SET RFC 8417 permits.
- Replacing the name of the statement already present with a fixed phrase is caught, so the message is pinned rather than merely written.

The control is the boundary rather than the barrier: refusing the second statement outright turns several pre-existing rows red as well, including the fixture that rebuilds RFC 8417's own two-statement figure. It is what says the permission is intended, in a place a reader can find, rather than left to be inferred from a fixture about something else.

**One mutation survives with nothing red, and that is the expected result.** Removing `SingleEventStatement = true` from `MintAndEnqueueAsync` changes no test, because a descriptor carries one event type and nothing on that path can add a second statement. Its value is the day somebody widens that method: the widening then fails in the build or the suite instead of reaching a receiver as a SET the profile forbids. The reasoning now sits at the site, which is where the in-repo precedent for this - `AddressRefusalOf`'s unreachable arm - puts its own.

## What the reviews changed

The refusal told a caller to "clear `SingleEventStatement`", which is init-only, so the one action it named is the one the compiler refuses. Two guards stand over one call, and a repeated identifier was being answered with the profile's one-event sentence rather than RFC 8417 Section 2.2's duplicate rule, which is the one that applies - the existing statement is now read once and consumed by both the decision and the message. The typed overload threw the same exception and documented none, and the property's remarks named only the untyped door, in XML that ships in the package.

An identifier that is not one was being answered the same wrong way: a caller whose event-type variable came back null was told the token already holds another event, and sent to construct the builder without the declaration - which swaps the message and does not fix the call. It is judged as an argument now, before anything asks whether a second statement is being added.

**And the row added for that split a doc comment.** It went in between a `</remarks>` and the member it belonged to, so the control shipped undocumented while the duplicate-rule test carried a summary describing something else - valid C#, no diagnostic, green build under warnings-as-errors. That is a class rather than a slip: a checker now refuses a contiguous run of `///` lines carrying more than one `<summary>`, and it found three instances that predate this change, in the Redis store, the pairwise host builder and the security-events fixture. Each orphaned summary was moved to the member it describes.

Two committed files in this public repository named private ones, and the hooks config is one of them; both say the role now. The doc-comment checker also exited zero when given a path naming no readable C# file, which is an all-clear indistinguishable from a real one.

The later rounds went at the instruments rather than the change. One found that the split-doc-comment checker's own walk was scoped to the caller's directory: `git ls-files` defaults BOTH its pathspec and its output to where it is run, so from `src/` it read 1249 of 1762 files and from `.github/scripts/` it read none at all and exited zero. Anchored at the repository root with `--full-name` and `:(top)`, driven from five directories, and the count of sources read is now printed - which is the only thing separating a clean sweep from a sweep over nothing.

Another found the refusal naming an action the compiler forbids, and a private repository named in a public one - in the code owners file, in the hooks configuration, and in a sibling checker's own comment. All three say the role now. The class is not closed: two files this diff does not touch still name the private product, and they carry over from `develop` rather than arriving with this change, so they belong to a ticket of their own.

