### PR TITLE
Refuse a second completion of a CIBA request, and give push a record that says it was spent

### DIFF
--- a/.github/scripts/lint-no-bom-change.py
+++ b/.github/scripts/lint-no-bom-change.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Reject a byte-order mark that appears or disappears without anybody deciding it should.
+
+WHAT GOES WRONG. Python's ``utf-8-sig`` codec strips a mark on read and writes one unconditionally,
+so a scripted read-modify-write through it ADDS three bytes to the head of a file that never had one,
+and the symmetric mistake with plain ``utf-8`` REMOVES a mark from a file that did. Neither is
+announced. The mark sits INSIDE the first line, so most diffs render as the line you meant to edit or
+as nothing at all, and the check written in the same minute parses the result with the same forgiving
+codec that hid it.
+
+WHY IT IS WORTH A GUARD RATHER THAN A SENTENCE. This is written down in two places already and it
+still happened twice in one afternoon, on two different branches. A rule that has to fire while
+somebody is concentrating on something else is not a rule, it is a hope; the refusal is the part that
+works.
+
+THE CRITERION IS THE MARK NOT CHANGING, not the mark being absent. Files here legitimately carry one
+and files here legitimately do not, and either is somebody's decision. What nobody decides is that a
+file should swap. A NEW file is therefore accepted whichever way it comes, because there is no earlier
+state to contradict; only a file already in HEAD is compared.
+
+READ FROM THE INDEX, like the carriage-return check beside it: what matters is what git STORES and
+every other machine receives, not what a working copy happens to hold.
+
+WHERE THIS FILE SHOULD LIVE. Its sibling ``lint-no-cr-in-blobs.py`` is a copy of a canonical file in
+the workspace's shared hooks directory, so that no repository ends up guarded differently from the
+rest. This one starts here because this is where the class was caught; promote it the same way the
+moment a second repository needs it.
+"""
+
+import subprocess
+import sys
+
+BOM = b'\xef\xbb\xbf'
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(['git', *args], capture_output=True, check=False)
+
+
+def blob(ref: str, path: str) -> bytes | None:
+    """The first bytes of a path at a ref, or None when the ref does not have that path."""
+    done = run(['show', f'{ref}:{path}'])
+    return done.stdout if done.returncode == 0 else None
+
+
+def mark(content: bytes | None) -> str:
+    if content is None:
+        return 'absent from this revision'
+
+    return 'a byte-order mark' if content.startswith(BOM) else 'no byte-order mark'
+
+
+def main(paths: list[str]) -> int:
+    offenders = []
+    for path in paths:
+        before = blob('HEAD', path)
+
+        # A file this commit introduces has nothing to contradict, so whichever form it arrives in is
+        # the form somebody chose.
+        if before is None:
+            continue
+
+        after = blob('', path)
+        if after is None:
+            continue
+
+        if before.startswith(BOM) != after.startswith(BOM):
+            offenders.append((path, mark(before), mark(after)))
+
+    if not offenders:
+        # A silence has to mean something was read. The count is the only thing separating a clean run
+        # from a run over no files at all, and the two print the same nothing otherwise.
+        print(f'{len(paths)} path(s) checked; no byte-order mark changed.')
+        return 0
+
+    print('A byte-order mark changed in text staged for commit.\n', file=sys.stderr)
+    for path, before, after in offenders:
+        print(f'  {path}: had {before}, now has {after}', file=sys.stderr)
+
+    print(
+        '\nAlmost always a scripted edit rather than a decision: Python\'s utf-8-sig codec strips the\n'
+        'mark on read and writes one back unconditionally, so reading and writing through it plants a\n'
+        'mark in every file that had none. Plain utf-8 does the reverse to a file that had one.\n\n'
+        'Fix by rewriting the file as bytes and putting back exactly what it had, then re-staging.\n\n'
+        'If the change is deliberate, say so in the commit message and re-run with --no-verify; this\n'
+        'check has no allow-list, because a list of exceptions is how it stops meaning anything.',
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/lint-no-bom-change.py
+++ b/.github/scripts/lint-no-bom-change.py
@@ -8,10 +8,9 @@ announced. The mark sits INSIDE the first line, so most diffs render as the line
 as nothing at all, and the check written in the same minute parses the result with the same forgiving
 codec that hid it.
 
-WHY IT IS WORTH A GUARD RATHER THAN A SENTENCE. This is written down in two places already and it
-still happened twice in one afternoon, on two different branches. A rule that has to fire while
-somebody is concentrating on something else is not a rule, it is a hope; the refusal is the part that
-works.
+WHY IT IS WORTH A GUARD RATHER THAN A SENTENCE. The rule is written down and still gets missed,
+because it has to fire while somebody is concentrating on something else. A refusal needs nobody's
+attention.
 
 THE CRITERION IS THE MARK NOT CHANGING, not the mark being absent. Files here legitimately carry one
 and files here legitimately do not, and either is somebody's decision. What nobody decides is that a
@@ -52,6 +51,7 @@ def mark(content: bytes | None) -> str:
 
 def main(paths: list[str]) -> int:
     offenders = []
+    compared = 0
     for path in paths:
         before = blob('HEAD', path)
 
@@ -64,13 +64,15 @@ def main(paths: list[str]) -> int:
         if after is None:
             continue
 
+        compared += 1
+
         if before.startswith(BOM) != after.startswith(BOM):
             offenders.append((path, mark(before), mark(after)))
 
     if not offenders:
         # A silence has to mean something was read. The count is the only thing separating a clean run
         # from a run over no files at all, and the two print the same nothing otherwise.
-        print(f'{len(paths)} path(s) checked; no byte-order mark changed.')
+        print(f"{compared} of {len(paths)} path(s) compared; no byte-order mark changed. The rest are new here, so no earlier form contradicts them.")
         return 0
 
     print('A byte-order mark changed in text staged for commit.\n', file=sys.stderr)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
         # heuristic, then git's own diff output - both flagged committed PDFs that carry CR
         # harmlessly, and a check that fires on files nobody can fix gets waved away.
         types: [text]
+      - id: no-bom-change
+        name: "Block a byte-order mark appearing or disappearing"
+        entry: python .github/scripts/lint-no-bom-change.py
+        language: python
+        # Same delegation as above: pre-commit's identify library decides what is text, rather than
+        # this hook re-deriving it and disagreeing with its neighbour on the same file.
+        types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,9 @@
 # Run manually on all files:
 #   pre-commit run --all-files
 #
-# Bypass once (NOT recommended, and not a safety net: CI re-runs actionlint and the inline-secrets
-# check, and nothing else here - the carriage-return and doc-comment hooks run in this clone or
-# nowhere):
+# Bypass once (NOT recommended, and not a safety net). Of everything below, CI re-runs actionlint and
+# the inline-secrets check; EVERY OTHER hook here runs in this clone or nowhere. Said as the condition
+# rather than by naming them, because the list grows and a stale enumeration reads as a complete one:
 #   git commit --no-verify
 #
 # Rules and rationale: the workspace's GitHub Actions security checklist.

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
@@ -36,4 +36,16 @@ partial class AuthenticationCompletionHandler
                   "never asked for, so it is refused. ClientId: {ClientId}, types: {EscapedTypes}")]
     private partial void LogGrantedAuthorizationDetailsExceedTheRequest(
         string AuthReqId, string ClientId, string EscapedTypes);
+
+    /// <summary>
+    /// Logged as well as thrown. The throw reaches the host writing the recovery; the log reaches the
+    /// operator reading a live system, who sees the attempt whether or not the host caught it.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEvents.Device.AuthenticationCompletionHandler.AlreadyCompleted,
+        Level = LogLevel.Error,
+        Message = "auth_req_id {AuthReqId} was completed again, and refused: its status is {Status} " +
+                  "rather than Pending. A completion after a failed delivery is not a retry of that " +
+                  "delivery - it mints a second set of tokens for one authentication.")]
+    private partial void LogAlreadyCompleted(string AuthReqId, string Status);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
@@ -41,11 +41,18 @@ partial class AuthenticationCompletionHandler
     /// Logged as well as thrown. The throw reaches the host writing the recovery; the log reaches the
     /// operator reading a live system, who sees the attempt whether or not the host caught it.
     /// </summary>
+    /// <remarks>
+    /// It reports the state it found and nothing about the cause. Absence in particular has more causes
+    /// than this seam can tell apart, and the operator most likely to read this line is one who has just
+    /// fixed a client registration - a message asserting a second completion would send them hunting for
+    /// one that never happened. <c>Status</c> is null exactly when the record is not there, which is a
+    /// value the field's own domain does not have to carry.
+    /// </remarks>
     [LoggerMessage(
-        EventId = LogEvents.Device.AuthenticationCompletionHandler.AlreadyCompleted,
+        EventId = LogEvents.Device.AuthenticationCompletionHandler.NotPendingOnCompletion,
         Level = LogLevel.Error,
-        Message = "auth_req_id {AuthReqId} was completed again, and refused: its status is {Status} " +
-                  "rather than Pending. A completion after a failed delivery is not a retry of that " +
-                  "delivery - it mints a second set of tokens for one authentication.")]
-    private partial void LogAlreadyCompleted(string AuthReqId, string Status);
+        Message = "auth_req_id {AuthReqId} was refused at completion: the stored record reads {Status}, " +
+                  "or is absent when that is null, and only a pending request can be answered. It has " +
+                  "been answered, refused or has expired; recovering means asking the end user again.")]
+    private partial void LogNotPendingOnCompletion(string AuthReqId, string? Status);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
@@ -51,8 +51,9 @@ partial class AuthenticationCompletionHandler
     [LoggerMessage(
         EventId = LogEvents.Device.AuthenticationCompletionHandler.NotPendingOnCompletion,
         Level = LogLevel.Error,
-        Message = "auth_req_id {AuthReqId} was refused at completion: the stored record reads {Status}, " +
-                  "or is absent when that is null, and only a pending request can be answered. It has " +
-                  "been answered, refused or has expired; recovering means asking the end user again.")]
+        Message = "auth_req_id {AuthReqId} was refused at completion. The stored record reads {Status}, " +
+                  "and a null there means no record was found at all - it may have been answered, " +
+                  "refused, expired, evicted, or never have existed. Only a pending request can be " +
+                  "answered; recovering means asking the end user again.")]
     private partial void LogNotPendingOnCompletion(string AuthReqId, string? Status);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.Logging.cs
@@ -42,18 +42,20 @@ partial class AuthenticationCompletionHandler
     /// operator reading a live system, who sees the attempt whether or not the host caught it.
     /// </summary>
     /// <remarks>
-    /// It reports the state it found and nothing about the cause. Absence in particular has more causes
-    /// than this seam can tell apart, and the operator most likely to read this line is one who has just
-    /// fixed a client registration - a message asserting a second completion would send them hunting for
-    /// one that never happened. <c>Status</c> is null exactly when the record is not there, which is a
+    /// It reports the state it found and says the cause is unknown, rather than listing causes. A list is
+    /// complete until the next one, and this seam has already grown one nobody would have listed: push's
+    /// own refusal path removes the record after a configuration fault, so the operator most likely to
+    /// read this line - one who has just fixed a client registration - is in a case no enumeration of
+    /// answered, refused, expired or evicted covers. For the same reason the message no longer prescribes
+    /// a recovery: that operator's end user was never asked. <c>Status</c> is null exactly when the record is not there, which is a
     /// value the field's own domain does not have to carry.
     /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Device.AuthenticationCompletionHandler.NotPendingOnCompletion,
         Level = LogLevel.Error,
-        Message = "auth_req_id {AuthReqId} was refused at completion. The stored record reads {Status}, " +
-                  "and a null there means no record was found at all - it may have been answered, " +
-                  "refused, expired, evicted, or never have existed. Only a pending request can be " +
-                  "answered; recovering means asking the end user again.")]
+        Message = "auth_req_id {AuthReqId} was refused at completion. Only a pending request can be " +
+                  "answered, and the stored record reads {Status}. A null there means no record was " +
+                  "found, and this seam cannot tell why: absence has more causes than it can " +
+                  "distinguish, including a completion that already ran and removed the record.")]
     private partial void LogNotPendingOnCompletion(string AuthReqId, string? Status);
 }

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -41,18 +41,26 @@ public abstract partial class AuthenticationCompletionHandler(
     /// to the mode-specific delivery implementation.
     /// </summary>
     /// <param name="authenticationRequestId">The auth_req_id identifying the authentication request.</param>
-    /// <param name="request">The authentication request to mark as authenticated.</param>
+    /// <param name="request">The authentication request carrying the grant the end user approved. Its
+    /// own Status is not read: whether this request may still be answered is decided from the STORED
+    /// record, so a caller cannot make the decision by setting a field on its own copy.</param>
     /// <param name="clientInfo">Client information including delivery mode configuration.</param>
     /// <param name="expiresIn">How long the authenticated request remains valid.</param>
     /// <returns>A task representing the asynchronous authentication completion operation.</returns>
     /// <remarks>
     /// This method:
-    /// <list type="number">
+    /// <list type="bullet">
+    ///   <item>Refuses unless the STORED record reads Pending</item>
+    ///   <item>Refuses an answer from somebody other than the end user the request named, by denying or
+    ///   removing according to the mode</item>
     ///   <item>Sets the request status to Authenticated</item>
     ///   <item>Delegates to HandleDeliveryAsync for mode-specific token delivery (poll/ping/push)</item>
     /// </list>
     /// Called by AuthenticationCompletionRouter after determining the appropriate delivery mode handler.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">The store does not hold a PENDING record under this
+    /// identifier. The full statement of the condition, and why it is stated that way rather than as a
+    /// list of causes, is on <see cref="IAuthenticationCompletionHandler.CompleteAsync"/>.</exception>
     public async Task CompleteAuthenticationAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -59,30 +59,39 @@ public abstract partial class AuthenticationCompletionHandler(
         ClientInfo clientInfo,
         TimeSpan expiresIn)
     {
-        // One authentication, one completion. The end user answered once, so a second full token set is
-        // wrong whatever it contains - which is why this refuses rather than replaying the narrowed
-        // grant. Replaying would make the second set correctly scoped and no less of a second set.
+        // One authentication, one completion. The end user answered once, so a second delivery of that
+        // answer is wrong whatever it carries - which is why this refuses rather than replaying the
+        // narrowed grant. Replaying would make the second attempt correctly scoped and no less of a
+        // second attempt.
         //
-        // Loud rather than silent, and that is a behaviour change a host could be relying on: nothing on
-        // this seam returns a value, so a refusal a caller cannot detect is the one shape that reads as
-        // acceptance. The exception reaches the code writing the recovery, which is where the choice
-        // between re-completing and asking the end user again is actually made.
+        // Read from STORAGE, not from the request the caller handed in. The documented host pattern sets
+        // Status on its own copy before calling here, so a guard reading that field would refuse a
+        // conforming host on its FIRST completion - and, worse, would be advisory: whether the refusal
+        // fires would be up to the caller it is meant to constrain. The stored record is the one thing
+        // this seam owns.
         //
-        // Push is what makes this reachable at all. Poll and ping persist Authenticated before they
-        // deliver, so their records already answer this; push stored nothing until
+        // Push is what makes a second completion reachable at all. Poll and ping persist Authenticated
+        // before they deliver, so a repeat already found a spent record; push stored nothing until
         // PushModeCompletionHandler was given the same write, and until then a failed delivery left a
         // record that still read Pending and still carried what the CLIENT asked for.
-        if (request.Status != BackChannelAuthenticationStatus.Pending)
+        //
+        // Stated as what must be TRUE rather than as the ways it can fail. A record that is gone is not
+        // a lesser case of one that is spent: a poll can have redeemed and removed it, and completing on
+        // top of that mints against a record nobody can check and writes it back into existence.
+        var stored = await storage.TryGetAsync(authenticationRequestId);
+        if (stored is not { Status: BackChannelAuthenticationStatus.Pending })
         {
-            LogAlreadyCompleted(authenticationRequestId, request.Status.ToString());
+            LogAlreadyCompleted(authenticationRequestId, stored?.Status.ToString() ?? "gone");
 
             throw new InvalidOperationException(
-                $"The authentication request has already been completed. Its "
-                + $"{nameof(request.Status)} is {request.Status}, and only "
-                + $"{BackChannelAuthenticationStatus.Pending} can be completed. Recovering from a failed "
-                + $"delivery by completing again would issue a second set of tokens for one "
-                + $"authentication, carrying what the client asked for rather than what the end user "
-                + $"approved.");
+                $"The authentication request cannot be completed: the stored record "
+                + (stored is null
+                    ? "is gone, so it was answered and consumed already"
+                    : $"reads {stored.Status} rather than {BackChannelAuthenticationStatus.Pending}")
+                + ". Completing it would deliver a second answer for one authentication - in push mode a "
+                + "second set of tokens, and in every mode a grant carrying what the client asked for "
+                + "rather than what the end user approved. Recovering from a failed delivery means asking "
+                + "the end user again.");
         }
 
         // Whoever answered the device has to be the end user the request named. OpenID Connect Core 1.0

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -78,20 +78,25 @@ public abstract partial class AuthenticationCompletionHandler(
         // Stated as what must be TRUE rather than as the ways it can fail. A record that is gone is not
         // a lesser case of one that is spent: a poll can have redeemed and removed it, and completing on
         // top of that mints against a record nobody can check and writes it back into existence.
+        //
+        // And the refusal says only that, never WHY. Absence has more causes than this seam can tell
+        // apart - a poll redeemed it, a push delivered it, its lifetime ran out while the end user was
+        // deciding, or push's own refusal path removed it after a configuration fault, where nothing was
+        // answered at all. Naming one of them would send an operator who just fixed a client
+        // registration looking for a second completion that never happened.
         var stored = await storage.TryGetAsync(authenticationRequestId);
         if (stored is not { Status: BackChannelAuthenticationStatus.Pending })
         {
-            LogAlreadyCompleted(authenticationRequestId, stored?.Status.ToString() ?? "gone");
+            LogNotPendingOnCompletion(authenticationRequestId, stored?.Status.ToString());
 
             throw new InvalidOperationException(
-                $"The authentication request cannot be completed: the stored record "
+                "The authentication request cannot be completed: the stored record "
                 + (stored is null
-                    ? "is gone, so it was answered and consumed already"
+                    ? "is not there"
                     : $"reads {stored.Status} rather than {BackChannelAuthenticationStatus.Pending}")
-                + ". Completing it would deliver a second answer for one authentication - in push mode a "
-                + "second set of tokens, and in every mode a grant carrying what the client asked for "
-                + "rather than what the end user approved. Recovering from a failed delivery means asking "
-                + "the end user again.");
+                + ". Only a pending request can be answered, and this one has been answered, refused or "
+                + "has expired. Recovering from a failed delivery means asking the end user again rather "
+                + "than completing the same request twice.");
         }
 
         // Whoever answered the device has to be the end user the request named. OpenID Connect Core 1.0

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -64,11 +64,11 @@ public abstract partial class AuthenticationCompletionHandler(
         // narrowed grant. Replaying would make the second attempt correctly scoped and no less of a
         // second attempt.
         //
-        // Read from STORAGE, not from the request the caller handed in. The documented host pattern sets
-        // Status on its own copy before calling here, so a guard reading that field would refuse a
-        // conforming host on its FIRST completion - and, worse, would be advisory: whether the refusal
-        // fires would be up to the caller it is meant to constrain. The stored record is the one thing
-        // this seam owns.
+        // Read from STORAGE, not from the request the caller handed in. A host is free to set Status on
+        // its own copy - some do, and the end-to-end fixture here is one of them - so a guard reading
+        // that field would refuse those on their FIRST completion, and would be advisory besides:
+        // whether the refusal fires would be the choice of the caller it exists to constrain. The
+        // stored record is the one thing this seam owns.
         //
         // Push is what makes a second completion reachable at all. Poll and ping persist Authenticated
         // before they deliver, so a repeat already found a spent record; push stored nothing until
@@ -94,9 +94,8 @@ public abstract partial class AuthenticationCompletionHandler(
                 + (stored is null
                     ? "is not there"
                     : $"reads {stored.Status} rather than {BackChannelAuthenticationStatus.Pending}")
-                + ". Only a pending request can be answered, and this one has been answered, refused or "
-                + "has expired. Recovering from a failed delivery means asking the end user again rather "
-                + "than completing the same request twice.");
+                + ". Only a pending request can be answered. Recovering from a failed delivery means "
+                + "asking the end user again rather than completing the same request twice.");
         }
 
         // Whoever answered the device has to be the end user the request named. OpenID Connect Core 1.0

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/AuthenticationCompletionHandler.cs
@@ -59,6 +59,32 @@ public abstract partial class AuthenticationCompletionHandler(
         ClientInfo clientInfo,
         TimeSpan expiresIn)
     {
+        // One authentication, one completion. The end user answered once, so a second full token set is
+        // wrong whatever it contains - which is why this refuses rather than replaying the narrowed
+        // grant. Replaying would make the second set correctly scoped and no less of a second set.
+        //
+        // Loud rather than silent, and that is a behaviour change a host could be relying on: nothing on
+        // this seam returns a value, so a refusal a caller cannot detect is the one shape that reads as
+        // acceptance. The exception reaches the code writing the recovery, which is where the choice
+        // between re-completing and asking the end user again is actually made.
+        //
+        // Push is what makes this reachable at all. Poll and ping persist Authenticated before they
+        // deliver, so their records already answer this; push stored nothing until
+        // PushModeCompletionHandler was given the same write, and until then a failed delivery left a
+        // record that still read Pending and still carried what the CLIENT asked for.
+        if (request.Status != BackChannelAuthenticationStatus.Pending)
+        {
+            LogAlreadyCompleted(authenticationRequestId, request.Status.ToString());
+
+            throw new InvalidOperationException(
+                $"The authentication request has already been completed. Its "
+                + $"{nameof(request.Status)} is {request.Status}, and only "
+                + $"{BackChannelAuthenticationStatus.Pending} can be completed. Recovering from a failed "
+                + $"delivery by completing again would issue a second set of tokens for one "
+                + $"authentication, carrying what the client asked for rather than what the end user "
+                + $"approved.");
+        }
+
         // Whoever answered the device has to be the end user the request named. OpenID Connect Core 1.0
         // Section 3.1.2.2: the server "MUST NOT reply with an ID Token or Access Token for a different user,
         // even if they have an active session with the Authorization Server". The end user authenticated out

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
@@ -34,10 +34,9 @@ partial class PushModeCompletionHandler
         EventId = LogEvents.Device.PushModeCompletionHandler.PushDeliveryFailed,
         Level = LogLevel.Warning,
         Message = "CIBA push delivery failed for auth_req_id: {AuthReqId}. The tokens were minted and " +
-                  "are gone - nothing retries them. What is left in storage reads Authenticated and " +
-                  "still carries what the client asked for rather than what the end user approved, so " +
-                  "it cannot be completed again: recovering means asking the end user, not resending " +
-                  "from this record. It expires on its own.")]
+                  "are gone - nothing retries them. What is left in storage reads Authenticated, so it " +
+                  "cannot be completed again: recovering means asking the end user, not resending from " +
+                  "this record. It expires on its own.")]
     private partial void LogPushDeliveryFailed(string AuthReqId);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.Logging.cs
@@ -34,12 +34,10 @@ partial class PushModeCompletionHandler
         EventId = LogEvents.Device.PushModeCompletionHandler.PushDeliveryFailed,
         Level = LogLevel.Warning,
         Message = "CIBA push delivery failed for auth_req_id: {AuthReqId}. The tokens were minted and " +
-                  "are gone - nothing retries them. What is left in storage is the request as it stood " +
-                  "BEFORE the completion, because push never writes back: still Pending, still carrying " +
-                  "what the client asked for rather than what the end user approved, and still carrying " +
-                  "the session from initiation. It expires on its own, and until it does it CAN be " +
-                  "completed again - which would deliver what the end user refused, so treat a retry " +
-                  "from this record as re-asking the user rather than as resending.")]
+                  "are gone - nothing retries them. What is left in storage reads Authenticated and " +
+                  "still carries what the client asked for rather than what the end user approved, so " +
+                  "it cannot be completed again: recovering means asking the end user, not resending " +
+                  "from this record. It expires on its own.")]
     private partial void LogPushDeliveryFailed(string AuthReqId);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -61,9 +61,10 @@ public partial class PushModeCompletionHandler(
     /// <summary>
     /// Handles push mode token delivery by generating tokens and delivering them directly to the client endpoint.
     /// The status transition is persisted before the tokens are minted, and the request is removed after
-    /// a delivery that succeeded. Neither is hygiene. The write is what leaves a record no second
-    /// completion can use on the one path where a record survives, and the removal is what leaves none at
-    /// all on the path where the tokens did arrive. The write is the same one poll and ping make, so it
+    /// a delivery that succeeded. The WRITE is the protection: it leaves a record a sequential retry is
+    /// refused by, on the one path where a record survives. The removal is hygiene now that the write
+    /// exists - what it would otherwise leave is an Authenticated orphan that the completion handler and
+    /// the token endpoint both already refuse, waiting out its expiry. The write is the same one poll and ping make, so it
     /// carries the whole record including the grant the host completed with.
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -63,8 +63,8 @@ public partial class PushModeCompletionHandler(
     /// The status transition is persisted before the tokens are minted, and the request is removed after
     /// a delivery that succeeded. Neither is hygiene. The write is what leaves a record no second
     /// completion can use on the one path where a record survives, and the removal is what leaves none at
-    /// all on the path where the tokens did arrive. The grant itself is still not persisted: the record
-    /// says the request was spent, not what it was spent on.
+    /// all on the path where the tokens did arrive. The write is the same one poll and ping make, so it
+    /// carries the whole record including the grant the host completed with.
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="request">The authenticated request containing the authorized grant.</param>
@@ -120,10 +120,11 @@ public partial class PushModeCompletionHandler(
         // written after delivery it would never happen on the failure path, which is the one path where
         // the record survives to be completed again.
         //
-        // The status alone, deliberately, not the narrowed grant the host completed with. Persisting the
-        // grant would let a second completion replay the approval, which is a correctly-scoped second
-        // token set for one authentication - the symptom fixed and the disease kept. What the record has
-        // to carry is that it was spent, and the base handler refuses everything that is not Pending.
+        // The whole record, the same way poll and ping write theirs: the storage serializes the object it
+        // is handed, so the grant the host completed with goes down with the status. What stops a second
+        // completion is not anything the record omits - it is the base handler reading this status back
+        // and refusing everything that is not Pending. A record that carried the status alone would be
+        // just as unusable and harder to explain.
         //
         // On the delivery path this write is undone moments later by the removal below. That is a wasted
         // round trip on the successful case in exchange for the guarantee on the failing one, which is
@@ -181,15 +182,14 @@ public partial class PushModeCompletionHandler(
                     // retries them.
                     //
                     // What survives in storage reads Authenticated, written above before anything was
-                    // minted, and still carries what the client ASKED for rather than what the end user
-                    // approved - the narrowed grant was set on the in-memory object and is not persisted.
-                    // The status is what matters: the base handler completes only a Pending request, so
-                    // this record cannot be handed back for a second completion.
+                    // minted, and carries the grant the end user actually approved along with the
+                    // session naming them. Before that write it was the PRE-completion record - Pending,
+                    // carrying what the client asked for - and it had everything CompleteAsync needed
+                    // except any sign it had been used, which is what made handing it back an over-grant
+                    // rather than a retry.
                     //
-                    // It carries a session too - the one the device handler returned at initiation,
-                    // naming the end user - because AuthorizedGrant takes it as a non-nullable member.
-                    // Before the write above, that made the leftover a live over-grant rather than a
-                    // record: everything CompleteAsync needed was in it except any sign it had been used.
+                    // The status is what closes that: the base handler reads it from storage and
+                    // completes only a Pending request.
                     //
                     // It is kept rather than removed so a host can see the request existed, and it expires
                     // on its own. The correct recovery is to ask the end user again, which is what the

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -60,19 +60,18 @@ public partial class PushModeCompletionHandler(
 
     /// <summary>
     /// Handles push mode token delivery by generating tokens and delivering them directly to the client endpoint.
-    /// The authentication request is removed from storage after successful delivery. Not hygiene: push
-    /// never writes back, so a record left behind is the PRE-completion one - Pending, carrying what the
-    /// client asked for rather than what the end user approved, and carrying the session - and a host that
-    /// finds it can complete it again. Removing it is what stops that on the path where the tokens did
-    /// arrive.
+    /// The status transition is persisted before the tokens are minted, and the request is removed after
+    /// a delivery that succeeded. Neither is hygiene. The write is what leaves a record no second
+    /// completion can use on the one path where a record survives, and the removal is what leaves none at
+    /// all on the path where the tokens did arrive. The grant itself is still not persisted: the record
+    /// says the request was spent, not what it was spent on.
     /// </summary>
     /// <param name="authenticationRequestId">The authentication request identifier.</param>
     /// <param name="request">The authenticated request containing the authorized grant.</param>
     /// <param name="clientInfo">Client information for token generation.</param>
-    /// <param name="expiresIn">Has no effect here. Push either removes the request or leaves it exactly
-    /// as it was - it never writes a new lifetime - so on the one outcome that keeps the record, a failed
-    /// delivery, what expires is the lifetime set when the request was stored. The parameter exists
-    /// because the base class hands it to every mode, and poll and ping do use it.</param>
+    /// <param name="expiresIn">The lifetime applied when the status transition is persisted, which is
+    /// what a record surviving a failed delivery then expires on. Push writes once and only for that,
+    /// so a delivery that succeeds removes the record long before the lifetime matters.</param>
     protected override async Task HandleDeliveryAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request,
@@ -116,6 +115,20 @@ public partial class PushModeCompletionHandler(
             await RefuseAsync(authenticationRequestId, request, expiresIn);
             return;
         }
+
+        // Persisted BEFORE minting, and this is the only write push makes. The order is the whole point:
+        // written after delivery it would never happen on the failure path, which is the one path where
+        // the record survives to be completed again.
+        //
+        // The status alone, deliberately, not the narrowed grant the host completed with. Persisting the
+        // grant would let a second completion replay the approval, which is a correctly-scoped second
+        // token set for one authentication - the symptom fixed and the disease kept. What the record has
+        // to carry is that it was spent, and the base handler refuses everything that is not Pending.
+        //
+        // On the delivery path this write is undone moments later by the removal below. That is a wasted
+        // round trip on the successful case in exchange for the guarantee on the failing one, which is
+        // the case that mints tokens nobody asked for.
+        await _storage.UpdateAsync(authenticationRequestId, request, expiresIn);
 
         LogGeneratingTokens(authenticationRequestId);
 
@@ -167,21 +180,20 @@ public partial class PushModeCompletionHandler(
                     // Delivery failed, and the tokens just minted are dropped with this lambda - nothing
                     // retries them.
                     //
-                    // What survives in storage is the record as it stood BEFORE the completion, because
-                    // push never writes back: the status and the narrowed grant were set on the in-memory
-                    // object, and only the poll and ping paths persist that with UpdateAsync. So it still
-                    // reads Pending and still carries what the client ASKED for rather than what the end
-                    // user approved.
+                    // What survives in storage reads Authenticated, written above before anything was
+                    // minted, and still carries what the client ASKED for rather than what the end user
+                    // approved - the narrowed grant was set on the in-memory object and is not persisted.
+                    // The status is what matters: the base handler completes only a Pending request, so
+                    // this record cannot be handed back for a second completion.
                     //
-                    // It does carry a session - the one the device handler returned at initiation, naming
-                    // the end user - because AuthorizedGrant takes it as a non-nullable member and the
-                    // request was stored with it. That is what makes the leftover dangerous rather than
-                    // inert: it has everything CompleteAsync needs, so a host that reads it back and
-                    // completes it again succeeds, mints, and delivers the entries the end user refused.
+                    // It carries a session too - the one the device handler returned at initiation,
+                    // naming the end user - because AuthorizedGrant takes it as a non-nullable member.
+                    // Before the write above, that made the leftover a live over-grant rather than a
+                    // record: everything CompleteAsync needed was in it except any sign it had been used.
                     //
                     // It is kept rather than removed so a host can see the request existed, and it expires
-                    // on its own. Anything a host rebuilds from it replays what was asked for, and nothing
-                    // here refuses that.
+                    // on its own. The correct recovery is to ask the end user again, which is what the
+                    // refusal now makes the only one available.
                     LogPushDeliveryFailed(authenticationRequestId);
                 }
 

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -116,9 +116,15 @@ public partial class PushModeCompletionHandler(
             return;
         }
 
-        // Persisted BEFORE minting, and this is the only write push makes. The order is the whole point:
-        // written after delivery it would never happen on the failure path, which is the one path where
-        // the record survives to be completed again.
+        // Persisted BEFORE minting, and this is the only write push makes. The property the order buys
+        // is that no token set can exist over a record still reading Pending, and writing first makes it
+        // hold whatever runs afterwards. Any placement after the mint leaves a window instead: a fault, a
+        // crash or a cancellation between minting and the write leaves a full token set alive over a
+        // record the base handler would still complete - the hole this closes, reopened narrower.
+        //
+        // Not "otherwise it would never happen on the failure path". A write inside the delivery-failed
+        // branch runs on that path perfectly well and the failing-delivery row stays green; it is the
+        // span before it that stops being covered.
         //
         // The whole record, the same way poll and ping write theirs: the storage serializes the object it
         // is handed, so the grant the host completed with goes down with the status. What stops a second

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IAuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IAuthenticationCompletionHandler.cs
@@ -26,7 +26,12 @@ public interface IAuthenticationCompletionHandler
     /// the client's configured delivery mode.
     /// </summary>
     /// <param name="authenticationRequestId">The auth_req_id identifying the authentication request.</param>
-    /// <param name="request">The authentication request with Authenticated status and authorized grant.</param>
+    /// <param name="request">The authentication request carrying the grant the end user approved. Its
+    /// own Status is not read: whether this request may still be answered is decided from the STORED
+    /// record, so a caller cannot make the decision by setting a field on its own copy.</param>
+    /// <exception cref="InvalidOperationException">The stored record is not pending - it was already
+    /// answered, or a poll has redeemed and removed it. Completing again would deliver a second answer
+    /// for one authentication; recovering from a failed delivery means asking the end user.</exception>
     /// <param name="expiresIn">How long the authenticated request remains valid for token retrieval.</param>
     /// <returns>A task representing the asynchronous completion operation.</returns>
     /// <remarks>

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IAuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IAuthenticationCompletionHandler.cs
@@ -29,9 +29,6 @@ public interface IAuthenticationCompletionHandler
     /// <param name="request">The authentication request carrying the grant the end user approved. Its
     /// own Status is not read: whether this request may still be answered is decided from the STORED
     /// record, so a caller cannot make the decision by setting a field on its own copy.</param>
-    /// <exception cref="InvalidOperationException">The stored record is not pending - it was already
-    /// answered, or a poll has redeemed and removed it. Completing again would deliver a second answer
-    /// for one authentication; recovering from a failed delivery means asking the end user.</exception>
     /// <param name="expiresIn">How long the authenticated request remains valid for token retrieval.</param>
     /// <returns>A task representing the asynchronous completion operation.</returns>
     /// <remarks>
@@ -42,6 +39,9 @@ public interface IAuthenticationCompletionHandler
     ///   <item>Delegates to the mode-specific implementation for token delivery</item>
     /// </list>
     /// </remarks>
+    /// <exception cref="InvalidOperationException">The stored record is not pending - it was already
+    /// answered, refused or expired. Completing it would deliver a second answer
+    /// for one authentication; recovering from a failed delivery means asking the end user.</exception>
     Task CompleteAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IAuthenticationCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IAuthenticationCompletionHandler.cs
@@ -39,9 +39,18 @@ public interface IAuthenticationCompletionHandler
     ///   <item>Delegates to the mode-specific implementation for token delivery</item>
     /// </list>
     /// </remarks>
-    /// <exception cref="InvalidOperationException">The stored record is not pending - it was already
-    /// answered, refused or expired. Completing it would deliver a second answer
-    /// for one authentication; recovering from a failed delivery means asking the end user.</exception>
+    /// <exception cref="InvalidOperationException">The store does not hold a PENDING record under this
+    /// identifier. Stated as what must be true rather than as a list of causes, because the causes are
+    /// more numerous than they look and this seam cannot tell them apart: the request may have been
+    /// answered, refused or expired, its record may have been redeemed and removed by a poll, removed by
+    /// push's own refusal path after a configuration fault where nothing was answered at all, evicted,
+    /// or never stored. A host that persists the status itself before calling lands here too, on its
+    /// FIRST completion and with nothing over-granted.
+    /// <para>
+    /// Completing a request that is not pending would deliver a second answer for one authentication.
+    /// Recovering from a failed delivery therefore means asking the end user again, not repeating the
+    /// call.
+    /// </para></exception>
     Task CompleteAsync(
         string authenticationRequestId,
         BackChannelAuthenticationRequest request,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
@@ -49,11 +49,7 @@ public interface INotificationDeliveryService
     /// On <c>false</c> push keeps the stored record, and it is not a resumable delivery. The tokens were
     /// minted and are gone; nothing retries them. The record reads Authenticated, written before the
     /// mint, so a LATER completion of the same request is refused - the recovery is to ask the end user,
-    /// not to resend from what is left. Later, not concurrent: as this ships, the refusal reads the stored
-    /// status and acts on it with no claim protocol and no lock between the two, so two completions running
-    /// side by side can both read Pending. That second sentence describes the ABSENCE of a mechanism, and
-    /// nothing in the suite holds it - adding exclusion here would make it false without turning a row
-    /// red.
+    /// not to resend from what is left.
     /// </para>
     /// </returns>
     Task<bool> SendAsync(

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
@@ -48,8 +48,10 @@ public interface INotificationDeliveryService
     /// <para>
     /// On <c>false</c> push keeps the stored record, and it is not a resumable delivery. The tokens were
     /// minted and are gone; nothing retries them. The record reads Authenticated, written before the
-    /// mint, so completing the request again is refused - the recovery is to ask the end user, not to
-    /// resend from what is left.
+    /// mint, so a LATER completion of the same request is refused - the recovery is to ask the end user,
+    /// not to resend from what is left. Later, not concurrent: the refusal reads the stored status and
+    /// acts on it, with no claim protocol between the two, so two completions running side by side can
+    /// both read Pending.
     /// </para>
     /// </returns>
     Task<bool> SendAsync(

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
@@ -49,9 +49,11 @@ public interface INotificationDeliveryService
     /// On <c>false</c> push keeps the stored record, and it is not a resumable delivery. The tokens were
     /// minted and are gone; nothing retries them. The record reads Authenticated, written before the
     /// mint, so a LATER completion of the same request is refused - the recovery is to ask the end user,
-    /// not to resend from what is left. Later, not concurrent: the refusal reads the stored status and
-    /// acts on it, with no claim protocol between the two, so two completions running side by side can
-    /// both read Pending.
+    /// not to resend from what is left. Later, not concurrent: as this ships, the refusal reads the stored
+    /// status and acts on it with no claim protocol and no lock between the two, so two completions running
+    /// side by side can both read Pending. That second sentence describes the ABSENCE of a mechanism, and
+    /// nothing in the suite holds it - adding exclusion here would make it false without turning a row
+    /// red.
     /// </para>
     /// </returns>
     Task<bool> SendAsync(

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/INotificationDeliveryService.cs
@@ -46,11 +46,10 @@ public interface INotificationDeliveryService
     /// <c>true</c> if the client endpoint accepted the notification (2xx response); <c>false</c> if
     /// delivery failed (non-success status or transport error).
     /// <para>
-    /// On <c>false</c> push keeps the stored record, and that is not a saved grant. The authenticated,
-    /// narrowed grant lives on the in-memory object and is dropped with it; what storage holds is the
-    /// PRE-completion record - Pending, carrying what the client asked for rather than what the end user
-    /// approved. It is kept so a host can see the request existed, not so delivery can be resumed, and a
-    /// host that completes it again delivers entries the end user refused. See issue 451.
+    /// On <c>false</c> push keeps the stored record, and it is not a resumable delivery. The tokens were
+    /// minted and are gone; nothing retries them. The record reads Authenticated, written before the
+    /// mint, so completing the request again is refused - the recovery is to ask the end user, not to
+    /// resend from what is left.
     /// </para>
     /// </returns>
     Task<bool> SendAsync(

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -69,9 +69,10 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///             authenticationTime: DateTimeOffset.UtcNow,
 ///             identityProvider: "local");
 ///
-///         // Carry the end user's answer on the grant. Setting Status here is harmless and not required:
-///         // the completion handler reads the STORED status to decide whether this request may still be
-///         // answered, and sets Authenticated itself when it may.
+///         // Carry the end user's answer on the grant. Nothing needs to touch Status: the completion
+///         // handler decides from the STORED record whether this request may still be answered, and
+///         // sets Authenticated itself when it may. A host that does set it on its own copy changes
+///         // nothing either way.
 ///         storedRequest.AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context);
 ///
 ///         // Notify completion - automatically selects and delegates to the appropriate

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -69,8 +69,9 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///             authenticationTime: DateTimeOffset.UtcNow,
 ///             identityProvider: "local");
 ///
-///         // Update request with authenticated status
-///         storedRequest.Status = BackChannelAuthenticationStatus.Authenticated;
+///         // Carry the end user's answer on the grant. Setting Status here is harmless and not required:
+///         // the completion handler reads the STORED status to decide whether this request may still be
+///         // answered, and sets Authenticated itself when it may.
 ///         storedRequest.AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context);
 ///
 ///         // Notify completion - automatically selects and delegates to the appropriate

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -491,6 +491,7 @@ internal static class LogEvents
             public const int MissingNotificationConfig = Base + 1;
             public const int AuthenticatedUserNotTheOneRequested = Base + 2;
             public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 3;
+            public const int AlreadyCompleted = Base + 4;
         }
 
         /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -491,7 +491,7 @@ internal static class LogEvents
             public const int MissingNotificationConfig = Base + 1;
             public const int AuthenticatedUserNotTheOneRequested = Base + 2;
             public const int GrantedAuthorizationDetailsExceedTheRequest = Base + 3;
-            public const int AlreadyCompleted = Base + 4;
+            public const int NotPendingOnCompletion = Base + 4;
         }
 
         /// <summary>

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -226,10 +226,9 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.True(payload["expires_in"]!.GetValue<int>() > 0);
 
         // And the request is gone. That removal is this library's choice rather than a requirement -
-        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that a
-        // record left behind carries what the CLIENT asked for rather than what the end user approved,
-        // since push persists the status transition and not the narrowed grant. Nothing can complete it
-        // a second time, but a host reading it back learns the wrong thing about what was granted.
+        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that
+        // this client is finished with it: the tokens are delivered and it will never come to the token
+        // endpoint. A record kept here would be an orphan waiting out its expiry.
         //
         // Both arms of the delivery branch are already pinned by AuthenticationCompletionHandlerTests,
         // through a mock's call count. What this line adds is the same fact at the level a client sees,

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -226,9 +226,10 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.True(payload["expires_in"]!.GetValue<int>() > 0);
 
         // And the request is gone. That removal is this library's choice rather than a requirement -
-        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that push
-        // never writes back: a record left behind is the PRE-completion one, which a host can complete
-        // again, delivering what the end user did not approve.
+        // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that a
+        // record left behind carries what the CLIENT asked for rather than what the end user approved,
+        // since push persists the status transition and not the narrowed grant. Nothing can complete it
+        // a second time, but a host reading it back learns the wrong thing about what was granted.
         //
         // Both arms of the delivery branch are already pinned by AuthenticationCompletionHandlerTests,
         // through a mock's call count. What this line adds is the same fact at the level a client sees,

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -199,7 +199,7 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// The guard refuses a LATER completion, not a concurrent one, and this row is what says so.
+    /// The guard refuses a LATER completion, not a concurrent one, and this row holds the LATER half.
     /// </summary>
     /// <remarks>
     /// The guard is a read followed by an act: <c>TryGetAsync</c> is a plain get, with no claim protocol
@@ -211,8 +211,13 @@ public class AuthenticationCompletionHandlerTests
     /// assert the same thing less reliably.
     /// <para>
     /// It exists because the sentences around this guard used to promise at-most-one completion without
-    /// a condition, and nothing could contradict them. This row can: add a claim protocol or a lock and
-    /// it goes red, which is the moment those sentences would need rewriting anyway.
+    /// a condition, and nothing could contradict them. What it holds is NARROWER than that, and saying so
+    /// is the point: it goes red when the guard stops letting a second SEQUENTIAL completion through -
+    /// reading the caller's own copy instead of the stored record does it. A LOCK around the read-and-act
+    /// does NOT turn it red, measured: the store here answers Pending on every call regardless of what was
+    /// written, so serialising two callers changes nothing this row can see. The concurrent half of the
+    /// claim is held by nothing in this suite; what would catch a claim protocol is the strict mock, and
+    /// only because such a protocol reaches storage through a different call.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -199,59 +199,6 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// The guard refuses a LATER completion, not a concurrent one, and this row holds the LATER half.
-    /// </summary>
-    /// <remarks>
-    /// The guard is a read followed by an act: <c>TryGetAsync</c> is a plain get, with no claim protocol
-    /// and no lock between it and the write that makes the record spent. So a second completion whose
-    /// read lands before the first one's write still sees Pending and proceeds - both mint, both deliver.
-    /// That is modelled here without threads, because the property is about ORDER rather than about
-    /// timing: the store answers Pending on every read regardless of what was written to it, which is
-    /// exactly the state a second caller is in when it reads first. A barrier and two threads would
-    /// assert the same thing less reliably.
-    /// <para>
-    /// It exists because the sentences around this guard used to promise at-most-one completion without
-    /// a condition, and nothing could contradict them. What it holds is NARROWER than that, and saying so
-    /// is the point: it goes red when the guard stops letting a second SEQUENTIAL completion through -
-    /// reading the caller's own copy instead of the stored record does it. A LOCK around the read-and-act
-    /// does NOT turn it red, measured: the store here answers Pending on every call regardless of what was
-    /// written, so serialising two callers changes nothing this row can see. The concurrent half of the
-    /// claim is held by nothing in this suite; what would catch a claim protocol is the strict mock, and
-    /// only because such a protocol reaches storage through a different call.
-    /// </para>
-    /// </remarks>
-    [Fact]
-    public async Task CompleteAuthenticationAsync_WhenTheStoredReadStillPrecedesTheWrite_ASecondCompletionProceeds()
-    {
-        // Arrange
-        var authSession = new AuthSession(UserId, "session_123", DateTimeOffset.UtcNow, "backchannel");
-        var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
-        var request = new BackChannelAuthenticationRequest(
-            new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
-        {
-            Status = BackChannelAuthenticationStatus.Pending,
-        };
-
-        var clientInfo = new ClientInfo(ClientId)
-        {
-            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll,
-        };
-
-        // The write does not feed back into the read, which is the whole arrangement: it puts the second
-        // caller in the state it is in when its read wins the race with the first caller's write.
-        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
-
-        var handler = CreatePollModeHandler();
-
-        // Act
-        await handler.CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
-        await handler.CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
-
-        // Assert - neither call was refused, so the guard is not exclusion.
-        _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Exactly(2));
-    }
-
-    /// <summary>
     /// Verifies that when notification token is null (incomplete ping mode configuration),
     /// only storage update is performed and no notification is sent.
     /// </summary>
@@ -459,9 +406,8 @@ public class AuthenticationCompletionHandlerTests
 
     /// <summary>
     /// Verifies that when push delivery fails, the record is left in storage rather than removed - and
-    /// that what is left reads Authenticated, so a LATER completion of the same request is refused. Later,
-    /// not concurrent: the guard reads the stored status and acts on it, and nothing claims the record
-    /// between the two.
+    /// that what is left reads Authenticated, so a LATER completion of the same request is refused - the
+    /// guard reads the STORED status, not the caller's copy.
     /// </summary>
     /// <remarks>
     /// It is the whole record, written the way poll and ping write theirs: the storage serializes the

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -455,8 +455,10 @@ public class AuthenticationCompletionHandlerTests
 
         // What the store was HANDED, read at the moment of the call. Moq matches the argument by
         // reference, so reading request.Status afterwards reports where the field ended up rather than
-        // what was persisted - and a push that writes after delivering instead of before would satisfy
-        // that reading while the store received a record still marked Pending.
+        // what was persisted. The mutation this capture catches is hoisting the BASE handler's status
+        // assignment past HandleDeliveryAsync, which turns this row red on statusAtWrite - measured.
+        // Moving push's own write later cannot produce a Pending record at all: the assignment has
+        // already run by the time the base handler calls into delivery.
         BackChannelAuthenticationStatus? statusAtWrite = null;
         _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
             .Callback(() => statusAtWrite = request.Status)
@@ -1227,9 +1229,12 @@ public class AuthenticationCompletionHandlerTests
         // The status AT THE MOMENT of the write, not afterwards. Moq matches the argument by reference
         // and the row holds that same reference, so every assertion made after the call reads whatever
         // the object ended up as - which is Authenticated whether the assignment ran before the delivery
-        // or after it. Hoisting the assignment past HandleDeliveryAsync leaves both suites green without
-        // this capture, while push hands the store a record still reading Pending: the defect this
-        // change exists to close, written back verbatim.
+        // or after it. Without this capture THIS row goes green under the hoist while push hands the
+        // store a record still reading Pending - the defect this change exists to close, written back
+        // verbatim. The SUITE does not go green under it: measured, hoisting the assignment kills three
+        // rows, and one of them is the ping denial row, which holds no capture at all - Moq re-evaluates
+        // its predicate matcher at Verify time against the same reference the hoist has since flipped.
+        // A red ping row under that mutation is the mutation, not a defect in ping.
         BackChannelAuthenticationStatus? statusAtWrite = null;
 
         _storage

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -199,6 +199,54 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
+    /// The guard refuses a LATER completion, not a concurrent one, and this row is what says so.
+    /// </summary>
+    /// <remarks>
+    /// The guard is a read followed by an act: <c>TryGetAsync</c> is a plain get, with no claim protocol
+    /// and no lock between it and the write that makes the record spent. So a second completion whose
+    /// read lands before the first one's write still sees Pending and proceeds - both mint, both deliver.
+    /// That is modelled here without threads, because the property is about ORDER rather than about
+    /// timing: the store answers Pending on every read regardless of what was written to it, which is
+    /// exactly the state a second caller is in when it reads first. A barrier and two threads would
+    /// assert the same thing less reliably.
+    /// <para>
+    /// It exists because the sentences around this guard used to promise at-most-one completion without
+    /// a condition, and nothing could contradict them. This row can: add a claim protocol or a lock and
+    /// it goes red, which is the moment those sentences would need rewriting anyway.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheStoredReadStillPrecedesTheWrite_ASecondCompletionProceeds()
+    {
+        // Arrange
+        var authSession = new AuthSession(UserId, "session_123", DateTimeOffset.UtcNow, "backchannel");
+        var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
+        var request = new BackChannelAuthenticationRequest(
+            new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
+        {
+            Status = BackChannelAuthenticationStatus.Pending,
+        };
+
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            BackChannelTokenDeliveryMode = BackchannelTokenDeliveryModes.Poll,
+        };
+
+        // The write does not feed back into the read, which is the whole arrangement: it puts the second
+        // caller in the state it is in when its read wins the race with the first caller's write.
+        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
+
+        var handler = CreatePollModeHandler();
+
+        // Act
+        await handler.CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
+        await handler.CompleteAuthenticationAsync(AuthReqId, request, clientInfo, _expiresIn);
+
+        // Assert - neither call was refused, so the guard is not exclusion.
+        _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Exactly(2));
+    }
+
+    /// <summary>
     /// Verifies that when notification token is null (incomplete ping mode configuration),
     /// only storage update is performed and no notification is sent.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -401,10 +401,10 @@ public class AuthenticationCompletionHandlerTests
     /// that what is left reads Authenticated, so nobody can complete it a second time.
     /// </summary>
     /// <remarks>
-    /// It is still not the authenticated REQUEST. Only the status is persisted; the narrowed grant was
-    /// set on the in-memory object and stays there, so the record carries what the client asked for.
-    /// That is deliberate: persisting the grant would let a second completion replay the approval, which
-    /// is a correctly-scoped second token set for one authentication.
+    /// It is the whole record, written the way poll and ping write theirs: the storage serializes the
+    /// object it is handed, so the grant the host completed with goes down with the status. What stops a
+    /// second completion is not anything the record omits - it is the base handler reading this status
+    /// back out of storage and refusing everything that is not Pending.
     ///
     /// Nor does keeping it save any tokens: the ones just minted are dropped with the lambda that made
     /// them, and nothing retries. It is kept so a host can see the request existed.
@@ -1092,6 +1092,36 @@ public class AuthenticationCompletionHandlerTests
         _storage.VerifyNoOtherCalls();
     }
 
+    /// <summary>
+    /// The decision comes from STORAGE, not from the caller's copy: a request handed in already marked
+    /// Authenticated completes, because the stored record is the one that is pending.
+    /// </summary>
+    /// <remarks>
+    /// This is the row that tells the guard's two possible shapes apart, and without it they are
+    /// indistinguishable here: deleting the guard and pointing it at the caller's field turn exactly the
+    /// same refusal rows red. It is also the documented host pattern - the implementation guide has the
+    /// host set Status on its own copy before calling - so a guard reading that field refuses every
+    /// conforming host on its FIRST completion, and is advisory besides, since whether it fires is up to
+    /// the caller it exists to constrain.
+    /// </remarks>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WhenTheCallerMarkedItsOwnCopy_TheStoredRecordDecides()
+    {
+        var request = CreateRequest(UserId, null);
+
+        // What the documented host pattern does before calling.
+        request.Status = BackChannelAuthenticationStatus.Authenticated;
+
+        StoredRecordReads(BackChannelAuthenticationStatus.Pending);
+        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
+
+        var handler = CreatePollModeHandler();
+
+        await handler.CompleteAuthenticationAsync(AuthReqId, request, PollClient(), _expiresIn);
+
+        _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Once);
+    }
+
     /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses"/>
     [Theory]
     [InlineData(BackChannelAuthenticationStatus.Authenticated)]
@@ -1148,9 +1178,9 @@ public class AuthenticationCompletionHandlerTests
     /// The order is the assertion: written after delivery instead, it would never happen on the failure
     /// path, which is the only path where the record survives to be completed again.
     /// <para>
-    /// The status alone, not the narrowed grant. Persisting the grant would make a second completion
-    /// replay the approval, which is a correctly-scoped second token set for one authentication - the
-    /// symptom fixed and the disease kept.
+    /// The whole record goes down, grant included - the storage serializes what it is handed. The row
+    /// asserts the ORDER rather than the contents, because the order is what the fix is: a write after
+    /// the delivery would never run on the failure path, which is the only path where a record survives.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -59,10 +59,10 @@ public class AuthenticationCompletionHandlerTests
     /// Arranges what the STORED record reads, which is what the completion guard consults.
     /// </summary>
     /// <remarks>
-    /// A DISTINCT object from the one handed to the handler, deliberately. The documented host pattern
-    /// has the caller set Status on its own copy before calling, so a fixture returning that same
-    /// instance would make the two indistinguishable - and a guard reading the caller's field instead of
-    /// the store would pass every row while refusing every conforming host.
+    /// A DISTINCT object from the one handed to the handler, deliberately. A caller may set Status on
+    /// its own copy, so a fixture returning that same instance would make the caller's field and the
+    /// stored one indistinguishable - and a guard reading the caller's would pass every row here while
+    /// refusing those hosts on their first completion.
     /// </remarks>
     private void StoredRecordReads(BackChannelAuthenticationStatus status)
     {
@@ -1099,17 +1099,17 @@ public class AuthenticationCompletionHandlerTests
     /// <remarks>
     /// This is the row that tells the guard's two possible shapes apart, and without it they are
     /// indistinguishable here: deleting the guard and pointing it at the caller's field turn exactly the
-    /// same refusal rows red. It is also the documented host pattern - the implementation guide has the
-    /// host set Status on its own copy before calling - so a guard reading that field refuses every
-    /// conforming host on its FIRST completion, and is advisory besides, since whether it fires is up to
-    /// the caller it exists to constrain.
+    /// same refusal rows red. And it is a shape hosts really take - the end-to-end fixture in this
+    /// repository sets Status on its own copy before calling - so a guard reading that field refuses
+    /// them on their FIRST completion, and is advisory besides, since whether it fires is up to the
+    /// caller it exists to constrain.
     /// </remarks>
     [Fact]
     public async Task CompleteAuthenticationAsync_WhenTheCallerMarkedItsOwnCopy_TheStoredRecordDecides()
     {
         var request = CreateRequest(UserId, null);
 
-        // What the documented host pattern does before calling.
+        // What a host may do to its own copy before calling, and what must not decide anything.
         request.Status = BackChannelAuthenticationStatus.Authenticated;
 
         StoredRecordReads(BackChannelAuthenticationStatus.Pending);
@@ -1191,9 +1191,21 @@ public class AuthenticationCompletionHandlerTests
 
         var order = new List<string>();
 
+        // The status AT THE MOMENT of the write, not afterwards. Moq matches the argument by reference
+        // and the row holds that same reference, so every assertion made after the call reads whatever
+        // the object ended up as - which is Authenticated whether the assignment ran before the delivery
+        // or after it. Hoisting the assignment past HandleDeliveryAsync leaves both suites green without
+        // this capture, while push hands the store a record still reading Pending: the defect this
+        // change exists to close, written back verbatim.
+        BackChannelAuthenticationStatus? statusAtWrite = null;
+
         _storage
             .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
-            .Callback(() => order.Add("persisted"))
+            .Callback(() =>
+            {
+                order.Add("persisted");
+                statusAtWrite = request.Status;
+            })
             .Returns(Task.CompletedTask);
 
         _tokenRequestProcessor
@@ -1218,7 +1230,11 @@ public class AuthenticationCompletionHandlerTests
         await handler.CompleteAuthenticationAsync(AuthReqId, request, PushClient(), _expiresIn);
 
         Assert.Equal(["persisted", "minted", "delivered"], order);
-        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, request.Status);
+
+        // What was WRITTEN, which is the property every sentence about this change rests on. Asserting
+        // request.Status here instead would pass on a record persisted as Pending.
+        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, statusAtWrite);
+
         _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -56,7 +56,8 @@ public class AuthenticationCompletionHandlerTests
     }
 
     /// <summary>
-    /// Arranges what the STORED record reads, which is what the completion guard consults.
+    /// Arranges what the STORED record reads, which is what the completion guard consults. A null
+    /// status arranges NO record at all, which is a different thing from a record reading anything.
     /// </summary>
     /// <remarks>
     /// A DISTINCT object from the one handed to the handler, deliberately. A caller may set Status on
@@ -64,15 +65,22 @@ public class AuthenticationCompletionHandlerTests
     /// stored one indistinguishable - and a guard reading the caller's would pass every row here while
     /// refusing those hosts on their first completion.
     /// </remarks>
-    private void StoredRecordReads(BackChannelAuthenticationStatus status)
+    private void StoredRecordReads(BackChannelAuthenticationStatus? status)
     {
+        if (status is not { } present)
+        {
+            _storage.Setup(s => s.TryGetAsync(It.IsAny<string>()))
+                .ReturnsAsync((BackChannelAuthenticationRequest?)null);
+            return;
+        }
+
         var stored = new BackChannelAuthenticationRequest(
             new AuthorizedGrant(
                 new AuthSession(UserId, "stored_session", DateTimeOffset.UnixEpoch, "test"),
                 new AuthorizationContext(ClientId, [Scopes.OpenId], null)),
             DateTimeOffset.UnixEpoch.AddHours(1))
         {
-            Status = status,
+            Status = present,
         };
 
         _storage.Setup(s => s.TryGetAsync(It.IsAny<string>())).ReturnsAsync(stored);
@@ -445,7 +453,14 @@ public class AuthenticationCompletionHandlerTests
                 BackchannelTokenDeliveryModes.Push))
             .ReturnsAsync(false);
 
-        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
+        // What the store was HANDED, read at the moment of the call. Moq matches the argument by
+        // reference, so reading request.Status afterwards reports where the field ended up rather than
+        // what was persisted - and a push that writes after delivering instead of before would satisfy
+        // that reading while the store received a record still marked Pending.
+        BackChannelAuthenticationStatus? statusAtWrite = null;
+        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Callback(() => statusAtWrite = request.Status)
+            .Returns(Task.CompletedTask);
 
         var handler = CreatePushModeHandler();
 
@@ -461,7 +476,7 @@ public class AuthenticationCompletionHandlerTests
         // The record survives, and it survives Authenticated. Both halves matter: the first is what lets
         // a host see the request existed, the second is what stops the same host completing it again.
         _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Once);
-        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, request.Status);
+        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, statusAtWrite);
     }
 
     /// <summary>
@@ -1059,12 +1074,20 @@ public class AuthenticationCompletionHandlerTests
                 .Any(parameter => parameter.ParameterType == typeof(IAuthorizationDetailsPolicy));
     }
     /// <summary>
-    /// A completion of a request that is not pending refuses, and touches neither storage nor delivery.
+    /// A completion refuses unless the store holds a PENDING record for the identifier, and touches
+    /// neither storage nor delivery when it refuses.
     /// </summary>
     /// <remarks>
     /// One authentication, one completion. The end user answered once, so a second full token set is
     /// wrong whatever it contains - which is why this refuses rather than replaying the narrowed grant:
     /// replaying would make the second set correctly scoped and no less of a second set.
+    /// <para>
+    /// A null case, because a record that is GONE is not a lesser case of one that is spent and is not a
+    /// value of the status enum at all: a poll can have redeemed and removed it, its lifetime can have
+    /// run out, push's own refusal path removes it. Without this row a guard asking whether the status is
+    /// something other than Pending passes every one of those straight through, mints, and writes the
+    /// record back into existence - and the two shapes are indistinguishable over the enum alone.
+    /// </para>
     /// <para>
     /// A row per mode, because the guard lives in the base and what must NOT run is each mode's own
     /// delivery. Loud rather than silent: nothing on this seam returns a value, so a host that was
@@ -1075,8 +1098,9 @@ public class AuthenticationCompletionHandlerTests
     [Theory]
     [InlineData(BackChannelAuthenticationStatus.Authenticated)]
     [InlineData(BackChannelAuthenticationStatus.Denied)]
-    public async Task CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses(
-        BackChannelAuthenticationStatus already)
+    [InlineData(null)]
+    public async Task CompleteAuthenticationAsync_PollMode_WhenTheStoreHasNoPendingRecord_Refuses(
+        BackChannelAuthenticationStatus? already)
     {
         var request = CreateRequest(UserId, null);
         StoredRecordReads(already);
@@ -1122,12 +1146,13 @@ public class AuthenticationCompletionHandlerTests
         _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Once);
     }
 
-    /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses"/>
+    /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenTheStoreHasNoPendingRecord_Refuses"/>
     [Theory]
     [InlineData(BackChannelAuthenticationStatus.Authenticated)]
     [InlineData(BackChannelAuthenticationStatus.Denied)]
-    public async Task CompleteAuthenticationAsync_PingMode_WhenNotPending_Refuses(
-        BackChannelAuthenticationStatus already)
+    [InlineData(null)]
+    public async Task CompleteAuthenticationAsync_PingMode_WhenTheStoreHasNoPendingRecord_Refuses(
+        BackChannelAuthenticationStatus? already)
     {
         var request = CreateRequest(UserId, null);
         StoredRecordReads(already);
@@ -1145,12 +1170,13 @@ public class AuthenticationCompletionHandlerTests
         _notificationService.VerifyNoOtherCalls();
     }
 
-    /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses"/>
+    /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenTheStoreHasNoPendingRecord_Refuses"/>
     [Theory]
     [InlineData(BackChannelAuthenticationStatus.Authenticated)]
     [InlineData(BackChannelAuthenticationStatus.Denied)]
-    public async Task CompleteAuthenticationAsync_PushMode_WhenNotPending_Refuses(
-        BackChannelAuthenticationStatus already)
+    [InlineData(null)]
+    public async Task CompleteAuthenticationAsync_PushMode_WhenTheStoreHasNoPendingRecord_Refuses(
+        BackChannelAuthenticationStatus? already)
     {
         var request = CreateRequest(UserId, null);
         StoredRecordReads(already);

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -406,7 +406,9 @@ public class AuthenticationCompletionHandlerTests
 
     /// <summary>
     /// Verifies that when push delivery fails, the record is left in storage rather than removed - and
-    /// that what is left reads Authenticated, so nobody can complete it a second time.
+    /// that what is left reads Authenticated, so a LATER completion of the same request is refused. Later,
+    /// not concurrent: the guard reads the stored status and acts on it, and nothing claims the record
+    /// between the two.
     /// </summary>
     /// <remarks>
     /// It is the whole record, written the way poll and ping write theirs: the storage serializes the
@@ -1209,8 +1211,10 @@ public class AuthenticationCompletionHandlerTests
     /// record.
     /// <para>
     /// Not "otherwise it would never run on the failure path" - measured, a write inside the
-    /// delivery-failed branch runs there and leaves the failing-delivery row green. The span this row
-    /// covers is the one between the mint and the write, which nothing else can see.
+    /// delivery-failed branch runs there and leaves the failing-delivery row green. What this row covers
+    /// is the SPAN between the mint and the write, which no other row is about; moving the write into
+    /// that branch kills this row and the delivered-tokens row with it, so the mutation is not this
+    /// row's alone even though the span is.
     /// </para>
     /// <para>
     /// The whole record goes down, grant included - the storage serializes what it is handed. The row

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -1200,13 +1200,20 @@ public class AuthenticationCompletionHandlerTests
     /// leaves a record no second completion can use.
     /// </summary>
     /// <remarks>
-    /// This is the write that makes "completed once" a stored fact for the one mode that stored nothing.
-    /// The order is the assertion: written after delivery instead, it would never happen on the failure
-    /// path, which is the only path where the record survives to be completed again.
+    /// This is the write that makes "completed once" a stored fact for the one mode that stored nothing,
+    /// and the order is what this row asserts. The property is that no token set exists over a record
+    /// still reading Pending: writing first makes it hold whatever runs afterwards, while any placement
+    /// after the mint leaves a fault or a crash in between able to strand tokens over a completable
+    /// record.
+    /// <para>
+    /// Not "otherwise it would never run on the failure path" - measured, a write inside the
+    /// delivery-failed branch runs there and leaves the failing-delivery row green. The span this row
+    /// covers is the one between the mint and the write, which nothing else can see.
+    /// </para>
     /// <para>
     /// The whole record goes down, grant included - the storage serializes what it is handed. The row
-    /// asserts the ORDER rather than the contents, because the order is what the fix is: a write after
-    /// the delivery would never run on the failure path, which is the only path where a record survives.
+    /// asserts the ORDER rather than the contents, because the contents are pinned where they matter, by
+    /// the failing-delivery row's capture of what the store was handed.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -48,6 +48,36 @@ public class AuthenticationCompletionHandlerTests
     private readonly Mock<ITokenRequestProcessor> _tokenRequestProcessor = new(MockBehavior.Strict);
     private readonly TimeSpan _expiresIn = TimeSpan.FromMinutes(5);
 
+    public AuthenticationCompletionHandlerTests()
+    {
+        // Every row completes a request the store holds as Pending, because that is what a record
+        // awaiting an answer reads. A row about refusing a spent one overrides this.
+        StoredRecordReads(BackChannelAuthenticationStatus.Pending);
+    }
+
+    /// <summary>
+    /// Arranges what the STORED record reads, which is what the completion guard consults.
+    /// </summary>
+    /// <remarks>
+    /// A DISTINCT object from the one handed to the handler, deliberately. The documented host pattern
+    /// has the caller set Status on its own copy before calling, so a fixture returning that same
+    /// instance would make the two indistinguishable - and a guard reading the caller's field instead of
+    /// the store would pass every row while refusing every conforming host.
+    /// </remarks>
+    private void StoredRecordReads(BackChannelAuthenticationStatus status)
+    {
+        var stored = new BackChannelAuthenticationRequest(
+            new AuthorizedGrant(
+                new AuthSession(UserId, "stored_session", DateTimeOffset.UnixEpoch, "test"),
+                new AuthorizationContext(ClientId, [Scopes.OpenId], null)),
+            DateTimeOffset.UnixEpoch.AddHours(1))
+        {
+            Status = status,
+        };
+
+        _storage.Setup(s => s.TryGetAsync(It.IsAny<string>())).ReturnsAsync(stored);
+    }
+
     private PollModeCompletionHandler CreatePollModeHandler() =>
         new(Mock.Of<ILogger<PollModeCompletionHandler>>(), _storage.Object, PublicSubjects(), null);
 
@@ -1049,13 +1079,16 @@ public class AuthenticationCompletionHandlerTests
         BackChannelAuthenticationStatus already)
     {
         var request = CreateRequest(UserId, null);
-        request.Status = already;
+        StoredRecordReads(already);
 
         var handler = CreatePollModeHandler();
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => handler.CompleteAuthenticationAsync(AuthReqId, request, PollClient(), _expiresIn));
 
+        // It read the stored record and did nothing else: the guard consults storage, and refusing
+        // costs no write.
+        _storage.Verify(s => s.TryGetAsync(AuthReqId), Times.Once);
         _storage.VerifyNoOtherCalls();
     }
 
@@ -1067,7 +1100,7 @@ public class AuthenticationCompletionHandlerTests
         BackChannelAuthenticationStatus already)
     {
         var request = CreateRequest(UserId, null);
-        request.Status = already;
+        StoredRecordReads(already);
         request.ClientNotificationEndpoint = _notificationEndpoint;
 
         var handler = CreatePingModeHandler();
@@ -1075,6 +1108,9 @@ public class AuthenticationCompletionHandlerTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => handler.CompleteAuthenticationAsync(AuthReqId, request, PingClient(), _expiresIn));
 
+        // It read the stored record and did nothing else: the guard consults storage, and refusing
+        // costs no write.
+        _storage.Verify(s => s.TryGetAsync(AuthReqId), Times.Once);
         _storage.VerifyNoOtherCalls();
         _notificationService.VerifyNoOtherCalls();
     }
@@ -1087,7 +1123,7 @@ public class AuthenticationCompletionHandlerTests
         BackChannelAuthenticationStatus already)
     {
         var request = CreateRequest(UserId, null);
-        request.Status = already;
+        StoredRecordReads(already);
         request.ClientNotificationEndpoint = _notificationEndpoint;
 
         var handler = CreatePushModeHandler();
@@ -1095,6 +1131,9 @@ public class AuthenticationCompletionHandlerTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => handler.CompleteAuthenticationAsync(AuthReqId, request, PushClient(), _expiresIn));
 
+        // It read the stored record and did nothing else: the guard consults storage, and refusing
+        // costs no write.
+        _storage.Verify(s => s.TryGetAsync(AuthReqId), Times.Once);
         _storage.VerifyNoOtherCalls();
         _notificationService.VerifyNoOtherCalls();
         _tokenRequestProcessor.VerifyNoOtherCalls();

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/BackChannelAuthentication/AuthenticationCompletionHandlerTests.cs
@@ -89,7 +89,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = _notificationEndpoint,
             ClientNotificationToken = NotificationToken,
         };
@@ -135,7 +135,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = null,
             ClientNotificationToken = null,
         };
@@ -172,7 +172,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = _notificationEndpoint,
             ClientNotificationToken = null,
         };
@@ -209,7 +209,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = null,
             ClientNotificationToken = NotificationToken,
         };
@@ -246,7 +246,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
         };
 
         var clientInfo = new ClientInfo(ClientId)
@@ -277,7 +277,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = _notificationEndpoint,
             ClientNotificationToken = NotificationToken,
         };
@@ -316,7 +316,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = _notificationEndpoint,
             ClientNotificationToken = NotificationToken,
         };
@@ -343,6 +343,8 @@ public class AuthenticationCompletionHandlerTests
                 BackchannelTokenDeliveryModes.Push))
             .ReturnsAsync(true);
 
+        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
+
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId))
             .ReturnsAsync((BackChannelAuthenticationRequest?)null);
 
@@ -356,22 +358,27 @@ public class AuthenticationCompletionHandlerTests
         _notificationService.Verify(
             s => s.SendAsync(_notificationEndpoint, NotificationToken, It.IsAny<IBackChannelNotificationRequest>(), BackchannelTokenDeliveryModes.Push),
             Times.Once);
+
+        // Written before the mint and removed after the delivery. The write is a round trip this path
+        // does not need, and it is what the failing path depends on - the two cannot be told apart until
+        // the delivery has already been attempted.
+        _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Once);
         _storage.Verify(s => s.TryRemoveAsync(AuthReqId), Times.Once);
-        _storage.Verify(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<BackChannelAuthenticationRequest>(), It.IsAny<TimeSpan>()), Times.Never);
     }
 
     /// <summary>
-    /// Verifies that when push delivery fails, the stored record is left alone rather than removed.
+    /// Verifies that when push delivery fails, the record is left in storage rather than removed - and
+    /// that what is left reads Authenticated, so nobody can complete it a second time.
     /// </summary>
     /// <remarks>
-    /// It is not the authenticated request. Push never writes back - the status and the narrowed grant
-    /// were set on the in-memory object - so what stays is the PRE-completion record: Pending, carrying
-    /// what the client asked for, and carrying the session from initiation.
+    /// It is still not the authenticated REQUEST. Only the status is persisted; the narrowed grant was
+    /// set on the in-memory object and stays there, so the record carries what the client asked for.
+    /// That is deliberate: persisting the grant would let a second completion replay the approval, which
+    /// is a correctly-scoped second token set for one authentication.
     ///
     /// Nor does keeping it save any tokens: the ones just minted are dropped with the lambda that made
-    /// them, and nothing retries. It is kept so a host can see the request existed, and because a host can
-    /// complete it again - which is a hazard rather than a recovery, and is issue 451.
-    /// </summary>
+    /// them, and nothing retries. It is kept so a host can see the request existed.
+    /// </remarks>
     [Fact]
     public async Task CompleteAuthenticationAsync_PushMode_DeliveryFails_RetainsRequest()
     {
@@ -381,7 +388,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), fixedTime.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = _notificationEndpoint,
             ClientNotificationToken = NotificationToken,
         };
@@ -408,6 +415,8 @@ public class AuthenticationCompletionHandlerTests
                 BackchannelTokenDeliveryModes.Push))
             .ReturnsAsync(false);
 
+        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
+
         var handler = CreatePushModeHandler();
 
         // Act
@@ -418,6 +427,11 @@ public class AuthenticationCompletionHandlerTests
             s => s.SendAsync(_notificationEndpoint, NotificationToken, It.IsAny<IBackChannelNotificationRequest>(), BackchannelTokenDeliveryModes.Push),
             Times.Once);
         _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
+
+        // The record survives, and it survives Authenticated. Both halves matter: the first is what lets
+        // a host see the request existed, the second is what stops the same host completing it again.
+        _storage.Verify(s => s.UpdateAsync(AuthReqId, request, _expiresIn), Times.Once);
+        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, request.Status);
     }
 
     /// <summary>
@@ -433,7 +447,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = _notificationEndpoint,
             ClientNotificationToken = NotificationToken,
         };
@@ -447,6 +461,8 @@ public class AuthenticationCompletionHandlerTests
 
         _tokenRequestProcessor.Setup(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()))
             .ReturnsAsync(Result<TokenIssued, OidcError>.Failure(error));
+
+        _storage.Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn)).Returns(Task.CompletedTask);
 
         _storage.Setup(s => s.TryRemoveAsync(AuthReqId))
             .ReturnsAsync((BackChannelAuthenticationRequest?)null);
@@ -486,7 +502,7 @@ public class AuthenticationCompletionHandlerTests
         var request = new BackChannelAuthenticationRequest(
             new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = null,
             ClientNotificationToken = NotificationToken,
         };
@@ -529,7 +545,7 @@ public class AuthenticationCompletionHandlerTests
         var request = new BackChannelAuthenticationRequest(
             new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = new Uri("https://client.example/ciba"),
             ClientNotificationToken = null,
         };
@@ -570,7 +586,7 @@ public class AuthenticationCompletionHandlerTests
         var context = new AuthorizationContext(ClientId, [Scopes.OpenId], null);
         var request = new BackChannelAuthenticationRequest(new AuthorizedGrant(authSession, context), DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            Status = BackChannelAuthenticationStatus.Authenticated,
+            Status = BackChannelAuthenticationStatus.Pending,
             ClientNotificationEndpoint = null,
             ClientNotificationToken = NotificationToken,
         };
@@ -1011,5 +1027,129 @@ public class AuthenticationCompletionHandlerTests
                 .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .SelectMany(constructor => constructor.GetParameters())
                 .Any(parameter => parameter.ParameterType == typeof(IAuthorizationDetailsPolicy));
+    }
+    /// <summary>
+    /// A completion of a request that is not pending refuses, and touches neither storage nor delivery.
+    /// </summary>
+    /// <remarks>
+    /// One authentication, one completion. The end user answered once, so a second full token set is
+    /// wrong whatever it contains - which is why this refuses rather than replaying the narrowed grant:
+    /// replaying would make the second set correctly scoped and no less of a second set.
+    /// <para>
+    /// A row per mode, because the guard lives in the base and what must NOT run is each mode's own
+    /// delivery. Loud rather than silent: nothing on this seam returns a value, so a host that was
+    /// relying on the old behaviour learns about it from an exception rather than from a token set the
+    /// end user refused.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(BackChannelAuthenticationStatus.Authenticated)]
+    [InlineData(BackChannelAuthenticationStatus.Denied)]
+    public async Task CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses(
+        BackChannelAuthenticationStatus already)
+    {
+        var request = CreateRequest(UserId, null);
+        request.Status = already;
+
+        var handler = CreatePollModeHandler();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.CompleteAuthenticationAsync(AuthReqId, request, PollClient(), _expiresIn));
+
+        _storage.VerifyNoOtherCalls();
+    }
+
+    /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses"/>
+    [Theory]
+    [InlineData(BackChannelAuthenticationStatus.Authenticated)]
+    [InlineData(BackChannelAuthenticationStatus.Denied)]
+    public async Task CompleteAuthenticationAsync_PingMode_WhenNotPending_Refuses(
+        BackChannelAuthenticationStatus already)
+    {
+        var request = CreateRequest(UserId, null);
+        request.Status = already;
+        request.ClientNotificationEndpoint = _notificationEndpoint;
+
+        var handler = CreatePingModeHandler();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.CompleteAuthenticationAsync(AuthReqId, request, PingClient(), _expiresIn));
+
+        _storage.VerifyNoOtherCalls();
+        _notificationService.VerifyNoOtherCalls();
+    }
+
+    /// <inheritdoc cref="CompleteAuthenticationAsync_PollMode_WhenNotPending_Refuses"/>
+    [Theory]
+    [InlineData(BackChannelAuthenticationStatus.Authenticated)]
+    [InlineData(BackChannelAuthenticationStatus.Denied)]
+    public async Task CompleteAuthenticationAsync_PushMode_WhenNotPending_Refuses(
+        BackChannelAuthenticationStatus already)
+    {
+        var request = CreateRequest(UserId, null);
+        request.Status = already;
+        request.ClientNotificationEndpoint = _notificationEndpoint;
+
+        var handler = CreatePushModeHandler();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.CompleteAuthenticationAsync(AuthReqId, request, PushClient(), _expiresIn));
+
+        _storage.VerifyNoOtherCalls();
+        _notificationService.VerifyNoOtherCalls();
+        _tokenRequestProcessor.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// A push completion persists the status transition BEFORE it mints, so a delivery that then fails
+    /// leaves a record no second completion can use.
+    /// </summary>
+    /// <remarks>
+    /// This is the write that makes "completed once" a stored fact for the one mode that stored nothing.
+    /// The order is the assertion: written after delivery instead, it would never happen on the failure
+    /// path, which is the only path where the record survives to be completed again.
+    /// <para>
+    /// The status alone, not the narrowed grant. Persisting the grant would make a second completion
+    /// replay the approval, which is a correctly-scoped second token set for one authentication - the
+    /// symptom fixed and the disease kept.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_PushMode_PersistsTheTransitionBeforeMinting()
+    {
+        var request = CreateRequest(UserId, null);
+        request.ClientNotificationEndpoint = _notificationEndpoint;
+
+        var order = new List<string>();
+
+        _storage
+            .Setup(s => s.UpdateAsync(AuthReqId, request, _expiresIn))
+            .Callback(() => order.Add("persisted"))
+            .Returns(Task.CompletedTask);
+
+        _tokenRequestProcessor
+            .Setup(p => p.ProcessAsync(It.IsAny<ValidTokenRequest>()))
+            .Callback(() => order.Add("minted"))
+            .ReturnsAsync(Result<TokenIssued, OidcError>.Success(
+                new TokenIssued(
+                    new EncodedJsonWebToken(new Jwt.JsonWebToken(), "access_token_jwt"),
+                    TokenTypes.Bearer,
+                    TimeSpan.FromHours(1),
+                    new Uri("urn:ietf:params:oauth:token-type:access_token"))));
+
+        _notificationService
+            .Setup(s => s.SendAsync(
+                _notificationEndpoint, NotificationToken, It.IsAny<IBackChannelNotificationRequest>(),
+                BackchannelTokenDeliveryModes.Push))
+            .Callback(() => order.Add("delivered"))
+            .ReturnsAsync(false);
+
+        var handler = CreatePushModeHandler();
+
+        await handler.CompleteAuthenticationAsync(AuthReqId, request, PushClient(), _expiresIn);
+
+        Assert.Equal(["persisted", "minted", "delivered"], order);
+        Assert.Equal(BackChannelAuthenticationStatus.Authenticated, request.Status);
+        _storage.Verify(s => s.TryRemoveAsync(It.IsAny<string>()), Times.Never);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(149, EventIds().Count);
+        Assert.Equal(150, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()


### PR DESCRIPTION
Ref #451.

## What was reachable

A push delivery that fails leaves the record in storage. Before this, that record was the one from initiation: `Pending`, carrying what the client asked for rather than what the end user approved, and carrying the session, because `AuthorizedGrant` takes it as a non-nullable member.

Handing it back to `CompleteAsync` completed, minted and posted. It looks like a retry of the delivery and is not one - the tokens from the first attempt went with the lambda that minted them, so the second call is a fresh completion from a record that predates the end user's answer. The narrowing lived only in the grant the host passed the first time, and that grant was never stored.

So the natural recovery a host reaches for was the one that over-grants.

## Two halves, and neither works alone

**The base handler completes only a `Pending` request.** Poll and ping already persisted `Authenticated` before delivering, so their records already answered this and nothing checked it; push stored nothing at all, so the guard alone would have refused nothing on the mode where the hole was.

**Push persists the status transition before it mints.** That is the write that makes "completed once" a stored fact for the one mode that stored none. It sits before the mint rather than in the delivery-failed branch, and that is a choice rather than a necessity: measured, a write placed in that branch does run on the failure path and leaves the failing-delivery row green. What it would lose is the ordering the suite pins - the store sees the transition before any token exists.

## What the record carries, and what actually stops a second completion

The write persists the WHOLE record, because the storage serializes the object it is handed - the same write poll and ping make, grant included. An earlier revision of this branch said the opposite in six places, including the operator's failure log and the exception a host reads; it was believed rather than measured, and a review measured it.

So the second direction the issue offers - persist the narrowed grant so a repeat replays the approval - is not a direction this code could have avoided taking. What it would have bought is not worth having either: one authentication minting two full token sets, correctly scoped, is the symptom fixed and the disease kept. The end user answered once.

What stops a repeat is the GUARD, not anything the record omits.

What the record has to carry is that it was spent, and the status is what carries it. It also carries the grant the host completed with, since the storage serializes the object it is handed - two earlier revisions of this branch said otherwise, in nine places between them, and a review measured it.

## What the refusal says, and what it refuses to guess

A missing record has more causes than this seam can tell apart: a poll redeemed it, a push delivered it, its lifetime ran out while the end user was deciding, or push's own refusal path removed it after a configuration fault - where nothing was answered at all. An earlier revision told that last operator the request "was completed again", which sent them hunting for a completion that never happened.

It reports the state it found and nothing about how the record got there.

## The decision is the seam's, not the caller's

The guard reads the STORED record. It read the request handed in at first, and that was wrong twice over: hosts do set that field on their own copy before calling - the end-to-end fixture in this repository is one of them - so such a host was refused on its FIRST completion and the end-to-end suite went red, and the check was advisory besides, since whether it fired was up to the caller it exists to constrain. Proved by putting the old shape back: exactly three end-to-end rows go red, and they are the rows whose fixture marks its own copy.

Stated as what must be true rather than as the ways it can fail: only a stored record reading `Pending` may be completed. A record that is GONE is not a lesser case of one that is spent - a poll can have redeemed and removed it, and completing on top of that mints against a record nobody can check and writes it back into existence.

## The refusal throws

Nothing on this seam returns a value: `IAuthenticationCompletionHandler.CompleteAsync` returns `Task`. A refusal a caller cannot detect is the one shape that reads as acceptance, and carrying a result would change the signature every host implements against.

This refuses something a host could be doing today. That is a security defect being closed rather than a preference, and the throw is what lets a host relying on it find out while it is writing the recovery - which is where the choice between re-completing and asking the end user again is actually made. It is logged as well as thrown, because an operator reading a live system sees the attempt whether or not the host caught it.

CIBA Core 1.0 does not settle any of this. Section 10.1.1's "once redeemed for a successful token response, the `auth_req_id` value that was used is no longer valid" is about the token response, and a push client never makes a token request; sections 10.3 and 10.3.1 say nothing about repeating a delivery. Both were read rather than 10.1.1 being stretched over them.

## The prose that became false

Every comment asserting that push never writes back moved with the behaviour, including the delivery-failure log an operator reads and the end-to-end test's own explanation of why the record is removed on success.

## What the fixtures turned out to be wrong about

Twelve existing unit fixtures arranged the input status as `Authenticated`, which describes a record already spent rather than one awaiting completion. The guard refuses those, which is how they turned out to be wrong about their own pre-condition; each now arranges `Pending`, and none of their assertions changed.

## Evidence

Every new row is red under at least one mutation of the change and green without it. A refusal per mode over each way the store can fail to hold a pending record - already answered, already refused, and NO RECORD AT ALL, which is not a value of the status enum and is the arm the rest of the change is written about; one asserting the write lands before the mint and before the delivery; one that captures what the store was HANDED on a failed delivery, rather than where the field ended up afterwards; and one that tells the guard's two possible shapes apart, which nothing else does - deleting the guard and pointing it at the caller's own field turn exactly the same refusal rows red.

The order row also captures the status AT the write. Asserting it afterwards reads whatever the object ended up as, because the mock matches its argument by reference - so without that capture the row goes green under a hoist of the assignment past the delivery while push hands the store a record still reading Pending, which is this defect verbatim. The SUITE does not stay green under that hoist: three rows die, one of them a ping denial row holding no capture, whose predicate matcher the mock re-evaluates at Verify time against the flipped reference.

Three end-to-end rows go red when the guard reads the caller's object instead of storage, and none when it is deleted. That difference is the whole of what the guard being authoritative means.

The two push rows that already existed changed their expectations, because the write is now visible to a strict mock - and the two configuration-refusal rows did not, which is what confirms the write sits after those checks rather than before them.

## Also in this branch

A pre-commit check refusing a byte-order mark that appears or disappears. Python's `utf-8-sig` codec strips one on read and writes one unconditionally, so a scripted edit through it plants three bytes at the head of a file that had none, and the mark sits inside the first line where the diff reads as the line somebody meant to change. Its own commit, and it ran on the commit that follows it.

**Round 4.** The guard's missing-record arm had no row: asking whether the stored status is something OTHER than Pending passed the whole suite while a completion against a removed record minted and wrote it back into existence. The three refusal theories now take a nullable status where null arranges no record, named for what the guard requires rather than for the enum values it rejects. And `PushMode_DeliveryFails_RetainsRequest` asserted the status after the call on the reference Moq matched, so it held only that the record survives, not that it survives Authenticated - captured at the write now. Nothing failing and nothing left unrun.

**Round 5.** Three statements corrected, none of them behaviour. The published `<exception>` enumerated three causes of the refusal as fact; absence has more causes than this seam can tell apart, so it states the condition that must hold and names the ones it cannot distinguish - including a record that was never there, and a host that persists the status itself and is refused on its first completion with nothing over-granted. The base class's own summary, `<param>` and step list were the sibling of that sentence and were re-pointed with it. And the reason given for the write's position was false: a write placed inside the delivery-failed branch does run on that path, measured, and leaves the failing-delivery row green. What the order actually buys is that no token set can exist over a record still reading Pending, whatever runs after the mint - that is what the four sites say now.

**Round 6.** Two comments over the order capture described mutations nobody had run, and this description carried both. The counterfactual about push writing after delivery cannot happen - push's write is inside `HandleDeliveryAsync` and the base handler sets the status on the line above the call - and "leaves both suites green" is false: the hoist kills three rows, the third being a ping denial row with no capture at all. Both are now stated from a planted, measured run.

**Round 7.** Three statements this branch added claimed more than the mechanism gives, and all three were verified against the code rather than argued.

The refusal log listed five causes for a missing record, and this change itself added a sixth: push's refusal path removes the record after a configuration fault - which is precisely the case the message's own remarks name as its likeliest reader. It says the cause is unknown now, and names that case, rather than enumerating.

"Neither is hygiene" was true of the removal before this change. With the write and the guard in place, deleting the removal leaves an `Authenticated` record that `CompleteAuthenticationAsync` refuses and `PushModeGrantProcessor.ValidateTokenEndpointAccess` refuses - an orphan, which is what the same file says twenty lines down and what the end-to-end comment this branch rewrote already said.

And three sentences promised at-most-one completion without a condition, while `TryGetAsync` is `GetAsync(..., removeOnRetrieval: false)` - no claim protocol, no lock. Two completions running side by side both read `Pending` and both proceed. What this change closes is the SEQUENTIAL retry, which is what #451 is; the sentences say "later" now, and say why. Whoever debugs a concurrent double delivery is no longer sent away from this seam.

**Rounds 8 and 9.** Round 8 added a row to make the qualified claim measurable, and the remark installed with it said a claim protocol OR a lock would turn it red. The lock half is false, measured: a per-key semaphore around the read-and-act builds clean and leaves the suite green, because the store in that row answers Pending on every call regardless of what was written, so serialising two callers changes nothing it can see. That sentence was written in the same minute as the row, from what the row was FOR rather than from a run - the same diagnosis round 8 wrote for itself, arriving through the door built to close it. The row holds the sequential half and now says so, and the published returns block says "as this ships", names both absent mechanisms, and states outright that nothing in the suite holds it.

**Round 10 - the claim is gone rather than qualified.** Rounds 8 and 9 spent themselves on a sentence describing what this guard does NOT have. A contract is not obliged to describe an absence, and that sentence had nothing that could contradict it: adding exclusion would have made it false in silence, which is how it survived two rounds. The returns block now states only what the change closes - a later completion of the same request is refused - and says nothing about concurrent ones.

The row added in round 8 went with it. Measured, not assumed: under the guard reading the caller's own copy, eleven rows died and that row was one of eleven, the other ten including `WhenTheCallerMarkedItsOwnCopy_TheStoredRecordDecides`, written for exactly that property. With the row removed the same mutation still kills ten, that one among them - nothing moved from covered to uncovered. It was installed to make a claim measurable and could not measure the half it was named for; with the claim gone it holds nothing, and a row whose name promises what the contract no longer states is worse than no row, because the next reader takes the name for the coverage.

Suites 2915 and 193.
