### PR TITLE
Attribute the TLS clause to the section that carries it

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -14,7 +14,7 @@ using Abblix.Utils;
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 
 /// <summary>
-/// Validates CIBA-related metadata (OpenID Connect Client-Initiated Backchannel Authentication 1.0, section 4):
+/// Validates CIBA-related metadata (OpenID Connect Client-Initiated Backchannel Authentication 1.0, Section 4):
 /// the consistency between <c>backchannel_token_delivery_mode</c> and
 /// <c>backchannel_client_notification_endpoint</c>, and that
 /// <c>backchannel_authentication_request_signing_alg</c> is on the server's supported list.
@@ -68,16 +68,20 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
                     "The specified token delivery mode is not supported");
         }
 
-        // CIBA Core 1.0 section 4, describing backchannel_client_notification_endpoint as registration
-        // metadata: "It MUST be an HTTPS URL." That is the whole of what section 4 says about it, and it
-        // is also the whole of what is checkable at registration - the registered value is all there is
-        // here.
+        // CIBA Core 1.0 Section 4, describing backchannel_client_notification_endpoint as registration
+        // metadata: "It MUST be an HTTPS URL." That is the clause this line enforces, and Section 4 is
+        // where it is written for a registration request.
         //
-        // The TLS half belongs to section 9, which restates the HTTPS rule and adds "Communication with
-        // the Client Notification Endpoint MUST utilize TLS". PingModeValidator and PushModeValidator
-        // quote section 9 because they run when the endpoint is about to be called; this runs when it is
-        // being registered, and nothing has called anything yet. Attributing the TLS clause to section 4
-        // sends a reader to a section that does not contain it.
+        // The TLS half is NOT in Section 4. It is Section 9, which restates the HTTPS rule and adds
+        // "Communication with the Client Notification Endpoint MUST utilize TLS" - a property of the
+        // transport a host establishes when it calls the endpoint, so nothing about the registered value
+        // can decide it. PingModeValidator and PushModeValidator quote Section 9 and say the same of it.
+        //
+        // Section 4 says more about this parameter than the one clause, and the rest is not implemented
+        // here: under pairwise subject types it requires the endpoint to be listed in the document a
+        // sector_identifier_uri points at. SubjectTypeValidator, in this same pipeline, already fetches
+        // that document for redirect_uris and does not check this one - a gap rather than a decision,
+        // tracked as issue 480.
         //
         // Only ping/push reach here with an endpoint set - poll-with-endpoint and the missing-endpoint
         // cases are already rejected above.

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -77,14 +77,21 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
         // transport a host establishes when it calls the endpoint, so nothing about the registered value
         // can decide it. PingModeValidator and PushModeValidator quote Section 9 and say the same of it.
         //
-        // Section 4 says more about this parameter than the one clause, and the rest is not implemented
-        // here: under pairwise subject types it requires the endpoint to be listed in the document a
-        // sector_identifier_uri points at. SubjectTypeValidator, in this same pipeline, already fetches
-        // that document for redirect_uris and does not check this one - a gap rather than a decision,
-        // tracked as issue 480.
+        // Section 4 carries two further rules about this parameter, and both belong to PUSH mode under
+        // pairwise subject types: the endpoint "is used in place of the redirect_uri" as the sector
+        // identifier, and where a sector_identifier_uri is registered the endpoint "must be included in
+        // the list of URIs pointed to by" it. Poll and ping put the jwks_uri in both of those roles
+        // instead, so neither rule reaches a ping registration - which is why they cannot be enforced
+        // beside the HTTPS check, whose arm covers ping and push alike. Neither is implemented anywhere:
+        // SubjectTypeValidator, in this same pipeline, fetches the sector document for redirect_uris
+        // alone. That is a gap rather than a decision, tracked as issue 480.
         //
-        // Only ping/push reach here with an endpoint set - poll-with-endpoint and the missing-endpoint
-        // cases are already rejected above.
+        // The remaining Section 4 rule for this parameter, "REQUIRED if the token delivery mode is set
+        // to ping or push", IS implemented - by the switch above, in the words of the refusal it returns.
+        //
+        // A poll request carrying NO endpoint reaches this line: the switch rejects poll WITH one and
+        // ping or push WITHOUT one, which leaves poll-with-nothing to fall through. That is what the null
+        // check below is for.
         var notificationEndpoint = context.Request.BackChannelClientNotificationEndpoint;
         if (notificationEndpoint != null && notificationEndpoint.Scheme != Uri.UriSchemeHttps)
         {

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -14,7 +14,7 @@ using Abblix.Utils;
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 
 /// <summary>
-/// Validates CIBA-related metadata (OpenID Connect Client-Initiated Backchannel Authentication 1.0 §4):
+/// Validates CIBA-related metadata (OpenID Connect Client-Initiated Backchannel Authentication 1.0, section 4):
 /// the consistency between <c>backchannel_token_delivery_mode</c> and
 /// <c>backchannel_client_notification_endpoint</c>, and that
 /// <c>backchannel_authentication_request_signing_alg</c> is on the server's supported list.
@@ -68,9 +68,19 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
                     "The specified token delivery mode is not supported");
         }
 
-        // CIBA Core 1.0 §4: the notification endpoint MUST be an HTTPS URL (communication with it
-        // MUST use TLS). Only ping/push reach here with an endpoint set - poll-with-endpoint and the
-        // missing-endpoint cases are already rejected above.
+        // CIBA Core 1.0 section 4, describing backchannel_client_notification_endpoint as registration
+        // metadata: "It MUST be an HTTPS URL." That is the whole of what section 4 says about it, and it
+        // is also the whole of what is checkable at registration - the registered value is all there is
+        // here.
+        //
+        // The TLS half belongs to section 9, which restates the HTTPS rule and adds "Communication with
+        // the Client Notification Endpoint MUST utilize TLS". PingModeValidator and PushModeValidator
+        // quote section 9 because they run when the endpoint is about to be called; this runs when it is
+        // being registered, and nothing has called anything yet. Attributing the TLS clause to section 4
+        // sends a reader to a section that does not contain it.
+        //
+        // Only ping/push reach here with an endpoint set - poll-with-endpoint and the missing-endpoint
+        // cases are already rejected above.
         var notificationEndpoint = context.Request.BackChannelClientNotificationEndpoint;
         if (notificationEndpoint != null && notificationEndpoint.Scheme != Uri.UriSchemeHttps)
         {

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
@@ -123,7 +123,7 @@ public class BackChannelAuthenticationValidatorTests
 
     /// <summary>
     /// Verifies validation succeeds with ping mode and a notification endpoint.
-    /// Per CIBA Core 1.0 section 4, backchannel_client_notification_endpoint is "REQUIRED if the token
+    /// Per CIBA Core 1.0 Section 4, backchannel_client_notification_endpoint is "REQUIRED if the token
     /// delivery mode is set to ping or push".
     /// </summary>
     [Fact]
@@ -143,8 +143,8 @@ public class BackChannelAuthenticationValidatorTests
 
     /// <summary>
     /// Verifies error when the notification endpoint is not an HTTPS URL.
-    /// CIBA Core 1.0 section 4, on the registration metadata: "It MUST be an HTTPS URL." The TLS clause
-    /// that usually travels with it is section 9 and is not a property of the registered value, so
+    /// CIBA Core 1.0 Section 4, on the registration metadata: "It MUST be an HTTPS URL." The TLS clause
+    /// that usually travels with it is Section 9 and is not a property of the registered value, so
     /// nothing here can check it.
     /// </summary>
     [Theory]
@@ -185,7 +185,7 @@ public class BackChannelAuthenticationValidatorTests
 
     /// <summary>
     /// Verifies validation succeeds with push mode and a notification endpoint.
-    /// Per CIBA Core 1.0 section 4, backchannel_client_notification_endpoint is "REQUIRED if the token
+    /// Per CIBA Core 1.0 Section 4, backchannel_client_notification_endpoint is "REQUIRED if the token
     /// delivery mode is set to ping or push".
     /// </summary>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidatorTests.cs
@@ -123,7 +123,8 @@ public class BackChannelAuthenticationValidatorTests
 
     /// <summary>
     /// Verifies validation succeeds with ping mode and a notification endpoint.
-    /// Per OIDC CIBA §4, ping mode is a valid delivery mode and requires the endpoint.
+    /// Per CIBA Core 1.0 section 4, backchannel_client_notification_endpoint is "REQUIRED if the token
+    /// delivery mode is set to ping or push".
     /// </summary>
     [Fact]
     public async Task ValidateAsync_PingModeWithEndpoint_ShouldReturnNull()
@@ -142,7 +143,9 @@ public class BackChannelAuthenticationValidatorTests
 
     /// <summary>
     /// Verifies error when the notification endpoint is not an HTTPS URL.
-    /// CIBA Core 1.0 §4 states it MUST be an HTTPS URL and communication MUST use TLS.
+    /// CIBA Core 1.0 section 4, on the registration metadata: "It MUST be an HTTPS URL." The TLS clause
+    /// that usually travels with it is section 9 and is not a property of the registered value, so
+    /// nothing here can check it.
     /// </summary>
     [Theory]
     [InlineData(BackchannelTokenDeliveryModes.Ping)]
@@ -182,7 +185,8 @@ public class BackChannelAuthenticationValidatorTests
 
     /// <summary>
     /// Verifies validation succeeds with push mode and a notification endpoint.
-    /// Per OIDC CIBA §4, push mode is a valid delivery mode and requires the endpoint.
+    /// Per CIBA Core 1.0 section 4, backchannel_client_notification_endpoint is "REQUIRED if the token
+    /// delivery mode is set to ping or push".
     /// </summary>
     [Fact]
     public async Task ValidateAsync_PushModeWithEndpoint_ShouldReturnNull()


### PR DESCRIPTION
Closes #450.

## What was wrong

`BackChannelAuthenticationValidator` attributed both halves of the client notification endpoint rule to CIBA Core 1.0 section 4:

> CIBA Core 1.0 §4: the notification endpoint MUST be an HTTPS URL (communication with it MUST use TLS).

Section 4 carries the first half only.

## Read from the document, not recalled

Retrieved the specification and located every occurrence of both clauses with its enclosing heading:

| clause | occurrences | sections |
|---|---|---|
| `MUST be an HTTPS URL` | 2 | 4 (Registration and Discovery Metadata), 9 (Client Notification Endpoint) |
| `MUST utilize TLS` | 2 | 7 (Backchannel Authentication Endpoint), 9 (Client Notification Endpoint) |
| `MUST use TLS` | 0 | - |

The form the comment used does not appear in the document at all.

## Why Section 4 stays here

The issue proposed matching the two siblings, which quote Section 9. Section 4 is where the clause this validator enforces is written for a registration request: "It MUST be an HTTPS URL", in the description of `backchannel_client_notification_endpoint` as client metadata. Both sections carry that sentence verbatim, so neither citation is a citation error; Section 4 is the better home for the validator that runs on the registration request, because it is also where the ping/push conditionality the other branches of this same method enforce is written.

Section 9 is named for the TLS half, which is a property of the transport the host establishes when it calls the endpoint and therefore not decidable from the registered value at all. That is the same reason the two siblings give in their own comments.

## Also in these two files

Two test comments cited section 4 for the delivery mode. Those were already right - "REQUIRED if the token delivery mode is set to ping or push" is section 4's own sentence - and now quote it instead of paraphrasing.

Five section signs become the word, per the workspace punctuation rule, on contact.

## No detector here, and the corrected reason

This is the third instance of the class - #416 ruled it for `PingModeValidator`, #434 for `PushModeValidator`, this one for the third of the three - so a detector is owed.

An earlier revision of this description argued that no regex could tell a right citation from a wrong one. That is true of the instrument it tried, a keyword sweep, which flags the corrected sentence in this very diff - and false in general. A review built two checks that work and measured both: a presence-anchored rule requiring every normative citation to QUOTE, which needs no copy of the document and fires on `origin/develop` at the exact line this PR corrects; and a quote-anchored rule checking each quoted fragment against the cited heading in the document itself, which returns zero here and fires on a planted wrong section number.

The second is the stronger check and needs the specification TEXT at check time - a vendored document per specification, or a network fetch inside a lint job. That is a decision rather than a detail, so it is #481 with both designs and their measurements, not a paragraph in this change.

The hand sweep still ran, over all 1887 tracked text files with a control that fired three times: one hit, the known false positive. No other site in the repository attributes the TLS clause to a section that does not carry it.

## Evidence

All 39 changed lines are comments - measured, not asserted: a diff walk classifying every added and removed line found zero non-comment lines, against a control over a code change that found 113. `dotnet build` clean on both projects, `0 Warning(s), 0 Error(s)`. Unit suite 2904, nothing failing, nothing skipped, nothing left unrun.

**Round 1.** Two sentences added with the fix were written from intent and are gone. "That is the whole of what Section 4 says about it" is false - Section 4 also puts the endpoint in place of the redirect_uri in push mode and requires it to be in the sector identifier document under pairwise identifiers, which is a registration-time rule this pipeline does not implement and which `SubjectTypeValidator` beside it already performs for `redirect_uris` alone. Filed as #480, and the comment now points there instead of telling the next reader there is nothing more to find. And "the siblings quote Section 9 because they run when the endpoint is about to be called" is false: both are registered as `IBackChannelAuthenticationContextValidator`, run in the backchannel authentication request pipeline, and read the same registered value this one reads. That sentence was the entire argument for departing from the issue; the real reason is the one the siblings themselves give.

**Round 2.** Three more sentences, all in the paragraph round 1 rewrote, and the specification contradicts each one. The pairwise rule was cited without its mode: Section 4 states it under "Push Mode with Pairwise Identifiers", and poll and ping put the `jwks_uri` in both of the roles it names, so over a check whose arm covers ping and push the sentence claimed a refusal the document does not ask for. "The rest is not implemented here" was false, because the delivery-mode clause of the same section is implemented twenty lines above in the words of its own refusal. And "only ping/push reach here with an endpoint set" was false, which made the null check below it read as dead code: poll carrying no endpoint falls through the switch, and that is the case the check exists for.
