### PR TITLE
Name the missing parameter instead of answering a bare 400

### DIFF
--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -592,10 +592,11 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     }
 
     /// <summary>
-    /// A status and one <c>WWW-Authenticate</c> line, with no body: 401 with a bare challenge when
-    /// nobody was identified, 403 naming <c>insufficient_scope</c> when somebody was and their token is
-    /// too narrow. Written by hand because <c>Results.Unauthorized()</c> emits no headers, and the header
-    /// is the whole point.
+    /// A status and one <c>WWW-Authenticate</c> line, with no body. The status is the caller's, not
+    /// this type's: any refusal whose explanation belongs in the challenge rather than in a payload
+    /// builds one of these, and the callers in this file are what say which statuses those are.
+    /// Written by hand because <c>Results.Unauthorized()</c> emits no headers, and the header is the
+    /// whole point.
     /// </summary>
     private sealed class ChallengeResult(int statusCode, string challenge) : IResult
     {

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -292,7 +292,11 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
             return Unauthenticated(http);
         }
 
-        return streamId is null
+        // Same reading of "named" as the two refusal routes below, so the three do not disagree
+        // about one word. Here an unnamed stream is an ANSWER rather than an error, so
+        // "?stream_id=" lists every stream instead of looking one up under the empty name and
+        // reporting it missing.
+        return string.IsNullOrEmpty(streamId)
             ? Render(await service.ListStreamsAsync(receiverId, cancellationToken))
             : Render(await service.GetStreamAsync(receiverId, streamId, cancellationToken));
     }
@@ -327,8 +331,11 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         }
 
         // "The DELETE request MUST include the 'stream_id'" per SSF 1.0 Section 8.1.1.5 -
-        // without it there is nothing to delete.
-        return streamId is null
+        // without it there is nothing to delete. The condition asks whether a stream was
+        // NAMED, not whether the parameter was absent: "?stream_id=" is present and names
+        // nothing, and RFC 6750 Section 3.1 puts an unusable value in the same
+        // invalid_request bucket as a missing one.
+        return string.IsNullOrEmpty(streamId)
             ? MissingRequiredParameter(http, StreamMemberNames.StreamId)
             : Render(await service.DeleteStreamAsync(receiverId, streamId, cancellationToken));
     }
@@ -345,8 +352,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         }
 
         // The status read has no list fallback: "stream_id" is its REQUIRED parameter
-        // (SSF 1.0 Section 8.1.2.1).
-        return streamId is null
+        // (SSF 1.0 Section 8.1.2.1). Named rather than merely present, for the reason the
+        // delete route states.
+        return string.IsNullOrEmpty(streamId)
             ? MissingRequiredParameter(http, StreamMemberNames.StreamId)
             : Render(await service.GetStreamStatusAsync(receiverId, streamId, cancellationToken));
     }

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -329,7 +329,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         // "The DELETE request MUST include the 'stream_id'" per SSF 1.0 Section 8.1.1.5 -
         // without it there is nothing to delete.
         return streamId is null
-            ? Results.BadRequest()
+            ? MissingRequiredParameter(http, StreamMemberNames.StreamId)
             : Render(await service.DeleteStreamAsync(receiverId, streamId, cancellationToken));
     }
 
@@ -347,7 +347,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         // The status read has no list fallback: "stream_id" is its REQUIRED parameter
         // (SSF 1.0 Section 8.1.2.1).
         return streamId is null
-            ? Results.BadRequest()
+            ? MissingRequiredParameter(http, StreamMemberNames.StreamId)
             : Render(await service.GetStreamStatusAsync(receiverId, streamId, cancellationToken));
     }
 
@@ -450,6 +450,37 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     }
 
     /// <summary>
+    /// A required parameter is absent, so the request cannot be acted on. RFC 6750 Section 3.1:
+    /// <c>invalid_request</c> is "The request is missing a required parameter ... The resource server
+    /// SHOULD respond with the HTTP 400 (Bad Request) status code."
+    /// </summary>
+    /// <remarks>
+    /// The header is a MAY here, unlike the 401 below. Section 3 makes <c>WWW-Authenticate</c> mandatory
+    /// when the request "does not include authentication credentials or does not contain an access token
+    /// that enables access", and adds that a server "MAY include it in response to other conditions as
+    /// well". This is one of those others: the receiver was identified and its token is not in question,
+    /// only a protocol parameter is missing. The header carries it anyway, because that is where Section
+    /// 3.1's vocabulary lives and it is what the 401 and 403 on these same routes already use, so a
+    /// receiver has one place to read a refusal from.
+    /// <para>
+    /// This answers only where the parameter is REQUIRED. <see cref="GetStreamsAsync"/> takes the same
+    /// query parameter and lists every stream when it is absent, so an absent value there is an answer
+    /// rather than an error.
+    /// </para>
+    /// </remarks>
+    private static IResult MissingRequiredParameter(HttpContext http, string parameterName)
+    {
+        var issuer = http.RequestServices.GetService<SharedSignalsTransmitterOptions>()?.Issuer;
+        return new ChallengeResult(
+            StatusCodes.Status400BadRequest,
+            WwwAuthenticate.Challenge(
+                BearerScheme,
+                ("realm", issuer),
+                ("error", "invalid_request"),
+                ("error_description", $"The request is missing the required parameter {parameterName}.")));
+    }
+
+    /// <summary>
     /// The answer to a management request that named no receiver: 401 with a bare Bearer challenge.
     /// </summary>
     /// <remarks>
@@ -468,16 +499,15 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// scopes.
     /// </para>
     /// <para>
-    /// The third, <c>invalid_request</c> with 400, IS decided here and is not emitted: a request missing
-    /// its <c>stream_id</c> is answered with a bare <c>Results.BadRequest()</c> by
-    /// <see cref="DeleteStreamAsync"/> and <see cref="GetStatusAsync"/>. That is a separate gap from
-    /// this one and is not closed by this method.
+    /// The third, <c>invalid_request</c> with 400, is also decided here rather than by the host, and is
+    /// emitted by <see cref="MissingRequiredParameter"/>.
     /// </para>
     /// <para>
     /// The realm is the transmitter's issuer, which is the one name a receiver already holds for this
     /// protection space and the one it used to find these endpoints.
     /// </para>
     /// </remarks>
+
     private static IResult Unauthenticated(HttpContext http)
     {
         var issuer = http.RequestServices.GetService<SharedSignalsTransmitterOptions>()?.Issuer;

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -507,7 +507,6 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// protection space and the one it used to find these endpoints.
     /// </para>
     /// </remarks>
-
     private static IResult Unauthenticated(HttpContext http)
     {
         var issuer = http.RequestServices.GetService<SharedSignalsTransmitterOptions>()?.Issuer;

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -487,9 +487,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
                 BearerScheme,
                 ("realm", issuer),
                 ("error", "invalid_request"),
-                // Says NAMES NO STREAM rather than "is missing", because the empty value reaches here
-                // too and the receiver sent it - a developer told the parameter is missing goes looking
-                // for where their client drops it, and it does not drop it.
+                // Says the parameter NAMES NOTHING rather than that it is missing, because the empty
+                // value reaches here too and the receiver sent it - a developer told the parameter is
+                // missing goes looking for where their client drops it, and it does not drop it.
                 ("error_description",
                     $"The required parameter {parameterName} names nothing.")));
     }

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -458,22 +458,24 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     }
 
     /// <summary>
-    /// A required parameter is absent, so the request cannot be acted on. RFC 6750 Section 3.1:
-    /// <c>invalid_request</c> is "The request is missing a required parameter ... The resource server
-    /// SHOULD respond with the HTTP 400 (Bad Request) status code."
+    /// A required parameter names nothing, so the request cannot be acted on. That covers a parameter
+    /// left out and one sent empty alike, and RFC 6750 Section 3.1 puts both in the same bucket:
+    /// <c>invalid_request</c> is "The request is missing a required parameter, includes an unsupported
+    /// parameter or parameter value ... The resource server SHOULD respond with the HTTP 400 (Bad
+    /// Request) status code."
     /// </summary>
     /// <remarks>
     /// The header is a MAY here, unlike the 401 below. Section 3 makes <c>WWW-Authenticate</c> mandatory
     /// when the request "does not include authentication credentials or does not contain an access token
     /// that enables access", and adds that a server "MAY include it in response to other conditions as
     /// well". This is one of those others: the receiver was identified and its token is not in question,
-    /// only a protocol parameter is missing. The header carries it anyway, because that is where Section
+    /// only a protocol parameter names nothing. The header carries it anyway, because that is where Section
     /// 3.1's vocabulary lives and it is what the 401 and 403 on these same routes already use, so a
     /// receiver has one place to read a refusal from.
     /// <para>
     /// This answers only where the parameter is REQUIRED. <see cref="GetStreamsAsync"/> takes the same
-    /// query parameter and lists every stream when it is absent, so an absent value there is an answer
-    /// rather than an error.
+    /// query parameter and lists every stream when it names nothing, so an unnamed stream there is an
+    /// answer rather than an error. Both routes read "named" the same way; they differ in what it means.
     /// </para>
     /// </remarks>
     private static IResult MissingRequiredParameter(HttpContext http, string parameterName)
@@ -485,7 +487,11 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
                 BearerScheme,
                 ("realm", issuer),
                 ("error", "invalid_request"),
-                ("error_description", $"The request is missing the required parameter {parameterName}.")));
+                // Says NAMES NO STREAM rather than "is missing", because the empty value reaches here
+                // too and the receiver sent it - a developer told the parameter is missing goes looking
+                // for where their client drops it, and it does not drop it.
+                ("error_description",
+                    $"The required parameter {parameterName} names nothing.")));
     }
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -26,9 +26,9 @@ namespace Abblix.SharedSignals.E2E.Tests;
 /// </summary>
 /// <remarks>
 /// The rows split by who the caller is, because the answer does. When the request names nobody the
-/// refusal is a bare 401 challenge; when it names somebody and omits a required parameter it is a 400
-/// naming that parameter. Both are the same question - can the receiver act on what it was told - and
-/// neither is answered by a status alone.
+/// refusal is a bare 401 challenge; when it names somebody but names no stream in a parameter the
+/// route requires, it is a 400 naming that parameter. Both are the same question - can the receiver
+/// act on what it was told - and neither is answered by a status alone.
 /// <para>
 /// A bare 401 with an empty body carries no challenge naming a scheme, so a client library has nothing to
 /// retry with and nothing to log.
@@ -131,8 +131,8 @@ public sealed class ManagementRefusalTests
     }
 
     /// <summary>
-    /// A request that names somebody and omits a parameter the route REQUIRES. A bare 400 tells the
-    /// receiver that something was wrong and nothing about what.
+    /// A request that names somebody but names no stream in a parameter the route REQUIRES - left out
+    /// or sent empty. A bare 400 tells the receiver that something was wrong and nothing about what.
     /// </summary>
     /// <remarks>
     /// RFC 6750 Section 3.1 has a code for exactly this: <c>invalid_request</c> - "The request is missing
@@ -189,9 +189,17 @@ public sealed class ManagementRefusalTests
 
     /// <summary>
     /// The control, and it is what keeps the row above from becoming a rule about the whole surface: the
-    /// LIST route takes the same query parameter and answers every stream when it is absent. Refusing an
-    /// absent <c>stream_id</c> everywhere would break it, and nothing else in this file would notice.
+    /// LIST route takes the same query parameter and answers every stream when it names none. Refusing an
+    /// unnamed <c>stream_id</c> everywhere would break it.
     /// </summary>
+    /// <remarks>
+    /// This row is not the only thing that would notice, and an earlier version of this summary said it
+    /// was - true when the only refusal shape here was a bare 400, false once the refusal grew a
+    /// challenge header. Measured at head, refusing on this route kills six rows, one of them
+    /// <see cref="AnIdentifiedCaller_IsServed"/> directly above, on its assertion that no challenge
+    /// header comes back. What this row alone holds is the answer's SHAPE: that an unnamed stream here
+    /// is a list rather than a refusal.
+    /// </remarks>
     [Fact]
     public async Task AMissingStreamId_OnTheListRoute_IsNotAnError()
     {

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -124,6 +124,65 @@ public sealed class ManagementRefusalTests
         Assert.Empty(response.Headers.WwwAuthenticate);
     }
 
+    /// <summary>
+    /// A request that names somebody and omits a parameter the route REQUIRES. A bare 400 tells the
+    /// receiver that something was wrong and nothing about what.
+    /// </summary>
+    /// <remarks>
+    /// RFC 6750 Section 3.1 has a code for exactly this: <c>invalid_request</c> - "The request is missing
+    /// a required parameter, includes an unsupported parameter or parameter value, repeats the same
+    /// parameter, uses more than one method for including an access token, or is otherwise malformed. The
+    /// resource server SHOULD respond with the HTTP 400 (Bad Request) status code."
+    /// <para>
+    /// The header is a MAY here, not the MUST that governs the unidentified case above. Section 3 makes
+    /// <c>WWW-Authenticate</c> mandatory when the request "does not include authentication credentials or
+    /// does not contain an access token that enables access", and adds that a server "MAY include it in
+    /// response to other conditions as well". This is one of those others - the receiver was identified
+    /// and its token is not in question. It is used anyway because that is where Section 3.1's vocabulary
+    /// lives, and because it is what the 401 and 403 on these same routes already carry.
+    /// </para>
+    /// <para>
+    /// The parameter name is asserted as the LITERAL a receiver reads off the wire rather than through
+    /// the constant that builds it: comparing a constant with itself would let a rename pass while every
+    /// deployed receiver broke.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("DELETE", "/ssf/stream")]
+    [InlineData("GET", "/ssf/status")]
+    public async Task AMissingStreamId_IsNamedRatherThanLeftBare(string method, string route)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await StartAsync(_ => "receiver-1");
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), route);
+        using var response = await host.GetTestClient().SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var challenge = Assert.Single(response.Headers.WwwAuthenticate);
+        Assert.Equal("Bearer", challenge.Scheme);
+        Assert.Contains("error=\"invalid_request\"", challenge.Parameter!);
+        Assert.Contains("stream_id", challenge.Parameter!);
+    }
+
+    /// <summary>
+    /// The control, and it is what keeps the row above from becoming a rule about the whole surface: the
+    /// LIST route takes the same query parameter and answers every stream when it is absent. Refusing an
+    /// absent <c>stream_id</c> everywhere would break it, and nothing else in this file would notice.
+    /// </summary>
+    [Fact]
+    public async Task AMissingStreamId_OnTheListRoute_IsNotAnError()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await StartAsync(_ => "receiver-1");
+
+        using var response = await host.GetTestClient().GetAsync("/ssf/stream", cancellationToken);
+
+        Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(response.Headers.WwwAuthenticate);
+    }
+
     private static async Task<WebApplication> StartAsync(Func<HttpContext, string?>? receiverId = null)
     {
         var builder = WebApplication.CreateBuilder();

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -22,11 +22,17 @@ using Xunit;
 namespace Abblix.SharedSignals.E2E.Tests;
 
 /// <summary>
-/// What a receiver is told when a Stream Management request names nobody.
+/// What a receiver is TOLD when a Stream Management request is refused - whoever it came from.
 /// </summary>
 /// <remarks>
+/// The rows split by who the caller is, because the answer does. When the request names nobody the
+/// refusal is a bare 401 challenge; when it names somebody and omits a required parameter it is a 400
+/// naming that parameter. Both are the same question - can the receiver act on what it was told - and
+/// neither is answered by a status alone.
+/// <para>
 /// A bare 401 with an empty body carries no challenge naming a scheme, so a client library has nothing to
 /// retry with and nothing to log.
+/// </para>
 /// <para>
 /// The CAEP Interoperability Profile Section 2.7.2 does require errors "as per Section 3.1 of [RFC6750]",
 /// but that MUST hangs on a condition this case does not meet: "If the access token is not sufficient for
@@ -164,6 +170,12 @@ public sealed class ManagementRefusalTests
         Assert.Equal("Bearer", challenge.Scheme);
         Assert.Contains("error=\"invalid_request\"", challenge.Parameter!);
         Assert.Contains("stream_id", challenge.Parameter!);
+
+        // The helper builds three attributes and the two above hold only two of them. Without this the
+        // realm can vanish - the issuer resolving to nothing produces a well-formed challenge that simply
+        // omits it - and no row anywhere goes red. The 401 row above asserts the same realm exactly, so
+        // the two refusals agree on who is challenging rather than only on why.
+        Assert.Contains($"realm=\"{Issuer}\"", challenge.Parameter!);
     }
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -152,10 +152,19 @@ public sealed class ManagementRefusalTests
     /// the constant that builds it: comparing a constant with itself would let a rename pass while every
     /// deployed receiver broke.
     /// </para>
+    /// <para>
+    /// The empty rows are the same defect wearing a second face. A guard asking whether the
+    /// parameter was ABSENT enumerates the ways it can be, and "?stream_id=" is present and names
+    /// nothing - it used to reach the store and come back as a bare 404, an answer about a stream
+    /// rather than about the request. The guard now asks whether a stream was NAMED, so both faces
+    /// fail at once and a third would too.
+    /// </para>
     /// </remarks>
     [Theory]
     [InlineData("DELETE", "/ssf/stream")]
     [InlineData("GET", "/ssf/status")]
+    [InlineData("DELETE", "/ssf/stream?stream_id=")]
+    [InlineData("GET", "/ssf/status?stream_id=")]
     public async Task AMissingStreamId_IsNamedRatherThanLeftBare(string method, string route)
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -193,6 +202,15 @@ public sealed class ManagementRefusalTests
 
         Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Empty(response.Headers.WwwAuthenticate);
+
+        // And the empty value reads the same way here as it does on the refusal routes: not
+        // named. The three routes have to agree about that word, and they differ only in what
+        // an unnamed stream MEANS - an answer here, a refusal there. Without this row the list
+        // route could quietly go on looking one up under the empty name.
+        using var empty = await host.GetTestClient().GetAsync("/ssf/stream?stream_id=", cancellationToken);
+
+        Assert.Equal(response.StatusCode, empty.StatusCode);
+        Assert.Empty(empty.Headers.WwwAuthenticate);
     }
 
     private static async Task<WebApplication> StartAsync(Func<HttpContext, string?>? receiverId = null)


### PR DESCRIPTION
Ref #463.

## What was wrong

`DELETE /ssf/stream` and `GET /ssf/status` answered a request without `stream_id` with a bare `400`: no body, no error code, no header. The receiver learned that something was wrong and nothing about what.

## Read from the document, not recalled

RFC 6750 was retrieved and both sections read. Section 3.1 names this case exactly:

> invalid_request - The request is missing a required parameter, includes an unsupported parameter or parameter value, repeats the same parameter, uses more than one method for including an access token, or is otherwise malformed. The resource server SHOULD respond with the HTTP 400 (Bad Request) status code.

**The header is a MAY here, and the comment says so rather than borrowing the MUST beside it.** Section 3 makes `WWW-Authenticate` mandatory when the request "does not include authentication credentials or does not contain an access token that enables access", and adds that a server "MAY include it in response to other conditions as well". This is one of those others: the receiver was identified and its token is not in question, only a protocol parameter is missing.

It carries the code anyway, for two reasons that are checkable rather than aesthetic: Section 3.1's vocabulary lives in that header, and the 401 and 403 on these same routes already use it, so a receiver has one place to read a refusal from.

## The fork the issue raised is a lookup, not a decision

The issue asked whether `stream_id` belongs in the route instead. It does not, and the reason is in this repository's own routes rather than in the specification. **The sibling list route answers WITHOUT the parameter**: `GET /ssf/stream` lists every stream when it is absent, so the same route cannot also require it in its path. That is the whole argument, and it is checkable here.

For the management routes the specification does put the parameter in the query - SSF 1.0 Section 8.1.2.1: "The Stream Status method takes the following parameters: stream_id ... REQUIRED" on an HTTP GET. The poll route is a different matter and an earlier version of this text got it wrong: Section 8.1.1.1 ("Creating a Stream") says "Note that in the case of the poll method, the endpoint_url value is supplied by the Transmitter", so the specification puts that address nowhere. `{streamId}` in the poll path is this repository's choice, which is exactly why the escaping and the decode trap around it needed their own issue.

## Evidence

- **The reproduction is a failing test committed BEFORE the fix and not edited by it** (`ad9a3dbd`, then `ce8118bc`). Two rows failed on `Assert.Single` over the `WWW-Authenticate` collection - the status was already 400, the explanation was what was absent.
- **A control row in the same commit** asserts the list route is NOT refused without the parameter, so the fix cannot become a rule about the whole surface. Nothing else in that file would have noticed THEN, when the only refusal shape here was a bare 400; once the refusal grew a challenge header six rows notice, which is what Round 2 below records.
- Solution builds at `0 Warning(s), 0 Error(s)`. Every suite this change can reach runs green, nothing failing and nothing skipped. No totals are given: they have already moved twice under this branch's own commits, and a number written once reads as current forever.
- The parameter name is asserted as the literal a receiver reads off the wire, not through the constant that builds it: comparing a constant with itself would let a rename pass while every deployed receiver broke.

## The stale comment this closes

The `<remarks>` on the 401 helper declared this gap and named both sites - the right thing to write while fixing the 401 half, and exactly the kind of note that stops being visible, since nobody greps a `<remarks>` block for work. It now names the helper that closes it.

## Swept, and what was left alone

Condition: a refusal this package decides for itself that carries no error code. Across the two Shared Signals Minimal API packages the `Results.*` sites are nine (the tenth occurrence is inside a doc comment); the third Minimal API package in `src/` is out of scope here because it serves a different protocol; the pass-through ones render a status the service already decided, and one remains bare - `Results.NotFound()` on the poll route when the stream is not the receiver's. **Deliberately not touched:** the parameter is present there and the resource is absent, which is not any of the three codes Section 3.1 defines. Inventing one would be worse than giving none, and deciding what SSF wants there needs its own reading of that specification.

## What the first review added

Four changes, three of them the same defect in different places.

**The guard enumerated absences.** It asked `streamId is null`, so `?stream_id=` - present, empty, naming nothing - slipped past, reached the store and came back as a bare 404: an answer about a stream when the problem was the request. That is the very refusal this change exists to stop, wearing a second face. The condition now asks whether a stream was NAMED, all three routes taking the parameter read that word the same way, and each guard is held by a row that dies alone when reverted.

**A summary listed its callers.** `ChallengeResult` was documented as the 401 and 403 it served; this change gives it a 400, so the list was short by one and nothing in the suite could go red for it. It now states the property - a status and one challenge line, the status belonging to the caller.

**A test class described one of the two cases it drives.** Several of its rows now drive an identified caller, so anyone looking for where that refusal is covered would have skipped the class on its own summary.

**The realm was the one attribute nothing held.** Making the issuer resolve to nothing was green across all three suites - the challenge stays well formed and simply omits it. The row asserts it now, and the 401 row beside it asserts the same value.

Filed rather than fixed: #493, a refusal whose explanation the service already wrote and the transport discards. Larger family, different owner, and a fork worth deciding rather than folding in here.

## Round 2

Three findings, all in text rather than in behaviour, and the third is the one that mattered.

**The refusal told a receiver its parameter was missing when the receiver had sent it.** Once the guard widened to accept an empty value as naming nothing, the message did not follow. It now says the parameter names nothing, which is true of a parameter left out and one sent empty alike, and four further sentences that still said absent or omitted were brought into line with the guards beneath them.

**The list control claimed nothing else in this file would notice** if that route started refusing. True when the only refusal shape here was a bare 400; false once the refusal grew a challenge header, and measured: six rows die, one of them the identified-caller control directly above. The summary now states what this row alone holds.

**The specification citation for the poll route carried the wrong section number.** The quotation is verbatim and came from the document; the number came from the report that prompted the previous repair, and the two were written into one sentence as though both had been read. It is Section 8.1.1.1, "Creating a Stream". This is the second time this paragraph has needed correcting, and both times the error was in the half of the sentence nobody had run a command against.

