### PR TITLE
Say the Status claim once, and say what the handler actually writes

### DIFF
--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -75,11 +75,7 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///         //
 ///         // Nothing needs to touch Status ON THIS PATH - the denial below is a different one, and it
 ///         // never calls CompleteAsync. A host that does set it on its own copy changes nothing
-///         // either way: completion reads the STORED record to decide whether the request may still be
-///         // answered, and then writes the outcome itself - accepted, or refused for one of several
-///         // reasons this sample does not need to know. How a refusal is RECORDED is the delivery
-///         // mode's business: poll and ping write Denied, push removes the request outright, since a
-///         // client that never comes back cannot read a denial.
+///         // either way: completion reads the STORED record and writes whatever it decides itself.
 ///         var authenticated = storedRequest with
 ///         {
 ///             AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context),

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -73,17 +73,17 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///         // record, so it is init-only and a `with` expression is how it is replaced; the copy carries
 ///         // every other member unchanged.
 ///         //
-///         // Nothing needs to touch Status: the completion handler decides from the STORED record
-///         // whether this request may still be answered, and sets Authenticated itself when it may. A
-///         // host that does set it on its own copy changes nothing either way.
+///         // Nothing needs to touch Status. A host that does set it on its own copy changes nothing
+///         // either way, because the completion handler judges the STORED record and writes the final
+///         // status itself - Authenticated when the request may still be answered, Denied when the
+///         // subject does not match or the authorization details policy refuses.
 ///         var authenticated = storedRequest with
 ///         {
 ///             AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context),
 ///         };
 ///
 ///         // Completion selects the mode-specific handler from the client's registered delivery mode
-///         // (PollModeCompletionHandler, PingModeCompletionHandler or PushModeCompletionHandler) and
-///         // marks the request authenticated itself - the caller does not set the status.
+///         // (PollModeCompletionHandler, PingModeCompletionHandler or PushModeCompletionHandler).
 ///         await _completion.CompleteAsync(
 ///             authReqId,
 ///             authenticated,

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/Interfaces/IUserDeviceAuthenticationHandler.cs
@@ -73,10 +73,13 @@ namespace Abblix.Oidc.Server.Features.BackChannelAuthentication.Interfaces;
 ///         // record, so it is init-only and a `with` expression is how it is replaced; the copy carries
 ///         // every other member unchanged.
 ///         //
-///         // Nothing needs to touch Status. A host that does set it on its own copy changes nothing
-///         // either way, because the completion handler judges the STORED record and writes the final
-///         // status itself - Authenticated when the request may still be answered, Denied when the
-///         // subject does not match or the authorization details policy refuses.
+///         // Nothing needs to touch Status ON THIS PATH - the denial below is a different one, and it
+///         // never calls CompleteAsync. A host that does set it on its own copy changes nothing
+///         // either way: completion reads the STORED record to decide whether the request may still be
+///         // answered, and then writes the outcome itself - accepted, or refused for one of several
+///         // reasons this sample does not need to know. How a refusal is RECORDED is the delivery
+///         // mode's business: poll and ping write Denied, push removes the request outright, since a
+///         // client that never comes back cannot read a denial.
 ///         var authenticated = storedRequest with
 ///         {
 ///             AuthorizedGrant = new AuthorizedGrant(authSession, storedRequest.AuthorizedGrant.Context),


### PR DESCRIPTION
The CIBA host sample stated the same thing twice, in two wordings, eight lines apart - and BOTH were wrong the same way. One said the handler sets Authenticated itself when it may; the other that it marks the request authenticated itself. Each describes only the accepting outcome, which is why both were edited rather than one reconciled to the other.

## What was wrong

`AuthenticationCompletionHandler` writes the outcome itself, and the old comment described only the accepting one. It refuses on several conditions, and how a refusal is RECORDED is not the same across modes: `RefuseAsync` denies on poll and ping, while `PushModeCompletionHandler` overrides it to REMOVE the request, because a client that never returns cannot read a denial.

The comment said only the first. A host reading it expects an approval or nothing, and never accounts for the record coming back denied without its own device flow having denied anything.

## What changed

Five lines replaced. The surviving comment names no outcomes and no conditions at all. The second comment keeps only the part it alone carried - which handler completion selects from the delivery mode - and drops its restatement of the status claim.

No code changed; the diff is entirely inside one `<code>` block's comments.

## How it was checked

- The refusal paths call `RefuseAsync`, whose base implementation forwards to `DenyRequestAsync`; `PushModeCompletionHandler` overrides it with a removal. Read at the branch rather than summarised: the check the base handler makes against the requested `authorization_details` is a types-only comparison, not a policy, and ping refuses on its own missing notification configuration as well.
- Library build: `0 Error(s)`, `0 Warning(s)`.
- The claim that the sample compiles is unaffected - the change touches only `//` comments inside the sample, not the C# it contains.

Ref #436

## Round 1

Two findings, and both were the same defect as the one this PR set out to fix: a wrong list replaced by a different wrong list.

The replacement named `Denied` on two conditions. Push writes `Denied` on neither - it removes the request instead, which the base class's own remarks already say and a green test already pins. The list also omitted ping's refusal on a missing notification configuration, which is the denial a host meets after a registration mistake. And "the authorization details policy" names a type that writes `Denied` in no path at all: what refuses there is a types-only comparison against what the client requested, so a host debugging a denied record was being sent to its per-type validators, where nothing can have caused it.

The comment now names no causes. Completion decides from the stored record and writes the outcome; how a refusal is recorded belongs to the delivery mode, which is the one distinction a host holding a record actually needs.

My own ratcheted rule says the fix for a wrong list is almost never a longer list - it is the sentence with no list in it. This round is that rule catching me writing the shorter list instead.

## Round 2

The same defect a third time, on the same five lines.

The replacement said the delivery mode decides how a refusal is recorded - poll and ping deny, push removes. A third outcome involves no mode: `AuthenticationCompletionRouter` returns silently when the client cannot be found, before any storage read and before a mode is chosen, writing nothing and throwing nothing. The record stays `Pending` and the host's `await` completes normally, so a host debugging exactly that reads two candidates here and the answer is in neither.

The clause is deleted rather than corrected, and the repair is a net deletion - one line where five stood. That is what the rule about wrong lists predicts, and it is what rounds one and two should have been: each of them wrote a shorter list instead of removing the list.

