### PR TITLE
Apply a device decision to the record as it stands, not as it was read

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -92,8 +92,9 @@ public partial class DeviceCodeGrantHandler(
 
                 // Removed through the store's claim protocol, which is what keeps two polls from both
                 // being told they took the authorized grant, however many processes are polling. The
-                // grant itself was read before the switch, outside any of it, so what stays open is a
-                // record restored by an ungated write after the claim - issue 459, on one node.
+                // grant itself was read before the switch, outside any of it. A decision landing after
+                // the claim no longer restores the record - it re-reads and refuses - so what stays
+                // open is the window that re-read narrows rather than closes: issues 194 and 435.
                 // A refusal below is not a diagnosis: a competitor produces it, and so does a
                 // claim that expired mid-protocol with nobody to lose to. RFC 8628 requires no such
                 // single exchange of a device code anywhere; that is this library's decision, and this

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/DeviceCodeGrantHandler.cs
@@ -93,8 +93,8 @@ public partial class DeviceCodeGrantHandler(
                 // Removed through the store's claim protocol, which is what keeps two polls from both
                 // being told they took the authorized grant, however many processes are polling. The
                 // grant itself was read before the switch, outside any of it. A decision landing after
-                // the claim no longer restores the record - it re-reads and refuses - so what stays
-                // open is the window that re-read narrows rather than closes: issues 194 and 435.
+                // the claim re-reads the record and refuses, so what stays open is the window between
+                // that read and its write: issues 194 and 435.
                 // A refusal below is not a diagnosis: a competitor produces it, and so does a
                 // claim that expired mid-protocol with nobody to lose to. RFC 8628 requires no such
                 // single exchange of a device code anywhere; that is this library's decision, and this

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -112,9 +112,10 @@ public class DeviceAuthorizationStorage(
     /// <para>
     /// <strong>Use Case:</strong> This method is used in the Device Authorization Grant flow (RFC 8628)
     /// when exchanging an authorized device code for tokens. The claim keeps two token requests from both
-    /// being told they took one device code, however many processes are polling; what it does not stop is
-    /// a record RESTORED after the claim by an ungated write, which the next poll then claims in its turn.
-    /// That needs no second process and is issue 459. The Atomicity note below says what the claim reaches.
+    /// being told they took one device code, however many processes are polling. A decision landing after
+    /// the claim used to RESTORE the record for the next poll to claim in its turn; it re-reads and
+    /// refuses now, which narrows that window to a store round trip rather than closing it - issues 194
+    /// and 435. The Atomicity note below says what the claim itself reaches.
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -112,10 +112,10 @@ public class DeviceAuthorizationStorage(
     /// <para>
     /// <strong>Use Case:</strong> This method is used in the Device Authorization Grant flow (RFC 8628)
     /// when exchanging an authorized device code for tokens. The claim keeps two token requests from both
-    /// being told they took one device code, however many processes are polling. A decision landing after
-    /// the claim used to RESTORE the record for the next poll to claim in its turn; it re-reads and
-    /// refuses now, which narrows that window to a store round trip rather than closing it - issues 194
-    /// and 435. The Atomicity note below says what the claim itself reaches.
+    /// being told they took one device code, however many processes are polling. What it does not reach
+    /// is a decision landing after the claim: that path re-reads the record and refuses, which leaves a
+    /// window one store round trip wide rather than none - issues 194 and 435. The Atomicity note below
+    /// says what the claim itself reaches.
     /// </para>
     /// <para>
     /// <strong>Atomicity:</strong> Uses <see cref="Abblix.Utils.DistributedCacheExtensions.TryRemoveAsync"/>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
@@ -34,13 +34,19 @@ public interface IUserCodeVerificationService
     /// context. Its <c>authorization_details</c> are what the device is granted: the library adds none, and
     /// refuses an approval carrying a type the request never asked for. Its scopes and resources are a
     /// starting point rather than the final word - the token endpoint narrows them against the token
-    /// request (RFC 8707 §2.2) and adds the certificate and proof-key confirmations.</param>
+    /// request (RFC 8707 section 2.2) and adds the certificate and proof-key confirmations.</param>
     /// <returns>
     /// True when this call is the one that recorded the approval. False otherwise, and otherwise is
-    /// wider than a bad code: the stored record must still be pending when the decision is written,
-    /// so a denial or another approval landing first answers false too, as does a request whose
-    /// lifetime ran out and one whose grant carries a type the request never asked for. The decision
-    /// is not applied in any of those cases, and nothing about the record changes.
+    /// wider than a bad code: the stored record is re-read and must still be pending, so a denial or
+    /// another approval landing first answers false too, as does a request whose lifetime ran out and
+    /// one whose grant carries a type the request never asked for. The decision is not applied in any
+    /// of those cases, and nothing about the record changes.
+    /// <para>
+    /// A true is not a guarantee that nothing landed in between. The re-read and the write are two
+    /// store calls, and the store exposes no conditional write, so two concurrent approvals can each
+    /// be told true and the later write wins. The window is a store round trip wide rather than the
+    /// whole verification page, which is what this narrows and does not close.
+    /// </para>
     /// </returns>
     /// <remarks>
     /// <c>authorization_details</c> are the host's to carry. The requested entries arrive on
@@ -50,8 +56,8 @@ public interface IUserCodeVerificationService
     /// payment nobody was shown is worse than granting none.
     /// <para>
     /// Approving with entries on the record and none on the grant is therefore allowed and logged at
-    /// warning level. RFC 9396 §7 is satisfied either way, since its MUST is to return what the
-    /// resource owner GRANTED and nothing granted is nothing to return. §9 of that document is the
+    /// warning level. RFC 9396 section 7 is satisfied either way, since its MUST is to return what the
+    /// resource owner GRANTED and nothing granted is nothing to return. section 9 of that document is the
     /// one that matters here: it makes the
     /// details reaching the resource server the point of having them, and a token carrying none leaves
     /// it nothing to enforce, which is worth seeing in a log rather than discovering at the resource
@@ -70,10 +76,10 @@ public interface IUserCodeVerificationService
     /// </summary>
     /// <param name="userCode">The user-entered verification code.</param>
     /// <returns>
-    /// True when this call is the one that recorded the denial. False otherwise, on the same condition
-    /// as <see cref="ApproveAsync"/>: the stored record must still be pending when the decision is
-    /// written, so a decision that landed first answers false, as does a request whose lifetime ran
-    /// out. Nothing about the record changes in those cases.
+    /// True when this call is the one that recorded the denial. False otherwise: the stored record is
+    /// re-read and must still be pending, so a decision that landed first answers false, as does a
+    /// request whose lifetime ran out. Nothing about the record changes in those cases, and a true
+    /// carries the same narrowed-not-closed window <see cref="ApproveAsync"/> describes.
     /// </returns>
     Task<bool> DenyAsync(string userCode);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
@@ -36,7 +36,11 @@ public interface IUserCodeVerificationService
     /// starting point rather than the final word - the token endpoint narrows them against the token
     /// request (RFC 8707 §2.2) and adds the certificate and proof-key confirmations.</param>
     /// <returns>
-    /// A task that returns true if the approval was successful; false if the code is invalid or expired.
+    /// True when this call is the one that recorded the approval. False otherwise, and otherwise is
+    /// wider than a bad code: the stored record must still be pending when the decision is written,
+    /// so a denial or another approval landing first answers false too, as does a request whose
+    /// lifetime ran out and one whose grant carries a type the request never asked for. The decision
+    /// is not applied in any of those cases, and nothing about the record changes.
     /// </returns>
     /// <remarks>
     /// <c>authorization_details</c> are the host's to carry. The requested entries arrive on
@@ -66,7 +70,10 @@ public interface IUserCodeVerificationService
     /// </summary>
     /// <param name="userCode">The user-entered verification code.</param>
     /// <returns>
-    /// A task that returns true if the denial was successful; false if the code is invalid or expired.
+    /// True when this call is the one that recorded the denial. False otherwise, on the same condition
+    /// as <see cref="ApproveAsync"/>: the stored record must still be pending when the decision is
+    /// written, so a decision that landed first answers false, as does a request whose lifetime ran
+    /// out. Nothing about the record changes in those cases.
     /// </returns>
     Task<bool> DenyAsync(string userCode);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IUserCodeVerificationService.cs
@@ -44,8 +44,7 @@ public interface IUserCodeVerificationService
     /// <para>
     /// A true is not a guarantee that nothing landed in between. The re-read and the write are two
     /// store calls, and the store exposes no conditional write, so two concurrent approvals can each
-    /// be told true and the later write wins. The window is a store round trip wide rather than the
-    /// whole verification page, which is what this narrows and does not close.
+    /// be told true and the later write wins. That window is one store round trip wide.
     /// </para>
     /// </returns>
     /// <remarks>
@@ -57,10 +56,10 @@ public interface IUserCodeVerificationService
     /// <para>
     /// Approving with entries on the record and none on the grant is therefore allowed and logged at
     /// warning level. RFC 9396 section 7 is satisfied either way, since its MUST is to return what the
-    /// resource owner GRANTED and nothing granted is nothing to return. section 9 of that document is the
-    /// one that matters here: it makes the
-    /// details reaching the resource server the point of having them, and a token carrying none leaves
-    /// it nothing to enforce, which is worth seeing in a log rather than discovering at the resource
+    /// resource owner GRANTED and nothing granted is nothing to return. What matters here is section 9 of
+    /// that document: it makes the details reaching the resource server the point of having them, and a
+    /// token carrying none leaves it nothing to enforce, which is worth seeing in a log rather than
+    /// discovering at the resource
     /// server.
     /// </para>
     /// <para>
@@ -76,9 +75,9 @@ public interface IUserCodeVerificationService
     /// </summary>
     /// <param name="userCode">The user-entered verification code.</param>
     /// <returns>
-    /// True when this call is the one that recorded the denial. False otherwise: the stored record is
-    /// re-read and must still be pending, so a decision that landed first answers false, as does a
-    /// request whose lifetime ran out. Nothing about the record changes in those cases, and a true
+    /// True when this call is the one that recorded the denial. False otherwise, and otherwise is wider
+    /// than a bad code: the stored record is re-read and must still be pending, so a decision that
+    /// landed first answers false, as does a request whose lifetime ran out. Nothing about the record changes in those cases, and a true
     /// carries the same narrowed-not-closed window <see cref="ApproveAsync"/> describes.
     /// </returns>
     Task<bool> DenyAsync(string userCode);

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -162,16 +162,22 @@ public partial class UserCodeVerificationService(
     /// code was looked up.
     /// </summary>
     /// <remarks>
-    /// Everything between the lookup and the write is the window, and the record can be consumed inside
-    /// it: a poll redeems the device code and removes it, and a write of the record read earlier RESTORES
-    /// an authorized record carrying its grant. A later poll finds that, and a second full token set is
-    /// issued for one device code - with nothing downstream to catch it, since the net the
-    /// authorization-code path has is the reuse decorator inspecting the claimed grant, and the device
-    /// path has no equivalent.
+    /// Everything between the lookup and the write is a window, and a write of the record read earlier
+    /// RESTORES it - so a later poll finds an authorized record for a code that was already exchanged,
+    /// and a second full token set is issued for one device code. Nothing downstream catches it: the net
+    /// the authorization-code path has is the reuse decorator inspecting the claimed grant, and the
+    /// device path has no equivalent.
+    /// <para>
+    /// It takes TWO decisions, and that is the precondition the hazard is easy to state without. While
+    /// the record reads Pending no poll removes it: every removing arm of the token endpoint needs it to
+    /// be Authorized, Denied or expired first, and the expired arm issues nothing. So the sequence needs
+    /// another decision to move the record off Pending before a poll can consume it - which is exactly
+    /// the clause a guard written only against a REMOVED record would miss.
+    /// </para>
     /// <para>
     /// The same shape <c>DeviceCodeGrantHandler.TryBumpNextPollAsync</c> already uses on this store, and
     /// with the same limit: re-reading NARROWS the window to the store round trip and does not close it.
-    /// Closing it needs a compare-and-swap the entity storage does not expose.
+    /// Closing it needs a compare-and-swap the entity storage does not expose, which is issue 194.
     /// </para>
     /// </remarks>
     /// <param name="deviceCode">The record to decide on.</param>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -88,7 +88,7 @@ public partial class UserCodeVerificationService(
         if (request.Status != DeviceAuthorizationStatus.Pending)
             return false;
 
-        // An approval landing after the code's fixed lifetime (RFC 8628 §3.2) cannot be redeemed, so treat
+        // An approval landing after the code's fixed lifetime (RFC 8628 section 3.2) cannot be redeemed, so treat
         // it as a no-op rather than reviving an expired code; this also keeps the refreshed cache TTL positive.
         var remaining = request.ExpiresAt - timeProvider.GetUtcNow();
         if (remaining <= TimeSpan.Zero)
@@ -147,7 +147,7 @@ public partial class UserCodeVerificationService(
         if (request.Status != DeviceAuthorizationStatus.Pending)
             return false;
 
-        // A denial after the code's fixed lifetime (RFC 8628 §3.2) is moot - the code is already unusable, so
+        // A denial after the code's fixed lifetime (RFC 8628 section 3.2) is moot - the code is already unusable, so
         // treat it as a no-op rather than writing a record with a non-positive cache TTL.
         var remaining = request.ExpiresAt - timeProvider.GetUtcNow();
         if (remaining <= TimeSpan.Zero)
@@ -169,10 +169,11 @@ public partial class UserCodeVerificationService(
     /// device path has no equivalent.
     /// <para>
     /// It takes TWO decisions, and that is the precondition the hazard is easy to state without. While
-    /// the record reads Pending no poll removes it: every removing arm of the token endpoint needs it to
-    /// be Authorized, Denied or expired first, and the expired arm issues nothing. So the sequence needs
-    /// another decision to move the record off Pending before a poll can consume it - which is exactly
-    /// the clause a guard written only against a REMOVED record would miss.
+    /// the record reads Pending no poll CONSUMES it: the only arm that issues anything needs it to read
+    /// Authorized first. A poll does remove a pending record once its lifetime is over, and that arm
+    /// issues nothing, so it cannot produce the second token set. The sequence therefore needs another
+    /// decision to move the record off Pending - which is exactly the clause a guard written only
+    /// against a REMOVED record would miss.
     /// </para>
     /// <para>
     /// The same shape <c>DeviceCodeGrantHandler.TryBumpNextPollAsync</c> already uses on this store, and

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -106,10 +106,17 @@ public partial class UserCodeVerificationService(
             return false;
         }
 
-        request.Status = DeviceAuthorizationStatus.Authorized;
-        request.AuthorizedGrant = authorizedGrant;
-
-        await storage.UpdateAsync(deviceCode, request, remaining);
+        if (!await TryDecideAsync(
+                deviceCode,
+                remaining,
+                current =>
+                {
+                    current.Status = DeviceAuthorizationStatus.Authorized;
+                    current.AuthorizedGrant = authorizedGrant;
+                }))
+        {
+            return false;
+        }
 
         // The requested entries were handed to the host on ValidUserCode, and whether they reach the
         // grant is its decision: only its verification page knows whether it displayed them, and a
@@ -146,9 +153,43 @@ public partial class UserCodeVerificationService(
         if (remaining <= TimeSpan.Zero)
             return false;
 
-        request.Status = DeviceAuthorizationStatus.Denied;
+        return await TryDecideAsync(
+            deviceCode, remaining, current => current.Status = DeviceAuthorizationStatus.Denied);
+    }
 
-        await storage.UpdateAsync(deviceCode, request, remaining);
+    /// <summary>
+    /// Applies a decision to the record as it stands NOW, refusing when it has moved on since the user
+    /// code was looked up.
+    /// </summary>
+    /// <remarks>
+    /// Everything between the lookup and the write is the window, and the record can be consumed inside
+    /// it: a poll redeems the device code and removes it, and a write of the record read earlier RESTORES
+    /// an authorized record carrying its grant. A later poll finds that, and a second full token set is
+    /// issued for one device code - with nothing downstream to catch it, since the net the
+    /// authorization-code path has is the reuse decorator inspecting the claimed grant, and the device
+    /// path has no equivalent.
+    /// <para>
+    /// The same shape <c>DeviceCodeGrantHandler.TryBumpNextPollAsync</c> already uses on this store, and
+    /// with the same limit: re-reading NARROWS the window to the store round trip and does not close it.
+    /// Closing it needs a compare-and-swap the entity storage does not expose.
+    /// </para>
+    /// </remarks>
+    /// <param name="deviceCode">The record to decide on.</param>
+    /// <param name="remaining">The lifetime left, applied as the cache TTL so the code cannot be extended.</param>
+    /// <param name="decide">Applies the decision to the freshly read record.</param>
+    private async Task<bool> TryDecideAsync(
+        string deviceCode,
+        TimeSpan remaining,
+        Action<DeviceAuthorizationRequest> decide)
+    {
+        var current = await storage.TryGetByDeviceCodeAsync(deviceCode);
+        if (current is not { Status: DeviceAuthorizationStatus.Pending })
+        {
+            return false;
+        }
+
+        decide(current);
+        await storage.UpdateAsync(deviceCode, current, remaining);
         return true;
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -197,6 +197,69 @@ public class UserCodeVerificationServiceTests
                 AuthorizationDetails = authorizationDetails,
             });
 
+    /// <summary>
+    /// The decision is applied to the record read from the DEVICE-CODE lookup, and that record is what
+    /// is written back.
+    /// </summary>
+    /// <remarks>
+    /// The whole of this change is which object the decision lands on, and nothing measured it: every
+    /// other fixture answers both lookups with ONE instance, so deciding the stale record and deciding
+    /// the fresh one are the same call. A mutant that writes the user-code record back leaves the suite
+    /// green while silently discarding approvals - it writes a record still reading Pending, answers
+    /// true, and the device polls authorization_pending for ever.
+    /// <para>
+    /// So the two lookups return DISTINCT pending objects here, which is what production does anyway:
+    /// the storage deserializes on every call.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ApproveAsync_AppliesTheDecision_ToTheRecordItReadForTheWrite()
+    {
+        var fromUserCode = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            ExpiresAt = Now.AddMinutes(5),
+        };
+
+        var fromDeviceCode = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            ExpiresAt = Now.AddMinutes(5),
+        };
+
+        var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
+        storage
+            .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, fromUserCode) : null);
+
+        storage
+            .Setup(store => store.TryGetByDeviceCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == DeviceCode ? fromDeviceCode : null);
+
+        DeviceAuthorizationRequest? written = null;
+        storage
+            .Setup(store => store.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<DeviceAuthorizationRequest>(), It.IsAny<TimeSpan>()))
+            .Callback<string, DeviceAuthorizationRequest, TimeSpan>((_, r, _) => written = r)
+            .Returns(Task.CompletedTask);
+
+        var service = new UserCodeVerificationService(
+            new CapturingLogger<UserCodeVerificationService>(),
+            storage.Object,
+            Mock.Of<IUserCodeRateLimiter>(),
+            new UserCodeNormalizer(Options.Create(DeviceOptions())),
+            Mock.Of<IRequestInfoProvider>(),
+            new FakeTimeProvider(Now));
+
+        Assert.True(await service.ApproveAsync(CanonicalUserCode, GrantWith(null)));
+
+        // The object identity is the assertion. Both records carry the same fields, so comparing values
+        // would pass on either one.
+        Assert.Same(fromDeviceCode, written);
+        Assert.Equal(DeviceAuthorizationStatus.Authorized, fromDeviceCode.Status);
+
+        // And the stale one was left alone, which is what a caller reading it back would rely on.
+        Assert.Equal(DeviceAuthorizationStatus.Pending, fromUserCode.Status);
+    }
+
     private static UserCodeVerificationService BuildService(
         JsonArray? requestedDetails,
         out CapturingLogger<UserCodeVerificationService> logs)

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -55,6 +55,11 @@ public class UserCodeVerificationServiceTests
             .ReturnsAsync((string code) =>
                 code == CanonicalUserCode ? (DeviceCode, request) : null);
 
+        // See the note in BuildService: the decision reads the record again before writing it.
+        storage
+            .Setup(s => s.TryGetByDeviceCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == DeviceCode ? request : null);
+
         var rateLimiter = new Mock<IUserCodeRateLimiter>(MockBehavior.Loose);
         rateLimiter
             .Setup(r => r.CheckAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -212,6 +217,13 @@ public class UserCodeVerificationServiceTests
             .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
             .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, request) : null);
 
+        // The decision is applied to the record as it stands at the write, so a fixture that answers the
+        // user-code lookup and not this one is describing a record consumed in between - which is its own
+        // row rather than the arrangement these tests want.
+        storage
+            .Setup(store => store.TryGetByDeviceCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == DeviceCode ? request : null);
+
         logs = new CapturingLogger<UserCodeVerificationService>();
         return new UserCodeVerificationService(
             logs,
@@ -220,6 +232,59 @@ public class UserCodeVerificationServiceTests
             new UserCodeNormalizer(Options.Create(DeviceOptions())),
             Mock.Of<IRequestInfoProvider>(),
             new FakeTimeProvider(Now));
+    }
+
+    /// <summary>
+    /// A decision taken on a record that was consumed while the decision was being taken does not write
+    /// that record back.
+    /// </summary>
+    /// <remarks>
+    /// Approval reads the record, checks its status, and writes it back. Between those, a poll can redeem
+    /// the device code and remove it - and the write then RESTORES an authorized record carrying its
+    /// grant. A later poll finds it, and a second full token set is issued for one device code. The
+    /// authorization-code path has a net for this, the reuse decorator inspecting IssuedTokens on the
+    /// claimed grant; the device path has none, so nothing downstream catches it.
+    /// <para>
+    /// The record is reported gone at the moment of the re-read rather than by racing two callers, so the
+    /// row measures the ordering the code guarantees rather than one a scheduler happened to produce.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ADecisionOnARecordConsumedMeanwhile_IsNotWrittenBack(bool approving)
+    {
+        var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            ExpiresAt = Now.AddMinutes(5),
+        };
+
+        var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
+        storage
+            .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, request) : null);
+
+        // Consumed in between: the device code was redeemed and removed while the decision was taken.
+        storage
+            .Setup(store => store.TryGetByDeviceCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((DeviceAuthorizationRequest?)null);
+
+        var service = new UserCodeVerificationService(
+            new CapturingLogger<UserCodeVerificationService>(),
+            storage.Object,
+            Mock.Of<IUserCodeRateLimiter>(),
+            new UserCodeNormalizer(Options.Create(DeviceOptions())),
+            Mock.Of<IRequestInfoProvider>(),
+            new FakeTimeProvider(Now));
+
+        var decided = approving
+            ? await service.ApproveAsync(CanonicalUserCode, GrantWith(null))
+            : await service.DenyAsync(CanonicalUserCode);
+
+        Assert.False(decided);
+        storage.Verify(
+            store => store.UpdateAsync(It.IsAny<string>(), It.IsAny<DeviceAuthorizationRequest>(), It.IsAny<TimeSpan>()),
+            Times.Never);
     }
 
     private static OidcOptions DeviceOptions() => new()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -55,11 +55,6 @@ public class UserCodeVerificationServiceTests
             .ReturnsAsync((string code) =>
                 code == CanonicalUserCode ? (DeviceCode, request) : null);
 
-        // See the note in BuildService: the decision reads the record again before writing it.
-        storage
-            .Setup(s => s.TryGetByDeviceCodeAsync(It.IsAny<string>()))
-            .ReturnsAsync((string code) => code == DeviceCode ? request : null);
-
         var rateLimiter = new Mock<IUserCodeRateLimiter>(MockBehavior.Loose);
         rateLimiter
             .Setup(r => r.CheckAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -235,39 +230,65 @@ public class UserCodeVerificationServiceTests
     }
 
     /// <summary>
-    /// A decision taken on a record that was consumed while the decision was being taken does not write
-    /// that record back.
+    /// A decision taken on a record that stopped being pending while the decision was being taken does
+    /// not write that record back.
     /// </summary>
     /// <remarks>
-    /// Approval reads the record, checks its status, and writes it back. Between those, a poll can redeem
-    /// the device code and remove it - and the write then RESTORES an authorized record carrying its
-    /// grant. A later poll finds it, and a second full token set is issued for one device code. The
-    /// authorization-code path has a net for this, the reuse decorator inspecting IssuedTokens on the
-    /// claimed grant; the device path has none, so nothing downstream catches it.
+    /// Approval reads the record, checks its status, and writes it back. Between those the record can
+    /// move, in two ways, and the guard covers a record that is no longer pending rather than either of
+    /// them by name.
     /// <para>
-    /// The record is reported gone at the moment of the re-read rather than by racing two callers, so the
-    /// row measures the ordering the code guarantees rather than one a scheduler happened to produce.
+    /// A poll can redeem the device code and REMOVE it, and the write then restores an authorized record
+    /// carrying its grant. A later poll finds it, and a second full token set is issued for one device
+    /// code. The authorization-code path has a net for this, the reuse decorator inspecting IssuedTokens
+    /// on the claimed grant; the device path has none, so nothing downstream catches it.
+    /// </para>
+    /// <para>
+    /// Or another decision can land FIRST, leaving the record present and decided. Writing over it
+    /// reverses somebody's answer: an approval overwriting a denial hands the device the tokens the end
+    /// user refused. This half is the one with no removal in it, so a guard written for the first would
+    /// pass every row of the first and none of this.
+    /// </para>
+    /// <para>
+    /// What the re-read finds is arranged at the moment of the re-read rather than by racing two callers,
+    /// so the rows measure the ordering the code guarantees rather than one a scheduler happened to
+    /// produce. Where the record survives, the re-read returns a DISTINCT object, which is what makes
+    /// "wrote the stale one" a different outcome from "wrote the fresh one" instead of the same.
     /// </para>
     /// </remarks>
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ADecisionOnARecordConsumedMeanwhile_IsNotWrittenBack(bool approving)
+    [InlineData(true, null)]
+    [InlineData(false, null)]
+    [InlineData(true, DeviceAuthorizationStatus.Denied)]
+    [InlineData(true, DeviceAuthorizationStatus.Authorized)]
+    [InlineData(false, DeviceAuthorizationStatus.Authorized)]
+    [InlineData(false, DeviceAuthorizationStatus.Denied)]
+    public async Task ADecisionOnARecordNoLongerPending_IsNotWrittenBack(
+        bool approving, DeviceAuthorizationStatus? advancedTo)
     {
         var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
         {
             ExpiresAt = Now.AddMinutes(5),
         };
 
+        // What the re-read finds. Null is the record consumed and gone; a status is another decision
+        // having landed first, on a record that is still there.
+        var current = advancedTo is null
+            ? null
+            : new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+            {
+                ExpiresAt = Now.AddMinutes(5),
+                Status = advancedTo.Value,
+            };
+
         var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
         storage
             .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
             .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, request) : null);
 
-        // Consumed in between: the device code was redeemed and removed while the decision was taken.
         storage
             .Setup(store => store.TryGetByDeviceCodeAsync(It.IsAny<string>()))
-            .ReturnsAsync((DeviceAuthorizationRequest?)null);
+            .ReturnsAsync(current);
 
         var service = new UserCodeVerificationService(
             new CapturingLogger<UserCodeVerificationService>(),

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -204,9 +204,10 @@ public class UserCodeVerificationServiceTests
     /// <remarks>
     /// The whole of this change is which object the decision lands on, and nothing measured it: every
     /// other fixture answers both lookups with ONE instance, so deciding the stale record and deciding
-    /// the fresh one are the same call. A mutant that writes the user-code record back leaves the suite
-    /// green while silently discarding approvals - it writes a record still reading Pending, answers
-    /// true, and the device polls authorization_pending for ever.
+    /// the fresh one are the same call. Two mutants live in that blind spot and both leave the suite
+    /// green: deciding the stale record writes back one still reading Pending, so the device polls
+    /// authorization_pending for ever; deciding the fresh one and WRITING the stale one loses the
+    /// approval just as quietly. Only the identity assertion below sees the second.
     /// <para>
     /// So the two lookups return DISTINCT pending objects here, which is what production does anyway:
     /// the storage deserializes on every call.


### PR DESCRIPTION
Closes #459.

## What a duplicate approval can do

`UserCodeVerificationService.ApproveAsync` read the device-authorization record, checked its status, and wrote it back. Everything between those is a window, and the record can be consumed inside it:

- an approval reads the record while it is still `Pending`,
- a poll redeems the device code and removes it,
- the approval's `UpdateAsync` lands, **restoring** an `Authorized` record that carries its grant,
- a later poll finds an authorized record for a code that was already exchanged, and a second full token set is issued for one device code.

Nothing downstream catches it. The authorization-code path has a net - `AuthorizationCodeReusePreventingDecorator` inspects `IssuedTokens` on the claimed grant and revokes what it finds - and the device path has no equivalent.

`DenyAsync` has the same shape with a milder consequence, and is fixed alongside it: one guard for one hazard rather than two readings of the same code.

## The fix, and its stated limit

Both decisions read the record again and apply themselves to what is there, refusing when it has moved on. That is the shape `DeviceCodeGrantHandler.TryBumpNextPollAsync` already uses on this same store, which is what makes the store's raciness at this shape a known thing rather than a new claim.

**Re-reading narrows the window to a store round trip; it does not close it.** Closing needs a compare-and-swap the entity storage does not expose - #194 on the 3.0 milestone. The limit is stated where the guard stands rather than only here.

## Evidence

CI is green, and the row measures the ordering the code guarantees rather than one a scheduler happened to produce: the record is reported gone at the moment of the re-read, by the fixture, with no threads and nothing to flake.

- Applying the decision whatever the current record says is caught over both decisions and both terminal statuses, with the re-read returning a DISTINCT object so writing the stale one and writing the fresh one are different outcomes.
- Applying it to the WRONG record has its own row, and needed one: every other fixture answers both lookups with a single instance, so a version deciding the stale record left the suite green while silently discarding approvals. That row gives the two lookups distinct objects and asserts identity, because the records carry the same field values and comparing them would pass on either.
- Three existing rows had to learn about the re-read. A fixture that answers the user-code lookup and not the record lookup is describing a record consumed in between - which is exactly the new row's arrangement, so leaving them would have made every approval test assert the hazard instead of the feature.

## What this does not claim

The interleaving was found by reading both paths rather than by building it, and the fix is written the same way: an unguarded read-modify-write narrowed to the extent a re-read can narrow one.

Narrowed, not closed, and both public contracts now say so rather than leaving it in a private remark the generated documentation never carries. The re-read and the write are two store calls with no conditional write between them, so two concurrent approvals can each be told true and the later one wins. What that leaves is a window a store round trip wide instead of one as wide as the verification page. Closing it needs a compare-and-swap the entity storage does not expose, which is #194, and #435 is the same gap one layer down.

