### PR TITLE
Let a failed user-code index cleanup keep its silence, not the caller's answer

### DIFF
--- a/.github/scripts/lint-take-once-consumers.py
+++ b/.github/scripts/lint-take-once-consumers.py
@@ -65,6 +65,7 @@ KNOWN = {
     "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/GrantProcessors/PollModeGrantProcessor.cs",
     "src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelRequestStorage.cs",
     "src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs",
+    "src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs",
     "src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs",
     "src/Abblix.Oidc.Server/Features/Storages/DistributedCacheStorage.cs",
     "src/Abblix.Oidc.Server/Features/PushedAuthorization/PushedAuthorizationRequestProcessorDecorator.cs",

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -16,19 +16,30 @@ partial class DeviceAuthorizationStorage
     /// The index survived a CLAIM: the device code is consumed and its caller was told so.
     /// </summary>
     /// <remarks>
-    /// The key is named because it is what an operator would search for or delete. It EMBEDS the user
-    /// code - the factory builds it by interpolation - so this line writes the code in full. That is
-    /// acceptable HERE and only here: the claim has already removed the request, so the code cannot be
-    /// verified or redeemed by the time this runs. Warning rather than error, because the caller was
-    /// answered and nothing downstream is waiting.
+    /// It names the DEVICE code key and not the user-code one, which is the opposite of the sibling
+    /// below, and the difference is where each method gets the code from. There the user code is read
+    /// out of the stored record, so it belongs to the request being removed. Here it arrives as a
+    /// PARAMETER and nothing checks the two belong together - <c>TryRemoveAsync</c> never reads the
+    /// record - so on the public interface a host can hand this method a live code belonging to some
+    /// other request, and the key that embeds it would be written to a log in full while it is still
+    /// redeemable. The device code carries no such doubt: this line is only reached because the claim
+    /// removed it.
+    /// <para>
+    /// The entry cannot be named exactly as a result. That costs less than it looks: the action this
+    /// line asks for is never "delete that key" - the entry expires on its own - it is "the store
+    /// refused a write". Warning rather than error, because the caller was answered and nothing
+    /// downstream is waiting.
+    /// </para>
     /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedAfterClaim,
         Level = LogLevel.Warning,
-        Message = "The device code was claimed and removed, but its user-code index at {UserCodeKey} " +
-                  "could not be. The entry now points at a request that is gone, and it expires on its " +
-                  "own; the caller was told it took the code, which it did.")]
-    private partial void LogUserCodeIndexNotRemovedAfterClaim(Exception exception, string UserCodeKey);
+        Message = "The device code at {DeviceCodeKey} was claimed and removed, but the store refused to " +
+                  "remove its user-code index entry. That entry now points at a request that is gone " +
+                  "and expires on its own; the caller was told it took the code, which it did. The " +
+                  "entry is not named here because this method cannot establish that the user code it " +
+                  "was handed is the spent one.")]
+    private partial void LogUserCodeIndexNotRemovedAfterClaim(Exception exception, string DeviceCodeKey);
 
     /// <summary>
     /// The index survived a DISCARD, where nothing was consumed and the request is still being removed.
@@ -51,8 +62,8 @@ partial class DeviceAuthorizationStorage
         Level = LogLevel.Warning,
         Message = "A device authorization request is being discarded, and its user-code index at " +
                   "{UserCodeKey} could not be removed. Nothing was issued and no caller was told it took " +
-                  "the code. Removing the request runs next and is NOT guarded, so a store refusing writes " +
-                  "fails there too and the caller sees THAT fault rather than this line; the index entry " +
-                  "expires on its own either way.")]
+                  "the code. Removing the request itself runs next and is NOT guarded, so whether the " +
+                  "caller sees a fault or a grant error depends on whether that write is refused too; " +
+                  "the index entry expires on its own either way.")]
     private partial void LogUserCodeIndexNotRemovedBeforeDiscard(Exception exception, string UserCodeKey);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -52,10 +52,10 @@ partial class DeviceAuthorizationStorage
     /// neither could act on.
     /// <para>
     /// The code it names is dead at both shipped call sites - the record is expired or denied, and such a
-    /// record cannot be carried to an approval: <c>ApproveAsync</c> and <c>DenyAsync</c> refuse anything
-    /// not pending, and <c>ApproveAsync</c> refuses an expired record besides. <c>VerifyAsync</c> reads the
-    /// status alone, so an expired-but-pending record still gets an answer there; it just cannot go
-    /// further than that answer. This method is on the public
+    /// record cannot be carried to a decision: <c>ApproveAsync</c> and <c>DenyAsync</c> refuse anything not
+    /// pending, and each refuses an expired record besides. <c>VerifyAsync</c> reads the status alone, so
+    /// an expired-but-pending record still gets an answer there; it just cannot go further than that
+    /// answer. This method is on the public
     /// interface though, so a host calling it with a live record logs a live code; that is the host's
     /// choice, and it is why the sibling's blanket "the code is spent" does not appear here.
     /// </para>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -21,9 +21,18 @@ partial class DeviceAuthorizationStorage
     /// out of the stored record, so it belongs to the request being removed. Here it arrives as a
     /// PARAMETER and nothing checks the two belong together - <c>TryRemoveAsync</c> never reads the
     /// record - so on the public interface a host can hand this method a live code belonging to some
-    /// other request, and the key that embeds it would be written to a log in full while it is still
-    /// redeemable. The device code carries no such doubt: this line is only reached because the claim
-    /// removed it.
+    /// other request, and the key that embeds it would be written into THIS MESSAGE in full while it is
+    /// still redeemable. The device code carries no such doubt: this line is only reached because the
+    /// claim removed it.
+    /// <para>
+    /// That bounds the message, not the log RECORD. The store's own fault travels beside it on the
+    /// exception channel, and a store routinely quotes the key it failed on - a Redis client's refusal
+    /// reads "No connection is active/available to service this operation: DEL &lt;key&gt;". It is passed
+    /// through on purpose: an operator who cannot see why the write was refused cannot act on the line
+    /// at all, and a library cannot sanitise a fault it did not author - redacting the key it happens to
+    /// know is a list, and the next store formats it differently. A host that must keep user codes out
+    /// of its logs entirely does that at the sink, where it owns both channels.
+    /// </para>
     /// <para>
     /// The entry cannot be named exactly as a result. That costs less than it looks: the action this
     /// line asks for is never "delete that key" - the entry expires on its own - it is "the store

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -1,0 +1,31 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
+
+public partial class DeviceAuthorizationStorage
+{
+    /// <summary>
+    /// The only report a dangling user-code index ever produces.
+    /// </summary>
+    /// <remarks>
+    /// The key is named because it is what an operator would search for or delete; it is a derived
+    /// storage key rather than the user code itself, and it points at a request that is already gone.
+    /// Warning rather than error: the device code was consumed and the caller was answered, so nothing
+    /// downstream is waiting on this.
+    /// </remarks>
+    [LoggerMessage(
+        EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemoved,
+        Level = LogLevel.Warning,
+        Message = "The device code was consumed, but its user-code index at {UserCodeKey} could not be " +
+                  "removed. The entry points at a request that no longer exists and expires on its own; " +
+                  "the caller was told it took the code, which it did.")]
+    private partial void LogUserCodeIndexNotRemoved(Exception exception, string UserCodeKey);
+}

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -10,16 +10,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
-public partial class DeviceAuthorizationStorage
+partial class DeviceAuthorizationStorage
 {
     /// <summary>
     /// The only report a dangling user-code index ever produces.
     /// </summary>
     /// <remarks>
-    /// The key is named because it is what an operator would search for or delete; it is a derived
-    /// storage key rather than the user code itself, and it points at a request that is already gone.
-    /// Warning rather than error: the device code was consumed and the caller was answered, so nothing
-    /// downstream is waiting on this.
+    /// The key is named because it is what an operator would search for or delete. It EMBEDS the user
+    /// code - the factory builds it by interpolation - so this line writes the code in full; that is
+    /// acceptable here and nowhere near free elsewhere, because the record it addressed is gone and the
+    /// code is spent the moment this runs. Warning rather than error: the device code was consumed and
+    /// the caller was answered, so nothing downstream is waiting on this.
     /// </remarks>
     [LoggerMessage(
         EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemoved,

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -51,6 +51,8 @@ partial class DeviceAuthorizationStorage
         Level = LogLevel.Warning,
         Message = "A device authorization request is being discarded, and its user-code index at " +
                   "{UserCodeKey} could not be removed. Nothing was issued and no caller was told it took " +
-                  "the code; the request itself is removed next, and the entry expires on its own.")]
+                  "the code. Removing the request runs next and is NOT guarded, so a store refusing writes " +
+                  "fails there too and the caller sees THAT fault rather than this line; the index entry " +
+                  "expires on its own either way.")]
     private partial void LogUserCodeIndexNotRemovedBeforeDiscard(Exception exception, string UserCodeKey);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -13,20 +13,44 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 partial class DeviceAuthorizationStorage
 {
     /// <summary>
-    /// The only report a dangling user-code index ever produces.
+    /// The index survived a CLAIM: the device code is consumed and its caller was told so.
     /// </summary>
     /// <remarks>
     /// The key is named because it is what an operator would search for or delete. It EMBEDS the user
-    /// code - the factory builds it by interpolation - so this line writes the code in full; that is
-    /// acceptable here and nowhere near free elsewhere, because the record it addressed is gone and the
-    /// code is spent the moment this runs. Warning rather than error: the device code was consumed and
-    /// the caller was answered, so nothing downstream is waiting on this.
+    /// code - the factory builds it by interpolation - so this line writes the code in full. That is
+    /// acceptable HERE and only here: the claim has already removed the request, so the code cannot be
+    /// verified or redeemed by the time this runs. Warning rather than error, because the caller was
+    /// answered and nothing downstream is waiting.
     /// </remarks>
     [LoggerMessage(
-        EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemoved,
+        EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedAfterClaim,
         Level = LogLevel.Warning,
-        Message = "The device code was consumed, but its user-code index at {UserCodeKey} could not be " +
-                  "removed. The entry points at a request that no longer exists and expires on its own; " +
-                  "the caller was told it took the code, which it did.")]
-    private partial void LogUserCodeIndexNotRemoved(Exception exception, string UserCodeKey);
+        Message = "The device code was claimed and removed, but its user-code index at {UserCodeKey} " +
+                  "could not be. The entry now points at a request that is gone, and it expires on its " +
+                  "own; the caller was told it took the code, which it did.")]
+    private partial void LogUserCodeIndexNotRemovedAfterClaim(Exception exception, string UserCodeKey);
+
+    /// <summary>
+    /// The index survived a DISCARD, where nothing was consumed and the request is still being removed.
+    /// </summary>
+    /// <remarks>
+    /// A separate id from its sibling because the two say different things to whoever reads them. Here
+    /// the record is expired or denied, no token was issued, nobody was told they took anything, and the
+    /// request removal has not run yet - so a message borrowed from the claim path would send an operator
+    /// looking for an issuance that never happened. One message true of both sites could only be one that
+    /// neither could act on.
+    /// <para>
+    /// The code it names is dead at both shipped call sites - the record is expired or denied, and every
+    /// entry point refuses a record that is not pending and unexpired. This method is on the public
+    /// interface though, so a host calling it with a live record logs a live code; that is the host's
+    /// choice, and it is why the sibling's blanket "the code is spent" does not appear here.
+    /// </para>
+    /// </remarks>
+    [LoggerMessage(
+        EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedBeforeDiscard,
+        Level = LogLevel.Warning,
+        Message = "A device authorization request is being discarded, and its user-code index at " +
+                  "{UserCodeKey} could not be removed. Nothing was issued and no caller was told it took " +
+                  "the code; the request itself is removed next, and the entry expires on its own.")]
+    private partial void LogUserCodeIndexNotRemovedBeforeDiscard(Exception exception, string UserCodeKey);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.Logging.cs
@@ -35,10 +35,10 @@ partial class DeviceAuthorizationStorage
         EventId = LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedAfterClaim,
         Level = LogLevel.Warning,
         Message = "The device code at {DeviceCodeKey} was claimed and removed, but the store refused to " +
-                  "remove its user-code index entry. That entry now points at a request that is gone " +
-                  "and expires on its own; the caller was told it took the code, which it did. The " +
-                  "entry is not named here because this method cannot establish that the user code it " +
-                  "was handed is the spent one.")]
+                  "remove the user-code index entry it was handed. That entry expires on its own; the " +
+                  "caller was told it took the code, which it did. The entry is not named here because " +
+                  "this method cannot establish that the user code it was handed is the spent one - " +
+                  "which is the same reason nothing here can say what that entry still points at.")]
     private partial void LogUserCodeIndexNotRemovedAfterClaim(Exception exception, string DeviceCodeKey);
 
     /// <summary>
@@ -51,8 +51,11 @@ partial class DeviceAuthorizationStorage
     /// looking for an issuance that never happened. One message true of both sites could only be one that
     /// neither could act on.
     /// <para>
-    /// The code it names is dead at both shipped call sites - the record is expired or denied, and every
-    /// entry point refuses a record that is not pending and unexpired. This method is on the public
+    /// The code it names is dead at both shipped call sites - the record is expired or denied, and such a
+    /// record cannot be carried to an approval: <c>ApproveAsync</c> and <c>DenyAsync</c> refuse anything
+    /// not pending, and <c>ApproveAsync</c> refuses an expired record besides. <c>VerifyAsync</c> reads the
+    /// status alone, so an expired-but-pending record still gets an answer there; it just cannot go
+    /// further than that answer. This method is on the public
     /// interface though, so a host calling it with a live record logs a live code; that is the host's
     /// choice, and it is why the sibling's blanket "the code is spent" does not appear here.
     /// </para>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -92,12 +92,31 @@ public partial class DeviceAuthorizationStorage(
     /// <inheritdoc />
     public async Task RemoveAsync(string deviceCode)
     {
+        // The secondary index is best-effort here for the same reason it is in TryRemoveAsync: it is not
+        // what the caller asked for. The token endpoint calls this from its expired and denied arms and
+        // then returns a grant error, so a store that refuses this write would turn that error into a
+        // server fault - the client gets a 500 where it should be told the code expired.
+        //
+        // Less costly than the same failure in TryRemoveAsync, and worth saying so: nothing has been
+        // consumed here, so the request is still live and the client's next poll gets the same answer.
+        // The shape is identical though, and leaving one arm best-effort and the other not is how a
+        // class comes back.
         var request = await TryGetByDeviceCodeAsync(deviceCode);
         if (request != null)
         {
-            await cache.RemoveAsync(keyFactory.DeviceAuthorizationUserCodeKey(request.UserCode));
+            var userCodeKey = keyFactory.DeviceAuthorizationUserCodeKey(request.UserCode);
+            try
+            {
+                await cache.RemoveAsync(userCodeKey);
+            }
+            catch (Exception exception)
+            {
+                LogUserCodeIndexNotRemoved(exception, userCodeKey);
+            }
         }
 
+        // Not guarded. This one IS what the caller asked for, and a failure means the request is still
+        // there - swallowing it would report a removal that did not happen.
         await cache.RemoveAsync(keyFactory.DeviceAuthorizationRequestKey(deviceCode));
     }
 

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -166,8 +166,9 @@ public partial class DeviceAuthorizationStorage(
     /// <para>
     /// The index cleanup that runs after the claim cannot change that answer either way. Removing the
     /// user-code index is a different question from whether this caller took the code, so a refusal is logged
-    /// and the true stands: the entry left behind points at a request that no longer exists and carries
-    /// its own expiry.
+    /// and the true stands. What the entry left behind still points at is not knowable here - this method
+    /// never reads the record, so the user code it was handed need not belong to the request it removed -
+    /// but that entry carries its own expiry either way.
     /// </para>
     /// </returns>
     public async Task<bool> TryRemoveAsync(string deviceCode, string userCode)
@@ -182,8 +183,9 @@ public partial class DeviceAuthorizationStorage(
         // server fault rather than a grant error - no tokens for a code that can never be presented again,
         // and the end user's approval lost with it.
         //
-        // The entry left behind is harmless on its own: it points at a request key that no longer exists,
-        // and it carries its own expiry. Removing it FIRST instead would make the fault retryable, at the
+        // The entry left behind carries its own expiry, so it goes away unattended. Whether it still
+        // resolves to a live request is not knowable from here, because this method never reads the
+        // record it is removing. Removing the index FIRST instead would make the fault retryable, at the
         // cost of a window in which the user code resolves to nothing while the device code is still live
         // - a worse trade, because that window is on the path that succeeds.
         //

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -153,15 +153,18 @@ public partial class DeviceAuthorizationStorage(
     /// </para>
     /// </remarks>
     /// <param name="deviceCode">The device code identifying the authorization request to remove.</param>
-    /// <param name="userCode">The user code for cleaning up the secondary index mapping.</param>
+    /// <param name="userCode">The user code of THAT request, used to find its secondary index entry.
+    /// Nothing here checks the two belong together - this method never reads the record - so a caller
+    /// passing a code from a different request removes that other request's index entry instead, leaving
+    /// a live request findable only by its device code.</param>
     /// <returns>
     /// A task that completes when the operation finishes, containing true when this caller removed the
     /// request AND still held the claim afterwards. False otherwise, which is wider than "another caller
     /// won or it was never there": the code can be consumed and the caller still told false, when the lock
     /// guarding the removal expires mid-protocol. The extension's remarks carry that condition.
     /// <para>
-    /// The cleanup below them cannot change that answer either way. Removing the user-code index is a
-    /// different question from whether this caller took the code, so a store that refuses it is logged
+    /// The index cleanup that runs after the claim cannot change that answer either way. Removing the
+    /// user-code index is a different question from whether this caller took the code, so a refusal is logged
     /// and the true stands: the entry left behind points at a request that no longer exists and carries
     /// its own expiry.
     /// </para>
@@ -185,14 +188,18 @@ public partial class DeviceAuthorizationStorage(
         //
         // Swallowed, not hidden. Nothing else in the system reports a dangling index, so without this line
         // an operator has no way to learn the store refused a write at all.
-        var userCodeKey = keyFactory.DeviceAuthorizationUserCodeKey(userCode);
+        var deviceCodeKey = keyFactory.DeviceAuthorizationRequestKey(deviceCode);
         try
         {
-            await cache.RemoveAsync(userCodeKey);
+            await cache.RemoveAsync(keyFactory.DeviceAuthorizationUserCodeKey(userCode));
         }
         catch (Exception exception)
         {
-            LogUserCodeIndexNotRemovedAfterClaim(exception, userCodeKey);
+            // The DEVICE code key, not the user-code one. This method never reads the record, so it
+            // cannot establish that the user code it was handed belongs to the request it just claimed -
+            // and on the public interface a host may hand it a live one. The device code carries no such
+            // doubt: this line is reached only because the claim removed it.
+            LogUserCodeIndexNotRemovedAfterClaim(exception, deviceCodeKey);
         }
 
         return true;

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -11,6 +11,7 @@ using Abblix.Oidc.Server.Features.DeviceAuthorization.Interfaces;
 using Abblix.Oidc.Server.Features.Storages;
 using Abblix.Utils;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 
 namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 
@@ -19,11 +20,13 @@ namespace Abblix.Oidc.Server.Features.DeviceAuthorization;
 /// Stores requests by device_code (for client polling) with a secondary index by user_code (for user verification).
 /// Uses atomic distributed cache operations to prevent race conditions in token issuance.
 /// </summary>
+/// <param name="logger">Records a secondary-index entry left behind, which nothing else reports.</param>
 /// <param name="cache">The distributed cache backend used for atomic operations.</param>
 /// <param name="serializer">The serializer for converting objects to/from binary format.</param>
 /// <param name="keyFactory">The factory for generating standardized storage keys.</param>
 /// <param name="timeProvider">Provides the current time for seeding the request's absolute expiry.</param>
-public class DeviceAuthorizationStorage(
+public partial class DeviceAuthorizationStorage(
+    ILogger<DeviceAuthorizationStorage> logger,
     IDistributedCache cache,
     IBinarySerializer serializer,
     IEntityStorageKeyFactory keyFactory,
@@ -132,9 +135,10 @@ public class DeviceAuthorizationStorage(
     /// won or it was never there": the code can be consumed and the caller still told false, when the lock
     /// guarding the removal expires mid-protocol. The extension's remarks carry that condition.
     /// <para>
-    /// They cannot cover the cleanup below them, which is this method's own call: if removing the user-code
-    /// index throws, the device code is already consumed and the caller gets the exception instead of true,
-    /// so no tokens are issued for a code that can never be presented again. Tracked as issue 453.
+    /// The cleanup below them cannot change that answer either way. Removing the user-code index is a
+    /// different question from whether this caller took the code, so a store that refuses it is logged
+    /// and the true stands: the entry left behind points at a request that no longer exists and carries
+    /// its own expiry.
     /// </para>
     /// </returns>
     public async Task<bool> TryRemoveAsync(string deviceCode, string userCode)
@@ -143,7 +147,29 @@ public class DeviceAuthorizationStorage(
         if (!removed)
             return false;
 
-        await cache.RemoveAsync(keyFactory.DeviceAuthorizationUserCodeKey(userCode));
+        // The device code is consumed at this point, and that is the fact the caller asked about. Tidying
+        // the secondary index is a different question, so a store that refuses it does not get to take the
+        // answer away: the token endpoint calls this inside a `when` clause, where an exception becomes a
+        // server fault rather than a grant error - no tokens for a code that can never be presented again,
+        // and the end user's approval lost with it.
+        //
+        // The entry left behind is harmless on its own: it points at a request key that no longer exists,
+        // and it carries its own expiry. Removing it FIRST instead would make the fault retryable, at the
+        // cost of a window in which the user code resolves to nothing while the device code is still live
+        // - a worse trade, because that window is on the path that succeeds.
+        //
+        // Swallowed, not hidden. Nothing else in the system reports a dangling index, so without this line
+        // an operator has no way to learn the store refused a write at all.
+        var userCodeKey = keyFactory.DeviceAuthorizationUserCodeKey(userCode);
+        try
+        {
+            await cache.RemoveAsync(userCodeKey);
+        }
+        catch (Exception exception)
+        {
+            LogUserCodeIndexNotRemoved(exception, userCodeKey);
+        }
+
         return true;
     }
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationStorage.cs
@@ -96,12 +96,13 @@ public partial class DeviceAuthorizationStorage(
         // The secondary index is best-effort here for the same reason it is in TryRemoveAsync: it is not
         // what the caller asked for. The token endpoint calls this from its expired and denied arms and
         // then returns a grant error, so a store that refuses this write would turn that error into a
-        // server fault - the client gets a 500 where it should be told the code expired.
+        // server fault - the client gets a 500 where it should be told the code expired or was denied.
         //
-        // Less costly than the same failure in TryRemoveAsync, and worth saying so: nothing has been
-        // consumed here, so the request is still live and the client's next poll gets the same answer.
-        // The shape is identical though, and leaving one arm best-effort and the other not is how a
-        // class comes back.
+        // The two arms are NOT the same shape, and the difference is the order. There the claim has
+        // already removed the request, so the index is all that is left; here the request is removed
+        // AFTER this, so a refusal at this line leaves both keys in place and the removal still runs.
+        // What they share is the reason for guarding: the index is never the caller's question, and its
+        // store deciding otherwise must not become the caller's answer.
         var request = await TryGetByDeviceCodeAsync(deviceCode);
         if (request != null)
         {
@@ -112,12 +113,15 @@ public partial class DeviceAuthorizationStorage(
             }
             catch (Exception exception)
             {
-                LogUserCodeIndexNotRemoved(exception, userCodeKey);
+                LogUserCodeIndexNotRemovedBeforeDiscard(exception, userCodeKey);
             }
         }
 
-        // Not guarded. This one IS what the caller asked for, and a failure means the request is still
-        // there - swallowing it would report a removal that did not happen.
+        // Not guarded, and the reason is not symmetry with the arm above. Removing the request is the
+        // whole of what this method is for, so a store that refuses it has not done the thing asked;
+        // reporting otherwise would leave a live record behind a call that looked like it worked. The
+        // caller does see a fault where it expected a grant error, which is the cost, and it is a cost
+        // over a record that is expired or denied rather than one carrying an approval.
         await cache.RemoveAsync(keyFactory.DeviceAuthorizationRequestKey(deviceCode));
     }
 
@@ -188,7 +192,7 @@ public partial class DeviceAuthorizationStorage(
         }
         catch (Exception exception)
         {
-            LogUserCodeIndexNotRemoved(exception, userCodeKey);
+            LogUserCodeIndexNotRemovedAfterClaim(exception, userCodeKey);
         }
 
         return true;

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -74,9 +74,12 @@ public interface IDeviceAuthorizationStorage
     /// request not being there and a claim that expired while a store call was in flight - the second
     /// on one caller with nobody to lose to, and its outcome is the request gone with nobody able to be
     /// told they took it. An operator told a second REQUEST was the cause goes looking for one, and the
-    /// expiry case is exactly the one that never produces a second request. A failure of the second store call,
-    /// which removes the user-code index, raises rather than answering: the device code is already
-    /// consumed and the caller is handed the exception.
+    /// expiry case is exactly the one that never produces a second request.
+    /// <para>
+    /// Removing the secondary user-code index is not part of that answer. It runs after the claim has
+    /// already decided, so a store that refuses it is logged and the answer stands: the entry left behind
+    /// points at a request that is gone and expires on its own.
+    /// </para>
     /// </returns>
     Task<bool> TryRemoveAsync(string deviceCode, string userCode);
 }

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -82,8 +82,9 @@ public interface IDeviceAuthorizationStorage
     /// expiry case is exactly the one that never produces a second request.
     /// <para>
     /// Removing the secondary user-code index is not part of that answer. It runs after the claim has
-    /// already decided, so a store that refuses it is logged and the answer stands: the entry left behind
-    /// points at a request that is gone and expires on its own.
+    /// already decided, so a store that refuses it is logged and the answer stands. The entry left behind
+    /// expires on its own; what it still resolves to depends on the user code the caller passed, which
+    /// this method never checks against the record it removed.
     /// </para>
     /// </returns>
     Task<bool> TryRemoveAsync(string deviceCode, string userCode);

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/Interfaces/IDeviceAuthorizationStorage.cs
@@ -58,7 +58,12 @@ public interface IDeviceAuthorizationStorage
     /// Removes a device authorization request from storage using its device code.
     /// </summary>
     /// <param name="deviceCode">The device code identifier.</param>
-    /// <returns>A task that completes when the request is removed from storage.</returns>
+    /// <returns>
+    /// A task that completes when the request is removed. Tidying the secondary user-code index is
+    /// best-effort and is logged rather than raised: it is not what the caller asked for, and a store
+    /// deciding otherwise must not become a fault where a grant error belongs. Removing the request
+    /// itself is not guarded - that IS what was asked, so a refusal there raises.
+    /// </returns>
     Task RemoveAsync(string deviceCode);
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -597,7 +597,7 @@ internal static class LogEvents
 
         /// <summary>
         /// <c>Endpoints/Token/Grants/DeviceCodeGrantHandler.cs</c> - what the token endpoint refuses when
-        /// the stored record is not one a token can be issued from (sub-ranges 7083-7084 and 7100-7119).
+        /// the stored record is not one a token can be issued from (sub-ranges 7083-7084 and 7100-7109).
         /// </summary>
         /// <remarks>
         /// Two windows rather than one, because 7083-7084 is all the original range had left: 7085-7099
@@ -622,9 +622,11 @@ internal static class LogEvents
         /// about what it could not tidy (sub-range 7110-7119).
         /// </summary>
         /// <remarks>
-        /// Placed in the range's continuation rather than beside the other storage ids, because the
-        /// windows below 7100 are packed and moving any of them would change ids a deployment may
-        /// already alert on.
+        /// Placed in the range's continuation rather than beside the other device-authorization windows,
+        /// because those are packed and moving any of them would change ids a deployment may already
+        /// alert on. Taking 7110-7119 narrows the neighbour above from 7100-7119 to 7100-7109, and that
+        /// narrowing is written there in the same change: this file is the whole allocation record, and
+        /// the uniqueness test only catches ids that collide outright, never two windows that overlap.
         /// </remarks>
         public static class DeviceAuthorizationStorage
         {

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -616,6 +616,22 @@ internal static class LogEvents
 
             public const int AuthorizedRecordCarriesNoGrant = Continued;
         }
+
+        /// <summary>
+        /// <c>Features/DeviceAuthorization/DeviceAuthorizationStorage.cs</c> - the store's own reports
+        /// about what it could not tidy (sub-range 7110-7119).
+        /// </summary>
+        /// <remarks>
+        /// Placed in the range's continuation rather than beside the other storage ids, because the
+        /// windows below 7100 are packed and moving any of them would change ids a deployment may
+        /// already alert on.
+        /// </remarks>
+        public static class DeviceAuthorizationStorage
+        {
+            private const int Base = 7110;
+
+            public const int UserCodeIndexNotRemoved = Base;
+        }
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -632,7 +632,8 @@ internal static class LogEvents
         {
             private const int Base = 7110;
 
-            public const int UserCodeIndexNotRemoved = Base;
+            public const int UserCodeIndexNotRemovedAfterClaim = Base;
+            public const int UserCodeIndexNotRemovedBeforeDiscard = Base + 1;
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -140,7 +140,15 @@ public class DeviceAuthorizationStorageTests
         Assert.Equal(LogLevel.Warning, entry.Level);
         Assert.Equal(
             LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedAfterClaim, entry.EventId.Id);
-        Assert.Contains(UserCodeKey, entry.Message);
+
+        // The DEVICE code key, and the user code NOWHERE in the line. TryRemoveAsync never reads the
+        // record, so it cannot establish that the user code it was handed is the spent one - and on the
+        // public interface a host can hand it a live code belonging to another request. Asserting the
+        // absence as well as the presence, because a message that named both would satisfy a check for
+        // the device code alone.
+        Assert.Contains(RequestKey, entry.Message);
+        Assert.DoesNotContain(UserCodeKey, entry.Message);
+        Assert.DoesNotContain(UserCode, entry.Message);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -166,19 +166,18 @@ public class DeviceAuthorizationStorageTests
     }
 
     /// <summary>
-    /// The same behaviour with the failure double OUT of the path: a plain cache, nothing arranged to
-    /// throw, the index removed and the answer still true.
+    /// The success path, and the only row that observes the index entry actually GONE once the claim
+    /// succeeded.
     /// </summary>
     /// <remarks>
-    /// What it does NOT do is hold a property the failing row leaves open, and saying so is the point.
-    /// Measured, not reasoned: a build whose cleanup removes nothing kills both rows, because the failing
-    /// row's own <c>Assert.Single</c> over the log needs a real attempt at the key to produce the
-    /// exception it asserts on; and a build whose success path answers false kills both, because both
-    /// assert the answer. No mutation found so far turns this row red alone.
+    /// Measured rather than argued: guarding the index removal on the index being ABSENT kills this row
+    /// and nothing else in the suite, on the <c>Assert.Null</c> over the user-code key that no other row
+    /// makes.
     /// <para>
-    /// It earns its place as the one row that runs the take-once protocol against an UNDECORATED cache.
-    /// Every other row here reaches the store through <see cref="FailOnRemove"/>, and a double that
-    /// misbehaved would be invisible to a suite that only ever looks through it.
+    /// The failing row cannot cover that, and the reason is structural rather than incidental: it
+    /// observes an ATTEMPT, through a double that throws before anything is deleted. No change to the
+    /// source can stop the deletion without also stopping the attempt, which is why a cleanup removing
+    /// nothing, or a success path answering false, kills both rows rather than one.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -166,9 +166,21 @@ public class DeviceAuthorizationStorageTests
     }
 
     /// <summary>
-    /// The control, in the same shape: with nothing failing, the index is removed and the answer is the
-    /// same. Without it, a method that swallowed everything would satisfy the row above.
+    /// The same behaviour with the failure double OUT of the path: a plain cache, nothing arranged to
+    /// throw, the index removed and the answer still true.
     /// </summary>
+    /// <remarks>
+    /// What it does NOT do is hold a property the failing row leaves open, and saying so is the point.
+    /// Measured, not reasoned: a build whose cleanup removes nothing kills both rows, because the failing
+    /// row's own <c>Assert.Single</c> over the log needs a real attempt at the key to produce the
+    /// exception it asserts on; and a build whose success path answers false kills both, because both
+    /// assert the answer. No mutation found so far turns this row red alone.
+    /// <para>
+    /// It earns its place as the one row that runs the take-once protocol against an UNDECORATED cache.
+    /// Every other row here reaches the store through <see cref="FailOnRemove"/>, and a double that
+    /// misbehaved would be invisible to a suite that only ever looks through it.
+    /// </para>
+    /// </remarks>
     [Fact]
     public async Task TryRemoveAsync_RemovesTheIndex_AndTellsTheCallerItTookTheCode()
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -104,10 +104,12 @@ public class DeviceAuthorizationStorageTests
     /// consumed by this caller, which is the fact the caller asked about.
     /// </summary>
     /// <remarks>
-    /// The removal that matters has already happened when the index cleanup runs, so an exception from it
-    /// leaves the code gone AND the caller unanswered: the token endpoint calls this inside a `when`
-    /// clause, so the fault propagates as a server error instead of a grant error. No tokens are issued
-    /// for a code that can never be presented again, and the end user's approval is lost.
+    /// The removal that matters has already happened when the index cleanup runs, which is what makes the
+    /// catch the whole of the fix. WITHOUT it, an exception from the cleanup would leave the code gone and
+    /// the caller unanswered: the token endpoint calls this inside a `when` clause, so the fault would
+    /// propagate as a server error instead of a grant error - no tokens for a code that can never be
+    /// presented again, and the end user's approval lost with it. This row is what stands between that
+    /// sentence and the present tense; remove the catch and it goes red.
     /// <para>
     /// The entry left behind carries its own expiry, so it goes away unattended; what it still resolves to
     /// is not knowable from the method, which never reads the record. Either way the whole of the damage

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -28,7 +28,8 @@ namespace Abblix.Oidc.Server.UnitTests.Features.DeviceAuthorization;
 /// fixed absolute expiry (RFC 8628 Section 3.2): StoreAsync seeds ExpiresAt, and UpdateAsync applies the
 /// caller-supplied remaining lifetime as the refreshed cache TTL so polling cannot extend the code
 /// indefinitely. And the user-code index cleanup is best-effort on both paths: a store that refuses it is
-/// logged rather than raised, and the claim path's warning names only the key this method can prove spent.
+/// logged rather than raised, and the claim path's MESSAGE names only the key this method can prove spent -
+/// the store's own fault rides beside it and is not bounded by that choice.
 /// </summary>
 public class DeviceAuthorizationStorageTests
 {
@@ -146,7 +147,7 @@ public class DeviceAuthorizationStorageTests
         Assert.Equal(
             LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedAfterClaim, entry.EventId.Id);
 
-        // The DEVICE code key, and the user code NOWHERE in the line. TryRemoveAsync never reads the
+        // The DEVICE code key, and the user code NOWHERE in the MESSAGE. TryRemoveAsync never reads the
         // record, so it cannot establish that the user code it was handed is the spent one - and on the
         // public interface a host can hand it a live code belonging to another request. Asserting the
         // absence as well as the presence, because a message that named both would satisfy a check for
@@ -154,6 +155,14 @@ public class DeviceAuthorizationStorageTests
         Assert.Contains(RequestKey, entry.Message);
         Assert.DoesNotContain(UserCodeKey, entry.Message);
         Assert.DoesNotContain(UserCode, entry.Message);
+
+        // And the RECORD is wider than the message: the store's fault rides the exception channel, which
+        // a sink renders too. The double names the key it failed on the way a real client does, so this
+        // pair says what the method actually bounds - its own text - rather than asserting an absence
+        // over a record only half of which it was ever shown. Without the second assertion the first is
+        // green over a line that does contain the code.
+        Assert.NotNull(entry.Exception);
+        Assert.Contains(UserCodeKey, entry.Exception!.Message);
     }
 
     /// <summary>
@@ -310,7 +319,11 @@ public class DeviceAuthorizationStorageTests
                 return inner.RemoveAsync(key, token);
 
             Attempts++;
-            throw new InvalidOperationException("the store is unavailable");
+
+            // Named the way a real client names it: StackExchange.Redis reports "No connection is
+            // active/available to service this operation: DEL <key>". A double whose fault carries no
+            // key makes every assertion about what a log record does NOT contain pass by construction.
+            throw new InvalidOperationException($"the store is unavailable: DEL {key}");
         }
 
         public Task<byte[]?> GetAsync(string key, CancellationToken token = default)

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -174,10 +174,11 @@ public class DeviceAuthorizationStorageTests
     /// and nothing else in the suite, on the <c>Assert.Null</c> over the user-code key that no other row
     /// makes.
     /// <para>
-    /// The failing row cannot cover that, and the reason is structural rather than incidental: it
-    /// observes an ATTEMPT, through a double that throws before anything is deleted. No change to the
-    /// source can stop the deletion without also stopping the attempt, which is why a cleanup removing
-    /// nothing, or a success path answering false, kills both rows rather than one.
+    /// The failing row does not cover it: under that same mutation it stays GREEN, attempt count and
+    /// all, because it never seeds the user-code key and the guard therefore lets its call through to
+    /// the throwing double. Two other mutations kill both rows - a cleanup that removes nothing, and a
+    /// success path answering false. Which ones do which is measured and written down; why that pattern
+    /// holds in general is not, because the sentence that said so was refuted by the run above it.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -139,7 +139,7 @@ public class DeviceAuthorizationStorageTests
         var entry = Assert.Single(log.Entries);
         Assert.Equal(LogLevel.Warning, entry.Level);
         Assert.Equal(
-            LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemoved, entry.EventId.Id);
+            LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedAfterClaim, entry.EventId.Id);
         Assert.Contains(UserCodeKey, entry.Message);
     }
 
@@ -185,10 +185,13 @@ public class DeviceAuthorizationStorageTests
     /// </summary>
     /// <remarks>
     /// The token endpoint calls this from its expired and denied arms and then answers with a grant
-    /// error, so a store refusing the index write would turn that answer into a server fault. Cheaper
-    /// than the same failure in TryRemoveAsync - nothing has been consumed, so the client's next poll
-    /// gets the same answer - but the same shape, and one arm guarded while the other is not is how a
-    /// class comes back.
+    /// error, so a store refusing the index write would turn that answer into a server fault. Nothing was
+    /// consumed and nobody was told they took anything, which is what makes this the cheaper of the two
+    /// failures - not that the request survives, since it is removed on the very next line.
+    /// <para>
+    /// The order is the other way round from TryRemoveAsync, and that is why the two carry different log
+    /// events: there the request is already gone when the index cleanup runs, here it is not.
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task RemoveAsync_WhenTheIndexCleanupFails_StillRemovesTheRequest()
@@ -208,6 +211,43 @@ public class DeviceAuthorizationStorageTests
         Assert.Null(await failing.GetAsync(RequestKey, TestContext.Current.CancellationToken));
         Assert.Equal(1, failing.Attempts);
         Assert.Single(log.Entries);
+    }
+
+    /// <summary>
+    /// The discard path reports under its OWN event, because what an operator must do differs.
+    /// </summary>
+    /// <remarks>
+    /// Its sibling says the code was claimed and the caller was told it took it. Neither is true
+    /// here - nothing was issued, nobody was told anything, and the request is removed on the next
+    /// line - so borrowing that message would send somebody looking for an issuance that never
+    /// happened. The row asserts the ID rather than the wording, because the id is what a filter is
+    /// built on and what a renumbering would silently break.
+    /// </remarks>
+    [Fact]
+    public async Task RemoveAsync_WhenTheIndexCleanupFails_ReportsUnderTheDiscardEvent()
+    {
+        var failing = new FailOnRemove(RealCache(), UserCodeKey);
+        var log = new RecordingLoggerFactory();
+        var storage = StorageOver(failing, log);
+
+        _serializer
+            .Setup(s => s.Deserialize<DeviceAuthorizationRequest>(It.IsAny<byte[]>()))
+            .Returns(NewRequest(_now.AddMinutes(5)));
+
+        await failing.SetAsync(RequestKey, [1, 2, 3], new(), TestContext.Current.CancellationToken);
+
+        await storage.RemoveAsync(DeviceCode);
+
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(
+            LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemovedBeforeDiscard,
+            entry.EventId.Id);
+        Assert.Contains(UserCodeKey, entry.Message);
+
+        // And it really is the discard path: the request is gone by the time this returns, even
+        // though the log fired while it was still there.
+        Assert.Null(await failing.GetAsync(RequestKey, TestContext.Current.CancellationToken));
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -24,9 +24,11 @@ using Xunit;
 namespace Abblix.Oidc.Server.UnitTests.Features.DeviceAuthorization;
 
 /// <summary>
-/// Verifies that <see cref="DeviceAuthorizationStorage"/> anchors the device_code lifetime to a fixed
-/// absolute expiry (RFC 8628 §3.2): StoreAsync seeds ExpiresAt, and UpdateAsync applies the caller-supplied
-/// remaining lifetime as the refreshed cache TTL so polling cannot extend the code indefinitely.
+/// Covers <see cref="DeviceAuthorizationStorage"/> on two counts. It anchors the device_code lifetime to a
+/// fixed absolute expiry (RFC 8628 Section 3.2): StoreAsync seeds ExpiresAt, and UpdateAsync applies the
+/// caller-supplied remaining lifetime as the refreshed cache TTL so polling cannot extend the code
+/// indefinitely. And the user-code index cleanup is best-effort on both paths: a store that refuses it is
+/// logged rather than raised, and the claim path's warning names only the key this method can prove spent.
 /// </summary>
 public class DeviceAuthorizationStorageTests
 {
@@ -107,8 +109,9 @@ public class DeviceAuthorizationStorageTests
     /// clause, so the fault propagates as a server error instead of a grant error. No tokens are issued
     /// for a code that can never be presented again, and the end user's approval is lost.
     /// <para>
-    /// The entry left behind is harmless on its own - it points at a request key that no longer exists,
-    /// and it carries its own expiry - so the whole of the damage was in the answer.
+    /// The entry left behind carries its own expiry, so it goes away unattended; what it still resolves to
+    /// is not knowable from the method, which never reads the record. Either way the whole of the damage
+    /// was in the answer.
     /// </para>
     /// <para>
     /// Driven against a real cache rather than a mocked one, because what must succeed first is the

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -12,11 +12,11 @@ using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization;
 using Abblix.Oidc.Server.Features.Storages;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
-using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
@@ -96,6 +96,7 @@ public class DeviceAuthorizationStorageTests
         Assert.NotNull(captured);
         Assert.Equal(TimeSpan.FromMinutes(3), captured!.AbsoluteExpirationRelativeToNow);
     }
+
     /// <summary>
     /// A failure to remove the SECONDARY index does not take the caller's answer away. The device code was
     /// consumed by this caller, which is the fact the caller asked about.
@@ -132,8 +133,13 @@ public class DeviceAuthorizationStorageTests
 
         // Swallowed, not hidden. Nothing else records that the index is dangling, so an operator who
         // never sees this line has no way to learn the store refused a write at all.
+        //
+        // The EVENT ID as well as the text: an operator's filter is built on the id, so a renumbering
+        // that broke it would leave a row asserting only on a message green.
         var entry = Assert.Single(log.Entries);
         Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(
+            LogEvents.Device.DeviceAuthorizationStorage.UserCodeIndexNotRemoved, entry.EventId.Id);
         Assert.Contains(UserCodeKey, entry.Message);
     }
 
@@ -171,6 +177,52 @@ public class DeviceAuthorizationStorageTests
         Assert.False(await storage.TryRemoveAsync(DeviceCode, UserCode));
 
         Assert.NotNull(await cache.GetAsync(UserCodeKey, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// The same arm one over: RemoveAsync's index cleanup does not take the caller's outcome away
+    /// either, and its PRIMARY removal still does.
+    /// </summary>
+    /// <remarks>
+    /// The token endpoint calls this from its expired and denied arms and then answers with a grant
+    /// error, so a store refusing the index write would turn that answer into a server fault. Cheaper
+    /// than the same failure in TryRemoveAsync - nothing has been consumed, so the client's next poll
+    /// gets the same answer - but the same shape, and one arm guarded while the other is not is how a
+    /// class comes back.
+    /// </remarks>
+    [Fact]
+    public async Task RemoveAsync_WhenTheIndexCleanupFails_StillRemovesTheRequest()
+    {
+        var failing = new FailOnRemove(RealCache(), UserCodeKey);
+        var log = new RecordingLoggerFactory();
+        var storage = StorageOver(failing, log);
+
+        _serializer
+            .Setup(s => s.Deserialize<DeviceAuthorizationRequest>(It.IsAny<byte[]>()))
+            .Returns(NewRequest(_now.AddMinutes(5)));
+
+        await failing.SetAsync(RequestKey, [1, 2, 3], new(), TestContext.Current.CancellationToken);
+
+        await storage.RemoveAsync(DeviceCode);
+
+        Assert.Null(await failing.GetAsync(RequestKey, TestContext.Current.CancellationToken));
+        Assert.Equal(1, failing.Attempts);
+        Assert.Single(log.Entries);
+    }
+
+    /// <summary>
+    /// And the PRIMARY removal is not swallowed: a caller told nothing would believe the request is
+    /// gone when it is still there.
+    /// </summary>
+    [Fact]
+    public async Task RemoveAsync_WhenThePrimaryRemovalFails_Raises()
+    {
+        var failing = new FailOnRemove(RealCache(), RequestKey);
+        var storage = StorageOver(failing);
+
+        await failing.SetAsync(RequestKey, [1, 2, 3], new(), TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => storage.RemoveAsync(DeviceCode));
     }
 
     private static IDistributedCache RealCache()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/DeviceAuthorizationStorageTests.cs
@@ -13,6 +13,10 @@ using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.DeviceAuthorization;
 using Abblix.Oidc.Server.Features.Storages;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
@@ -46,6 +50,7 @@ public class DeviceAuthorizationStorageTests
         _serializer.Setup(s => s.Serialize(It.IsAny<string>())).Returns([4, 5, 6]);
 
         _storage = new DeviceAuthorizationStorage(
+            new RecordingLoggerFactory().CreateLogger<DeviceAuthorizationStorage>(),
             _cache.Object,
             _serializer.Object,
             keyFactory.Object,
@@ -90,5 +95,136 @@ public class DeviceAuthorizationStorageTests
 
         Assert.NotNull(captured);
         Assert.Equal(TimeSpan.FromMinutes(3), captured!.AbsoluteExpirationRelativeToNow);
+    }
+    /// <summary>
+    /// A failure to remove the SECONDARY index does not take the caller's answer away. The device code was
+    /// consumed by this caller, which is the fact the caller asked about.
+    /// </summary>
+    /// <remarks>
+    /// The removal that matters has already happened when the index cleanup runs, so an exception from it
+    /// leaves the code gone AND the caller unanswered: the token endpoint calls this inside a `when`
+    /// clause, so the fault propagates as a server error instead of a grant error. No tokens are issued
+    /// for a code that can never be presented again, and the end user's approval is lost.
+    /// <para>
+    /// The entry left behind is harmless on its own - it points at a request key that no longer exists,
+    /// and it carries its own expiry - so the whole of the damage was in the answer.
+    /// </para>
+    /// <para>
+    /// Driven against a real cache rather than a mocked one, because what must succeed first is the
+    /// take-once protocol itself: several store calls whose interleaving is the thing under test one layer
+    /// down. A mock arranged to return true would assert against a protocol that never ran.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task TryRemoveAsync_WhenTheIndexCleanupFails_StillTellsTheCallerItTookTheCode()
+    {
+        var failing = new FailOnRemove(RealCache(), UserCodeKey);
+        var log = new RecordingLoggerFactory();
+        var storage = StorageOver(failing, log);
+
+        await failing.SetAsync(RequestKey, [1, 2, 3], new(), TestContext.Current.CancellationToken);
+
+        Assert.True(await storage.TryRemoveAsync(DeviceCode, UserCode));
+
+        // And the code really is gone, which is what makes the answer true rather than merely reassuring.
+        Assert.Null(await failing.GetAsync(RequestKey, TestContext.Current.CancellationToken));
+        Assert.Equal(1, failing.Attempts);
+
+        // Swallowed, not hidden. Nothing else records that the index is dangling, so an operator who
+        // never sees this line has no way to learn the store refused a write at all.
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains(UserCodeKey, entry.Message);
+    }
+
+    /// <summary>
+    /// The control, in the same shape: with nothing failing, the index is removed and the answer is the
+    /// same. Without it, a method that swallowed everything would satisfy the row above.
+    /// </summary>
+    [Fact]
+    public async Task TryRemoveAsync_RemovesTheIndex_AndTellsTheCallerItTookTheCode()
+    {
+        var cache = RealCache();
+        var storage = StorageOver(cache);
+
+        await cache.SetAsync(RequestKey, [1, 2, 3], new(), TestContext.Current.CancellationToken);
+        await cache.SetAsync(UserCodeKey, [4, 5, 6], new(), TestContext.Current.CancellationToken);
+
+        Assert.True(await storage.TryRemoveAsync(DeviceCode, UserCode));
+
+        Assert.Null(await cache.GetAsync(RequestKey, TestContext.Current.CancellationToken));
+        Assert.Null(await cache.GetAsync(UserCodeKey, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// The other control: a code that was NOT taken is answered false, and the index is left alone - the
+    /// caller did not consume anything, so tidying after somebody else is not this call's business.
+    /// </summary>
+    [Fact]
+    public async Task TryRemoveAsync_WhenTheCodeIsGone_LeavesTheIndexAlone()
+    {
+        var cache = RealCache();
+        var storage = StorageOver(cache);
+
+        await cache.SetAsync(UserCodeKey, [4, 5, 6], new(), TestContext.Current.CancellationToken);
+
+        Assert.False(await storage.TryRemoveAsync(DeviceCode, UserCode));
+
+        Assert.NotNull(await cache.GetAsync(UserCodeKey, TestContext.Current.CancellationToken));
+    }
+
+    private static IDistributedCache RealCache()
+        => new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+    private DeviceAuthorizationStorage StorageOver(
+        IDistributedCache cache, RecordingLoggerFactory? log = null)
+    {
+        var keyFactory = new Mock<IEntityStorageKeyFactory>(MockBehavior.Loose);
+        keyFactory.Setup(f => f.DeviceAuthorizationRequestKey(DeviceCode)).Returns(RequestKey);
+        keyFactory.Setup(f => f.DeviceAuthorizationUserCodeKey(UserCode)).Returns(UserCodeKey);
+
+        return new DeviceAuthorizationStorage(
+            (log ?? new RecordingLoggerFactory()).CreateLogger<DeviceAuthorizationStorage>(),
+            cache,
+            _serializer.Object,
+            keyFactory.Object,
+            new FakeTimeProvider(_now));
+    }
+
+    /// <summary>
+    /// A cache that fails one key's removal and passes everything else through, so the row above measures
+    /// the composition rather than a mocked answer.
+    /// </summary>
+    private sealed class FailOnRemove(IDistributedCache inner, string failingKey) : IDistributedCache
+    {
+        public int Attempts { get; private set; }
+
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            if (key != failingKey)
+                return inner.RemoveAsync(key, token);
+
+            Attempts++;
+            throw new InvalidOperationException("the store is unavailable");
+        }
+
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+            => inner.GetAsync(key, token);
+
+        public Task SetAsync(
+            string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+            => inner.SetAsync(key, value, options, token);
+
+        public Task RefreshAsync(string key, CancellationToken token = default)
+            => inner.RefreshAsync(key, token);
+
+        public byte[]? Get(string key) => inner.Get(key);
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+            => inner.Set(key, value, options);
+
+        public void Remove(string key) => inner.Remove(key);
+
+        public void Refresh(string key) => inner.Refresh(key);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(150, EventIds().Count);
+        Assert.Equal(151, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(149, EventIds().Count);
+        Assert.Equal(150, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/RecordingLoggerFactory.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/RecordingLoggerFactory.cs
@@ -13,7 +13,13 @@ using Microsoft.Extensions.Logging;
 namespace Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 
 /// <summary>What a single log write carried.</summary>
-internal sealed record LogRecord(LogLevel Level, EventId EventId, string Message);
+/// <remarks>
+/// The EXCEPTION is kept as well as the formatted message, because they are two channels and a sink
+/// renders both. A recorder that kept only the message made every assertion about what a log line does
+/// NOT contain blind to whatever the exception carried - and a store's own fault routinely quotes the
+/// key it failed on.
+/// </remarks>
+internal sealed record LogRecord(LogLevel Level, EventId EventId, string Message, Exception? Exception = null);
 
 /// <summary>
 /// A factory whose loggers keep what was written, so a test can assert on the record itself.
@@ -50,6 +56,6 @@ internal sealed class RecordingLoggerFactory : ILoggerFactory
             TState state,
             Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => entries.Add(new LogRecord(logLevel, eventId, formatter(state, exception)));
+            => entries.Add(new LogRecord(logLevel, eventId, formatter(state, exception), exception));
     }
 }


### PR DESCRIPTION
Closes #453.

## What the caller lost

`DeviceAuthorizationStorage.TryRemoveAsync` consumed the device code, then removed the user-code index in a second store call. A failure of that second call took the answer away, not just the tidiness: the code was already gone, and `DeviceCodeGrantHandler` invokes this inside a `when` clause, so the exception propagated as a server fault rather than a grant error. No tokens were issued, and the code could not be presented again because it no longer existed. The end user's approval was lost with no recovery short of restarting the flow.

## The question the caller asked

Whether it took the device code. That was already settled when the cleanup ran, so the cleanup is now best-effort and the answer stands.

The entry left behind carries its own expiry, which is what makes this the right side of the trade. What it still resolves to is deliberately not claimed anywhere: this method never reads the record, so the user code it was handed need not belong to the request it removed.

## The same arm one over

`RemoveAsync` carried the identical unguarded cleanup, and the token endpoint calls it from its expired and denied arms before answering with a grant error - so a store refusing that write turned the answer into a server fault there too. Its index cleanup is guarded now; its PRIMARY removal is not, because removing the request is the whole of what that method is for and reporting otherwise would leave a live record behind a call that looked like it worked.

The two arms are not the same shape, and the difference is the order: the claim removes the request first, the discard removes it last. That is why they carry different log events.

## The direction not taken

Removing the index FIRST would make the fault retryable, because a failure would leave the device code intact. It opens a window in which the user code resolves to nothing while the device code is still live - and that window is on the path that succeeds rather than on the path that fails. Between a leftover that points nowhere and a live code the user cannot verify, the leftover is the cheaper wrong state.

An earlier revision of this text also claimed the reorder costs a store round trip. It does not: the same two operations run either way, and the user code is a parameter rather than something that would have to be read. The window is the whole argument.

## Swallowed, not hidden

Nothing else in the system reports a dangling index, so a caught exception with no log would make the decision to continue indistinguishable from a store that never refused. Each warning names a storage key. On the DISCARD path that is the user-code key, which an operator can search for or delete; it embeds the code verbatim because the factory builds it by interpolation, which is acceptable there because that path reads the code out of the stored record anyway. On the CLAIM path it is the DEVICE code key, and the dangling entry is deliberately not named - the action that line asks for is never "delete that key", since the entry lapses on its own, for the reason round 3 sets out below.

Two events, not one. The two cleanup sites say different things to whoever reads them: after a CLAIM the code is consumed, its caller was told so and the request is already gone; on a DISCARD nothing was issued, nobody was told anything, and the request is removed on the next line. One message serving both was false in all three of those clauses at the second site, and would send an operator looking for an issuance that never happened.

That also settles the disclosure question per site. The claim path can say the code is dead. The discard path cannot say it in general, because the method is on the public interface and a host calling it with a live record logs a live code.

The class gains a logger and its `.Logging.cs` partial, matching how every other component here reports. It is resolved from the container (`TryAddSingleton<IDeviceAuthorizationStorage, DeviceAuthorizationStorage>`), so a host that does not construct it by hand is unaffected.

## Evidence

Rows for both methods and both events, driven against a real `MemoryDistributedCache` behind a decorator that fails one key's removal - not a mocked storage, because what must succeed first is the take-once protocol itself, several store calls whose interleaving is the subject one layer down. A mock arranged to return true would assert against a protocol that never ran.

The failing row is red with the `catch` removed and the two controls stay green, so the trio measures the change rather than the arrangement. Each control is pinned by a mutation that reaches it, and the two claims are not equally narrow. The success-path row is killed by guarding the index removal on the index being ABSENT - that mutation is confined to `DeviceAuthorizationStorage.cs` and kills this row alone in the Oidc.Server unit suite, which it catches on the `Assert.Null` over the user-code key that no other row makes. The took-nothing row is killed by deleting the protocol's own existence check, and that is NOT unique: the check lives in `Abblix.Utils`, so the same mutation also turns nine rows red in `Abblix.Utils.UnitTests`, including the two named for it. What this row holds is the narrower property that a refused claim leaves the index alone; the existence check itself is covered where its code lives. Two other mutations - a cleanup that removes nothing, and a success path answering false - kill both rows rather than one.

The `<returns>` block that described the old behaviour moved with it, and the log-event count ratchet moves by TWO, because the change adds two events - which is its own headline. The absolute figures are deliberately not given: they have moved twice already with merges of the base, and a stale count reads exactly like a current one.

**Round 3.** The claim-path warning named the user-code key, and that key embeds the code verbatim. The argument for writing it in full held for the one shipped caller and not for the method: `TryRemoveAsync` takes the user code as a PARAMETER, never reads the record, and sits on the public storage interface, so nothing establishes the two belong together and a host could have a live code written into a warning while it is still redeemable. The asymmetry was inverted - the path that reads the code out of storage carried the caveat, the path that can establish nothing carried the blanket clearance. It names the device code key now, which the line is reached only because the claim removed, and the row asserts the user code is ABSENT as well as the device code present. Two statements went with it: the discard message predicted the unguarded removal would fail too and hide this line, which is the opposite of what the guard above it exists for and of what a green row already asserts; and a pronoun whose referent had moved now names its subject. The parameter documentation states what nothing checks.

**Round 4.** The claim-path warning asserted what the entry it failed to remove now points at, in the same sentence that says the method cannot establish whose the user code is - and in the mismatched case, the one round 3 exists for, that entry points at a LIVE request. The claim stood at four sites, one more than a review found: the fourth was located by searching for the CLAIM across `src` and `tests` rather than for the sentence. All four now state what is known and stop there. Separately, "every entry point refuses a record that is not pending and unexpired" - the argument for logging the user code in full on the discard path - is false against `VerifyAsync`, which reads the status alone; the conclusion survives because `ApproveAsync` refuses an expired record, but the mechanism named was not the one doing the work. Filed as its own issue.

**Round 5.** The remarks over the row proving a failed cleanup no longer costs the caller its answer stated that defect in the PRESENT tense, under a summary saying the opposite - so the test read as evidence the defect was live. It is a counterfactual now, naming the row that holds it up, and measured: a rethrow after the log turns exactly one row red, this one. And this description carried two sentences the branch had already retracted from the code, both corrected above. One further enumeration short by one: the expiry refusal was credited to `ApproveAsync` alone, while `DenyAsync` carries the identical check that the surrounding conclusion depends on.

**Round 6.** The whole argument for naming the device-code key bounds this METHOD'S MESSAGE, not the log record: the store's own fault travels beside it on the exception channel, and a Redis client refuses with `No connection is active/available to service this operation: DEL <key>` - the user-code key verbatim, rendered by the stock console sink directly under the sentence saying the entry is not named here. The suite could not see it, because the recorder kept only the formatted message and the test double's fault was constructed to carry no key: a double collapsing the distinction it existed to measure. Both halves fixed - the recorder keeps the exception, the double names the key it failed on the way a real client does, and the row asserts our message is clean AND that the store's fault is not. Restoring the keyless fault turns that row red. The exception is still passed through deliberately, and the comments now say why rather than claiming a bound the code does not deliver.

**Round 7.** The success-path control carried a reason that was false, measured: a build whose cleanup removes nothing kills both rows, because the failing row's own `Assert.Single` over the log needs a real attempt at the key to produce the exception it asserts on. The review's proposed replacement - that a success path answering false kills this row alone - is also false by the same method, since both rows assert the answer. Neither reason is written. The remark now states what the row does hold (the only run against an undecorated cache) and says outright that no mutation found so far turns it red alone.

**Round 8.** The round-7 replacement was false too, and this is the third round on one sentence. "The one row that runs the take-once protocol against an UNDECORATED cache" is wrong - the code-is-gone row eighteen lines below does as well, and a mutation to the protocol's own existence check reaches THAT one in this suite. (Round 10: "alone" was wrong even so - the same mutation kills nine rows in `Abblix.Utils.UnitTests`. The search was run for the row a reviewer pointed at and not for its twin in the same sentence.) "Every other row here reaches the store through the failure double" is wrong - the first two use a mock. And "no mutation found so far turns this row red alone" was an unrun search wearing the clothes of honesty: guarding the index removal on the index being ABSENT kills this row alone in the Oidc.Server unit suite.

So the row does hold a unique property and it is now named positively: it is the only one observing the index entry actually GONE once the claim succeeded. With it, the structural reason the failing row cannot cover that - it observes an ATTEMPT, through a double that throws before anything is deleted, so nothing can stop the deletion without also stopping the attempt.

**Round 9.** Round 8 measured which mutation kills which row and then wrote a universal to explain the pattern - "no change to the source can stop the deletion without also stopping the attempt" - which the mutation quoted three lines above refutes: under it the success row goes red and the failing row stays green, attempt count intact, because that row never seeds the user-code key. The run had said so on screen, one row red rather than two. Worse than false, it argued against the row it supported: if it held, the failing row would catch every deletion-losing change and this one would be redundant. What is left is what was run.

## One file in the diff the text above does not account for

`.github/scripts/lint-take-once-consumers.py` gains one name. That script refuses an unreviewed consumer
of the take-once protocol, and its own contract says adding a name to its list is the moment to re-read
what the list holds - so the line is part of the change rather than bookkeeping. Removing it makes the
check refuse this branch by name, which is how the addition was shown to be required rather than
decorative.
