### PR TITLE
Upload test results only when the run is red

### DIFF
--- a/.github/workflows/test-shards.yml
+++ b/.github/workflows/test-shards.yml
@@ -88,13 +88,16 @@ jobs:
             --coverage-settings tests/code-coverage.settings.xml \
             --results-directory ./tests/results
         timeout-minutes: 5
+      # A RED run only. Nobody opens these after a green one, and the storage they take is shared
+      # across the account: six of them per run, a hundred in three hours, all younger than the
+      # retention window - so the window cannot help, because there is nothing old to expire.
       - name: Upload test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ matrix.project }}
           path: |
             tests/results/*.trx
             tests/results/**/*.cobertura.xml
-          retention-days: 7
+          retention-days: 3
         timeout-minutes: 3


### PR DESCRIPTION
Nobody opens them after a green run, and the storage they take is shared across the account.

Measured before the cleanup: 4177 live artifacts at 830 MB here, six per run and a hundred in three hours. Against a 500 MB allowance the upload step began failing every run in every repository with `Artifact storage quota has been hit`.

The retention window cannot help: `retention-days: 7` was already set, and only three live artifacts were older than seven days. The overflow happens inside the window, so it is fixed by producing less rather than by deleting more.

Nothing downstream consumes them - the release workflow downloads `nuget-packages`. The window drops to three days, which is how long anybody looks at a failed run.

Checked: Failure semantics, Pinning, Inputs, Timeouts. N/A: Permissions, Secrets, Concurrency.