### PR TITLE
Make the CIBA completion sample compile against the shipped API

### DIFF
--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelLongPollingService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelLongPollingService.cs
@@ -40,7 +40,7 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 /// var statusChange = await longPollingSignaler.WaitForStatusChangeAsync(authReqId, timeout, cancellationToken);
 ///
 /// // 3. Meanwhile: User authenticates on device
-/// // 4. BackChannelDeliveryModeRouter signals change
+/// // 4. AuthenticationCompletionRouter signals change
 /// await longPollingSignaler.NotifyStatusChangeAsync(authReqId, BackChannelAuthenticationStatus.Authenticated);
 ///
 /// // 5. Waiting request wakes up, checks storage, returns tokens

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelLongPollingService.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IBackChannelLongPollingService.cs
@@ -40,7 +40,8 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 /// var statusChange = await longPollingSignaler.WaitForStatusChangeAsync(authReqId, timeout, cancellationToken);
 ///
 /// // 3. Meanwhile: User authenticates on device
-/// // 4. AuthenticationCompletionRouter signals change
+/// // 4. PollModeCompletionHandler signals the change - and only it: ping and push never call
+/// //    NotifyStatusChangeAsync, and poll skips it when no notifier is registered
 /// await longPollingSignaler.NotifyStatusChangeAsync(authReqId, BackChannelAuthenticationStatus.Authenticated);
 ///
 /// // 5. Waiting request wakes up, checks storage, returns tokens

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -35,8 +35,8 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 /// <code>
 /// public class MyUserDeviceAuthenticationHandler : IUserDeviceAuthenticationHandler
 /// {
-///     private readonly IBackChannelAuthenticationStorage _storage;
-///     private readonly IBackChannelDeliveryModeRouter _notifier;
+///     private readonly IBackChannelRequestStorage _storage;
+///     private readonly IAuthenticationCompletionHandler _completion;
 ///     private readonly ISessionIdGenerator _sessionIdGenerator;
 ///     private readonly IMyPushNotificationService _pushService;
 ///
@@ -65,19 +65,24 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///         // Create authenticated session
 ///         var authSession = new AuthSession(
 ///             userId,
-///             sessionId: _sessionIdGenerator.GenerateSessionId(),
-///             authenticationTime: DateTimeOffset.UtcNow,
-///             identityProvider: "local");
+///             SessionId: _sessionIdGenerator.GenerateSessionId(),
+///             AuthenticationTime: DateTimeOffset.UtcNow,
+///             IdentityProvider: "local");
 ///
-///         // Update request with authenticated status
-///         storedRequest.Status = BackChannelAuthenticationStatus.Authenticated;
-///         storedRequest.AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context);
+///         // AuthorizedGrant is a positional member of the record, so it is init-only: a `with`
+///         // expression is how it is replaced. The copy carries the mutable members - Status,
+///         // NextPollAt, the notification endpoint and token - so nothing has to be restated.
+///         var authenticated = storedRequest with
+///         {
+///             AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context),
+///         };
 ///
-///         // Notify completion - automatically selects and delegates to the appropriate
-///         // mode-specific notifier (PollModeNotifier, PingModeNotifier, or PushModeNotifier)
-///         await _notifier.NotifyAuthenticationCompleteAsync(
+///         // Completion selects the mode-specific handler from the client's registered delivery mode
+///         // (PollModeCompletionHandler, PingModeCompletionHandler or PushModeCompletionHandler) and
+///         // marks the request authenticated itself - the caller does not set the status.
+///         await _completion.CompleteAsync(
 ///             authReqId,
-///             storedRequest,
+///             authenticated,
 ///             TimeSpan.FromMinutes(5));
 ///     }
 ///


### PR DESCRIPTION
Ref #436.

## Why this sample matters more than most

Nothing in the library calls `IAuthenticationCompletionHandler.CompleteAsync`. The integrator supplies the device interaction and then drives the completion, so there is no working call site anywhere in the source for a reader to copy instead - the `<remarks>` sample on `IUserDeviceAuthenticationHandler` is the whole documentation of that step, and it did not compile.

## Eight defects

**Six names, each appearing exactly once in the repository - inside this sample:**

| in the sample | shipped |
|---|---|
| `IBackChannelAuthenticationStorage` | `IBackChannelRequestStorage` |
| `IBackChannelDeliveryModeRouter` | `IAuthenticationCompletionHandler` |
| `NotifyAuthenticationCompleteAsync` | `CompleteAsync` |
| `PollModeNotifier`, `PingModeNotifier`, `PushModeNotifier` | `PollModeCompletionHandler`, `PingModeCompletionHandler`, `PushModeCompletionHandler` |

The last three are spelled correctly in `IAuthenticationCompletionHandler.cs`, in the `<remarks>` on `CompleteAsync` - a sibling file, not this one. Two files disagreed; a reader looking further down this file would have found nothing.

**One shape.** `AuthorizedGrant` is a positional member of the `BackChannelAuthenticationRequest` record, so it is init-only and `storedRequest.AuthorizedGrant = ...` does not compile. A `with` expression replaces it.

The issue says an integrator then "has to carry the mutable members across". **That is not true, and it is the kind of clause that gets repeated under a new author's name.** A five-line probe settled it: a record `with` expression copies every instance field, mutable auto-properties included, so `Status`, `NextPollAt`, `ClientNotificationEndpoint` and `ClientNotificationToken` all survive untouched. The comment now says so.

**One the compiler found and no reader would.** `AuthSession`'s parameters are `Subject`, `SessionId`, `AuthenticationTime`, `IdentityProvider`. The sample's named arguments were `sessionId:`, `authenticationTime:`, `identityProvider:` - camelCase binds to nothing (`CS1739`).

## "It compiles" is measured here, not asserted

A doc comment is not compiled by anything, so the claim needed an instrument. The sample was extracted from the `<code>` block into a project referencing `Abblix.Oidc.Server`, with stubs for **only what the sample itself invents**: `IMyPushNotificationService` and one `ExtractUserIdentifier` helper, both explicitly the integrator's own. Everything else must come from the library, which is the point.

- As shipped: `Build succeeded. 0 Error(s)`. The probe suppresses `CS0649` and `CS8618`, because the sample declares fields it never constructs - that is a property of a fragment lifted out of its class, not of the sample. An earlier version of this line named `CS8632`, which the run never emitted: it is the nullable-context warning and could only appear with nullable disabled, so the reason given did not cover the code named. Only the error count is evidence here.
- Control: restoring `IBackChannelDeliveryModeRouter` alone gives `CS0246`, `1 Error(s)`.

Reading the sample found six of the eight defects. Compiling it found the other two.

## The sweep, and why its result is not a check

The issue asks whether any other sample names something that no longer exists. The criterion used is positive rather than a list: **an identifier a sample BORROWS must appear on at least one line of real code somewhere in the repository.** A real type does - `TimeSpan` as much as `IBackChannelRequestStorage` - while one that was renamed away appears only inside comments.

It found one more site: `IBackChannelLongPollingService`'s sample step 4 named `BackChannelDeliveryModeRouter`, the same renamed-away router. Fixed here.

**It is deliberately not shipped as a check.** Over the tree it flagged 22 items against that 1 real find, and every false positive was a name the sample legitimately invents - its own class, its own helpers, the interface it declares for its own push service. Narrowing it means enumerating what a sample is allowed to invent, which is the same failure the check exists to catch. A guard with that ratio teaches everyone to wave it away, and that habit is what greets the true positive.

**What would be a real gate is the probe above**, promoted from a throwaway into a project CI builds - it has no false positives, because a sample either compiles or it does not. That is its own unit with its own questions (where it lives, whether the stubs drift), filed separately rather than bolted on here.

## Evidence

`dotnet build` on `Abblix.Oidc.Server`: `0 Warning(s), 0 Error(s)`. Every changed line is a comment. None of the seven renamed-away names survives anywhere in the tree, against a control that finds `IAuthenticationCompletionHandler` in 7 files.

**Round 2.** Step 4 of the long-polling sequence in the second file was fixed to `AuthenticationCompletionRouter`, and that made it worse rather than better. The router has no reference to long polling at all; the only production caller of `NotifyStatusChangeAsync` is `PollModeCompletionHandler`, and only when a notifier is registered. A DEAD name is honest - a reader greps it, finds nothing, and knows the comment is behind the code - while a LIVE wrong name ends that search inside a real file where nothing matches. It names the real signaller now, and says poll is the only mode that signals, which is the failure a reader of that sequence has actually hit. Two claims in this description were also wrong and are corrected above.

