### PR TITLE
Read the value under the same hold of the gate that removes it

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -23,10 +23,11 @@ namespace Abblix.Oidc.Server.Endpoints.Token;
 /// back at the key catch one arriving after it. Both hold across processes.
 /// </summary>
 /// <remarks>
-/// Neither is complete on its own terms. The claim reads the value before it takes the claim, so two
-/// callers can be handed the same grant on ONE node, which is issue 454; and the write-back is what the
-/// second defence rests on, so a first redemption that ends without issuing tokens leaves nothing for it
-/// to catch. Both are open, and the refusal this class returns is the same string either way.
+/// Neither is complete on its own terms. The claim reads the value under the same hold of the gate that
+/// removes it, so on ONE node two callers cannot be handed the same grant; across processes the gate
+/// holds nothing and both can be, which is issue 435. And the write-back is what the second defence
+/// rests on, so a first redemption that ends without issuing tokens leaves nothing for it to catch. The
+/// refusal this class returns is the same string either way.
 /// <para>
 /// This class decorates the standard token request processing flow with additional security measures
 /// to ensure the integrity of the authorization process. It detects when an authorization code,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
@@ -87,8 +87,15 @@ public class BackChannelRequestStorage(
 	/// protocol. The claim is what keeps two polls from both being told they took the same request; the
 	/// per-key gate around the removal is what keeps a contended key from ending with NEITHER of them
 	/// told. The value is read under that same hold, so a poll is handed the bytes the removal took rather
-	/// than the ones it read on its way in, and a write landing beside it is either destroyed before the
-	/// read or seen by it. The returns block below says what is still open.
+	/// than the ones it read on its way in.
+	/// <para>
+	/// That is the whole of what the hold buys, and it is narrower than "no write is lost". Only the read
+	/// and the removal are inside it: <see cref="UpdateAsync"/> is a plain set on this key and takes no
+	/// gate, so a write from the CIBA grant handler's next-poll bump can still land after the in-gate read
+	/// and be destroyed by the removal without ever being seen - which that handler's own remarks already
+	/// treat as an ordinary race. Closing THAT needs the writers to take the gate too, not a wider claim
+	/// here.
+	/// </para>
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
@@ -86,9 +86,9 @@ public class BackChannelRequestStorage(
 	/// Retrieves and removes a backchannel authentication request from storage, through the store's claim
 	/// protocol. The claim is what keeps two polls from both being told they took the same request; the
 	/// per-key gate around the removal is what keeps a contended key from ending with NEITHER of them
-	/// told. The VALUE, though, is read before the gate is taken, so a write landing between that read
-	/// and the removal is destroyed and the earlier bytes handed back - issue 454. The returns block below
-	/// says what else is still open.
+	/// told. The value is read under that same hold, so a poll is handed the bytes the removal took rather
+	/// than the ones it read on its way in, and a write landing beside it is either destroyed before the
+	/// read or seen by it. The returns block below says what is still open.
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>

--- a/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -71,9 +71,12 @@ public class AuthorizationCodeService(
 	{
 		// removeOnRetrieval: true claims the code, and every caller that finds it gone is rejected.
 		// What the claim does NOT give: a removal can end with nobody holding the grant, when the claim
-		// expires mid-protocol. Two callers both holding it needs a second node - within one process the
-		// read and the removal are under one hold of the per-key gate, so the write-back this decorator
-		// performs at the same key cannot land between them. Issue 435.
+		// expires mid-protocol. Two callers both holding it needs a second node, because within one
+		// process the read and the removal are one hold of the per-key gate. The reuse decorator writes
+		// the grant back at the same key WITHOUT that gate, and what keeps it out of the window is
+		// ordering rather than exclusion: it writes only after its own take has returned, so a redeemer
+		// entering afterwards reads either nothing or a grant already carrying issued tokens, and the
+		// second is the arm that revokes and rejects. Issue 435.
 		var grant = await storage.GetAsync<AuthorizedGrant>(
 			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);
 

--- a/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs
@@ -71,8 +71,9 @@ public class AuthorizationCodeService(
 	{
 		// removeOnRetrieval: true claims the code, and every caller that finds it gone is rejected.
 		// What the claim does NOT give: a removal can end with nobody holding the grant, when the claim
-		// expires mid-protocol; and two callers can both hold it, because the value is read before the
-		// claim is taken and the reuse decorator writes the grant back at this same key. Issue 454.
+		// expires mid-protocol. Two callers both holding it needs a second node - within one process the
+		// read and the removal are under one hold of the per-key gate, so the write-back this decorator
+		// performs at the same key cannot land between them. Issue 435.
 		var grant = await storage.GetAsync<AuthorizedGrant>(
 			keyFactory.AuthorizedGrantKey(authorizationCode), removeOnRetrieval: true);
 

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -55,15 +55,17 @@ public interface IAuthorizationCodeService
     /// One exception on a single node, and it is a loss rather than a duplication: a removal can end with
     /// NOBODY receiving the grant, when the claim expires mid-protocol. A store fault after the removal
     /// costs the grant the same way, and raises rather than answering.
-    /// <para>
-    /// Two callers both receiving it needs a SECOND NODE. Within one process the read and the removal
-    /// happen under one hold of the per-key gate, so a redeemer is never between them while another
-    /// completes a take - which is what the write-back at that key would have to interleave with. Across
-    /// processes the gate holds nothing and the window reopens: the value is read before the claim is
-    /// taken, the second caller is handed what it read rather than what it removed, and the reuse check
-    /// sees no issued tokens. That is issue 435, and it needs a store primitive this interface does not
-    /// expose.
     /// </para>
+    /// <para>
+    /// Two callers both receiving it needs a SECOND NODE, and that holds of the storage this library
+    /// ships rather than of the seam: the read and the removal happen under one hold of a per-key gate,
+    /// so within one process a redeemer is never between them while another completes a take. A host
+    /// substituting its own <c>IEntityStorage</c> owns that property, and a naive get-then-remove
+    /// reopens the duplication on one node. Across processes the gate holds nothing either: the value is
+    /// read before the claim is taken, the second caller is handed what it read rather than what it
+    /// removed, and the reuse check sees no issued tokens. That is issue 435, and it needs a store
+    /// primitive <see cref="Microsoft.Extensions.Caching.Distributed.IDistributedCache"/> does not
+    /// expose.
     /// </para>
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs
@@ -52,12 +52,18 @@ public interface IAuthorizationCodeService
     /// code (RFC 6749 section 4.1.2) - every other caller finds the code already gone and receives an
     /// <c>invalid_grant</c> failure.
     /// <para>
-    /// Two exceptions, and neither needs a second node. A removal can end with NOBODY receiving the
-    /// grant - an expiring claim is one way there and a store fault after the removal is another. And two
-    /// callers CAN both receive it, when
-    /// one of them redeems while the other writes the grant back at the same key - the second is handed
-    /// what it read before the claim, not what it removed, so the reuse check sees no issued tokens and
-    /// mints a second set. That is issue 454, and it is why this sentence no longer says "never two".
+    /// One exception on a single node, and it is a loss rather than a duplication: a removal can end with
+    /// NOBODY receiving the grant, when the claim expires mid-protocol. A store fault after the removal
+    /// costs the grant the same way, and raises rather than answering.
+    /// <para>
+    /// Two callers both receiving it needs a SECOND NODE. Within one process the read and the removal
+    /// happen under one hold of the per-key gate, so a redeemer is never between them while another
+    /// completes a take - which is what the write-back at that key would have to interleave with. Across
+    /// processes the gate holds nothing and the window reopens: the value is read before the claim is
+    /// taken, the second caller is handed what it read rather than what it removed, and the reuse check
+    /// sees no issued tokens. That is issue 435, and it needs a store primitive this interface does not
+    /// expose.
+    /// </para>
     /// </para>
     /// </summary>
     /// <param name="authorizationCode">The authorization code to remove and claim.</param>

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -303,10 +303,13 @@ public static class DistributedCacheExtensions
 	/// evaluated before the authorized one, so a poll arriving after the lifetime ran out removes the
 	/// record ungated while another poll holds it.
 	/// <para>
-	/// The denied arm removes it too and cannot reach this: a hold is entered only on an authorized
-	/// record, and nothing moves a record from authorized to denied - approval and denial both refuse
-	/// anything that is not pending. Naming it here would offer an operator a second explanation for a
-	/// value lost under a hold, and only one of the two can produce it.
+	/// The denied arm removes it too, and it is not named here because it needs a race the expired arm
+	/// does not. A hold is entered only on an AUTHORIZED record, and a denial is applied by a read-then-
+	/// write that refuses anything not reading Pending at the moment it reads. So reaching this arm under
+	/// a hold means a denial whose read landed before the approval's write - the window that service's own
+	/// remarks file as issue 194, which re-reading narrows and does not close. Offering an operator both
+	/// explanations for a value lost under a hold would send them to the likelier-sounding one; the
+	/// expired arm needs no race at all.
 	/// </para>
 	/// </para>
 	/// <para>

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -112,9 +112,10 @@ public static class DistributedCacheExtensions
 	/// the bytes at the key when this caller got IN - not the ones there before it waited, and that wait
 	/// is as long as another caller's whole redemption. What is still open is narrower and real: a writer
 	/// that takes no gate can land between the read and the removal, so this caller destroys that write
-	/// and is handed the earlier bytes. Nothing in this class closes THAT, and nothing here survives a
-	/// second process at all: a store whose own primitive returns the removed value is what closes both,
-	/// and issue 435 tracks it.
+	/// and is handed the earlier bytes. Nothing in this class closes THAT, and the SERIALIZATION survives
+	/// no second process at all - the lock protocol still admits at most one winner across nodes, but
+	/// nothing there holds the read and the removal together. A store whose own primitive returns the
+	/// removed value closes both, and issue 435 tracks it.
 	/// </para>
 	/// <para>
 	/// <strong>Lock timeout:</strong> the claim auto-expires after the specified timeout (5 seconds by
@@ -287,12 +288,16 @@ public static class DistributedCacheExtensions
 	/// <see cref="TryGetAndRemoveAsync"/> its read and its removal together - and neither body calls the
 	/// other's public method, which is what a body taking the gate twice on one key would do.
 	/// <para>
-	/// What that buys is bounded by what the gate holds out, which is other REDEMPTIONS and not other
-	/// writers. A plain <c>SetAsync</c> on the same key takes nothing and is not held out at all - and
-	/// those callers are in this repository, on these keys: the authorization grant written back after
-	/// minting, the back-channel request updated on completion, the device record bumped while polling.
+	/// What that buys is bounded by what the gate holds out, which is other REDEMPTIONS and nothing else.
+	/// A plain <c>SetAsync</c> or <c>RemoveAsync</c> on the same key takes nothing and is not held out at
+	/// all, so one landing between the read and the removal is destroyed by this caller while it is handed
+	/// the earlier bytes - or turns a live value into a refusal with nobody told. The live example in this
+	/// repository is the back-channel request, updated on completion from four handlers on the key this
+	/// protocol redeems, by an approval genuinely concurrent with a token-endpoint poll.
+	/// <para>
 	/// So the value returned is the value at the key when this caller got IN, which is a narrower window
 	/// than before and not a guarantee that it is the value removed.
+	/// </para>
 	/// </para>
 	/// </remarks>
 	private static async Task<T> UnderGateAsync<T>(

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -299,9 +299,15 @@ public static class DistributedCacheExtensions
 	/// a poll bumping its next-poll instant, on the key <see cref="TryGetAndRemoveAsync"/> redeems. The
 	/// device authorization request is written the same way, by a poll's next-poll bump, and REMOVED
 	/// outside the gate on the key <see cref="TryRemoveAsync"/> redeems - by a second poll taking the
-	/// expired or the denied arm, which is where the removal half of the sentence above gets its site.
-	/// A user's approval or denial writes that key too, but only while the record is still pending, and a
-	/// hold is entered only once it is authorized.
+	/// EXPIRED arm, which is where the removal half of the sentence above gets its site. That arm is
+	/// evaluated before the authorized one, so a poll arriving after the lifetime ran out removes the
+	/// record ungated while another poll holds it.
+	/// <para>
+	/// The denied arm removes it too and cannot reach this: a hold is entered only on an authorized
+	/// record, and nothing moves a record from authorized to denied - approval and denial both refuse
+	/// anything that is not pending. Naming it here would offer an operator a second explanation for a
+	/// value lost under a hold, and only one of the two can produce it.
+	/// </para>
 	/// </para>
 	/// <para>
 	/// So the value returned is the value at the key when this caller got IN, which is a narrower window

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -294,12 +294,14 @@ public static class DistributedCacheExtensions
 	/// the earlier bytes - or turns a live value into a refusal with nobody told.
 	/// </para>
 	/// <para>
-	/// Both entry points are exposed to that, so both have live examples here. The back-channel request is
-	/// written on completion and again by the poll bumping its next-poll instant, on the key
-	/// <see cref="TryGetAndRemoveAsync"/> redeems. The device authorization request is written and
-	/// REMOVED outside the gate by its own storage, on the key <see cref="TryRemoveAsync"/> redeems, from
-	/// a user's approval or denial genuinely concurrent with a token-endpoint poll - which is where the
-	/// second half of the sentence above gets its site.
+	/// Both entry points are exposed to that, so both have live examples here, and in both the other actor
+	/// is another POLL rather than a user. The back-channel request is written on completion and again by
+	/// a poll bumping its next-poll instant, on the key <see cref="TryGetAndRemoveAsync"/> redeems. The
+	/// device authorization request is written the same way, by a poll's next-poll bump, and REMOVED
+	/// outside the gate on the key <see cref="TryRemoveAsync"/> redeems - by a second poll taking the
+	/// expired or the denied arm, which is where the removal half of the sentence above gets its site.
+	/// A user's approval or denial writes that key too, but only while the record is still pending, and a
+	/// hold is entered only once it is authorized.
 	/// </para>
 	/// <para>
 	/// So the value returned is the value at the key when this caller got IN, which is a narrower window

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -95,19 +95,25 @@ public static class DistributedCacheExtensions
 	/// <remarks>
 	/// <para><strong>Atomicity Protocol:</strong></para>
 	/// <list type="number">
-	///   <item><term>Step 1:</term> Get the value from cache</item>
-	///   <item><term>Step 2:</term> Delegate to <see cref="TryRemoveAsync"/> for atomic removal</item>
+	///   <item><term>Step 1:</term> Take the per-key gate, so no other redemption of this key runs in
+	///   this process while the rest happens</item>
+	///   <item><term>Step 2:</term> Read the value, and give up if there is none</item>
+	///   <item><term>Step 3:</term> Run the removal protocol of <see cref="TryRemoveAsync"/> under the
+	///   same hold</item>
 	/// </list>
 	/// <para>
-	/// <strong>How it provides atomicity:</strong> the removal is delegated to
-	/// <see cref="TryRemoveAsync"/>, and the condition for reporting one is under that method.
+	/// <strong>How it provides atomicity:</strong> the removal reports itself under the same condition
+	/// <see cref="TryRemoveAsync"/> states, and the read is inside the same hold of the gate rather than
+	/// in front of it.
 	/// </para>
 	/// <para>
-	/// <strong>The value returned is the one read BEFORE that removal, not the one removed.</strong> The
-	/// read happens here and the removal happens inside the delegate, so anything that writes the key
-	/// between them is destroyed by this caller and handed to nobody, while this caller receives the
-	/// earlier bytes and is told it won. Nothing in this class closes that: a store whose own primitive
-	/// returns the removed value is what closes it, and issue 454 tracks the change.
+	/// <strong>What the read's placement buys, and what it does not.</strong> The bytes handed back are
+	/// the bytes at the key when this caller got IN - not the ones there before it waited, and that wait
+	/// is as long as another caller's whole redemption. What is still open is narrower and real: a writer
+	/// that takes no gate can land between the read and the removal, so this caller destroys that write
+	/// and is handed the earlier bytes. Nothing in this class closes THAT, and nothing here survives a
+	/// second process at all: a store whose own primitive returns the removed value is what closes both,
+	/// and issue 435 tracks it.
 	/// </para>
 	/// <para>
 	/// <strong>Lock timeout:</strong> the claim auto-expires after the specified timeout (5 seconds by
@@ -115,9 +121,10 @@ public static class DistributedCacheExtensions
 	/// means a caller slower than the timeout loses its own claim: see <see cref="TryRemoveAsync"/>.
 	/// </para>
 	/// <para>
-	/// <strong>Performance:</strong> up to six cache operations - one read here, and up to five inside
-	/// <see cref="TryRemoveAsync"/> - so it has higher latency than a store's own atomic primitive, and
-	/// works with any IDistributedCache in exchange.
+	/// <strong>Performance:</strong> up to six cache operations - one read, and up to five in the removal
+	/// protocol - so it has higher latency than a store's own atomic primitive, and works with any
+	/// IDistributedCache in exchange. All of them inside the gate, so a contended key serializes for the
+	/// whole of that rather than for the removal alone.
 	/// </para>
 	/// </remarks>
 	/// <param name="cache">The distributed cache instance.</param>
@@ -125,13 +132,13 @@ public static class DistributedCacheExtensions
 	/// <param name="lockTimeout">Duration after which the lock expires, 5 seconds if null.</param>
 	/// <param name="cancellationToken">Optional cancellation token to cancel the operation.</param>
 	/// <returns>
-	/// A task that completes when the operation finishes, containing the value READ BEFORE the removal
-	/// when this caller's own claim was still in the store afterwards - not necessarily the value it
-	/// removed, see the remarks and issue 454. Null otherwise, which does NOT mean somebody else took it:
-	/// see <see cref="TryRemoveAsync"/>, whose remarks carry the condition; this
-	/// method adds nothing to it beyond returning the value.
+	/// A task that completes when the operation finishes, containing the value read under this caller's
+	/// own hold of the gate, when its claim was still in the store afterwards. Null otherwise, which does
+	/// NOT mean somebody else took it: see <see cref="TryRemoveAsync"/>, whose remarks carry the
+	/// condition; this method adds nothing to it beyond returning the value. What the placement of the
+	/// read does and does not settle is in the remarks.
 	/// </returns>
-	public static async Task<byte[]?> TryGetAndRemoveAsync(
+	public static Task<byte[]?> TryGetAndRemoveAsync(
 		this IDistributedCache cache,
 		string key,
 		TimeSpan? lockTimeout = null,
@@ -140,23 +147,24 @@ public static class DistributedCacheExtensions
 		ArgumentNullException.ThrowIfNull(cache);
 		ArgumentNullException.ThrowIfNull(key);
 
-		// Get the value (return null if not found)
-		var valueData = await cache.GetAsync(key, cancellationToken);
-		if (valueData == null)
+		// Read and removal under ONE hold of the gate, so the bytes handed back are the bytes that were at
+		// the key when this caller got in - rather than the ones that were there before it waited, which is
+		// a wait as long as another caller's whole redemption. RemoveUnderGateAsync is called directly
+		// instead of TryRemoveAsync, because taking the gate twice on one key deadlocks a caller against
+		// itself.
+		return UnderGateAsync(key, cancellationToken, async () =>
 		{
-			return null;
-		}
+			var valueData = await cache.GetAsync(key, cancellationToken);
+			if (valueData == null)
+			{
+				return null;
+			}
 
-		if (!await cache.TryRemoveAsync(key, lockTimeout, cancellationToken))
-		{
-			// Not necessarily somebody else: see TryRemoveAsync's remarks for what false covers.
-			return null;
-		}
-
-		// The claim held, so this caller is the one entitled to A value - but not necessarily to THIS
-		// one. These bytes were read before the gate, and what the protocol removed is whatever was at
-		// the key when it ran. See the remarks, and issue 454.
-		return valueData;
+			// Not necessarily somebody else when this is false: see TryRemoveAsync's remarks.
+			return await RemoveUnderGateAsync(cache, key, lockTimeout, cancellationToken)
+				? valueData
+				: null;
+		});
 	}
 
 	/// <summary>
@@ -199,12 +207,9 @@ public static class DistributedCacheExtensions
 	/// outcome reached by a fault, where the caller gets an exception rather than an answer at all.
 	/// </para>
 	/// <para>
-	/// <strong>Two things the check does NOT give you.</strong> It does not make this a take-once: the
-	/// gate serializes callers within one process, so a competitor cannot overwrite another's token HERE,
-	/// and nothing about that survives a second node - see below. And passing it is not the same as being
-	/// handed the value, because <see cref="TryGetAndRemoveAsync"/> returns what it read BEFORE the
-	/// protocol; where something writes the key in between, two callers pass and are handed the same
-	/// bytes. That is issue 454, and this class does not close it.
+	/// <strong>What the check does NOT give you.</strong> It does not make this a take-once: the gate
+	/// serializes callers within one process, so a competitor cannot overwrite another's token HERE, and
+	/// nothing about that survives a second node - see below.
 	/// </para>
 	/// <para>
 	/// <strong>Across processes even the overwrite reopens.</strong> Two nodes redeeming the same key at
@@ -250,7 +255,7 @@ public static class DistributedCacheExtensions
 	/// nobody can be told they took it. That last one does not need a second node: see the remarks. A
 	/// store fault after the removal raises rather than returning, and loses the value the same way.
 	/// </returns>
-	public static async Task<bool> TryRemoveAsync(
+	public static Task<bool> TryRemoveAsync(
 		this IDistributedCache cache,
 		string key,
 		TimeSpan? lockTimeout = null,
@@ -275,13 +280,31 @@ public static class DistributedCacheExtensions
 		// not necessarily the value removed inside it. Bringing the read inside the serialized section is
 		// what closes the in-process half; the deadlock is an objection to the naive shape of that, not to
 		// the goal.
+		return UnderGateAsync(
+			key, cancellationToken, () => RemoveUnderGateAsync(cache, key, lockTimeout, cancellationToken));
+	}
+
+	/// <summary>
+	/// Runs one redemption of a key with every other redemption of that key in this process held out.
+	/// </summary>
+	/// <remarks>
+	/// The single door to the gate, so a body cannot take it twice and deadlock against itself. Both
+	/// entry points hand their whole protocol in - <see cref="TryGetAndRemoveAsync"/> its read and its
+	/// removal together, which is what makes the value it returns the value it removed within this
+	/// process.
+	/// </remarks>
+	private static async Task<T> UnderGateAsync<T>(
+		string key,
+		CancellationToken cancellationToken,
+		Func<Task<T>> body)
+	{
 		var gate = RentGate(key);
 		try
 		{
 			await gate.WaitAsync(cancellationToken);
 			try
 			{
-				return await RemoveUnderGateAsync(cache, key, lockTimeout, cancellationToken);
+				return await body();
 			}
 			finally
 			{

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -291,13 +291,19 @@ public static class DistributedCacheExtensions
 	/// What that buys is bounded by what the gate holds out, which is other REDEMPTIONS and nothing else.
 	/// A plain <c>SetAsync</c> or <c>RemoveAsync</c> on the same key takes nothing and is not held out at
 	/// all, so one landing between the read and the removal is destroyed by this caller while it is handed
-	/// the earlier bytes - or turns a live value into a refusal with nobody told. The live example in this
-	/// repository is the back-channel request, updated on completion from four handlers on the key this
-	/// protocol redeems, by an approval genuinely concurrent with a token-endpoint poll.
+	/// the earlier bytes - or turns a live value into a refusal with nobody told.
+	/// </para>
+	/// <para>
+	/// Both entry points are exposed to that, so both have live examples here. The back-channel request is
+	/// written on completion and again by the poll bumping its next-poll instant, on the key
+	/// <see cref="TryGetAndRemoveAsync"/> redeems. The device authorization request is written and
+	/// REMOVED outside the gate by its own storage, on the key <see cref="TryRemoveAsync"/> redeems, from
+	/// a user's approval or denial genuinely concurrent with a token-endpoint poll - which is where the
+	/// second half of the sentence above gets its site.
+	/// </para>
 	/// <para>
 	/// So the value returned is the value at the key when this caller got IN, which is a narrower window
 	/// than before and not a guarantee that it is the value removed.
-	/// </para>
 	/// </para>
 	/// </remarks>
 	private static async Task<T> UnderGateAsync<T>(

--- a/src/Abblix.Utils/DistributedCacheExtensions.cs
+++ b/src/Abblix.Utils/DistributedCacheExtensions.cs
@@ -86,11 +86,12 @@ public static class DistributedCacheExtensions
 	}
 
 	/// <summary>
-	/// Reads a value and then removes it under a lock, for a cache with no native primitive of its own.
-	/// This is NOT the equivalent of Redis GETDEL. The bytes returned are the ones read BEFORE the lock,
-	/// so anything writing the key in between is destroyed by this caller while it is handed the earlier
-	/// value - and that is only one of the ways the two differ. AT MOST one caller is handed the value
-	/// when nothing writes the key, and none may be. Read the remarks before relying on it.
+	/// Reads a value and removes it, both under one hold of the per-key gate, for a cache with no native
+	/// primitive of its own. This is NOT the equivalent of Redis GETDEL. The gate holds out other
+	/// REDEMPTIONS of the key and nothing else, so a plain write landing between the read and the removal
+	/// is destroyed by this caller while it is handed the earlier bytes - and that is only one of the ways
+	/// the two differ. AT MOST one caller is handed the value when nothing writes the key, and none may be.
+	/// Read the remarks before relying on it.
 	/// </summary>
 	/// <remarks>
 	/// <para><strong>Atomicity Protocol:</strong></para>
@@ -271,15 +272,9 @@ public static class DistributedCacheExtensions
 		// never meet: the gate exists only while a call is in flight and is discarded with the last one
 		// out.
 		//
-		// This gate is taken HERE and not in TryGetAndRemoveAsync, which calls this method - gating both
-		// naively would deadlock a caller against itself on one key.
-		//
-		// That placement is NOT settled, and this comment is not a reason to leave it. It is fine for the
-		// caller that LOSES: TryGetAndRemoveAsync discards the value it read whenever this returns false.
-		// The caller that WINS is issue 454 - it was handed the value it read before this gate, which is
-		// not necessarily the value removed inside it. Bringing the read inside the serialized section is
-		// what closes the in-process half; the deadlock is an objection to the naive shape of that, not to
-		// the goal.
+		// Both entry points hand their whole protocol to UnderGateAsync, which is the only place the gate
+		// is taken. Calling one public method from the other would take it twice on one key and deadlock a
+		// caller against itself, which is why the shared body is private rather than the public sibling.
 		return UnderGateAsync(
 			key, cancellationToken, () => RemoveUnderGateAsync(cache, key, lockTimeout, cancellationToken));
 	}
@@ -288,10 +283,17 @@ public static class DistributedCacheExtensions
 	/// Runs one redemption of a key with every other redemption of that key in this process held out.
 	/// </summary>
 	/// <remarks>
-	/// The single door to the gate, so a body cannot take it twice and deadlock against itself. Both
-	/// entry points hand their whole protocol in - <see cref="TryGetAndRemoveAsync"/> its read and its
-	/// removal together, which is what makes the value it returns the value it removed within this
-	/// process.
+	/// The only place the gate is taken. Both entry points hand their whole protocol in -
+	/// <see cref="TryGetAndRemoveAsync"/> its read and its removal together - and neither body calls the
+	/// other's public method, which is what a body taking the gate twice on one key would do.
+	/// <para>
+	/// What that buys is bounded by what the gate holds out, which is other REDEMPTIONS and not other
+	/// writers. A plain <c>SetAsync</c> on the same key takes nothing and is not held out at all - and
+	/// those callers are in this repository, on these keys: the authorization grant written back after
+	/// minting, the back-channel request updated on completion, the device record bumped while polling.
+	/// So the value returned is the value at the key when this caller got IN, which is a narrower window
+	/// than before and not a guarantee that it is the value removed.
+	/// </para>
 	/// </remarks>
 	private static async Task<T> UnderGateAsync<T>(
 		string key,

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -30,9 +30,9 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token;
 /// the write-back catches one arriving after it, and both hold however many processes are running - the
 /// claim's last-write-wins token check admits at most one caller wherever the callers are.
 /// <para>
-/// What a second process costs is a winner rather than exclusivity, which is issue 435; and the claim is
-/// not by itself enough within one process either, which is issue 454. Rows for both live beside the
-/// implementation they belong to.
+/// What a second process costs is a winner rather than exclusivity, which is issue 435. Within one
+/// process the claim is enough on its own, because the value is read under the same hold of the gate
+/// that removes it. Rows for both properties live beside the implementation they belong to.
 /// </para>
 /// </summary>
 public class AuthorizationCodeReusePreventingDecoratorTests

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -425,10 +425,11 @@ public class AuthorizationCodeServiceTests
 
     /// <summary>
     /// Verifies that RemoveAuthorizationCodeAsync performs an atomic get-and-remove
-    /// (removeOnRetrieval: true) and returns the claimed grant. The atomic claim is what enforces
-    /// single-use against two concurrent redemptions of the same code. Here nothing competes, nothing
-    /// expires and nothing writes the grant back, so this caller wins - which is what the test measures,
-    /// and is narrower than what the claim gives in general. See issue 454.
+    /// (removeOnRetrieval: true) and returns the claimed grant. The claim is what enforces single-use
+    /// against two redemptions of the same code. Here nothing competes and nothing expires, so this caller
+    /// wins - which is what the test measures, and is narrower than what the claim gives in general: a
+    /// claim expiring mid-protocol loses the grant to nobody, and a second NODE reopens the window in
+    /// which two callers are handed it. See issue 435.
     /// </summary>
     [Fact]
     public async Task RemoveAuthorizationCodeAsync_ShouldGetAndRemoveAtomically()

--- a/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -9,7 +9,9 @@
         <IsTestProject>true</IsTestProject>
         <OutputType>Exe</OutputType>
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    </PropertyGroup>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
 
     <ItemGroup>
         <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />

--- a/tests/Abblix.Utils.UnitTests/Base64UrlTests.cs
+++ b/tests/Abblix.Utils.UnitTests/Base64UrlTests.cs
@@ -17,7 +17,7 @@ namespace Abblix.Utils.UnitTests;
 /// The two sides MUST behave identically - these tests are the parity contract.
 /// </summary>
 /// <remarks>
-/// BCL's <see cref="Base64Url.DecodeFromChars"/> is strict on the alphabet (rejects standard-base64
+/// BCL's <see cref="Base64Url.DecodeFromChars(System.ReadOnlySpan{char})"/> is strict on the alphabet (rejects standard-base64
 /// <c>+</c> and <c>/</c>) and on length-mod-4-equals-1 inputs, which fixes the main correctness gap
 /// in the legacy <c>HttpServerUtility.UrlTokenDecode</c>. The BCL is permissive on <c>=</c> padding
 /// and on whitespace inside the input - accepting them as compat tolerance. That residual leniency

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -556,7 +556,7 @@ public class RedemptionSerializationTests
 		/// <summary>
 		/// How long a caller that should be held OUT is given to prove otherwise. Short, because this one
 		/// is spent on every passing run, and it is a fail-early assertion rather than the proof - see
-		/// <see cref="ParkedReachedAsync"/>.
+		/// <see cref="ResumesBefore"/>.
 		/// </summary>
 		private static readonly TimeSpan SettleWindow = TimeSpan.FromMilliseconds(250);
 
@@ -617,9 +617,13 @@ public class RedemptionSerializationTests
 		/// not run it yet" - are then the same reading, and the row fails in milliseconds under load
 		/// having measured nothing.
 		/// <para>
-		/// The timeout is what keeps the instrument's own failure a DIFFERENT outcome from the property
-		/// being false: a <see cref="TimeoutException"/> says the caller never arrived, where a failed
-		/// assertion would say the gate admitted the wrong number.
+		/// The timeout bounds the wait so a row that will never be satisfied ends in seconds rather than
+		/// hanging the suite. It does NOT separate the instrument's failure from the property being
+		/// false, and assuming it does sends whoever reads a red run to the harness: for a row whose
+		/// property is "this caller DOES get in", a broken gate produces exactly this timeout. Measured -
+		/// keying the gate by a constant instead of by the key makes the different-keys row die with a
+		/// <see cref="TimeoutException"/> rather than an assertion. What tells the two apart is
+		/// <see cref="ResumesBefore"/>, which reports a COUNT, so read that before blaming the harness.
 		/// </para>
 		/// </remarks>
 		public Task WaitUntilEnteredAsync(int callers)
@@ -648,12 +652,14 @@ public class RedemptionSerializationTests
 		/// the second caller was seen within about fifteen milliseconds - so the margin is an order of
 		/// magnitude, and widening it costs only time on a passing run.
 		/// <para>
-		/// It is not on its own what carries these rows, and that took a measurement to establish rather
-		/// than an argument. Neutralising it left a build with the read hoisted back out of the gate
-		/// entirely green, because the plain wait cannot tell an early entry from a late one. What
-		/// discriminates is <see cref="ResumesBefore"/> beside it, which asks how many callers had been
-		/// released when this one got in: a held-out caller records at least one, and a hoisted read
-		/// records zero. That is a fact rather than a moment, so it needs no window at all.
+		/// It is not on its own what carries these rows. Neutralising it USED to leave a build with the
+		/// read hoisted back out of the gate entirely green, because a plain wait cannot tell an early
+		/// entry from a late one - that was measured before <see cref="ResumesBefore"/> existed, and it
+		/// is no longer true: with both in place, neutralising the window and hoisting the read turns the
+		/// row red on the count rather than on the moment. What discriminates is
+		/// <see cref="ResumesBefore"/> beside it, which asks how many callers had been released when this
+		/// one got in: a held-out caller records at least one, and a hoisted read records zero. That is a
+		/// fact rather than a moment, so it needs no window at all.
 		/// </para>
 		/// </remarks>
 		public async Task<bool> EnteredWithinWindowAsync(int callers)

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -461,6 +461,57 @@ public class RedemptionSerializationTests
 	}
 
 	/// <summary>
+	/// The value read by <see cref="DistributedCacheExtensions.TryGetAndRemoveAsync"/> is read INSIDE the
+	/// serialized section, not before waiting for it.
+	/// </summary>
+	/// <remarks>
+	/// Measured by where the read happens rather than by trying to observe a stale value: one caller holds
+	/// the gate, parked at its own protocol read, and a second calls the take-once. If its read is outside
+	/// the gate it happens at once and parks too, so the store sees TWO parked reads; if it is inside, the
+	/// second caller is still waiting and the store sees one.
+	/// <para>
+	/// What this buys is the width of the window rather than its closure. Before, the bytes handed back
+	/// were the bytes present before an unbounded wait - the whole of another caller's redemption. Now they
+	/// are the bytes present when this caller got in, and what remains open is the removal protocol's own
+	/// few steps, to a writer that takes no gate and to any second process at all. That is issue 435, and
+	/// it needs a store primitive this interface does not expose.
+	/// </para>
+	/// </remarks>
+	[Fact]
+	public async Task TryGetAndRemoveAsync_ReadsInsideTheSerializedSection()
+	{
+		var inner = CreateCache();
+		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("value"), TestContext.Current.CancellationToken);
+		var cache = new ParkOnValueRead(inner, Key);
+
+		// The holder parks at its protocol read, inside the gate.
+		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		await cache.WaitUntilParkedAsync(1);
+
+		var taker = cache.TryGetAndRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		for (var i = 0; i < 50; i++) await Task.Yield();
+
+		// One, not two: the taker has not read anything, because it is waiting for the gate the holder has.
+		Assert.Equal(1, cache.Parked);
+
+		cache.ResumeNext();
+		Assert.True(await AnsweredAsync(holder));
+
+		// And it does read, once it is in. One park rather than two: the holder took the value, so the read
+		// finds nothing and the removal protocol - which would have read again - is never reached.
+		await cache.WaitUntilParkedAsync(1);
+		cache.ResumeNext();
+
+		var taken = await Task.WhenAny(
+			taker, Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+		Assert.True(ReferenceEquals(taken, taker), "the taker never answered");
+
+		// The holder took the value, so there is nothing left for the taker: null is the right answer, and
+		// the row is about WHERE it looked rather than what it found.
+		Assert.Null(await taker);
+	}
+
+	/// <summary>
 	/// Parks every read of one of <paramref name="gatedKeys"/> until the test resumes it. The lock keys the
 	/// protocol reads are deliberately not among them: parking those would suspend a caller somewhere the
 	/// property under test says nothing about.

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -95,12 +95,10 @@ public class RedemptionSerializationTests
 		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
-		// The second is started and given every chance to get in.
+		// The second is started and given a real window of time to get in. It does not: one caller is
+		// inside the protocol, not two, which is the whole property.
 		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		for (var i = 0; i < 50; i++) await Task.Yield();
-
-		// It did not. One caller is inside the protocol, not two - which is the whole property.
-		Assert.Equal(1, cache.Parked);
+		Assert.False(await cache.ParkedReachedAsync(2));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(first));
@@ -136,9 +134,9 @@ public class RedemptionSerializationTests
 
 		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 
-		// Give the second every chance to get in beside the first. Under a gate it does not; without one it
-		// does, and that is the arrangement in which the value is lost.
-		for (var i = 0; i < 50; i++) await Task.Yield();
+		// Give the second a real window to get in beside the first. Under a gate it does not; without one
+		// it does, and that is the arrangement in which the value is lost.
+		Assert.False(await cache.ParkedReachedAsync(2));
 
 		// Release the first and let it FINISH before releasing the second. Resuming both and yielding
 		// between them is not the same thing and does not build the arrangement: the second's read runs
@@ -396,8 +394,7 @@ public class RedemptionSerializationTests
 
 		// The second queues on the same lock, so the entry cannot be retired out from under it.
 		var queued = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		for (var i = 0; i < 50; i++) await Task.Yield();
-		Assert.Equal(1, cache.Parked);
+		Assert.False(await cache.ParkedReachedAsync(2));
 
 		// Resume the first, which now fails inside the section.
 		cache.ResumeNext();
@@ -449,9 +446,7 @@ public class RedemptionSerializationTests
 		var a = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 		var b = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		for (var i = 0; i < 50; i++) await Task.Yield();
-
-		Assert.Equal(1, cache.Parked);
+		Assert.False(await cache.ParkedReachedAsync(2));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(a));
@@ -488,11 +483,9 @@ public class RedemptionSerializationTests
 		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilParkedAsync(1);
 
-		var taker = cache.TryGetAndRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		for (var i = 0; i < 50; i++) await Task.Yield();
-
 		// One, not two: the taker has not read anything, because it is waiting for the gate the holder has.
-		Assert.Equal(1, cache.Parked);
+		var taker = cache.TryGetAndRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
+		Assert.False(await cache.ParkedReachedAsync(2));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(holder));
@@ -523,8 +516,24 @@ public class RedemptionSerializationTests
 	/// </remarks>
 	private sealed class ParkOnValueRead(IDistributedCache inner, params string[] gatedKeys) : IDistributedCache
 	{
+		/// <summary>
+		/// How long a wait for a parker may take before it is called a failure of the instrument rather
+		/// than of the property. Generous, because it is never spent on a passing run - a passing run
+		/// completes on the signal - and a busy shared runner is exactly where a tighter bound turns a
+		/// green property red.
+		/// </summary>
+		private static readonly TimeSpan ParkTimeout = TimeSpan.FromSeconds(30);
+
+		/// <summary>
+		/// How long a caller that should be held OUT is given to prove otherwise. Short, because this one
+		/// is spent on every passing run, and it is a fail-early assertion rather than the proof - see
+		/// <see cref="ParkedReachedAsync"/>.
+		/// </summary>
+		private static readonly TimeSpan SettleWindow = TimeSpan.FromMilliseconds(250);
+
 		private readonly HashSet<string> _gated = [..gatedKeys];
 		private readonly Queue<TaskCompletionSource> _parked = new();
+		private readonly List<(int Count, TaskCompletionSource Reached)> _watchers = [];
 		private readonly Lock _sync = new();
 		private int _resumedReads;
 
@@ -535,18 +544,60 @@ public class RedemptionSerializationTests
 		/// </summary>
 		public Action<int>? AfterResume { get; init; }
 
-		public int Parked
+		/// <summary>
+		/// Completes when at least <paramref name="count"/> callers are parked, and throws
+		/// <see cref="TimeoutException"/> if that has not happened within <see cref="ParkTimeout"/>.
+		/// </summary>
+		/// <remarks>
+		/// The wait is on a SIGNAL raised where the parking happens, not on a spin over
+		/// the parked count. A spin bounded by iterations of <c>Task.Yield</c> is bounded by
+		/// scheduling rather than by time: the yielding continuations go to the running thread's local
+		/// queue, so the loop can run to exhaustion on a busy pool while the awaited party's continuation
+		/// is still sitting in the global one. The two readings the test needs to tell apart - "the gate
+		/// held it out" and "the pool has not run it yet" - are then the same reading, and the row fails
+		/// in milliseconds under load having measured nothing.
+		/// <para>
+		/// The timeout is what keeps the instrument's own failure a DIFFERENT outcome from the property
+		/// being false: a <see cref="TimeoutException"/> says the parker never arrived, where a failed
+		/// assertion would say the gate admitted the wrong number.
+		/// </para>
+		/// </remarks>
+		public Task WaitUntilParkedAsync(int count)
 		{
-			get
+			TaskCompletionSource reached;
+			lock (_sync)
 			{
-				lock (_sync) return _parked.Count;
+				if (_parked.Count >= count) return Task.CompletedTask;
+
+				reached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+				_watchers.Add((count, reached));
 			}
+
+			return reached.Task.WaitAsync(ParkTimeout);
 		}
 
-		public async Task WaitUntilParkedAsync(int count)
+		/// <summary>
+		/// Whether <paramref name="count"/> callers park within <see cref="SettleWindow"/>. Used to assert
+		/// that one does NOT: a caller held out by the gate never arrives, and the window is what makes
+		/// that a statement about elapsed time rather than about how many continuations happened to run.
+		/// </summary>
+		/// <remarks>
+		/// A negative bounded by a window can only ever say "not within this long", so it is not what
+		/// carries these rows. The proof is the ADMISSION that follows: after the holder is resumed, the
+		/// same caller parks, and it could not have done so twice. This assertion exists to fail early and
+		/// legibly when the gate lets both in at once, where waiting for the admission would pass.
+		/// </remarks>
+		public async Task<bool> ParkedReachedAsync(int count)
 		{
-			for (var i = 0; i < 1000 && Parked < count; i++) await Task.Yield();
-			Assert.Equal(count, Parked);
+			try
+			{
+				await WaitUntilParkedAsync(count).WaitAsync(SettleWindow);
+				return true;
+			}
+			catch (TimeoutException)
+			{
+				return false;
+			}
 		}
 
 		public void ResumeNext()
@@ -561,7 +612,20 @@ public class RedemptionSerializationTests
 			if (_gated.Contains(key))
 			{
 				var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-				lock (_sync) _parked.Enqueue(gate);
+
+				// Chosen under the same lock that enqueues, so a waiter registering concurrently either
+				// sees the new count itself or is in this list, never neither. Completed outside it, to
+				// keep what the lock covers to the state it guards.
+				List<TaskCompletionSource> reached;
+				lock (_sync)
+				{
+					_parked.Enqueue(gate);
+					reached = [.._watchers.Where(w => w.Count <= _parked.Count).Select(w => w.Reached)];
+					_watchers.RemoveAll(w => w.Count <= _parked.Count);
+				}
+
+				foreach (var watcher in reached) watcher.SetResult();
+
 				await gate.Task;
 
 				AfterResume?.Invoke(Interlocked.Increment(ref _resumedReads));

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -461,18 +461,22 @@ public class RedemptionSerializationTests
 
 		var a = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		await cache.WaitUntilEnteredAsync(2);
-		Assert.True(
-			cache.ResumesBefore(2) >= 1,
-			$"caller 2 entered after {cache.ResumesBefore(2)} releases, so it was never held out");
+
+		// EXACTLY one, not at least one, and it is the HOLDER's release rather than anything about a:
+		// a is started after the holder answered, so nothing held it out. A threshold here would read as
+		// a claim that it was, and would pass whatever the gate did.
+		Assert.Equal(1, cache.ResumesBefore(2));
+
 		var b = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 		Assert.False(await cache.EnteredWithinWindowAsync(3));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(a));
 		await cache.WaitUntilEnteredAsync(3);
-		Assert.True(
-			cache.ResumesBefore(3) >= 1,
-			$"caller 3 entered after {cache.ResumesBefore(3)} releases, so it was never held out");
+
+		// b is the one held out, and it got in after BOTH releases - the holder's and a's. Two is the
+		// fact; a threshold of one would still pass if b had slipped in beside a.
+		Assert.Equal(2, cache.ResumesBefore(3));
 		cache.ResumeNext();
 		Assert.False(await AnsweredAsync(b));
 	}
@@ -566,8 +570,14 @@ public class RedemptionSerializationTests
 		/// How many callers have entered the gated read since this double was made. MONOTONIC, and that
 		/// is the point: the parked QUEUE shrinks when a caller is resumed, so a wait phrased against its
 		/// depth is satisfied by a caller that arrived before the resume as readily as by one admitted
-		/// after it - which is exactly the difference these rows exist to see. A caller cannot enter
-		/// twice, so a cumulative count admits only new arrivals.
+		/// after it - which is exactly the difference these rows exist to see.
+		/// <para>
+		/// It counts ENTRIES, not callers, and the two part company: a take-once against a key whose value
+		/// is still there reads the gated key TWICE, once for the value and once inside the removal
+		/// protocol, so one caller advances this by two. Every row below drives the take-once against a
+		/// key that is already empty, which is why their numbers read as caller counts. A row that does
+		/// not - the obvious next one to write - has to count reads instead.
+		/// </para>
 		/// </summary>
 		private int _entered;
 

--- a/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
+++ b/tests/Abblix.Utils.UnitTests/RedemptionSerializationTests.cs
@@ -93,17 +93,20 @@ public class RedemptionSerializationTests
 
 		// The first caller enters and parks at its read of the value, holding the key.
 		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(1);
 
 		// The second is started and given a real window of time to get in. It does not: one caller is
 		// inside the protocol, not two, which is the whole property.
 		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		Assert.False(await cache.ParkedReachedAsync(2));
+		Assert.False(await cache.EnteredWithinWindowAsync(2));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(first));
 
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(2);
+		Assert.True(
+			cache.ResumesBefore(2) >= 1,
+			$"caller 2 entered after {cache.ResumesBefore(2)} releases, so it was never held out");
 		cache.ResumeNext();
 		Assert.False(await AnsweredAsync(second));
 	}
@@ -130,13 +133,13 @@ public class RedemptionSerializationTests
 		var cache = new ParkOnValueRead(inner, Key);
 
 		var first = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(1);
 
 		var second = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
 
 		// Give the second a real window to get in beside the first. Under a gate it does not; without one
 		// it does, and that is the arrangement in which the value is lost.
-		Assert.False(await cache.ParkedReachedAsync(2));
+		Assert.False(await cache.EnteredWithinWindowAsync(2));
 
 		// Release the first and let it FINISH before releasing the second. Resuming both and yielding
 		// between them is not the same thing and does not build the arrangement: the second's read runs
@@ -147,7 +150,10 @@ public class RedemptionSerializationTests
 
 		// Serialized, the second only reaches its read now; unserialized it has been parked since before
 		// the first ran. Either way its gate is the next one out.
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(2);
+		Assert.True(
+			cache.ResumesBefore(2) >= 1,
+			$"caller 2 entered after {cache.ResumesBefore(2)} releases, so it was never held out");
 		cache.ResumeNext();
 		var secondWon = await AnsweredAsync(second);
 
@@ -355,8 +361,11 @@ public class RedemptionSerializationTests
 		var a = cache.TryRemoveAsync(first, cancellationToken: TestContext.Current.CancellationToken);
 		var b = cache.TryRemoveAsync(second, cancellationToken: TestContext.Current.CancellationToken);
 
-		// Both reach their read. Under a gate shared across keys the second would still be waiting.
-		await cache.WaitUntilParkedAsync(2);
+		// Both reach their read, and the second gets in WITHOUT anybody being released - which is the
+		// property here, and the exact inverse of what the same-key rows assert. Under a gate shared
+		// across keys the second would still be waiting.
+		await cache.WaitUntilEnteredAsync(2);
+		Assert.Equal(0, cache.ResumesBefore(2));
 
 		cache.ResumeNext();
 		cache.ResumeNext();
@@ -390,11 +399,11 @@ public class RedemptionSerializationTests
 
 		// The first caller holds the lock and parks inside the guarded section.
 		var failing = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(1);
 
 		// The second queues on the same lock, so the entry cannot be retired out from under it.
 		var queued = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		Assert.False(await cache.ParkedReachedAsync(2));
+		Assert.False(await cache.EnteredWithinWindowAsync(2));
 
 		// Resume the first, which now fails inside the section.
 		cache.ResumeNext();
@@ -402,7 +411,10 @@ public class RedemptionSerializationTests
 
 		// The queued caller must get in. Bounded, because without the release it would wait forever and a
 		// hanging test says nothing.
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(2);
+		Assert.True(
+			cache.ResumesBefore(2) >= 1,
+			$"caller 2 entered after {cache.ResumesBefore(2)} releases, so it was never held out");
 		cache.ResumeNext();
 
 		var finished = await Task.WhenAny(
@@ -429,7 +441,7 @@ public class RedemptionSerializationTests
 		var cache = new ParkOnValueRead(inner, Key);
 
 		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(1);
 
 		using var cancelled = new CancellationTokenSource();
 		var waiter = cache.TryRemoveAsync(Key, cancellationToken: cancelled.Token);
@@ -441,16 +453,26 @@ public class RedemptionSerializationTests
 
 		// If the cancelled waiter had over-released, two callers could now be inside at once. Drive the
 		// same arrangement again and require it to still serialize.
+		//
+		// The counts run on from the first arrangement, because entries are counted cumulatively rather
+		// than as a queue depth: the holder was the first, so a is the second and b would be the third.
+		// The cancelled waiter is not among them - it never got in, which is the property above.
 		await inner.SetAsync(Key, Encoding.UTF8.GetBytes("again"), TestContext.Current.CancellationToken);
 
 		var a = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(2);
+		Assert.True(
+			cache.ResumesBefore(2) >= 1,
+			$"caller 2 entered after {cache.ResumesBefore(2)} releases, so it was never held out");
 		var b = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		Assert.False(await cache.ParkedReachedAsync(2));
+		Assert.False(await cache.EnteredWithinWindowAsync(3));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(a));
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(3);
+		Assert.True(
+			cache.ResumesBefore(3) >= 1,
+			$"caller 3 entered after {cache.ResumesBefore(3)} releases, so it was never held out");
 		cache.ResumeNext();
 		Assert.False(await AnsweredAsync(b));
 	}
@@ -481,18 +503,21 @@ public class RedemptionSerializationTests
 
 		// The holder parks at its protocol read, inside the gate.
 		var holder = cache.TryRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(1);
 
 		// One, not two: the taker has not read anything, because it is waiting for the gate the holder has.
 		var taker = cache.TryGetAndRemoveAsync(Key, cancellationToken: TestContext.Current.CancellationToken);
-		Assert.False(await cache.ParkedReachedAsync(2));
+		Assert.False(await cache.EnteredWithinWindowAsync(2));
 
 		cache.ResumeNext();
 		Assert.True(await AnsweredAsync(holder));
 
 		// And it does read, once it is in. One park rather than two: the holder took the value, so the read
 		// finds nothing and the removal protocol - which would have read again - is never reached.
-		await cache.WaitUntilParkedAsync(1);
+		await cache.WaitUntilEnteredAsync(2);
+		Assert.True(
+			cache.ResumesBefore(2) >= 1,
+			$"caller 2 entered after {cache.ResumesBefore(2)} releases, so it was never held out");
 		cache.ResumeNext();
 
 		var taken = await Task.WhenAny(
@@ -533,9 +558,33 @@ public class RedemptionSerializationTests
 
 		private readonly HashSet<string> _gated = [..gatedKeys];
 		private readonly Queue<TaskCompletionSource> _parked = new();
-		private readonly List<(int Count, TaskCompletionSource Reached)> _watchers = [];
+		private readonly List<(int Entered, TaskCompletionSource Reached)> _watchers = [];
 		private readonly Lock _sync = new();
 		private int _resumedReads;
+
+		/// <summary>
+		/// How many callers have entered the gated read since this double was made. MONOTONIC, and that
+		/// is the point: the parked QUEUE shrinks when a caller is resumed, so a wait phrased against its
+		/// depth is satisfied by a caller that arrived before the resume as readily as by one admitted
+		/// after it - which is exactly the difference these rows exist to see. A caller cannot enter
+		/// twice, so a cumulative count admits only new arrivals.
+		/// </summary>
+		private int _entered;
+
+		/// <summary>
+		/// How many parked callers have been resumed, and how many had been resumed at the moment each
+		/// caller entered. The second list is what lets a row assert ORDER without asserting time.
+		/// </summary>
+		/// <remarks>
+		/// "The second caller was not in yet" is a statement about a moment, so testing it directly needs
+		/// a window and can only ever say "not within this long". Testing instead that the second caller
+		/// entered only AFTER the first was released says the same thing as a fact that either happened or
+		/// did not - and a hoisted read, which is the regression these rows exist to catch, records a
+		/// second entry at zero resumes.
+		/// </remarks>
+		private int _resumes;
+
+		private readonly List<int> _resumesAtEntry = [];
 
 		/// <summary>
 		/// Runs after a resumed read, before the value is fetched, so a test can make the store fail INSIDE
@@ -545,57 +594,71 @@ public class RedemptionSerializationTests
 		public Action<int>? AfterResume { get; init; }
 
 		/// <summary>
-		/// Completes when at least <paramref name="count"/> callers are parked, and throws
-		/// <see cref="TimeoutException"/> if that has not happened within <see cref="ParkTimeout"/>.
+		/// Completes when at least <paramref name="callers"/> have entered the gated read since this
+		/// double was made, and throws <see cref="TimeoutException"/> if that has not happened within
+		/// <see cref="ParkTimeout"/>.
 		/// </summary>
 		/// <remarks>
-		/// The wait is on a SIGNAL raised where the parking happens, not on a spin over
-		/// the parked count. A spin bounded by iterations of <c>Task.Yield</c> is bounded by
-		/// scheduling rather than by time: the yielding continuations go to the running thread's local
-		/// queue, so the loop can run to exhaustion on a busy pool while the awaited party's continuation
-		/// is still sitting in the global one. The two readings the test needs to tell apart - "the gate
-		/// held it out" and "the pool has not run it yet" - are then the same reading, and the row fails
-		/// in milliseconds under load having measured nothing.
+		/// The wait is on a SIGNAL raised where the entry happens, not on a spin over a count. A spin
+		/// bounded by iterations of <c>Task.Yield</c> is bounded by scheduling rather than by time: the
+		/// yielding continuations go to the running thread's local queue, so the loop can run to
+		/// exhaustion on a busy pool while the awaited party's continuation is still sitting in the global
+		/// one. The two readings these rows need to tell apart - "the gate held it out" and "the pool has
+		/// not run it yet" - are then the same reading, and the row fails in milliseconds under load
+		/// having measured nothing.
 		/// <para>
 		/// The timeout is what keeps the instrument's own failure a DIFFERENT outcome from the property
-		/// being false: a <see cref="TimeoutException"/> says the parker never arrived, where a failed
+		/// being false: a <see cref="TimeoutException"/> says the caller never arrived, where a failed
 		/// assertion would say the gate admitted the wrong number.
 		/// </para>
 		/// </remarks>
-		public Task WaitUntilParkedAsync(int count)
+		public Task WaitUntilEnteredAsync(int callers)
 		{
 			TaskCompletionSource reached;
 			lock (_sync)
 			{
-				if (_parked.Count >= count) return Task.CompletedTask;
+				if (_entered >= callers) return Task.CompletedTask;
 
 				reached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-				_watchers.Add((count, reached));
+				_watchers.Add((callers, reached));
 			}
 
 			return reached.Task.WaitAsync(ParkTimeout);
 		}
 
 		/// <summary>
-		/// Whether <paramref name="count"/> callers park within <see cref="SettleWindow"/>. Used to assert
-		/// that one does NOT: a caller held out by the gate never arrives, and the window is what makes
-		/// that a statement about elapsed time rather than about how many continuations happened to run.
+		/// Whether <paramref name="callers"/> have entered within <see cref="SettleWindow"/>. Used to
+		/// assert that one has NOT: a caller held out by the gate never arrives, and the window is what
+		/// makes that a statement about elapsed time rather than about how many continuations ran.
 		/// </summary>
 		/// <remarks>
-		/// A negative bounded by a window can only ever say "not within this long", so it is not what
-		/// carries these rows. The proof is the ADMISSION that follows: after the holder is resumed, the
-		/// same caller parks, and it could not have done so twice. This assertion exists to fail early and
-		/// legibly when the gate lets both in at once, where waiting for the admission would pass.
+		/// Its honest limit is the window: it says a second caller did not enter within
+		/// <see cref="SettleWindow"/>, never that one could not. The window was chosen by measurement
+		/// rather than by feel - with the gate removed under three times the machine's cores in spinners,
+		/// the second caller was seen within about fifteen milliseconds - so the margin is an order of
+		/// magnitude, and widening it costs only time on a passing run.
+		/// <para>
+		/// It is not on its own what carries these rows, and that took a measurement to establish rather
+		/// than an argument. Neutralising it left a build with the read hoisted back out of the gate
+		/// entirely green, because the plain wait cannot tell an early entry from a late one. What
+		/// discriminates is <see cref="ResumesBefore"/> beside it, which asks how many callers had been
+		/// released when this one got in: a held-out caller records at least one, and a hoisted read
+		/// records zero. That is a fact rather than a moment, so it needs no window at all.
+		/// </para>
 		/// </remarks>
-		public async Task<bool> ParkedReachedAsync(int count)
+		public async Task<bool> EnteredWithinWindowAsync(int callers)
 		{
 			try
 			{
-				await WaitUntilParkedAsync(count).WaitAsync(SettleWindow);
+				await WaitUntilEnteredAsync(callers).WaitAsync(SettleWindow);
 				return true;
 			}
 			catch (TimeoutException)
 			{
+				// Dropped rather than abandoned. A registration left behind holds an orphaned thirty-second
+				// wait that faults unobserved, and it is one more thing a later assertion on the same count
+				// could complete off.
+				lock (_sync) _watchers.RemoveAll(w => w.Entered == callers);
 				return false;
 			}
 		}
@@ -603,8 +666,22 @@ public class RedemptionSerializationTests
 		public void ResumeNext()
 		{
 			TaskCompletionSource gate;
-			lock (_sync) gate = _parked.Dequeue();
+			lock (_sync)
+			{
+				gate = _parked.Dequeue();
+				_resumes++;
+			}
+
 			gate.SetResult();
+		}
+
+		/// <summary>
+		/// How many parked callers had been resumed when the <paramref name="entry"/>-th caller entered.
+		/// Zero says it got in without waiting for anybody.
+		/// </summary>
+		public int ResumesBefore(int entry)
+		{
+			lock (_sync) return _resumesAtEntry[entry - 1];
 		}
 
 		public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
@@ -620,8 +697,10 @@ public class RedemptionSerializationTests
 				lock (_sync)
 				{
 					_parked.Enqueue(gate);
-					reached = [.._watchers.Where(w => w.Count <= _parked.Count).Select(w => w.Reached)];
-					_watchers.RemoveAll(w => w.Count <= _parked.Count);
+					_entered++;
+					_resumesAtEntry.Add(_resumes);
+					reached = [.._watchers.Where(w => w.Entered <= _entered).Select(w => w.Reached)];
+					_watchers.RemoveAll(w => w.Entered <= _entered);
 				}
 
 				foreach (var watcher in reached) watcher.SetResult();

--- a/tests/Abblix.Utils.UnitTests/UriBuilderTests.cs
+++ b/tests/Abblix.Utils.UnitTests/UriBuilderTests.cs
@@ -860,7 +860,7 @@ public class UriBuilderTests
 
     /// <summary>
     /// Verifies that query parameters with array-like names work correctly.
-    /// Common in API query strings like ?ids[]=1&ids[]=2
+    /// Common in API query strings like <c>?ids[]=1&amp;ids[]=2</c>
     /// </summary>
     [Fact]
     public void Query_WithArrayLikeNames_BuildsCorrectly()


### PR DESCRIPTION
Closes #454.

## What a caller was handed

`TryGetAndRemoveAsync` read the value, then delegated the removal to `TryRemoveAsync`, which takes the per-key gate. So the bytes handed back were the bytes at the key **before an unbounded wait** - and that wait is the whole of another caller's redemption, not a moment.

Anything landing in that window was destroyed by this caller and handed to nobody, while the caller received the earlier bytes and was told it won.

On the authorization code that is not academic. `AuthorizationCodeReusePreventingDecorator` removes the code, mints, and writes the grant back at the same key with `IssuedTokens` populated:

- Caller B reads the pre-issuance grant, `IssuedTokens` empty.
- Caller A removes the code, mints a full token set, writes the grant back.
- B enters the gate, removes A's written-back grant, and is handed its own stale copy.
- B's sequential-reuse check sees `IssuedTokens` empty, so it does not fire. A second full token set is minted for one authorization code, A's tokens are never revoked, and the record naming them has been destroyed - so no later redemption can catch it either.

## The change

Both entry points hand their whole protocol to one gate helper, so the read and the removal happen under a single hold. Taking the gate twice on one key would deadlock a caller against itself, which is why the read could not simply be wrapped where it stood - the objection in the old comment was to the naive shape, not to the goal.

## What it does NOT do, said where it used to say the opposite

The window narrows; it does not close. A writer that takes no gate can still land between the read and the removal, and the SERIALIZATION survives no second process. `TryGetAndRemoveAsync`'s remarks and `<returns>` now say that, where they previously described the value as read before the removal and pointed at this issue as the open one. `TryRemoveAsync`'s `<returns>` is untouched: it never claimed either. The single-node half is a property of the storage this library ships rather than of the seam, and the interface now says whose it is: a host substituting its own `IEntityStorage` owns it, and a naive get-then-remove reopens the duplication on one node.

The full answer is #435 and needs a store primitive `IDistributedCache` does not expose - `GETDEL`, `DELETE ... RETURNING`, `OUTPUT deleted`, `RETURNING INTO`.

## Evidence

The row measures WHERE the read happens rather than trying to observe a stale value - which is what makes it deterministic instead of a race:

One caller holds the gate, parked at its own protocol read. A second calls the take-once. The store must see **one** parked read, not two: if the second caller's read were outside the gate it would happen at once and park as well.

- Putting the read back in front of the gate is caught by that row, and by nothing else in the suite.
- The row also drives the taker to completion afterwards, so it fails rather than hangs if the gate is never released - a hung test takes its class with it and reports as a smaller suite with nothing failing.

Two files this list does not mention carry the diff's other half: `AuthorizationCodeService.cs`, which is where the ordering sentence lives, and `AuthorizationCodeServiceTests.cs`.

The instrument that carries those rows was rebuilt after it failed twice on this branch, once on a delta containing no line that is not a comment. It waited by spinning a fixed number of `Task.Yield()` calls, which bounds a wait by scheduling rather than by time: the yielding continuations go to the running thread's local queue, so on a busy runner the loop exhausts itself while the awaited party's continuation is still in the global one. "The gate held a caller out" and "the pool has not run it yet" were then the same reading. The wait is now on a signal raised where the parking happens, with a timeout. The timeout only bounds the wait: for every row whose property is that a caller DOES get in, a broken gate produces exactly that timeout too, measured by keying the gate on a constant. What separates the instrument's failure from the property being false is the COUNT `ResumesBefore` reports, and the harness says so at the line that waits.

Proved by removing the gate: rows go red across both entry points, and the suite total does not move. Not every rewritten row - one of them asserts the INVERSE, that two callers on different keys get in with nobody released, and no gate removal can make that false. It is the control. Both affected suites are green with the gate back.

A later round found the rest of it. The plain wait after a release proved nothing, because the parked queue shrinks when a caller is resumed, so a caller admitted early was still parked when the admission was awaited. Entries are now counted cumulatively, and each records how many callers had been released when it happened - which turns "the second was held out" into a fact rather than a moment: a held-out caller records at least one release, a hoisted read records zero. Measured both ways, with every windowed negative neutralised, so the assertion carrying the row is the one named rather than the one that looked stronger.

**Round 6.** The sentence above was the old, wrong mapping: this description kept it after round 5 corrected the same claim in the harness, so the two contradicted each other and the body was the copy a reader reaches first. Three comments outside the diff described the behaviour this change removes, each naming issue 454, which this change closes - the reuse decorator's class summary, the CIBA request storage's, and the decorator's test class. Found by grepping the tree for the issue number being closed: exactly three, against a control that found five for a neighbouring issue.

**Round 7.** Two sentences written by rounds 5 and 6 claimed more than their mechanism gives, and both are the same shape - a guard that holds at one moment written up as a property that holds always.

The first RETRACTED too much. Moving the read inside the gate made one half of the old sentence false, and the replacement retracted both halves: "a write landing beside it is either destroyed before the read or seen by it" is a closed pair, short by the case the extension it delegates to documents in its own remarks. `UpdateAsync` is a plain set on this key and takes no gate, so the CIBA grant handler's next-poll bump can land AFTER the in-gate read and be destroyed by the removal without ever being seen - which that handler's own comment already calls a race. The text now says the hold covers the read and the removal and nothing else, and what closing the rest would take.

The second turned a guard into an impossibility. "Nothing moves a record from authorized to denied - approval and denial both refuse anything that is not pending" reads as structural; the refusal is a read-then-write, and the same file's remarks file the gap between its read and its write as issue 194. The denied arm is still not named, with the true reason: reaching it under a hold needs that race, while the expired arm needs none.

**And a coverage gap in the central claim, filed rather than closed here: #489.** A review planted the read under one hold and the removal under a second - both suites stay green and `ReadsInsideTheSerializedSection` passes, although that split reopens #454's one-node window exactly. The suite pins that a competitor cannot get in while a holder holds; it does not pin that the read and the removal are ONE hold. Closing it needs new machinery in the concurrency harness, and this change's own ledger records that its rounds 3 and 4 were larger than the original change because the harness was designed inside the review loop. Adding to it at round 7 repeats that, so the gap is named and tracked instead.
