### PR TITLE
Stop naming a competitor as the cause of a redemption refusal

### DIFF
--- a/.github/scripts/lint-take-once-consumers.py
+++ b/.github/scripts/lint-take-once-consumers.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Refuse a new consumer of the take-once protocol that nobody has read the contract for.
+
+``DistributedCacheExtensions.TryRemoveAsync`` and ``TryGetAndRemoveAsync`` refuse for three reasons and
+only one of them involves a competitor: another caller took it, the claim EXPIRED mid-protocol, or a
+store call after the removal failed. The last two need neither a second caller nor a second node.
+
+Every consumer that wrote its own ``<returns>`` from the shape of the call - rather than from that
+contract - said "a concurrent request already claimed it", and an operator told a second request was the
+cause goes looking for a second node while the single-caller causes are exactly the ones that never
+produce one. Seven sites said it before this check existed.
+
+Prose cannot be checked here without crying wolf: "concurrent" is a legitimate word in most of these
+files, and a detector with false positives trains everyone to wave it away. What CAN be checked exactly
+is the REACH - who consumes the protocol at all. This list is the answer, and a change to it fails until
+somebody re-reads the contract and updates it deliberately.
+
+Usage: ``lint-take-once-consumers.py``; it walks the tracked ``.cs`` files.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+CALL = re.compile(r"\b(TryRemoveAsync|TryGetAndRemoveAsync)\b")
+
+DECLARING = "src/Abblix.Utils/DistributedCacheExtensions.cs"
+
+#: Every file in `src/` that consumes the take-once protocol, as of the sweep for issue 455. Each one
+#: describes a refusal in its own words, and each was checked against the contract rather than against
+#: the call's shape. Adding a name here is the moment to read that contract.
+KNOWN = {
+    "src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs",
+    "src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs",
+    "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs",
+    "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs",
+    "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs",
+    "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs",
+    "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs",
+    "src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs",
+    "src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs",
+    "src/Abblix.Oidc.Server/Features/Storages/DistributedCacheStorage.cs",
+}
+
+CONTRACT = (
+    "A caller is told it took the value only when the protocol ran to the end AND its own claim was "
+    "still in the store. A refusal covers the key not being there, another caller having taken it, a "
+    "claim that expired mid-protocol, and the value being gone with nobody able to be told they took "
+    "it - the last two on a single caller with no competitor at all. A store fault after the removal "
+    f"raises rather than returning. The contract is on {DECLARING}."
+)
+
+
+def tracked_sources() -> list[str]:
+    listed = subprocess.run(
+        ["git", "ls-files", "src/*.cs"], capture_output=True, text=True, check=True)
+    return [line for line in listed.stdout.splitlines() if line]
+
+
+def main() -> int:
+    found = {
+        path for path in tracked_sources()
+        if path != DECLARING and CALL.search(pathlib.Path(path).read_text(encoding="utf-8-sig"))
+    }
+
+    added = sorted(found - KNOWN)
+    gone = sorted(KNOWN - found)
+
+    if not added and not gone:
+        return 0
+
+    for path in added:
+        print(f"{path}: consumes the take-once protocol and is not in the reviewed list.")
+
+    for path in gone:
+        print(f"{path}: no longer consumes the take-once protocol, but is still in the list.")
+
+    print(f"\n{CONTRACT}")
+    print(
+        f"\nDescribe the refusal from that contract rather than from the shape of the call, then update "
+        f"KNOWN in {pathlib.Path(__file__).as_posix().split('/')[-1]}.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/lint-take-once-consumers.py
+++ b/.github/scripts/lint-take-once-consumers.py
@@ -26,13 +26,16 @@ import re
 import subprocess
 import sys
 
-#: Both ways in. The two extension methods by name, and the flag that routes a read through the same
+#: Three ways in. The two extension methods by name; the flag that routes a read through the same
 #: protocol one layer up - `IEntityStorage.GetAsync(..., removeOnRetrieval: true)` and
-#: `IAuthorizationRequestStorage.TryGetAsync(..., shouldRemove: true)`. A name grep alone was blind to
-#: the second, and files describing this refusal reach it only that way.
+#: `IAuthorizationRequestStorage.TryGetAsync(..., shouldRemove: true)`; and the DECLARATION of that
+#: flag, because the file declaring it is the one carrying the contract prose and it never passes the
+#: argument to itself. A name grep alone was blind to the second route, and both call-shaped routes
+#: were blind to the third - which is where the sentences this checker exists over actually live.
 CALL = re.compile(
     r"\b(TryRemoveAsync|TryGetAndRemoveAsync)\b"
-    r"|\b(removeOnRetrieval|shouldRemove)\s*:\s*true\b")
+    r"|\b(removeOnRetrieval|shouldRemove)\s*:\s*true\b"
+    r"|\bbool\s+(removeOnRetrieval|shouldRemove)\b")
 
 DECLARING = "src/Abblix.Utils/DistributedCacheExtensions.cs"
 
@@ -40,9 +43,8 @@ DECLARING = "src/Abblix.Utils/DistributedCacheExtensions.cs"
 #: 455. Each was checked against the contract rather than against the call's shape, and adding a name
 #: here is the moment to read that contract.
 #:
-#: This is what the checker CAN see. A caller reaching the protocol through some third wrapper, named
-#: neither way, is outside it - so the list is the reach of the two routes above rather than a proof that
-#: nothing else redeems.
+#: This is what the checker CAN see - the reach of the three routes above, rather than a proof that
+#: nothing else redeems. What it cannot see is in WRAPPERS below.
 KNOWN = {
     "src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs",
     "src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs",
@@ -56,6 +58,18 @@ KNOWN = {
     "src/Abblix.Oidc.Server/Features/Storages/DistributedCacheStorage.cs",
     "src/Abblix.Oidc.Server/Features/PushedAuthorization/PushedAuthorizationRequestProcessorDecorator.cs",
     "src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs",
+    "src/Abblix.Oidc.Server/Features/Storages/AuthorizationRequestStorage.cs",
+    "src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs",
+    "src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs",
+}
+
+#: A caller reaching the protocol through a WRAPPER that renames it names none of the three routes, so
+#: no pattern here finds it and no pattern here notices when it stops being one. These are recorded by
+#: hand, are not measured, and are listed so that the checker's blind spot is a NAMED file rather than a
+#: hypothetical: `IAuthorizationCodeService` declares `RemoveAuthorizationCodeAsync` over an
+#: implementation that IS measured, and describes this refusal in its own `<returns>`.
+WRAPPERS = {
+    "src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs",
 }
 
 CONTRACT = (
@@ -68,21 +82,45 @@ CONTRACT = (
 
 
 def tracked_sources() -> list[str]:
+    # Two separate defaults are relative to the CURRENT directory here, and each has to be overridden by
+    # its own flag. `:(top)` anchors the PATTERN, without which the same command run from `src/` matches
+    # nothing and this checker answers a clean zero over a sweep that read no files. `--full-name`
+    # anchors the OUTPUT, without which the paths come back relative to the caller and neither KNOWN nor
+    # the read below can be written against them. Anchoring one and not the other still moves the reach.
     listed = subprocess.run(
-        ["git", "ls-files", "src/*.cs"], capture_output=True, text=True, check=True)
+        ["git", "ls-files", "--full-name", ":(top)src/*.cs"],
+        capture_output=True, text=True, check=True)
     return [line for line in listed.stdout.splitlines() if line]
 
 
+def repository_root() -> pathlib.Path:
+    # The paths `tracked_sources` yields are repo-relative, so they are only readable from here - the
+    # command works from any directory and its answer does not.
+    located = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True)
+    return pathlib.Path(located.stdout.strip())
+
+
 def main() -> int:
+    root = repository_root()
+    sources = tracked_sources()
+
+    # A silence has to mean something was read. Nothing to read is a broken invocation, never an
+    # all-clear, and the two are the same output until this refuses one of them.
+    if not sources:
+        print("no tracked .cs files under src/; nothing was checked.")
+        return 2
+
     found = {
-        path for path in tracked_sources()
-        if path != DECLARING and CALL.search(pathlib.Path(path).read_text(encoding="utf-8-sig"))
+        path for path in sources
+        if path != DECLARING and CALL.search((root / path).read_text(encoding="utf-8-sig"))
     }
 
     added = sorted(found - KNOWN)
     gone = sorted(KNOWN - found)
 
     if not added and not gone:
+        print(f"{len(sources)} tracked source(s) read; {len(KNOWN)} known consumer(s), unchanged.")
         return 0
 
     for path in added:
@@ -95,6 +133,9 @@ def main() -> int:
     print(
         f"\nDescribe the refusal from that contract rather than from the shape of the call, then update "
         f"KNOWN in {pathlib.Path(__file__).name}.")
+    print(
+        "\nOutside what this checker measures, and carrying the same contract by hand: "
+        + ", ".join(sorted(WRAPPERS)))
     return 1
 
 

--- a/.github/scripts/lint-take-once-consumers.py
+++ b/.github/scripts/lint-take-once-consumers.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Refuse a new consumer of the take-once protocol that nobody has read the contract for.
 
-``DistributedCacheExtensions.TryRemoveAsync`` and ``TryGetAndRemoveAsync`` refuse for three reasons and
-only one of them involves a competitor: another caller took it, the claim EXPIRED mid-protocol, or a
-store call after the removal failed. The last two need neither a second caller nor a second node.
+``DistributedCacheExtensions.TryRemoveAsync`` and ``TryGetAndRemoveAsync`` refuse for two reasons and
+only one involves a competitor: another caller took it, or the claim EXPIRED mid-protocol - the second
+on a single caller with nobody to lose to. A store call that fails after the removal is a third OUTCOME
+rather than a third cause: it raises, and the caller is handed an exception instead of an answer.
 
 Every consumer that wrote its own ``<returns>`` from the shape of the call - rather than from that
 contract - said "a concurrent request already claimed it", and an operator told a second request was the
-cause goes looking for a second node while the single-caller causes are exactly the ones that never
-produce one. Seven sites said it before this check existed.
+cause goes looking for a second node while the single-caller case is exactly the one that never produces
+one.
 
 Prose cannot be checked here without crying wolf: "concurrent" is a legitimate word in most of these
 files, and a detector with false positives trains everyone to wave it away. What CAN be checked exactly
@@ -25,13 +26,23 @@ import re
 import subprocess
 import sys
 
-CALL = re.compile(r"\b(TryRemoveAsync|TryGetAndRemoveAsync)\b")
+#: Both ways in. The two extension methods by name, and the flag that routes a read through the same
+#: protocol one layer up - `IEntityStorage.GetAsync(..., removeOnRetrieval: true)` and
+#: `IAuthorizationRequestStorage.TryGetAsync(..., shouldRemove: true)`. A name grep alone was blind to
+#: the second, and files describing this refusal reach it only that way.
+CALL = re.compile(
+    r"\b(TryRemoveAsync|TryGetAndRemoveAsync)\b"
+    r"|\b(removeOnRetrieval|shouldRemove)\s*:\s*true\b")
 
 DECLARING = "src/Abblix.Utils/DistributedCacheExtensions.cs"
 
-#: Every file in `src/` that consumes the take-once protocol, as of the sweep for issue 455. Each one
-#: describes a refusal in its own words, and each was checked against the contract rather than against
-#: the call's shape. Adding a name here is the moment to read that contract.
+#: Every file in `src/` that reaches the take-once protocol, by either route, as of the sweep for issue
+#: 455. Each was checked against the contract rather than against the call's shape, and adding a name
+#: here is the moment to read that contract.
+#:
+#: This is what the checker CAN see. A caller reaching the protocol through some third wrapper, named
+#: neither way, is outside it - so the list is the reach of the two routes above rather than a proof that
+#: nothing else redeems.
 KNOWN = {
     "src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs",
     "src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs",
@@ -43,14 +54,16 @@ KNOWN = {
     "src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs",
     "src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs",
     "src/Abblix.Oidc.Server/Features/Storages/DistributedCacheStorage.cs",
+    "src/Abblix.Oidc.Server/Features/PushedAuthorization/PushedAuthorizationRequestProcessorDecorator.cs",
+    "src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs",
 }
 
 CONTRACT = (
     "A caller is told it took the value only when the protocol ran to the end AND its own claim was "
-    "still in the store. A refusal covers the key not being there, another caller having taken it, a "
-    "claim that expired mid-protocol, and the value being gone with nobody able to be told they took "
-    "it - the last two on a single caller with no competitor at all. A store fault after the removal "
-    f"raises rather than returning. The contract is on {DECLARING}."
+    "still in the store. A refusal covers the key not being there, another caller having taken it, and "
+    "a claim that expired mid-protocol - the last on a single caller with nobody to lose to, its "
+    "outcome being the value gone with nobody able to be told they took it. A store fault after the "
+    f"removal raises rather than returning, so it never reaches the refusal. Contract: {DECLARING}."
 )
 
 
@@ -81,7 +94,7 @@ def main() -> int:
     print(f"\n{CONTRACT}")
     print(
         f"\nDescribe the refusal from that contract rather than from the shape of the call, then update "
-        f"KNOWN in {pathlib.Path(__file__).as_posix().split('/')[-1]}.")
+        f"KNOWN in {pathlib.Path(__file__).name}.")
     return 1
 
 

--- a/.github/scripts/lint-take-once-consumers.py
+++ b/.github/scripts/lint-take-once-consumers.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Refuse a new consumer of the take-once protocol that nobody has read the contract for.
 
-``DistributedCacheExtensions.TryRemoveAsync`` and ``TryGetAndRemoveAsync`` refuse for two reasons and
-only one involves a competitor: another caller took it, or the claim EXPIRED mid-protocol - the second
-on a single caller with nobody to lose to. A store call that fails after the removal is a third OUTCOME
-rather than a third cause: it raises, and the caller is handed an exception instead of an answer.
+``DistributedCacheExtensions.TryRemoveAsync`` and ``TryGetAndRemoveAsync`` answer that a caller took the
+value only when the protocol ran to the end AND its own claim was still in the store. Everything else is
+a refusal, and only one of the ways there involves a competitor. A store call that fails after the removal
+is an OUTCOME rather than a cause: it raises, and the caller is handed an exception instead of an answer.
+The ``CONTRACT`` string below is the sentence this file exists to make somebody read; it is stated as the
+condition rather than as a list, for the same reason the consumers are.
 
 Every consumer that wrote its own ``<returns>`` from the shape of the call - rather than from that
 contract - said "a concurrent request already claimed it", and an operator told a second request was the
@@ -16,7 +18,8 @@ files, and a detector with false positives trains everyone to wave it away. What
 is the REACH - who consumes the protocol at all. This list is the answer, and a change to it fails until
 somebody re-reads the contract and updates it deliberately.
 
-Usage: ``lint-take-once-consumers.py``; it walks the tracked ``.cs`` files.
+Usage: ``lint-take-once-consumers.py``; it walks the tracked ``.cs`` files under ``src/``, from anywhere
+in the working tree. Tests are outside its reach, so a test repeating the competitor story is not caught.
 """
 
 from __future__ import annotations
@@ -26,16 +29,24 @@ import re
 import subprocess
 import sys
 
-#: Three ways in. The two extension methods by name; the flag that routes a read through the same
-#: protocol one layer up - `IEntityStorage.GetAsync(..., removeOnRetrieval: true)` and
-#: `IAuthorizationRequestStorage.TryGetAsync(..., shouldRemove: true)`; and the DECLARATION of that
-#: flag, because the file declaring it is the one carrying the contract prose and it never passes the
-#: argument to itself. A name grep alone was blind to the second route, and both call-shaped routes
-#: were blind to the third - which is where the sentences this checker exists over actually live.
+#: A WRAPPER renames the protocol, so a file reaching it through one names none of the routes below.
+#: Naming the wrapper's own method here is what turns that from a hand-kept list into a measurement, and
+#: it finds both ends at once - the interface declaring it and every caller invoking it. A new wrapper
+#: adds its name here; that is the one manual step, and it is one line rather than a roll of files.
+WRAPPED = ["RemoveAuthorizationCodeAsync"]
+
+#: Four ways in. The two extension methods by name; the flag that routes a read through the same protocol
+#: one layer up - `IEntityStorage.GetAsync(..., removeOnRetrieval: true)` and
+#: `IAuthorizationRequestStorage.TryGetAsync(..., shouldRemove: true)`; the DECLARATION of that flag,
+#: because the file declaring it carries the contract prose and never passes the argument to itself; and
+#: the wrapper names above. A name grep alone was blind to the flag, both call-shaped routes were blind to
+#: the declaration - which is where the sentences this checker exists over live - and all three were blind
+#: to the wrapper, including the decorator that mints the refusal string an operator greps.
 CALL = re.compile(
     r"\b(TryRemoveAsync|TryGetAndRemoveAsync)\b"
     r"|\b(removeOnRetrieval|shouldRemove)\s*:\s*true\b"
-    r"|\bbool\s+(removeOnRetrieval|shouldRemove)\b")
+    r"|\bbool\s+(removeOnRetrieval|shouldRemove)\b"
+    r"|\b(" + "|".join(WRAPPED) + r")\b")
 
 DECLARING = "src/Abblix.Utils/DistributedCacheExtensions.cs"
 
@@ -43,8 +54,8 @@ DECLARING = "src/Abblix.Utils/DistributedCacheExtensions.cs"
 #: 455. Each was checked against the contract rather than against the call's shape, and adding a name
 #: here is the moment to read that contract.
 #:
-#: This is what the checker CAN see - the reach of the three routes above, rather than a proof that
-#: nothing else redeems. What it cannot see is in WRAPPERS below.
+#: This is the reach of the four routes above. It is not a proof that nothing else redeems: a route this
+#: file does not name finds nothing, which is why WRAPPED is a list rather than a paragraph of prose.
 KNOWN = {
     "src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs",
     "src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs",
@@ -60,16 +71,9 @@ KNOWN = {
     "src/Abblix.Oidc.Server/Features/Storages/AuthorizationCodeService.cs",
     "src/Abblix.Oidc.Server/Features/Storages/AuthorizationRequestStorage.cs",
     "src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs",
-    "src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs",
-}
-
-#: A caller reaching the protocol through a WRAPPER that renames it names none of the three routes, so
-#: no pattern here finds it and no pattern here notices when it stops being one. These are recorded by
-#: hand, are not measured, and are listed so that the checker's blind spot is a NAMED file rather than a
-#: hypothetical: `IAuthorizationCodeService` declares `RemoveAuthorizationCodeAsync` over an
-#: implementation that IS measured, and describes this refusal in its own `<returns>`.
-WRAPPERS = {
     "src/Abblix.Oidc.Server/Features/Storages/IAuthorizationCodeService.cs",
+    "src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs",
+    "src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs",
 }
 
 CONTRACT = (
@@ -134,8 +138,8 @@ def main() -> int:
         f"\nDescribe the refusal from that contract rather than from the shape of the call, then update "
         f"KNOWN in {pathlib.Path(__file__).name}.")
     print(
-        "\nOutside what this checker measures, and carrying the same contract by hand: "
-        + ", ".join(sorted(WRAPPERS)))
+        "\nA file reaching the protocol through a wrapper is found only if that wrapper's method is in "
+        f"WRAPPED, which currently names: {', '.join(WRAPPED)}.")
     return 1
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,12 @@ repos:
         additional_dependencies: [pyyaml]
         files: ^\.github/(workflows/.*\.(yml|yaml)|scripts/lint-no-inline-secrets\.py)$
         pass_filenames: false
+      - id: take-once-consumers
+        name: "Refuse an unreviewed consumer of the take-once protocol"
+        entry: python .github/scripts/lint-take-once-consumers.py
+        language: python
+        pass_filenames: false
+        files: \.(cs)$
       - id: no-cr-in-blobs
         name: "Block carriage returns in committed text"
         entry: python .github/scripts/lint-no-cr-in-blobs.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,9 @@ repos:
         entry: python .github/scripts/lint-take-once-consumers.py
         language: python
         pass_filenames: false
-        files: \.(cs)$
+        # The script's own path is in the pattern: a commit editing only KNOWN must re-run the
+        # check, or the list is edited by whoever is not looking at what it holds.
+        files: (\.cs|\.github/scripts/lint-take-once-consumers\.py)$
       - id: no-cr-in-blobs
         name: "Block carriage returns in committed text"
         entry: python .github/scripts/lint-no-cr-in-blobs.py

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/RequestFetching/PushedRequestFetcher.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/RequestFetching/PushedRequestFetcher.cs
@@ -56,7 +56,7 @@ public class PushedRequestFetcher(
         if (request is { RequestUri: { } requestUrn } &&
             requestUrn.OriginalString.StartsWith(RequestUrn.Prefix))
         {
-            // Do not consume the request_uri here. RFC 9126 §7.3 says request_uri SHOULD be
+            // Do not consume the request_uri here. RFC 9126 section 7.3 says request_uri SHOULD be
             // one-time-use, and the natural moment to consume is at authorization-code
             // issuance - not at the first /authorize fetch. Consuming on fetch makes any
             // multi-step UI flow brittle: page refresh during login, back-button after
@@ -83,7 +83,7 @@ public class PushedRequestFetcher(
             return ErrorFactory.InvalidRequestObject("The Pushed Authorization Request (PAR) is required");
         }
 
-        // RFC 9126 §6: the per-client require_pushed_authorization_requests metadata makes PAR the
+        // RFC 9126 section 6: the per-client require_pushed_authorization_requests metadata makes PAR the
         // only way for this client to start an authorization flow, independent of the server-wide
         // flag. A code-only/high-assurance profile (FAPI 2.0) imposes the same requirement on the
         // client even when neither the server-wide flag nor the per-client metadata is set - the

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -72,7 +72,7 @@ public class AuthorizationCodeReusePreventingDecorator(
         }
 
         // The claimed grant carries tokens from a prior successful redemption - a sequential reuse.
-        // Revoke those tokens (OAuth 2.0 Security BCP §4.13) and reject.
+        // Revoke those tokens (OAuth 2.0 Security BCP section 4.13) and reject.
         if (claimedGrant.IssuedTokens is { Length: > 0 } issuedTokens)
         {
             foreach (var (jwtId, expiresAt) in issuedTokens)

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -56,10 +56,11 @@ public class AuthorizationCodeReusePreventingDecorator(
         // now contend for a single claim instead of both passing a stale "not yet used" check.
         var claim = await authorizationCodeService.RemoveAuthorizationCodeAsync(code);
 
-        // The code did not come back. That covers a competitor claiming it and a code already consumed,
-        // and equally a claim that expired mid-protocol or a store call that failed after the removal -
-        // neither of which needs a second request. The caller is told the code was used, which is the
-        // right refusal for every one of them and a diagnosis for none.
+        // The code did not come back. That covers a competitor claiming it, a code already consumed, and
+        // a claim that expired mid-protocol - the last needing no second request at all. A store call
+        // that fails after the removal does not arrive here: it raises, and the caller gets an exception
+        // rather than an answer. The refusal below is the right one for every case that DOES arrive, and
+        // a diagnosis for none of them.
         // Either way this redemption loses - reject without issuing a second set of tokens.
         if (!claim.TryGetSuccess(out var claimedGrant))
         {

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -56,12 +56,14 @@ public class AuthorizationCodeReusePreventingDecorator(
         // now contend for a single claim instead of both passing a stale "not yet used" check.
         var claim = await authorizationCodeService.RemoveAuthorizationCodeAsync(code);
 
-        // The code did not come back. That covers a competitor claiming it, a code already consumed, and
-        // a claim that expired mid-protocol - the last needing no second request at all. A store call
-        // that fails after the removal does not arrive here: it raises, and the caller gets an exception
-        // rather than an answer. The refusal below is the right one for every case that DOES arrive, and
-        // a diagnosis for none of them.
-        // Either way this redemption loses - reject without issuing a second set of tokens.
+        // The code did not come back. What can reach this: a competitor claimed it between validation
+        // and here, the entry's lifetime lapsed in that same window, or a claim expired mid-protocol -
+        // the last two needing no second request at all. What cannot: a code already consumed, because
+        // AuthorizeByCodeAsync reads the entry non-destructively and refuses before a consumed code ever
+        // becomes a valid request, and ORDINARY sequential reuse is caught by the next branch instead. Nor
+        // a store call that failed after the removal, which raises rather than answering. The refusal
+        // below is the right one for every case that does arrive, and a diagnosis for none.
+        // Whichever of them it was, this redemption loses - reject without issuing a second set.
         if (!claim.TryGetSuccess(out var claimedGrant))
         {
             return new OidcError(

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -18,8 +18,9 @@ namespace Abblix.Oidc.Server.Endpoints.Token;
 
 /// <summary>
 /// Refuses a second redemption of an authorization code, and revokes the tokens the first one issued, in
-/// compliance with OAuth 2.0 security best practices. It claims the code to refuse a repeat within this
-/// process, and reads back the tokens written at the key to catch one that got past the claim elsewhere.
+/// compliance with OAuth 2.0 security best practices. Two defences, split by WHEN the repeat arrives
+/// rather than by where: the claim refuses one arriving beside the first, and the issued tokens written
+/// back at the key catch one arriving after it. Both hold across processes.
 /// </summary>
 /// <remarks>
 /// This class decorates the standard token request processing flow with additional security measures

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -56,7 +56,10 @@ public class AuthorizationCodeReusePreventingDecorator(
         // now contend for a single claim instead of both passing a stale "not yet used" check.
         var claim = await authorizationCodeService.RemoveAuthorizationCodeAsync(code);
 
-        // The code is gone: a concurrent request already claimed it, or it was already consumed.
+        // The code did not come back. That covers a competitor claiming it and a code already consumed,
+        // and equally a claim that expired mid-protocol or a store call that failed after the removal -
+        // neither of which needs a second request. The caller is told the code was used, which is the
+        // right refusal for every one of them and a diagnosis for none.
         // Either way this redemption loses - reject without issuing a second set of tokens.
         if (!claim.TryGetSuccess(out var claimedGrant))
         {

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -17,8 +17,9 @@ using Abblix.Utils;
 namespace Abblix.Oidc.Server.Endpoints.Token;
 
 /// <summary>
-/// Enhances token processing by revoking tokens associated with previously used authorization codes,
-/// preventing authorization code reuse in compliance with OAuth 2.0 security best practices.
+/// Refuses a second redemption of an authorization code, and revokes the tokens the first one issued, in
+/// compliance with OAuth 2.0 security best practices. It claims the code to refuse a repeat within this
+/// process, and reads back the tokens written at the key to catch one that got past the claim elsewhere.
 /// </summary>
 /// <remarks>
 /// This class decorates the standard token request processing flow with additional security measures
@@ -58,11 +59,11 @@ public class AuthorizationCodeReusePreventingDecorator(
 
         // The code did not come back. What can reach this: a competitor claimed it between validation
         // and here, the entry's lifetime lapsed in that same window, or a claim expired mid-protocol -
-        // the last two needing no second request at all. What cannot: a code already consumed, because
-        // AuthorizeByCodeAsync reads the entry non-destructively and refuses before a consumed code ever
-        // becomes a valid request, and ORDINARY sequential reuse is caught by the next branch instead. Nor
-        // a store call that failed after the removal, which raises rather than answering. The refusal
-        // below is the right one for every case that does arrive, and a diagnosis for none.
+        // the last two needing no second request at all. What cannot: ordinary sequential reuse, which
+        // does NOT arrive gone, because the grant is written back at the key and comes back carrying its
+        // issued tokens - the next branch is where that is caught. Nor a store call that failed after the
+        // removal, which raises rather than answering. The refusal below is the right one for every case
+        // that does arrive, and a diagnosis for none.
         // Whichever of them it was, this redemption loses - reject without issuing a second set.
         if (!claim.TryGetSuccess(out var claimedGrant))
         {

--- a/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/AuthorizationCodeReusePreventingDecorator.cs
@@ -23,11 +23,17 @@ namespace Abblix.Oidc.Server.Endpoints.Token;
 /// back at the key catch one arriving after it. Both hold across processes.
 /// </summary>
 /// <remarks>
+/// Neither is complete on its own terms. The claim reads the value before it takes the claim, so two
+/// callers can be handed the same grant on ONE node, which is issue 454; and the write-back is what the
+/// second defence rests on, so a first redemption that ends without issuing tokens leaves nothing for it
+/// to catch. Both are open, and the refusal this class returns is the same string either way.
+/// <para>
 /// This class decorates the standard token request processing flow with additional security measures
 /// to ensure the integrity of the authorization process. It detects when an authorization code,
 /// which should only be used once, is attempted to be used multiple times. In such cases, it revokes any
 /// tokens previously issued with that code and denies the request, effectively mitigating potential
 /// security risks associated with code reuse.
+/// </para>
 /// </remarks>
 /// <param name="processor">The underlying token request processor to be enhanced.</param>
 /// <param name="tokenRegistry">The registry used for managing token states and revocation.</param>
@@ -52,19 +58,22 @@ public class AuthorizationCodeReusePreventingDecorator(
             return await processor.ProcessAsync(request);
         }
 
-        // Atomically claim the code by removing it (get-and-remove). This happens AFTER the grant
+        // Claim the code by removing it. Not atomically, whatever the store's method names suggest: the
+        // extension assembles the protocol from separate Get, Set and Remove calls, and says so. This
+        // happens AFTER the grant
         // validators have already checked client binding and PKCE, so a failed validation never
         // reaches here and never burns the code - but two concurrent redemptions of a valid code
         // now contend for a single claim instead of both passing a stale "not yet used" check.
         var claim = await authorizationCodeService.RemoveAuthorizationCodeAsync(code);
 
-        // The code did not come back. What can reach this: a competitor claimed it between validation
-        // and here, the entry's lifetime lapsed in that same window, or a claim expired mid-protocol -
-        // the last two needing no second request at all. What cannot: ordinary sequential reuse, which
-        // does NOT arrive gone, because the grant is written back at the key and comes back carrying its
-        // issued tokens - the next branch is where that is caught. Nor a store call that failed after the
-        // removal, which raises rather than answering. The refusal below is the right one for every case
-        // that does arrive, and a diagnosis for none.
+        // The code did not come back. The claim answers with the grant only when this caller ran the
+        // protocol to the end with its own claim still in the store, so everything short of that arrives
+        // here as one outcome - and there is no listing the ways, which is what the sibling comments this
+        // branch rewrote were each short of. It reaches a single caller with no competitor as readily as
+        // a contended one: a first request refused for scope or resource never writes the grant back, so
+        // the client's next attempt with that code finds nothing.
+        //
+        // The refusal below is the right answer for whatever arrived, and a diagnosis for none of it.
         // Whichever of them it was, this redemption loses - reject without issuing a second set.
         if (!claim.TryGetSuccess(out var claimedGrant))
         {

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -90,9 +90,11 @@ public partial class DeviceCodeGrantHandler(
             case { Status: DeviceAuthorizationStatus.Authorized }
                 when !await storage.TryRemoveAsync(request.DeviceCode, deviceRequest.UserCode):
 
-                // Removed under the store's per-key gate, which narrows the window in which two polls
-                // both act on the authorized grant - the grant itself was read before the switch, outside
-                // any gate. A refusal below is not a diagnosis: a competitor produces it, and so does a
+                // Removed through the store's claim protocol, which is what keeps two polls from both
+                // being told they took the authorized grant, however many processes are polling. The
+                // grant itself was read before the switch, outside any of it, so what stays open is a
+                // record restored by an ungated write after the claim - issue 459, on one node.
+                // A refusal below is not a diagnosis: a competitor produces it, and so does a
                 // claim that expired mid-protocol with nobody to lose to. RFC 8628 requires no such
                 // single exchange of a device code anywhere; that is this library's decision, and this
                 // arm is where it is enforced.

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -53,7 +53,7 @@ public partial class DeviceCodeGrantHandler(
         ClientInfo clientInfo,
     CancellationToken cancellationToken)
     {
-        // RFC 6749 §5.2: a missing required parameter is the caller's protocol error (invalid_request),
+        // RFC 6749 section 5.2: a missing required parameter is the caller's protocol error (invalid_request),
         // not a server fault - the previous throw-on-access surfaced it as HTTP 500.
         if (!request.DeviceCode.HasValue())
         {
@@ -67,7 +67,7 @@ public partial class DeviceCodeGrantHandler(
         var pollingInterval = deviceAuthOptions.PollingInterval;
 
         // A single clock read shared by the expiry gate and the remaining-lifetime passed to UpdateAsync, so
-        // the two never disagree and the refreshed cache TTL is guaranteed positive (RFC 8628 §3.2).
+        // the two never disagree and the refreshed cache TTL is guaranteed positive (RFC 8628 section 3.2).
         var now = timeProvider.GetUtcNow();
 
         switch (deviceRequest)
@@ -80,21 +80,22 @@ public partial class DeviceCodeGrantHandler(
             case { ClientId: var clientId } when clientId != clientInfo.ClientId:
                 return new OidcError(ErrorCodes.InvalidGrant, "The device code was issued to another client");
 
-            // Code has reached its fixed RFC 8628 §3.2 lifetime - reject and clean up rather than letting a
+            // Code has reached its fixed RFC 8628 section 3.2 lifetime - reject and clean up rather than letting a
             // polling client keep it alive by resetting the cache TTL
             case { } when now >= deviceRequest.ExpiresAt:
                 await storage.RemoveAsync(request.DeviceCode);
                 return new OidcError(ErrorCodes.ExpiredToken, "The device code has expired");
 
-            // User has authorized the device - atomically claim the authorization
+            // User has authorized the device - claim the authorization
             case { Status: DeviceAuthorizationStatus.Authorized }
                 when !await storage.TryRemoveAsync(request.DeviceCode, deviceRequest.UserCode):
 
                 // Removed under the store's per-key gate, which narrows the window in which two polls
                 // both act on the authorized grant - the grant itself was read before the switch, outside
                 // any gate. A refusal below is not a diagnosis: a competitor produces it, and so does a
-                // claim that expired mid-protocol with nobody to lose to. RFC 8628 states no such rule anywhere - exchanging a
-                // device code once is this library's decision, and this arm is where it is enforced.
+                // claim that expired mid-protocol with nobody to lose to. RFC 8628 requires no such
+                // single exchange of a device code anywhere; that is this library's decision, and this
+                // arm is where it is enforced.
 
                 return new OidcError(
                     ErrorCodes.ExpiredToken,
@@ -130,7 +131,7 @@ public partial class DeviceCodeGrantHandler(
 
                 // And what the type comparison above structurally cannot see: an entry of a type the
                 // request DID ask for, carrying content it did not - a raised amount, a widened set of
-                // accounts. RFC 9396 §6.1 leaves that to the type's own validator, so this asks it.
+                // accounts. RFC 9396 section 6.1 leaves that to the type's own validator, so this asks it.
                 // On a copy: the question must not rewrite its own subject.
                 if (await authorizationDetailsPolicy.RefuseAsync(
                         authorizedGrant, clientInfo, cancellationToken) is { } refusal)

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -90,8 +90,10 @@ public partial class DeviceCodeGrantHandler(
             case { Status: DeviceAuthorizationStatus.Authorized }
                 when !await storage.TryRemoveAsync(request.DeviceCode, deviceRequest.UserCode):
 
-                // Atomic get-and-remove, so two concurrent polls cannot both retrieve the authorized
-                // grant and both be issued tokens. RFC 8628 states no such rule anywhere - exchanging a
+                // Get-and-remove under the store's per-key gate, which narrows the window in which two
+                // polls both come back with the authorized grant. A refusal below is not a diagnosis: a
+                // competitor produces it, and so does a claim that expired mid-protocol with nobody to
+                // lose to. RFC 8628 states no such rule anywhere - exchanging a
                 // device code once is this library's decision, and this arm is where it is enforced.
 
                 return new OidcError(

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -90,10 +90,10 @@ public partial class DeviceCodeGrantHandler(
             case { Status: DeviceAuthorizationStatus.Authorized }
                 when !await storage.TryRemoveAsync(request.DeviceCode, deviceRequest.UserCode):
 
-                // Get-and-remove under the store's per-key gate, which narrows the window in which two
-                // polls both come back with the authorized grant. A refusal below is not a diagnosis: a
-                // competitor produces it, and so does a claim that expired mid-protocol with nobody to
-                // lose to. RFC 8628 states no such rule anywhere - exchanging a
+                // Removed under the store's per-key gate, which narrows the window in which two polls
+                // both act on the authorized grant - the grant itself was read before the switch, outside
+                // any gate. A refusal below is not a diagnosis: a competitor produces it, and so does a
+                // claim that expired mid-protocol with nobody to lose to. RFC 8628 states no such rule anywhere - exchanging a
                 // device code once is this library's decision, and this arm is where it is enforced.
 
                 return new OidcError(

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
@@ -89,8 +89,10 @@ public class BackChannelRequestStorage(
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>
-	/// A task that returns the authentication request if it existed and was successfully removed;
-	/// otherwise, null if the request was not found or already removed by another concurrent request.
+	/// A task that returns the authentication request when this caller removed it and still held its own
+	/// claim afterwards. Null otherwise, and that covers more than a competitor: the request not being
+	/// there, a claim that expired while a store call was in flight, and the request being gone with
+	/// nobody able to be told they took it. The last two need no second caller and no second node.
 	/// </returns>
 	public Task<BackChannelAuthenticationRequest?> TryRemoveAsync(string authenticationRequestId)
 	{

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
@@ -83,10 +83,10 @@ public class BackChannelRequestStorage(
 	}
 
 	/// <summary>
-	/// Retrieves and removes a backchannel authentication request from storage, under one hold of the
-	/// store's per-key gate. That is what narrows the poll-mode window in which two requests could both
-	/// come back with the same grant and both be issued tokens; the returns block below says what it does
-	/// not close.
+	/// Retrieves and removes a backchannel authentication request from storage, through the store's claim
+	/// protocol and under one hold of its per-key gate. The claim is what keeps two polls from both coming
+	/// back with the same grant; the gate is what keeps a contended key from ending with NEITHER of them
+	/// told they took it. The returns block below says what is still open.
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
@@ -83,16 +83,18 @@ public class BackChannelRequestStorage(
 	}
 
 	/// <summary>
-	/// Atomically retrieves and removes a backchannel authentication request from storage.
-	/// This prevents race conditions in poll mode where concurrent requests could both retrieve
-	/// the same authentication request before removal, leading to duplicate token issuance.
+	/// Retrieves and removes a backchannel authentication request from storage, under one hold of the
+	/// store's per-key gate. That is what narrows the poll-mode window in which two requests could both
+	/// come back with the same grant and both be issued tokens; the returns block below says what it does
+	/// not close.
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>
 	/// A task that returns the authentication request when this caller removed it and still held its own
 	/// claim afterwards. Null otherwise, and that covers more than a competitor: the request not being
-	/// there, a claim that expired while a store call was in flight, and the request being gone with
-	/// nobody able to be told they took it. The last two need no second caller and no second node.
+	/// there, and a claim that expired while a store call was in flight - the second on one caller with
+	/// nobody to lose to, its outcome being the request gone with nobody able to be told they took it. A
+	/// store call that fails after the removal raises instead of answering.
 	/// </returns>
 	public Task<BackChannelAuthenticationRequest?> TryRemoveAsync(string authenticationRequestId)
 	{

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/BackChannelRequestStorage.cs
@@ -84,9 +84,11 @@ public class BackChannelRequestStorage(
 
 	/// <summary>
 	/// Retrieves and removes a backchannel authentication request from storage, through the store's claim
-	/// protocol and under one hold of its per-key gate. The claim is what keeps two polls from both coming
-	/// back with the same grant; the gate is what keeps a contended key from ending with NEITHER of them
-	/// told they took it. The returns block below says what is still open.
+	/// protocol. The claim is what keeps two polls from both being told they took the same request; the
+	/// per-key gate around the removal is what keeps a contended key from ending with NEITHER of them
+	/// told. The VALUE, though, is read before the gate is taken, so a write landing between that read
+	/// and the removal is destroyed and the earlier bytes handed back - issue 454. The returns block below
+	/// says what else is still open.
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
@@ -36,8 +36,9 @@ public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
     /// authorized grant.
     /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 10.1.1), a retrieval that
     /// does not come back with the request is rejected with <c>invalid_grant</c> rather than re-issuing
-    /// tokens. Which is the right answer to give the caller, and not a diagnosis: a second retrieval
-    /// produces it, and so does a claim that expired mid-protocol on a single caller with no competitor.
+    /// tokens. Which is the right answer to give the caller, and not a diagnosis: the request comes back
+    /// only when this caller ran the protocol to the end with its own claim still in the store, and
+    /// every way short of that is one answer.
     /// A store call that fails after the removal produces neither - it raises, and the caller is handed
     /// an exception instead of a result.
     /// </summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
@@ -33,9 +33,11 @@ public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
 
     /// <summary>
     /// Atomically removes the authentication request from storage and returns its authorized grant.
-    /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 10.1.1), a second retrieval
-    /// - or a concurrent one that lost the race - finds nothing and is rejected with
-    /// <c>invalid_grant</c> rather than re-issuing tokens.
+    /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 10.1.1), a retrieval that
+    /// does not come back with the request is rejected with <c>invalid_grant</c> rather than re-issuing
+    /// tokens. Which is the right answer to give the caller, and not a diagnosis: a second retrieval
+    /// produces it, and so does a claim that expired mid-protocol or a store call that failed after the
+    /// removal, neither of which needs a competitor.
     /// </summary>
     public async Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
         string authenticationRequestId,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
@@ -32,7 +32,8 @@ public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
     public OidcError? ValidateTokenEndpointAccess() => null;
 
     /// <summary>
-    /// Atomically removes the authentication request from storage and returns its authorized grant.
+    /// Removes the authentication request from storage under the store's per-key gate and returns its
+    /// authorized grant.
     /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 10.1.1), a retrieval that
     /// does not come back with the request is rejected with <c>invalid_grant</c> rather than re-issuing
     /// tokens. Which is the right answer to give the caller, and not a diagnosis: a second retrieval

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PingModeGrantProcessor.cs
@@ -36,8 +36,9 @@ public class PingModeGrantProcessor(IBackChannelRequestStorage storage)
     /// Because the auth_req_id can be used only once (CIBA Core 1.0 Section 10.1.1), a retrieval that
     /// does not come back with the request is rejected with <c>invalid_grant</c> rather than re-issuing
     /// tokens. Which is the right answer to give the caller, and not a diagnosis: a second retrieval
-    /// produces it, and so does a claim that expired mid-protocol or a store call that failed after the
-    /// removal, neither of which needs a competitor.
+    /// produces it, and so does a claim that expired mid-protocol on a single caller with no competitor.
+    /// A store call that fails after the removal produces neither - it raises, and the caller is handed
+    /// an exception instead of a result.
     /// </summary>
     public async Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
         string authenticationRequestId,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
@@ -30,7 +30,8 @@ public class PollModeGrantProcessor(IBackChannelRequestStorage storage)
     public OidcError? ValidateTokenEndpointAccess() => null;
 
     /// <summary>
-    /// Atomically removes the authentication request from storage and returns its authorized grant.
+    /// Removes the authentication request from storage under the store's per-key gate and returns its
+    /// authorized grant.
     /// A removal that does not come back with the request is answered <c>invalid_grant</c> rather than
     /// re-issuing tokens. That is the right answer and not a diagnosis: a competitor produces it, and so
     /// does a claim that expired mid-protocol, on one caller with nobody to lose to. A store fault after
@@ -40,8 +41,10 @@ public class PollModeGrantProcessor(IBackChannelRequestStorage storage)
         string authenticationRequestId,
         BackChannelAuthenticationRequest request)
     {
-        // Removed atomically so two polls cannot both come back with the grant, which is the duplicate
-        // token issuance this exists to stop. Null does not say WHY - see the storage contract.
+        // Removed under the store's per-key gate, which NARROWS the window in which two polls both come
+        // back with the grant - the duplicate token issuance this exists to stop. Narrows rather than
+        // closes: the value is read before the claim is taken, so a write landing in between is destroyed
+        // and the earlier bytes handed out. Null does not say WHY - see the storage contract.
         var removedRequest = await storage.TryRemoveAsync(authenticationRequestId);
 
         if (removedRequest == null)

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
@@ -31,21 +31,24 @@ public class PollModeGrantProcessor(IBackChannelRequestStorage storage)
     public OidcError? ValidateTokenEndpointAccess() => null;
 
     /// <summary>
-    /// Removes the authentication request from storage under the store's per-key gate and returns its
+    /// Removes the authentication request from storage through the store's claim protocol and returns its
     /// authorized grant.
     /// A removal that does not come back with the request is answered <c>invalid_grant</c> rather than
-    /// re-issuing tokens. That is the right answer and not a diagnosis: a competitor produces it, and so
-    /// does a claim that expired mid-protocol, on one caller with nobody to lose to. A store fault after
-    /// the removal is a third outcome rather than a third cause - it raises past this method.
+    /// re-issuing tokens. That is the right answer and not a diagnosis: the request comes back only when
+    /// this caller ran the protocol to the end with its own claim still in the store, and every way short
+    /// of that is one answer. A store fault after the removal is not among them at all - it raises past
+    /// this method.
     /// </summary>
     public async Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request)
     {
-        // Removed under the store's per-key gate, which NARROWS the window in which two polls both come
-        // back with the grant - the duplicate token issuance this exists to stop. Narrows rather than
-        // closes: the value is read before the claim is taken, so a write landing in between is destroyed
-        // and the earlier bytes handed out. Null does not say WHY - see the storage contract.
+        // Removed through the store's claim protocol, which is what keeps two polls from both coming back
+        // with the grant - the duplicate token issuance this exists to stop, and it holds however many
+        // processes are polling. The per-key gate around it buys something else: a contended key that
+        // would otherwise end with NEITHER poll told it took the request. Neither closes the window in
+        // which a write lands between the read and the removal. Null does not say WHY - see the storage
+        // contract.
         var removedRequest = await storage.TryRemoveAsync(authenticationRequestId);
 
         if (removedRequest == null)

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
@@ -31,21 +31,22 @@ public class PollModeGrantProcessor(IBackChannelRequestStorage storage)
 
     /// <summary>
     /// Atomically removes the authentication request from storage and returns its authorized grant.
-    /// If a concurrent request already consumed the entry, returns an <c>invalid_grant</c> error
-    /// to prevent duplicate token issuance.
+    /// A removal that does not come back with the request is answered <c>invalid_grant</c> rather than
+    /// re-issuing tokens. That is the right answer and not a diagnosis: a competitor produces it, and so
+    /// does a claim that expired mid-protocol or a store call that failed after the removal.
     /// </summary>
     public async Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request)
     {
-        // Atomically remove from storage to prevent race condition where concurrent requests
-        // could both retrieve the same grant before removal (duplicate token issuance vulnerability)
-        // If another request already removed it, this returns null
+        // Removed atomically so two polls cannot both come back with the grant, which is the duplicate
+        // token issuance this exists to stop. Null does not say WHY - see the storage contract.
         var removedRequest = await storage.TryRemoveAsync(authenticationRequestId);
 
         if (removedRequest == null)
         {
-            // Request was already retrieved by another concurrent request
+            // Not necessarily a competitor: the claim can expire mid-protocol and a store call after the
+            // removal can fail, both on a single caller. The receiver gets the same answer either way.
             return new OidcError(
                 ErrorCodes.InvalidGrant,
                 "The authentication request has already been used");

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
@@ -17,8 +17,9 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.GrantProcessors;
 /// <summary>
 /// Handles CIBA poll mode token retrieval at the token endpoint.
 /// In poll mode, clients repeatedly poll until authentication completes.
-/// The stored request is removed immediately on retrieval to prevent duplicate issuance.
-/// Uses atomic try-remove operation to prevent race conditions.
+/// The stored request is claimed on retrieval - read and removed in one protocol - so that a poll told it
+/// took the request is the only poll that can be told so. That narrows the window in which two polls both
+/// issue rather than closing it; the method below says what its refusal covers.
 /// </summary>
 /// <param name="storage">Storage for backchannel authentication requests.</param>
 public class PollModeGrantProcessor(IBackChannelRequestStorage storage)

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs
@@ -33,7 +33,8 @@ public class PollModeGrantProcessor(IBackChannelRequestStorage storage)
     /// Atomically removes the authentication request from storage and returns its authorized grant.
     /// A removal that does not come back with the request is answered <c>invalid_grant</c> rather than
     /// re-issuing tokens. That is the right answer and not a diagnosis: a competitor produces it, and so
-    /// does a claim that expired mid-protocol or a store call that failed after the removal.
+    /// does a claim that expired mid-protocol, on one caller with nobody to lose to. A store fault after
+    /// the removal is a third outcome rather than a third cause - it raises past this method.
     /// </summary>
     public async Task<Result<AuthorizedGrant, OidcError>> ProcessAuthenticatedRequestAsync(
         string authenticationRequestId,
@@ -45,8 +46,9 @@ public class PollModeGrantProcessor(IBackChannelRequestStorage storage)
 
         if (removedRequest == null)
         {
-            // Not necessarily a competitor: the claim can expire mid-protocol and a store call after the
-            // removal can fail, both on a single caller. The receiver gets the same answer either way.
+            // Not necessarily a competitor: the claim can expire mid-protocol on a single caller with
+            // nobody to lose to, and the receiver is told the same thing either way. A store fault after
+            // the removal never reaches here - it raises, and the receiver gets no result at all.
             return new OidcError(
                 ErrorCodes.InvalidGrant,
                 "The authentication request has already been used");

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs
@@ -58,8 +58,9 @@ public interface IBackChannelRequestStorage
 	/// <returns>
 	/// A task that returns the authentication request when this caller removed it and still held its own
 	/// claim afterwards. Null otherwise, which covers the request not being there, another caller having
-	/// taken it, a claim that expired mid-protocol, and the request being gone with nobody able to be told
-	/// they took it - the last two without any competitor at all.
+	/// taken it, and a claim that expired mid-protocol - the last on one caller with nobody to lose to,
+	/// and its outcome is the request gone with nobody able to be told they took it. A store call that
+	/// fails after the removal raises instead of answering.
 	/// </returns>
 	Task<BackChannelAuthenticationRequest?> TryRemoveAsync(string authenticationRequestId);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs
@@ -56,8 +56,10 @@ public interface IBackChannelRequestStorage
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>
-	/// A task that returns the authentication request if it existed and was successfully removed;
-	/// otherwise, null if the request was not found or already removed.
+	/// A task that returns the authentication request when this caller removed it and still held its own
+	/// claim afterwards. Null otherwise, which covers the request not being there, another caller having
+	/// taken it, a claim that expired mid-protocol, and the request being gone with nobody able to be told
+	/// they took it - the last two without any competitor at all.
 	/// </returns>
 	Task<BackChannelAuthenticationRequest?> TryRemoveAsync(string authenticationRequestId);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs
@@ -50,9 +50,10 @@ public interface IBackChannelRequestStorage
 		TimeSpan expiresIn);
 
 	/// <summary>
-	/// Atomically retrieves and removes a backchannel authentication request from storage.
-	/// This operation prevents race conditions where multiple concurrent requests could retrieve the same
-	/// authentication request before it's removed (poll mode double-retrieval vulnerability).
+	/// Claims a backchannel authentication request, retrieving and removing it in one protocol, so that a
+	/// caller told it took the request is the only caller that can be told so. It narrows the window in
+	/// which two polls both retrieve one request rather than closing it; the returns block below says
+	/// what the claim covers and what it does not.
 	/// </summary>
 	/// <param name="authenticationRequestId">The unique identifier of the authentication request to remove.</param>
 	/// <returns>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -111,8 +111,10 @@ public class DeviceAuthorizationStorage(
     /// </para>
     /// <para>
     /// <strong>Use Case:</strong> This method is used in the Device Authorization Grant flow (RFC 8628)
-    /// when exchanging an authorized device code for tokens. Two token requests both claiming one device
-    /// code needs a second process; the Atomicity note below says what the claim reaches.
+    /// when exchanging an authorized device code for tokens. The claim keeps two token requests from both
+    /// being told they took one device code, however many processes are polling; what it does not stop is
+    /// a record RESTORED after the claim by an ungated write, which the next poll then claims in its turn.
+    /// That needs no second process and is issue 459. The Atomicity note below says what the claim reaches.
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -17,7 +17,8 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// <summary>
 /// Implements storage for device authorization requests as defined in RFC 8628.
 /// Stores requests by device_code (for client polling) with a secondary index by user_code (for user verification).
-/// Uses atomic distributed cache operations to prevent race conditions in token issuance.
+/// Redemption of a device code goes through the cache's claim protocol, which narrows the window in which
+/// two token requests both claim one code rather than closing it.
 /// </summary>
 /// <param name="cache">The distributed cache backend used for atomic operations.</param>
 /// <param name="serializer">The serializer for converting objects to/from binary format.</param>
@@ -99,9 +100,8 @@ public class DeviceAuthorizationStorage(
     }
 
     /// <summary>
-    /// Atomically attempts to remove a device authorization request by device code.
-    /// Uses lock-based atomic removal protocol to prevent race conditions where multiple threads
-    /// attempt to remove the same device code concurrently.
+    /// Claims a device authorization request by device code, deciding presence and removing it in one
+    /// protocol, so that a caller told it removed the request is the only caller that can be told so.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -111,8 +111,8 @@ public class DeviceAuthorizationStorage(
     /// </para>
     /// <para>
     /// <strong>Use Case:</strong> This method is used in the Device Authorization Grant flow (RFC 8628)
-    /// when exchanging an authorized device code for tokens. The atomic removal ensures that concurrent
-    /// token requests cannot both claim the same device code.
+    /// when exchanging an authorized device code for tokens. Two token requests both claiming one device
+    /// code needs a second process; the Atomicity note below says what the claim reaches.
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -68,7 +68,12 @@ public interface IDeviceAuthorizationStorage
     /// <param name="deviceCode">The device code identifier.</param>
     /// <param name="userCode">The user code for cleaning up the secondary index mapping.</param>
     /// <returns>
-    /// A task that returns true if the request was found and removed; false otherwise.
+    /// A task that returns true when this caller removed the request AND still held its own claim
+    /// afterwards. False otherwise, which is wider than "somebody else got it": it also covers the
+    /// request not being there, a claim that expired while a store call was in flight, and the request
+    /// being gone with nobody able to be told they took it. An operator told a second request was the
+    /// cause goes looking for a second node, and the single-caller cases are exactly the ones that never
+    /// produce one.
     /// </returns>
     Task<bool> TryRemoveAsync(string deviceCode, string userCode);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -70,10 +70,12 @@ public interface IDeviceAuthorizationStorage
     /// <returns>
     /// A task that returns true when this caller removed the request AND still held its own claim
     /// afterwards. False otherwise, which is wider than "somebody else got it": it also covers the
-    /// request not being there, a claim that expired while a store call was in flight, and the request
-    /// being gone with nobody able to be told they took it. An operator told a second request was the
-    /// cause goes looking for a second node, and the single-caller cases are exactly the ones that never
-    /// produce one.
+    /// request not being there and a claim that expired while a store call was in flight - the second
+    /// on one caller with nobody to lose to, and its outcome is the request gone with nobody able to be
+    /// told they took it. An operator told a second request was the cause goes looking for a second node,
+    /// and that case is exactly the one which never produces one. A failure of the second store call,
+    /// which removes the user-code index, raises rather than answering: the device code is already
+    /// consumed and the caller is handed the exception.
     /// </returns>
     Task<bool> TryRemoveAsync(string deviceCode, string userCode);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -73,8 +73,8 @@ public interface IDeviceAuthorizationStorage
     /// afterwards. False otherwise, which is wider than "somebody else got it": it also covers the
     /// request not being there and a claim that expired while a store call was in flight - the second
     /// on one caller with nobody to lose to, and its outcome is the request gone with nobody able to be
-    /// told they took it. An operator told a second request was the cause goes looking for a second node,
-    /// and that case is exactly the one which never produces one. A failure of the second store call,
+    /// told they took it. An operator told a second REQUEST was the cause goes looking for one, and the
+    /// expiry case is exactly the one that never produces a second request. A failure of the second store call,
     /// which removes the user-code index, raises rather than answering: the device code is already
     /// consumed and the caller is handed the exception.
     /// </returns>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -50,7 +50,7 @@ public interface IDeviceAuthorizationStorage
     /// <param name="deviceCode">The device code identifier.</param>
     /// <param name="request">The updated device authorization request.</param>
     /// <param name="expiresIn">The remaining lifetime to apply as the cache TTL. The caller derives it from
-    /// the request's fixed expiry (RFC 8628 §3.2) so that repeated polling cannot extend the code.</param>
+    /// the request's fixed expiry (RFC 8628 section 3.2) so that repeated polling cannot extend the code.</param>
     /// <returns>A task that completes when the request is updated.</returns>
     Task UpdateAsync(string deviceCode, DeviceAuthorizationRequest request, TimeSpan expiresIn);
 
@@ -62,8 +62,9 @@ public interface IDeviceAuthorizationStorage
     Task RemoveAsync(string deviceCode);
 
     /// <summary>
-    /// Atomically attempts to remove a device authorization request by its device code.
-    /// This operation is thread-safe and returns whether the removal was successful.
+    /// Claims a device authorization request by its device code, deciding presence and removing it in one
+    /// protocol, so that a caller told it removed the request is the only caller that can be told so. It
+    /// narrows that window rather than closing it; the returns block below says what a false covers.
     /// </summary>
     /// <param name="deviceCode">The device code identifier.</param>
     /// <param name="userCode">The user code for cleaning up the secondary index mapping.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs
@@ -36,11 +36,12 @@ public interface IAuthorizationRequestStorage
 	/// This method facilitates the retrieval of authorization requests for further processing or validation.
 	/// The shouldRemove parameter controls whether the request is deleted from storage upon retrieval,
 	/// which is what narrows the window in which it is retrieved twice. RFC 9126 puts the MUST on the
-	/// client - "the client MUST only use a request_uri value once" (Section 2.2) - and asks the
-	/// authorization server for no more than a SHOULD, in the same sentence that contemplates a server
-	/// allowing a duplicate after a user reloads. Consuming it here is therefore this library's choice
-	/// rather than an inherited requirement. Narrows rather than closes: the returns block says what a
-	/// null covers.
+	/// client - "the client MUST only use a request_uri value once" (Section 4, Authorization Request) -
+	/// and asks the authorization server for no more than a SHOULD, twice: Section 4 hedges it with a MAY
+	/// for a user reloading their user agent, and Section 7.3 states it plainly, "the authorization
+	/// server SHOULD make the request URIs one-time use". Consuming it here is therefore this library's
+	/// choice, taken on the specification's recommendation rather than on its requirement. Narrows rather
+	/// than closes: the returns block says what a null covers.
 	/// </summary>
 	/// <param name="requestUri">The unique identifier of the authorization request, typically a URI,
 	/// used to locate the request in storage.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs
@@ -35,14 +35,19 @@ public interface IAuthorizationRequestStorage
 	/// Asynchronously retrieves an authorization request using a previously stored unique identifier.
 	/// This method facilitates the retrieval of authorization requests for further processing or validation.
 	/// The shouldRemove parameter controls whether the request is deleted from storage upon retrieval,
-	/// ensuring it cannot be retrieved again, which is essential for one-time use scenarios like authorization codes.
+	/// which is what narrows the window in which it is retrieved twice - essential for the one-time use
+	/// RFC 9126 requires of a request_uri. Narrows rather than closes: the removal is a protocol over a
+	/// store with no indivisible read-modify-write, and the returns block says what a null covers.
 	/// </summary>
 	/// <param name="requestUri">The unique identifier of the authorization request, typically a URI,
 	/// used to locate the request in storage.</param>
-	/// <param name="shouldRemove">Specifies whether the request should be removed from storage on retrieval.
-	/// This is useful for one-time use scenarios, ensuring that an authorization request cannot be reused.</param>
+	/// <param name="shouldRemove">Specifies whether the request should be removed from storage on
+	/// retrieval, for the one-time use scenarios where a second retrieval must not succeed.</param>
 	/// <returns>A <see cref="Task"/> that, when completed successfully, yields
 	/// the <see cref="Model.AuthorizationRequest"/> associated with the specified identifier,
-	/// or null if no such request exists or if it has expired.</returns>
+	/// or null. With <paramref name="shouldRemove"/> set, null is wider than "no such request": it also
+	/// covers the entry having expired, another caller having removed it, and a claim that expired
+	/// mid-protocol on a single caller with nobody to lose to. A store call that fails after the removal
+	/// raises instead of answering.</returns>
 	Task<Model.AuthorizationRequest?> TryGetAsync(Uri requestUri, bool shouldRemove = false);
 }

--- a/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IAuthorizationRequestStorage.cs
@@ -35,9 +35,12 @@ public interface IAuthorizationRequestStorage
 	/// Asynchronously retrieves an authorization request using a previously stored unique identifier.
 	/// This method facilitates the retrieval of authorization requests for further processing or validation.
 	/// The shouldRemove parameter controls whether the request is deleted from storage upon retrieval,
-	/// which is what narrows the window in which it is retrieved twice - essential for the one-time use
-	/// RFC 9126 requires of a request_uri. Narrows rather than closes: the removal is a protocol over a
-	/// store with no indivisible read-modify-write, and the returns block says what a null covers.
+	/// which is what narrows the window in which it is retrieved twice. RFC 9126 puts the MUST on the
+	/// client - "the client MUST only use a request_uri value once" (Section 2.2) - and asks the
+	/// authorization server for no more than a SHOULD, in the same sentence that contemplates a server
+	/// allowing a duplicate after a user reloads. Consuming it here is therefore this library's choice
+	/// rather than an inherited requirement. Narrows rather than closes: the returns block says what a
+	/// null covers.
 	/// </summary>
 	/// <param name="requestUri">The unique identifier of the authorization request, typically a URI,
 	/// used to locate the request in storage.</param>

--- a/src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs
@@ -42,12 +42,7 @@ public interface IEntityStorage
     /// <param name="removeOnRetrieval">When true, the entry must be removed atomically with the
     /// read so that a concurrent caller cannot observe the same value.</param>
     /// <param name="token">An optional cancellation token.</param>
-    /// <returns>
-    /// The stored entity, or <c>null</c>. With <paramref name="removeOnRetrieval"/> set, null does not
-    /// mean the entry was absent: the removal is a protocol over a store with no indivisible
-    /// read-modify-write, so it also covers another caller having taken it, a claim that expired while a
-    /// store call was in flight, and the entry being gone with nobody able to be told they took it.
-    /// </returns>
+    /// <returns>The stored entity, or <c>null</c> when no entry is present or it has expired.</returns>
     Task<T?> GetAsync<T>(string key, bool removeOnRetrieval, CancellationToken? token = null);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/Storages/IEntityStorage.cs
@@ -42,7 +42,12 @@ public interface IEntityStorage
     /// <param name="removeOnRetrieval">When true, the entry must be removed atomically with the
     /// read so that a concurrent caller cannot observe the same value.</param>
     /// <param name="token">An optional cancellation token.</param>
-    /// <returns>The stored entity, or <c>null</c> when no entry is present or it has expired.</returns>
+    /// <returns>
+    /// The stored entity, or <c>null</c>. With <paramref name="removeOnRetrieval"/> set, null does not
+    /// mean the entry was absent: the removal is a protocol over a store with no indivisible
+    /// read-modify-write, so it also covers another caller having taken it, a claim that expired while a
+    /// store call was in flight, and the entry being gone with nobody able to be told they took it.
+    /// </returns>
     Task<T?> GetAsync<T>(string key, bool removeOnRetrieval, CancellationToken? token = null);
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -24,9 +24,11 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token;
 
 /// <summary>
 /// Verifies the authorization-code reuse defense in <see cref="AuthorizationCodeReusePreventingDecorator"/>.
-/// The decorator atomically claims the code before delegating to the inner processor, so a second
-/// (concurrent or sequential) redemption of the same code cannot issue a second set of tokens
-/// (RFC 6749 §4.1.2, OAuth 2.0 Security BCP §4.13).
+/// The decorator claims the code before delegating to the inner processor, so a second redemption of the
+/// same code is refused, and one that got past the claim on another node is caught by the issued tokens
+/// written back at the key (RFC 6749 section 4.1.2, OAuth 2.0 Security BCP section 4.13). Within one
+/// process the claim is what refuses; across processes it is the write-back, and issue 435 is the gap
+/// between them.
 /// </summary>
 public class AuthorizationCodeReusePreventingDecoratorTests
 {

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -63,11 +63,10 @@ public class AuthorizationCodeReusePreventingDecoratorTests
         };
 
     /// <summary>
-    /// When the code does not come back - a competitor claimed it between validation and the claim, the
-    /// entry's lifetime lapsed in that window, or a claim expired mid-protocol on a single caller - the
-    /// decorator rejects with invalid_grant and never invokes the inner processor, so no second set of
-    /// tokens is issued. Ordinary sequential reuse does not reach this branch: the next one catches it, on
-    /// the tokens the claimed grant already carries.
+    /// When the code does not come back, the decorator rejects with invalid_grant and never invokes the
+    /// inner processor, so no second set of tokens is issued. What this row pins is that outcome, not a
+    /// reason for it: the claim answers only when this caller ran the protocol to the end with its own
+    /// claim still in the store, and everything short of that arrives the same way.
     /// </summary>
     [Fact]
     public async Task UnclaimableCode_IsRejected_WithoutIssuingTokens()

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -24,11 +24,16 @@ namespace Abblix.Oidc.Server.UnitTests.Endpoints.Token;
 
 /// <summary>
 /// Verifies the authorization-code reuse defense in <see cref="AuthorizationCodeReusePreventingDecorator"/>.
-/// The decorator claims the code before delegating to the inner processor, so a second redemption of the
-/// same code is refused, and one that got past the claim on another node is caught by the issued tokens
-/// written back at the key (RFC 6749 section 4.1.2, OAuth 2.0 Security BCP section 4.13). Within one
-/// process the claim is what refuses; across processes it is the write-back, and issue 435 is the gap
-/// between them.
+/// The decorator claims the code before delegating to the inner processor, and reads back the tokens
+/// written at that key (RFC 6749 section 4.1.2, OAuth 2.0 Security BCP section 4.13). The two split by
+/// WHEN the repeat arrives, not by where it comes from: the claim refuses one arriving beside the first,
+/// the write-back catches one arriving after it, and both hold however many processes are running - the
+/// claim's last-write-wins token check admits at most one caller wherever the callers are.
+/// <para>
+/// What a second process costs is a winner rather than exclusivity, which is issue 435; and the claim is
+/// not by itself enough within one process either, which is issue 454. Rows for both live beside the
+/// implementation they belong to.
+/// </para>
 /// </summary>
 public class AuthorizationCodeReusePreventingDecoratorTests
 {

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -56,10 +56,11 @@ public class AuthorizationCodeReusePreventingDecoratorTests
         };
 
     /// <summary>
-    /// When the code does not come back - a competitor claimed it, it was already consumed, or a claim
-    /// expired mid-protocol on a single caller - the decorator rejects with invalid_grant and never
-    /// invokes the inner processor, so no second set of tokens is issued. The refusal is the same for
-    /// each, which is why it is an answer rather than a diagnosis.
+    /// When the code does not come back - a competitor claimed it between validation and the claim, the
+    /// entry's lifetime lapsed in that window, or a claim expired mid-protocol on a single caller - the
+    /// decorator rejects with invalid_grant and never invokes the inner processor, so no second set of
+    /// tokens is issued. Ordinary sequential reuse does not reach this branch: the next one catches it, on
+    /// the tokens the claimed grant already carries.
     /// </summary>
     [Fact]
     public async Task UnclaimableCode_IsRejected_WithoutIssuingTokens()

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/AuthorizationCodeReusePreventingDecoratorTests.cs
@@ -56,9 +56,10 @@ public class AuthorizationCodeReusePreventingDecoratorTests
         };
 
     /// <summary>
-    /// When the code cannot be claimed (a concurrent request already claimed it, or it was already
-    /// consumed, so the atomic remove returns a failure), the decorator rejects with invalid_grant
-    /// and never invokes the inner processor - so no second set of tokens is issued.
+    /// When the code does not come back - a competitor claimed it, it was already consumed, or a claim
+    /// expired mid-protocol on a single caller - the decorator rejects with invalid_grant and never
+    /// invokes the inner processor, so no second set of tokens is issued. The refusal is the same for
+    /// each, which is why it is an answer rather than a diagnosis.
     /// </summary>
     [Fact]
     public async Task UnclaimableCode_IsRejected_WithoutIssuingTokens()

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -72,7 +72,7 @@ public class DeviceCodeGrantHandlerTests
     }
 
     /// <summary>
-    /// RFC 6749 §5.2: a token request without the required device_code parameter is the caller's
+    /// RFC 6749 section 5.2: a token request without the required device_code parameter is the caller's
     /// protocol error and yields invalid_request - previously it threw and surfaced as HTTP 500.
     /// </summary>
     [Fact]
@@ -745,7 +745,7 @@ public class DeviceCodeGrantHandlerTests
     }
 
     /// <summary>
-    /// RFC 8628 §3.2: once the device_code reaches its fixed lifetime the token endpoint returns
+    /// RFC 8628 section 3.2: once the device_code reaches its fixed lifetime the token endpoint returns
     /// expired_token and the record is cleaned up - polling must not keep an expired code alive.
     /// </summary>
     [Fact]
@@ -827,7 +827,7 @@ public class DeviceCodeGrantHandlerTests
     }
 
     /// <summary>
-    /// RFC 8628 §3.2: each poll refreshes the cache TTL with the code's remaining lifetime, never the full
+    /// RFC 8628 section 3.2: each poll refreshes the cache TTL with the code's remaining lifetime, never the full
     /// CodeLifetime - so a client that keeps polling cannot extend the device_code past its fixed expiry.
     /// </summary>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/DeviceCodeGrantHandlerTests.cs
@@ -407,9 +407,10 @@ public class DeviceCodeGrantHandlerTests
             });
 
     /// <summary>
-    /// Verifies that when atomic removal fails (race condition - another concurrent request claimed the device code),
-    /// the handler returns an ExpiredToken error per RFC 8628 Section 3.5.
-    /// This prevents double-issuance of tokens for the same device code.
+    /// Verifies that when the removal does not come back with the record - a competitor claimed the
+    /// device code, or a claim expired mid-protocol with nobody to lose to - the handler returns an
+    /// ExpiredToken error per RFC 8628 Section 3.5, which is what stops a second set of tokens being
+    /// issued for one device code.
     /// </summary>
     [Fact]
     public async Task AuthorizedRequest_RaceCondition_ShouldReturnExpiredTokenError()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -457,8 +457,9 @@ public class AuthorizationCodeServiceTests
     }
 
     /// <summary>
-    /// Verifies that RemoveAuthorizationCodeAsync returns an invalid_grant failure when the code is
-    /// absent - already claimed by a concurrent request, already consumed, or never issued.
+    /// Verifies that RemoveAuthorizationCodeAsync returns an invalid_grant failure when the code does
+    /// not come back - claimed by a competitor, already consumed, never issued, or a claim that expired
+    /// mid-protocol with nobody to lose to.
     /// </summary>
     [Fact]
     public async Task RemoveAuthorizationCodeAsync_WithAbsentCode_ReturnsFailure()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Storages/AuthorizationCodeServiceTests.cs
@@ -457,9 +457,9 @@ public class AuthorizationCodeServiceTests
     }
 
     /// <summary>
-    /// Verifies that RemoveAuthorizationCodeAsync returns an invalid_grant failure when the code does
-    /// not come back - claimed by a competitor, already consumed, never issued, or a claim that expired
-    /// mid-protocol with nobody to lose to.
+    /// Verifies that RemoveAuthorizationCodeAsync returns an invalid_grant failure unless this caller ran
+    /// the protocol to the end with its own claim still in the store. Everything short of that is one
+    /// answer, and naming which way it fell short is not something the caller is told.
     /// </summary>
     [Fact]
     public async Task RemoveAuthorizationCodeAsync_WithAbsentCode_ReturnsFailure()

--- a/tests/Abblix.Utils.UnitTests/DistributedCacheExtensionsTests.cs
+++ b/tests/Abblix.Utils.UnitTests/DistributedCacheExtensionsTests.cs
@@ -14,7 +14,8 @@ namespace Abblix.Utils.UnitTests;
 
 /// <summary>
 /// Tests for <see cref="DistributedCacheExtensions.TryGetAndRemoveAsync"/>.
-/// Verifies the atomic get-and-remove protocol prevents race conditions in concurrent scenarios.
+/// Verifies the get-and-remove protocol admits one claimer at a time, which narrows the window in which
+/// two callers both take one value rather than closing it.
 /// </summary>
 public class DistributedCacheExtensionsTests
 {


### PR DESCRIPTION
Ref #455. Not `Closes`: one of that issue's bullets is declined rather than done, and another is being fixed in #470. The issue records both, and stays open until they land.

## The condition, and why every site got it wrong the same way

A redemption built on `IDistributedCache` tells a caller it took the value only when the protocol ran to the end AND its own claim was still in the store. Everything short of that is one refusal, and only one of the ways there involves a competitor: the others are the key not being there and a claim that EXPIRED mid-protocol, the last on a single caller with nobody to lose to.

Saying it as the condition rather than as a list is the whole point, and the reason this PR says it that way about itself too: a list can be short by one, and every one of these sites was.

A store call that fails after the removal is an OUTCOME rather than a cause: there is no `catch` anywhere between the extension and the endpoint, so it raises and the refusal branch is never entered.

`DistributedCacheExtensions` says all of this about itself. The sites a person actually reads during an incident did not, and each was wrong in the same direction - naming the one cause that has a competitor in it.

The cost is not the wording. An operator told the cause was a second request goes looking for a second node, and the single-caller cases are exactly the ones that never produce one.

## Where they were

- `IDeviceAuthorizationStorage` - "true if the request was found and removed; false otherwise". `DeviceCodeGrantHandler` holds the interface, so this is the documentation at the deciding call site, and the handler's own arm carried the same sentence.
- `AuthorizationCodeReusePreventingDecorator` - "a concurrent request already claimed it", one call below a `<returns>` saying a refusal proves no such thing, on the branch that mints the string an operator greps.
- `BackChannelRequestStorage`, `IBackChannelRequestStorage`, `PollModeGrantProcessor`, `PingModeGrantProcessor` - "already removed by another concurrent request", "a concurrent one that lost the race".
- `IAuthorizationRequestStorage` - the pushed-request contract, whose `<summary>` promised a guarantee the block below it retracts.
- The tests over those branches, which told the reader the same story from the other side.
- The `<summary>` blocks standing above several of them, which still promised what the block below retracted - including two that ship in the package documentation.

Each now states the condition for the GOOD outcome and lets the failures follow from it. A list of what went wrong was short everywhere it appeared, and a list cannot be shown complete while a condition can.

## What the issue asked for and this does not do

`IEntityStorage`'s `<returns>` stays as it is. The replacement written for it contradicted the `<param>` and class remarks standing above it, and was false both of the in-tree implementation and of any store built on `GETDEL`, where the value comes back with the removal. The interface's contract is its own question rather than a wording sweep, and rewriting one block of it while its neighbours describe something else makes the file worse than leaving it alone.

`IAuthorizationCodeService` is being corrected in #470, which owns that file this week. Two branches rewriting the same `<returns>` from different premises is how one of the two silently loses.

## RFC 9126, read at source rather than recalled

The specification does not require an authorization server to consume a `request_uri`. The MUST binds the client - "the client MUST only use a `request_uri` value once" - in section 4, Authorization Request. The server gets a SHOULD, twice: in the same section, hedged with a MAY for a user reloading their user agent, and again in section 7.3 without the hedge, "the authorization server SHOULD make the request URIs one-time use". Section 2.2 puts no one-time-use requirement on either party: its bearing sentence, "This URI is a single-use reference to the respective request data", describes the field rather than obliging anybody, and the requirements it does carry are about how the URI is generated and bound. An earlier revision of this branch cited it for the client MUST.

`PushedRequestFetcher` already pointed at section 7.3, and its two section signs went with the edit. Both sites now name the same sections, so a reader comparing them is not left deciding which one to believe.

## How the reach was found, and what the checker holds

By asking the mechanism - the callers of `TryRemoveAsync` and `TryGetAndRemoveAsync` - rather than by grepping prose. A word search over "concurrent" returns most of the repository, and the word is legitimate in nearly all of it.

That is also why the checker does not read prose. **A detector that cries wolf is worse than none**, and there is no phrase here that separates a false attribution from a true statement about what atomic removal prevents. What can be checked exactly is the REACH: `lint-take-once-consumers.py` holds the list of files that consume the protocol and fails when it changes - which is the moment somebody is writing a refusal sentence from the shape of the call rather than from the contract. The failure prints the contract.

It reaches the protocol by four routes: the two extension methods by name, the flag passed as an argument, the DECLARATION of that flag - which is how the files carrying the contract prose reach it, since they never pass the argument to themselves - and the name of a WRAPPER that renames the protocol. The wrapper route replaced a hand-kept list of blind spots, and it found what the list had missed: the reuse decorator, which is where the refusal string an operator greps is minted. A new wrapper adds its method name to one list, and both its declaration and every caller are found at once.

The walk is anchored at the repository root. Both the pathspec and git's output default to the caller's directory, so before that the same command run from `src/` matched nothing and the checker answered a clean zero over a sweep that had read no files.

Wired into `.pre-commit-config.yaml`. The CI half is a workflow edit and goes through the security checklist separately.

## Evidence

The checker was proved both ways before being believed, and on the route added last: silent on the tree as it stands, and speaking when a `bool shouldRemove` declaration is planted - naming the file and printing the contract. Both runs repeated from a subdirectory, which is the invocation that used to answer zero over nothing.

No behaviour changes. Every source edit is a comment or a documentation block, which is exactly why this needed a sweep rather than a fix: nothing in the suite goes red when one of these sentences is wrong, and nothing ever would.

## What the reviews changed, because a sweep of claims is made of claims

The first replacement carried its own false enumeration: three sites listed the store fault among the CAUSES of the refusal, on a path with no `catch` between the fault and the endpoint. One went further and said the receiver gets the same answer either way; it gets an exception instead of a result. Two `<returns>` blocks listed an outcome beside its own cause, which made the trailing clause cover ground it did not have.

The second found a "cannot" strengthened on a branch in the very change whose thesis is narrows-rather-than-closes, two summaries still opening "Atomically removes", and a cause that cannot reach the branch it was written on - a consumed authorization code never becomes a valid request, because the grant is read non-destructively first.

The third found the RFC 9126 citation above pointing at a section that carries no one-time-use rule, and a checker whose reach stopped at the boundary of the directory it happened to be run from.

The fourth found the retracted guarantee still standing in the `<summary>` ABOVE several of the rewritten blocks, two of them collapsed into the package XML an integrator reads, and the checker's blind spot containing no member of the class it described while the one real member went unlisted. The summary layer is swept by the same condition, derived from the grammar of an impossibility claim rather than from the sites already fixed; what it found in `DistributedCacheExtensions` and `IAuthorizationCodeService` belongs to #470, which owns those files.
