### PR TITLE
Stop the authorization_details type computation being re-inlined

### DIFF
--- a/.github/scripts/lint-no-inlined-detail-types.py
+++ b/.github/scripts/lint-no-inlined-detail-types.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Keeps the set of types an authorization_details array names computed in one place.
+
+Four call sites once computed it separately. They were not verbatim copies - two spelled the
+null case `?? []` and two used the null-forgiving operator - so a pattern seeded from either
+spelling finds half of them and says nothing about the half it missed. This check is therefore
+derived from the GRAMMAR of the computation rather than from the text of any instance: a
+conversion to typed entries whose result is projected to `Type`, however the null case, the
+lambda parameter, the query form or the tail happens to be written.
+
+The computation lives in `AuthorizationDetailTypes.NamedBy`. Two halves of one comparison in
+two files are what makes this worth a check rather than a habit: a copy that drifts by one
+clause makes them disagree on exactly the inputs nobody wrote a test for, and both stay green.
+
+The canonical member is also this check's own control. A run that finds it nowhere REFUSES
+instead of reporting a clean tree, because a search that cannot come back positive says
+nothing about the world - only about itself.
+
+    python .github/scripts/lint-no-inlined-detail-types.py             # check the tree
+    python .github/scripts/lint-no-inlined-detail-types.py --self-test # prove it can find one
+"""
+
+import io
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# The Windows console is not UTF-8 by default, and an unreadable refusal gets waved away
+# rather than read.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+CANONICAL = "src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailTypes.cs"
+CANONICAL_MEMBER = "AuthorizationDetailTypes.NamedBy"
+
+# Method syntax: the conversion, then anywhere in the same expression a projection of an entry
+# to its Type. The backreference is what makes it a projection OF THE ENTRY rather than any
+# `.Type` that happens to be nearby. `[^;{}]` keeps the window inside one expression - a
+# statement end or a block would leave it.
+METHOD_FORM = re.compile(
+    r"ToTypedArray\s*\(\s*\)"
+    r"[^;{}]{0,400}?"
+    r"\.\s*Select\s*\(\s*(?:static\s+)?\(?\s*(\w+)\s*\)?\s*=>\s*\1\s*\??\s*\.\s*Type\b",
+    re.S)
+
+# Query syntax spells the same computation without a lambda. Nothing in the tree uses it today,
+# which is exactly why it is here: the shape this check exists to stop is a second spelling.
+QUERY_FORM = re.compile(
+    r"\bfrom\s+(\w+)\s+in\b"
+    r"[^;{}]{0,400}?ToTypedArray\s*\(\s*\)"
+    r"[^;{}]{0,400}?\bselect\s+\1\s*\??\s*\.\s*Type\b",
+    re.S)
+
+FORMS = (("method syntax", METHOD_FORM), ("query syntax", QUERY_FORM))
+
+
+def strip_comments_and_strings(text):
+    """Blanks out comments and string literals, preserving every offset.
+
+    Offsets are preserved so a match still reports its real line. Prose is blanked because a
+    comment describing this computation - such as the one above the canonical member - is not
+    an instance of it, and a check that fires on its own documentation gets disabled.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+
+    def blank(start, end):
+        for k in range(start, min(end, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    while i < n:
+        ch = text[i]
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            blank(i, j)
+            i = j
+        elif ch == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            blank(i, j)
+            i = j
+        elif ch == '"' and text.startswith('"""', i):
+            fence = len(text[i:]) - len(text[i:].lstrip('"'))
+            close = '"' * fence
+            j = text.find(close, i + fence)
+            j = n if j == -1 else j + fence
+            blank(i, j)
+            i = j
+        elif ch == '@' and i + 1 < n and text[i + 1] == '"':
+            j = i + 2
+            while j < n:
+                if text[j] == '"':
+                    if j + 1 < n and text[j + 1] == '"':
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            blank(i, j)
+            i = j
+        elif ch in '"\'':
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == ch:
+                    j += 1
+                    break
+                if text[j] == "\n":
+                    break
+                j += 1
+            blank(i, j)
+            i = j
+        else:
+            i += 1
+    return "".join(out)
+
+
+def matches_in(text):
+    """Every occurrence of the computation, as (line number, which form matched)."""
+    stripped = strip_comments_and_strings(text)
+    found = []
+    for name, pattern in FORMS:
+        for m in pattern.finditer(stripped):
+            found.append((stripped.count("\n", 0, m.start()) + 1, name))
+    return sorted(found)
+
+
+def scan(root, rels, canonical):
+    """Splits every occurrence into the canonical one and the rest."""
+    canonical_hits, offenders = [], []
+    for rel in rels:
+        path = os.path.join(root, rel.replace("/", os.sep))
+        try:
+            with io.open(path, encoding="utf-8", errors="replace", newline="") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for line, form in matches_in(text):
+            target = canonical_hits if rel.replace(os.sep, "/") == canonical else offenders
+            target.append((rel.replace(os.sep, "/"), line, form))
+    return canonical_hits, offenders
+
+
+def tracked_sources(root):
+    out = subprocess.run(
+        ["git", "ls-files", "*.cs"],
+        cwd=root, capture_output=True, text=True, encoding="utf-8", check=True)
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+SELF_TEST_CASES = [
+    ("the null-coalescing spelling",
+     "var t = (details?.ToTypedArray() ?? [])\n    .Select(detail => detail.Type)\n"
+     "    .OfType<string>().ToHashSet(StringComparer.Ordinal);\n", True),
+    ("the null-forgiving spelling",
+     "var t = requested.ToTypedArray()!.Select(d => d.Type)"
+     ".OfType<string>().ToHashSet(StringComparer.Ordinal);\n", True),
+    ("a different tail",
+     "var t = granted.ToTypedArray()!.Select(entry => entry.Type).Distinct().ToArray();\n", True),
+    ("a parenthesised static lambda",
+     "var t = x.ToTypedArray()!.Select(static (e) => e.Type).ToArray();\n", True),
+    ("a null-conditional projection",
+     "var t = x.ToTypedArray()!.Select(e => e?.Type).ToArray();\n", True),
+    ("query syntax",
+     "var t = from d in details.ToTypedArray() select d.Type;\n", True),
+    ("the guard form, which converts but never projects to Type",
+     "if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)\n"
+     "    return false;\n", False),
+    ("a projection to something else",
+     "var k = details.ToTypedArray()!.Where(d => d.Locations is null).ToArray();\n", False),
+    ("a Type read that is not the projection of the converted entry",
+     "var t = details.ToTypedArray()!.Select(d => other.Type).ToArray();\n", False),
+    ("the computation described in a comment",
+     "// ToTypedArray().Select(detail => detail.Type) is what NamedBy does.\nvar x = 1;\n", False),
+    ("the computation inside a string literal",
+     "var s = \"ToTypedArray().Select(d => d.Type)\";\n", False),
+    ("a Type read in a later statement",
+     "var typed = details.ToTypedArray()!;\nvar first = typed[0].Type;\n", False),
+]
+
+
+def self_test():
+    """Refuses unless every branch answers with its own input, including both refusals."""
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        canonical_rel = "canonical/Home.cs"
+        os.makedirs(os.path.join(tmp, "canonical"))
+        io.open(os.path.join(tmp, canonical_rel), "w", encoding="utf-8", newline="").write(
+            "public static HashSet<string> NamedBy(JsonArray? details)\n"
+            "    => (details?.ToTypedArray() ?? []).Select(detail => detail.Type)\n"
+            "        .OfType<string>().ToHashSet(StringComparer.Ordinal);\n")
+
+        rels = [canonical_rel]
+        for i, (_, body, _) in enumerate(SELF_TEST_CASES):
+            rel = f"case{i}.cs"
+            io.open(os.path.join(tmp, rel), "w", encoding="utf-8", newline="").write(body)
+            rels.append(rel)
+
+        canonical_hits, offenders = scan(tmp, rels, canonical_rel)
+        caught = {rel for rel, _, _ in offenders}
+
+        for i, (name, _, expected) in enumerate(SELF_TEST_CASES):
+            got = f"case{i}.cs" in caught
+            ok &= got == expected
+            mark = "OK    " if got == expected else "FAILED"
+            print(f"{mark} {name:56} expected={'found' if expected else 'clean':5} "
+                  f"got={'found' if got else 'clean'}")
+
+        # The control itself: the canonical member must be visible to this check, or a clean
+        # tree means only that the search missed.
+        got_canonical = len(canonical_hits) == 1
+        ok &= got_canonical
+        print(f"{'OK    ' if got_canonical else 'FAILED'} "
+              f"{'the canonical member is found, exactly once':56} "
+              f"expected=found got={'found' if canonical_hits else 'nothing'}")
+
+        # And the refusal branch: with the canonical file absent, the run must not report clean.
+        absent_hits, _ = scan(tmp, [r for r in rels if r != canonical_rel], canonical_rel)
+        refuses = not absent_hits
+        ok &= refuses
+        print(f"{'OK    ' if refuses else 'FAILED'} "
+              f"{'a missing canonical member leaves the control empty':56} "
+              f"expected=empty got={'empty' if refuses else 'found'}")
+
+    print()
+    print("Self-test passed: every branch answered with its own input." if ok
+          else "Self-test FAILED: this check does not answer as described.")
+    return 0 if ok else 1
+
+
+def main():
+    argv = sys.argv[1:]
+    if "--self-test" in argv:
+        return self_test()
+
+    root = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, encoding="utf-8", check=True).stdout.strip()
+
+    rels = tracked_sources(root)
+    canonical_hits, offenders = scan(root, rels, CANONICAL)
+
+    print(f"C# files scanned: {len(rels)}")
+
+    if not canonical_hits:
+        print()
+        print(f"REFUSED: the computation was not found in {CANONICAL}.")
+        print("This check has no control, so it cannot tell a clean tree from a search that")
+        print(f"missed. If {CANONICAL_MEMBER} moved, update CANONICAL in this file; if it was")
+        print("rewritten, update the patterns and prove them with --self-test.")
+        return 1
+
+    print(f"Canonical occurrences in {CANONICAL}: {len(canonical_hits)}")
+
+    if not offenders:
+        print("No other site recomputes the types an authorization_details array names.")
+        return 0
+
+    print()
+    print(f"The computation is inlined in {len(offenders)} place(s) outside the canonical member:")
+    for rel, line, form in offenders:
+        print(f"  {rel}:{line} ({form})")
+    print()
+    print(f"Call {CANONICAL_MEMBER} instead. Two halves of one comparison living in two files")
+    print("drift by a clause and then disagree on the inputs nobody wrote a test for, while both")
+    print("stay green.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/lint-no-inlined-detail-types.py
+++ b/.github/scripts/lint-no-inlined-detail-types.py
@@ -3,18 +3,32 @@
 
 Four call sites once computed it separately. They were not verbatim copies - two spelled the
 null case `?? []` and two used the null-forgiving operator - so a pattern seeded from either
-spelling finds half of them and says nothing about the half it missed. This check is therefore
-derived from the GRAMMAR of the computation rather than from the text of any instance: a
-conversion to typed entries whose result is projected to `Type`, however the null case, the
-lambda parameter, the query form or the tail happens to be written.
+spelling finds half of them and says nothing about the half it missed.
+
+What this looks for is therefore the computation's RESULT: a projection of an entry to its
+`Type` whose result is turned into a set. Not the pipeline that produced the entries. An
+earlier version anchored on the conversion followed by the projection in the SAME expression,
+and it was blind to every live site in the tree, because they all convert in one statement and
+project in the next - it would not have caught the duplication it exists to prevent.
+
+The set's shape alone is not enough to say WHAT was counted, because the same
+`.Select(x => x.Type).ToHashSet(...)` is written over sequences of other things whose `Type`
+means something else. A regular expression cannot infer a sequence's type, so the file is asked
+the question it can answer: does it call the one conversion that produces these entries. A file
+that never does is not computing this set, whatever shape its projections take.
 
 The computation lives in `AuthorizationDetailTypes.NamedBy`. Two halves of one comparison in
 two files are what makes this worth a check rather than a habit: a copy that drifts by one
 clause makes them disagree on exactly the inputs nobody wrote a test for, and both stay green.
 
-The canonical member is also this check's own control. A run that finds it nowhere REFUSES
-instead of reporting a clean tree, because a search that cannot come back positive says
-nothing about the world - only about itself.
+The canonical member is this check's own control, and every entry in ALLOWED is another. A run
+where any control matches nothing REFUSES instead of reporting a clean tree, because a search
+that cannot come back positive says nothing about the world - only about itself.
+
+What it does NOT reach: the projection and the set in two different statements
+(`var names = typed.Select(d => d.Type); var set = names.ToHashSet(...);`), and the same set
+built by a loop rather than a projection. Both are said here rather than left to be discovered,
+because a check whose limits are unwritten gets read as having none.
 
     python .github/scripts/lint-no-inlined-detail-types.py             # check the tree
     python .github/scripts/lint-no-inlined-detail-types.py --self-test # prove it can find one
@@ -36,25 +50,68 @@ if hasattr(sys.stdout, "reconfigure"):
 CANONICAL = "src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailTypes.cs"
 CANONICAL_MEMBER = "AuthorizationDetailTypes.NamedBy"
 
-# Method syntax: the conversion, then anywhere in the same expression a projection of an entry
-# to its Type. The backreference is what makes it a projection OF THE ENTRY rather than any
-# `.Type` that happens to be nearby. `[^;{}]` keeps the window inside one expression - a
-# statement end or a block would leave it.
+# The one conversion that produces typed entries. Its presence in a file is what says the
+# projections there are over authorization_details entries rather than over something else.
+CONVERSION = "ToTypedArray"
+
+# Sites allowed to compute it themselves, each with the reason. This is an allowance rather than
+# an exclusion pattern: a form is permitted at a named place for a stated reason, not a shape
+# quietly dropped everywhere.
+#
+# Each allowance is also a control. A run where an allowed site no longer matches REFUSES rather
+# than passing, because an allowance nobody needs any more is an allowance nobody notices going
+# stale - and the next site that lands there inherits it.
+ALLOWED = {
+    "src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs":
+        "the grant side of the comparison, which REFUSES a typeless entry where the canonical "
+        "member drops it, so its guards run first and it holds the entries afterwards",
+}
+
+# The computation is a SET of the types the entries name, and that is what this looks for: a
+# projection of an entry to its Type whose result is turned into a set.
+#
+# An earlier version anchored on the conversion instead - ToTypedArray() followed by the
+# projection in the SAME expression - and it was blind to every live site in the tree, because
+# they all convert in one statement and project in the next. It would not have caught the
+# duplication it exists to prevent. The conversion is therefore not in the pattern at all: what
+# makes this computation itself is the set of names, not how the entries were obtained.
+#
+# The window between the projection and the set allows a filter or a cast to sit in between,
+# and stops at a statement end or a block, so a projection and a set belonging to two different
+# expressions are not joined into one finding.
+# The lambda parameter, however it is written: bare, parenthesised, explicitly typed,
+# static, or with the index parameter beside it. The capture is what ties the projection to
+# THAT parameter rather than to any Type standing nearby.
+_ENTRY = r"(?:static\s+)?\(?\s*(?:\w+\s+)?(\w+)\s*(?:,\s*\w+\s*)?\)?"
+
+# That same parameter's Type, through a null-forgiving or null-conditional operator, or
+# through neither.
+_ITS_TYPE = r"\1\s*!?\s*\??\s*\.\s*Type\b"
+
+# ... turned into a set. A filter, a cast or an ordering may sit in between.
+_INTO_A_SET = r"[^;{}]{0,300}?\.\s*ToHashSet\s*\("
+
+# .Select(d => d.Type) ... .ToHashSet(
 METHOD_FORM = re.compile(
-    r"ToTypedArray\s*\(\s*\)"
-    r"[^;{}]{0,400}?"
-    r"\.\s*Select\s*\(\s*(?:static\s+)?\(?\s*(\w+)\s*\)?\s*=>\s*\1\s*\??\s*\.\s*Type\b",
+    r"\.\s*Select\s*\(\s*" + _ENTRY + r"\s*=>\s*" + _ITS_TYPE + _INTO_A_SET,
     re.S)
 
-# Query syntax spells the same computation without a lambda. Nothing in the tree uses it today,
-# which is exactly why it is here: the shape this check exists to stop is a second spelling.
+# .Select(d => { return d.Type; }) ... .ToHashSet(
+BLOCK_LAMBDA_FORM = re.compile(
+    r"\.\s*Select\s*\(\s*" + _ENTRY + r"\s*=>\s*\{\s*return\s+" + _ITS_TYPE
+    + r"\s*;\s*\}" + _INTO_A_SET,
+    re.S)
+
+# from d in ... select d.Type, made into a set
 QUERY_FORM = re.compile(
-    r"\bfrom\s+(\w+)\s+in\b"
-    r"[^;{}]{0,400}?ToTypedArray\s*\(\s*\)"
-    r"[^;{}]{0,400}?\bselect\s+\1\s*\??\s*\.\s*Type\b",
+    r"\bfrom\s+(\w+)\s+in\b[^;{}]{0,400}?\bselect\s+" + _ITS_TYPE + _INTO_A_SET,
     re.S)
 
-FORMS = (("method syntax", METHOD_FORM), ("query syntax", QUERY_FORM))
+FORMS = (
+    ("method syntax", METHOD_FORM),
+    ("block-bodied lambda", BLOCK_LAMBDA_FORM),
+    ("query syntax", QUERY_FORM),
+)
 
 
 def strip_comments_and_strings(text):
@@ -142,6 +199,13 @@ def scan(root, rels, canonical):
                 text = fh.read()
         except OSError:
             continue
+        # A file that never converts to typed entries cannot be computing this set, whatever
+        # shape its projections take: the same `.Select(x => x.Type).ToHashSet(...)` is written
+        # over sequences of other things, where Type means something else entirely. The pattern
+        # cannot infer the sequence's type, so this asks the question it CAN answer.
+        if CONVERSION not in strip_comments_and_strings(text):
+            continue
+
         for line, form in matches_in(text):
             target = canonical_hits if rel.replace(os.sep, "/") == canonical else offenders
             target.append((rel.replace(os.sep, "/"), line, form))
@@ -155,34 +219,72 @@ def tracked_sources(root):
     return [line.strip() for line in out.stdout.splitlines() if line.strip()]
 
 
+# The conversion, so a case reads as a file that is asking this question at all.
+CONV = "var typed = details.ToTypedArray()!;"
+
 SELF_TEST_CASES = [
-    ("the null-coalescing spelling",
+    # Every case carries the conversion, because a file without it is not asking this question at
+    # all - which is its own case, below.
+    ("the null-coalescing spelling, all one expression",
      "var t = (details?.ToTypedArray() ?? [])\n    .Select(detail => detail.Type)\n"
      "    .OfType<string>().ToHashSet(StringComparer.Ordinal);\n", True),
-    ("the null-forgiving spelling",
-     "var t = requested.ToTypedArray()!.Select(d => d.Type)"
+    ("the null-forgiving spelling, all one expression",
+     "var t = details.ToTypedArray()!.Select(d => d.Type)"
      ".OfType<string>().ToHashSet(StringComparer.Ordinal);\n", True),
-    ("a different tail",
-     "var t = granted.ToTypedArray()!.Select(entry => entry.Type).Distinct().ToArray();\n", True),
+
+    # The two below are what the first version of this check could not see, and they are how
+    # every live site in the tree is written: convert in one statement, project in the next.
+    ("conversion and projection in separate statements",
+     "var typed = details?.ToTypedArray() ?? [];\n"
+     "var t = typed.Select(d => d.Type).OfType<string>().ToHashSet(StringComparer.Ordinal);\n",
+     True),
+    ("the guard form, then the projection of what it guarded",
+     "if (details.ToTypedArray() is not { } typed || typed.Length != details.Count)\n"
+     "    return null;\n"
+     "return typed.Select(detail => detail.Type!).ToHashSet(StringComparer.Ordinal);\n", True),
+
     ("a parenthesised static lambda",
-     "var t = x.ToTypedArray()!.Select(static (e) => e.Type).ToArray();\n", True),
+     CONV + "\nvar t = typed.Select(static (e) => e.Type).ToHashSet(StringComparer.Ordinal);\n",
+     True),
+    ("an explicitly typed lambda parameter",
+     CONV + "\nvar t = typed.Select((AuthorizationDetail d) => d.Type)"
+     ".ToHashSet(StringComparer.Ordinal);\n", True),
+    ("the index as a second parameter",
+     CONV + "\nvar t = typed.Select((d, i) => d.Type).ToHashSet(StringComparer.Ordinal);\n", True),
+    ("a block-bodied lambda",
+     CONV + "\nvar t = typed.Select(d => { return d.Type; }).ToHashSet(StringComparer.Ordinal);\n",
+     True),
     ("a null-conditional projection",
-     "var t = x.ToTypedArray()!.Select(e => e?.Type).ToArray();\n", True),
+     CONV + "\nvar t = typed.Select(e => e?.Type).ToHashSet(StringComparer.Ordinal);\n", True),
     ("query syntax",
-     "var t = from d in details.ToTypedArray() select d.Type;\n", True),
-    ("the guard form, which converts but never projects to Type",
+     CONV + "\nvar t = (from d in typed select d.Type).ToHashSet(StringComparer.Ordinal);\n", True),
+
+    # What must stay clean, and each of these exists in the tree today.
+    ("the guard form alone, which converts but never projects",
      "if (granted.ToTypedArray() is not { } typed || typed.Length != granted.Count)\n"
      "    return false;\n", False),
+    ("a projection that does not become a set",
+     CONV + "\nvar t = typed.Select(d => d.Type!).Where(x => !allowed.Contains(x))"
+     ".Distinct().ToArray();\n", False),
+    ("a validation over the types rather than a set of them",
+     CONV + "\nif (typed.All(d => d.Type is { } type && ok(type))) return true;\n", False),
     ("a projection to something else",
-     "var k = details.ToTypedArray()!.Where(d => d.Locations is null).ToArray();\n", False),
-    ("a Type read that is not the projection of the converted entry",
-     "var t = details.ToTypedArray()!.Select(d => other.Type).ToArray();\n", False),
+     CONV + "\nvar k = typed.Where(d => d.Locations is null).ToHashSet();\n", False),
+    ("a Type that is not the projected entry's",
+     CONV + "\nvar t = typed.Select(d => other.Type).ToHashSet(StringComparer.Ordinal);\n", False),
+
+    # The shape over a sequence of something ELSE. This is the one the check cannot tell apart by
+    # shape, and it is not hypothetical - a registration validator builds exactly this set over
+    # its validators, whose Type means the kind each one handles.
+    ("the same shape over a sequence that is not authorization_details entries",
+     "var supported = provider.GetKeyedServices<IAuthorizationDetailValidator>(AnyKey)\n"
+     "    .Select(v => v.Type).ToHashSet(StringComparer.Ordinal);\n", False),
+
     ("the computation described in a comment",
-     "// ToTypedArray().Select(detail => detail.Type) is what NamedBy does.\nvar x = 1;\n", False),
+     CONV + "\n// typed.Select(d => d.Type).ToHashSet(StringComparer.Ordinal) is what NamedBy does\n"
+     "var x = 1;\n", False),
     ("the computation inside a string literal",
-     "var s = \"ToTypedArray().Select(d => d.Type)\";\n", False),
-    ("a Type read in a later statement",
-     "var typed = details.ToTypedArray()!;\nvar first = typed[0].Type;\n", False),
+     CONV + "\nvar s = \"typed.Select(d => d.Type).ToHashSet()\";\n", False),
 ]
 
 
@@ -203,14 +305,14 @@ def self_test():
             io.open(os.path.join(tmp, rel), "w", encoding="utf-8", newline="").write(body)
             rels.append(rel)
 
-        canonical_hits, offenders = scan(tmp, rels, canonical_rel)
-        caught = {rel for rel, _, _ in offenders}
+        canonical_hits, found = scan(tmp, rels, canonical_rel)
+        caught = {rel for rel, _, _ in found}
 
         for i, (name, _, expected) in enumerate(SELF_TEST_CASES):
             got = f"case{i}.cs" in caught
             ok &= got == expected
             mark = "OK    " if got == expected else "FAILED"
-            print(f"{mark} {name:56} expected={'found' if expected else 'clean':5} "
+            print(f"{mark} {name:64} expected={'found' if expected else 'clean':5} "
                   f"got={'found' if got else 'clean'}")
 
         # The control itself: the canonical member must be visible to this check, or a clean
@@ -218,15 +320,15 @@ def self_test():
         got_canonical = len(canonical_hits) == 1
         ok &= got_canonical
         print(f"{'OK    ' if got_canonical else 'FAILED'} "
-              f"{'the canonical member is found, exactly once':56} "
+              f"{'the canonical member is found, exactly once':64} "
               f"expected=found got={'found' if canonical_hits else 'nothing'}")
 
-        # And the refusal branch: with the canonical file absent, the run must not report clean.
+        # And the refusal branch: with the canonical file absent, the control comes back empty.
         absent_hits, _ = scan(tmp, [r for r in rels if r != canonical_rel], canonical_rel)
         refuses = not absent_hits
         ok &= refuses
         print(f"{'OK    ' if refuses else 'FAILED'} "
-              f"{'a missing canonical member leaves the control empty':56} "
+              f"{'a missing canonical member leaves the control empty':64} "
               f"expected=empty got={'empty' if refuses else 'found'}")
 
     print()
@@ -235,8 +337,19 @@ def self_test():
     return 0 if ok else 1
 
 
+
 def main():
     argv = sys.argv[1:]
+
+    # An argument nobody recognises used to fall through to the tree walk, so a typo in
+    # --self-test printed a clean tree and exited 0. A run that did not do what it was asked
+    # must not look like a run that did.
+    unknown = [a for a in argv if a != "--self-test"]
+    if unknown:
+        print(f"Unrecognised argument(s): {' '.join(unknown)}")
+        print("Usage: lint-no-inlined-detail-types.py [--self-test]")
+        return 2
+
     if "--self-test" in argv:
         return self_test()
 
@@ -245,19 +358,40 @@ def main():
         capture_output=True, text=True, encoding="utf-8", check=True).stdout.strip()
 
     rels = tracked_sources(root)
-    canonical_hits, offenders = scan(root, rels, CANONICAL)
+    canonical_hits, found = scan(root, rels, CANONICAL)
 
     print(f"C# files scanned: {len(rels)}")
 
-    if not canonical_hits:
+    if len(canonical_hits) != 1:
         print()
-        print(f"REFUSED: the computation was not found in {CANONICAL}.")
-        print("This check has no control, so it cannot tell a clean tree from a search that")
-        print(f"missed. If {CANONICAL_MEMBER} moved, update CANONICAL in this file; if it was")
-        print("rewritten, update the patterns and prove them with --self-test.")
+        print(f"REFUSED: the computation was found {len(canonical_hits)} time(s) in {CANONICAL},")
+        print("and this check needs exactly one - that occurrence is its only control.")
+        print(f"If {CANONICAL_MEMBER} MOVED, update CANONICAL near the top of")
+        print(f"  .github/scripts/lint-no-inlined-detail-types.py")
+        print("If it was REWRITTEN and no longer reads as this computation, update the patterns")
+        print("beside it and prove them with --self-test. If a SECOND occurrence appeared in that")
+        print("file, one of them is the duplication this check exists to stop.")
         return 1
 
     print(f"Canonical occurrences in {CANONICAL}: {len(canonical_hits)}")
+
+    allowed_hits = [hit for hit in found if hit[0] in ALLOWED]
+    offenders = [hit for hit in found if hit[0] not in ALLOWED]
+
+    # Every allowance is a control. One that matches nothing is stale, and a stale allowance
+    # covers whatever lands at that path next without anybody deciding to.
+    silent = sorted(set(ALLOWED) - {hit[0] for hit in allowed_hits})
+    if silent:
+        print()
+        print(f"REFUSED: {len(silent)} allowance(s) matched nothing:")
+        for rel in silent:
+            print(f"  {rel}")
+        print("An allowance nobody needs is one nobody notices going stale. Remove it, or find")
+        print("out why the site it names stopped being an instance of this computation.")
+        return 1
+
+    for rel, line, form in allowed_hits:
+        print(f"Allowed: {rel}:{line} ({form}) - {ALLOWED[rel]}")
 
     if not offenders:
         print("No other site recomputes the types an authorization_details array names.")
@@ -270,7 +404,8 @@ def main():
     print()
     print(f"Call {CANONICAL_MEMBER} instead. Two halves of one comparison living in two files")
     print("drift by a clause and then disagree on the inputs nobody wrote a test for, while both")
-    print("stay green.")
+    print("stay green. If this site genuinely cannot call it, add it to ALLOWED with the reason -")
+    print("an allowance is a decision somebody made, and it carries its own control.")
     return 1
 
 

--- a/.github/scripts/lint-no-inlined-detail-types.py
+++ b/.github/scripts/lint-no-inlined-detail-types.py
@@ -14,21 +14,28 @@ project in the next - it would not have caught the duplication it exists to prev
 The set's shape alone is not enough to say WHAT was counted, because the same
 `.Select(x => x.Type).ToHashSet(...)` is written over sequences of other things whose `Type`
 means something else. A regular expression cannot infer a sequence's type, so the file is asked
-the question it can answer: does it call the one conversion that produces these entries. A file
-that never does is not computing this set, whatever shape its projections take.
+a question it can answer: does it name these entries at all - the conversion that produces them,
+or the type itself, which the library also hands out as a typed property. That is a NECESSARY
+condition, not a sufficient one, and it is the honest limit of a text-level check.
 
 The computation lives in `AuthorizationDetailTypes.NamedBy`. Two halves of one comparison in
 two files are what makes this worth a check rather than a habit: a copy that drifts by one
 clause makes them disagree on exactly the inputs nobody wrote a test for, and both stay green.
 
-The canonical member is this check's own control, and every entry in ALLOWED is another. A run
+The canonical member is this check's own control, and every allowance marker is another. A run
 where any control matches nothing REFUSES instead of reporting a clean tree, because a search
 that cannot come back positive says nothing about the world - only about itself.
 
-What it does NOT reach: the projection and the set in two different statements
-(`var names = typed.Select(d => d.Type); var set = names.ToHashSet(...);`), and the same set
-built by a loop rather than a projection. Both are said here rather than left to be discovered,
-because a check whose limits are unwritten gets read as having none.
+What it does NOT reach, said here rather than left to be discovered, because a check whose
+limits are unwritten gets read as having none:
+
+- the projection and the set in two different statements
+  (`var names = typed.Select(d => d.Type); var set = names.ToHashSet(...);`);
+- a set built by a loop, or by `new HashSet<string>(...)`, or by a collection expression;
+- a projection whose lambda body is a conditional expression ending in `.Type`;
+- entries reached in a file that names neither the conversion nor the type.
+
+Each of those is a way to write this computation that a green run says nothing about.
 
     python .github/scripts/lint-no-inlined-detail-types.py             # check the tree
     python .github/scripts/lint-no-inlined-detail-types.py --self-test # prove it can find one
@@ -50,22 +57,29 @@ if hasattr(sys.stdout, "reconfigure"):
 CANONICAL = "src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailTypes.cs"
 CANONICAL_MEMBER = "AuthorizationDetailTypes.NamedBy"
 
-# The one conversion that produces typed entries. Its presence in a file is what says the
-# projections there are over authorization_details entries rather than over something else.
-CONVERSION = "ToTypedArray"
+# What says a file is dealing in authorization_details entries at all. The conversion is one way
+# in; the library also exposes the entries as a typed property, and a file reaching them THAT way
+# names no conversion - a projection there was invisible while this asked only about the
+# conversion. Whole words, because IAuthorizationDetailValidator and AuthorizationDetailsTypes are
+# about something else entirely and must not drag their files in.
+ENTRIES_IN_PLAY = re.compile(r"\b(?:ToTypedArray|AuthorizationDetail|AuthorizationDetails)\b")
 
-# Sites allowed to compute it themselves, each with the reason. This is an allowance rather than
-# an exclusion pattern: a form is permitted at a named place for a stated reason, not a shape
-# quietly dropped everywhere.
+# An allowance lives AT the occurrence, as a comment within the few lines above it, and it must
+# carry a reason after the marker.
 #
-# Each allowance is also a control. A run where an allowed site no longer matches REFUSES rather
-# than passing, because an allowance nobody needs any more is an allowance nobody notices going
-# stale - and the next site that lands there inherits it.
-ALLOWED = {
-    "src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs":
-        "the grant side of the comparison, which REFUSES a typeless entry where the canonical "
-        "member drops it, so its guards run first and it holds the entries afterwards",
-}
+# It was keyed by FILE first, and that wiped out the check's own scenario: both original spellings
+# of the duplication, planted into the allowed file, were waved through - each printed with a
+# reason written for a different line. An allowance has to name the thing it allows, and a file is
+# not a thing. At the site it also moves with the code, and a second inlining ten lines away
+# inherits nothing.
+#
+# Every marker is a control. A marker with no occurrence beneath it REFUSES, because an allowance
+# nobody needs is one nobody notices going stale.
+ALLOWANCE_MARKER = "lint-inlined-detail-types: allowed"
+
+# How far above the occurrence the marker may sit. Wide enough for a comment paragraph, narrow
+# enough that it cannot reach past the statement it belongs to.
+ALLOWANCE_REACH = 8
 
 # The computation is a SET of the types the entries name, and that is what this looks for: a
 # projection of an entry to its Type whose result is turned into a set.
@@ -75,10 +89,7 @@ ALLOWED = {
 # they all convert in one statement and project in the next. It would not have caught the
 # duplication it exists to prevent. The conversion is therefore not in the pattern at all: what
 # makes this computation itself is the set of names, not how the entries were obtained.
-#
-# The window between the projection and the set allows a filter or a cast to sit in between,
-# and stops at a statement end or a block, so a projection and a set belonging to two different
-# expressions are not joined into one finding.
+
 # The lambda parameter, however it is written: bare, parenthesised, explicitly typed,
 # static, or with the index parameter beside it. The capture is what ties the projection to
 # THAT parameter rather than to any Type standing nearby.
@@ -88,8 +99,15 @@ _ENTRY = r"(?:static\s+)?\(?\s*(?:\w+\s+)?(\w+)\s*(?:,\s*\w+\s*)?\)?"
 # through neither.
 _ITS_TYPE = r"\1\s*!?\s*\??\s*\.\s*Type\b"
 
-# ... turned into a set. A filter, a cast or an ordering may sit in between.
-_INTO_A_SET = r"[^;{}]{0,300}?\.\s*ToHashSet\s*\("
+# ... turned into a set. A filter or a cast may sit in between, and the comma is excluded so the
+# window cannot cross from one argument to the next: without that, a projection in one argument
+# and somebody else's set in the next were joined into a finding, and the refusal named a site
+# that computes nothing of the sort.
+#
+# The set constructors here are the ones that say "set" in their name. `new HashSet<string>(...)`,
+# a collection expression and a set built by a loop are all missed, and that is stated in the
+# docstring rather than left to be found.
+_INTO_A_SET = r"[^;{},]{0,300}?\.\s*To(?:Hash|Frozen|Immutable(?:Hash|Sorted))Set\s*\("
 
 # .Select(d => d.Type) ... .ToHashSet(
 METHOD_FORM = re.compile(
@@ -179,9 +197,9 @@ def strip_comments_and_strings(text):
     return "".join(out)
 
 
-def matches_in(text):
+def matches_in(text, already_stripped=False):
     """Every occurrence of the computation, as (line number, which form matched)."""
-    stripped = strip_comments_and_strings(text)
+    stripped = text if already_stripped else strip_comments_and_strings(text)
     found = []
     for name, pattern in FORMS:
         for m in pattern.finditer(stripped):
@@ -189,9 +207,23 @@ def matches_in(text):
     return sorted(found)
 
 
+def allowance_above(lines, line_number):
+    """The reason on the allowance marker over this occurrence, or None.
+
+    Read from the ORIGINAL text rather than the stripped copy, because a marker IS a comment and
+    the stripped copy is where comments have gone.
+    """
+    first = max(0, line_number - 1 - ALLOWANCE_REACH)
+    for raw in lines[first:line_number]:
+        if ALLOWANCE_MARKER in raw:
+            reason = raw.split(ALLOWANCE_MARKER, 1)[1].strip(" -\t\r")
+            return reason or "(no reason given)"
+    return None
+
+
 def scan(root, rels, canonical):
-    """Splits every occurrence into the canonical one and the rest."""
-    canonical_hits, offenders = [], []
+    """Splits every occurrence into the canonical one, the allowed ones and the rest."""
+    canonical_hits, offenders, allowed = [], [], []
     for rel in rels:
         path = os.path.join(root, rel.replace("/", os.sep))
         try:
@@ -203,13 +235,48 @@ def scan(root, rels, canonical):
         # shape its projections take: the same `.Select(x => x.Type).ToHashSet(...)` is written
         # over sequences of other things, where Type means something else entirely. The pattern
         # cannot infer the sequence's type, so this asks the question it CAN answer.
-        if CONVERSION not in strip_comments_and_strings(text):
+        code = strip_comments_and_strings(text)
+        if not ENTRIES_IN_PLAY.search(code):
             continue
 
-        for line, form in matches_in(text):
-            target = canonical_hits if rel.replace(os.sep, "/") == canonical else offenders
-            target.append((rel.replace(os.sep, "/"), line, form))
-    return canonical_hits, offenders
+        lines = text.split("\n")
+        for line, form in matches_in(code, already_stripped=True):
+            rel_posix = rel.replace(os.sep, "/")
+            if rel_posix == canonical:
+                canonical_hits.append((rel_posix, line, form))
+                continue
+
+            reason = allowance_above(lines, line)
+            (allowed if reason else offenders).append((rel_posix, line, form, reason))
+
+    return canonical_hits, offenders, allowed
+
+
+def stale_markers(root, rels, allowed):
+    """Allowance markers with no occurrence beneath them.
+
+    A marker is a control: it says somebody looked at a site and decided. One that allows nothing
+    is a decision about code that is gone, waiting for whatever lands there next.
+    """
+    consumed = {}
+    for rel, line, _, _ in allowed:
+        consumed[rel] = consumed.get(rel, 0) + 1
+
+    stale = []
+    for rel in rels:
+        path = os.path.join(root, rel.replace("/", os.sep))
+        try:
+            with io.open(path, encoding="utf-8", errors="replace", newline="") as fh:
+                lines = fh.read().split("\n")
+        except OSError:
+            continue
+
+        marks = [i + 1 for i, raw in enumerate(lines) if ALLOWANCE_MARKER in raw]
+        rel_posix = rel.replace(os.sep, "/")
+        extra = len(marks) - consumed.get(rel_posix, 0)
+        for line in marks[len(marks) - extra:] if extra > 0 else []:
+            stale.append((rel_posix, line))
+    return stale
 
 
 def tracked_sources(root):
@@ -268,8 +335,17 @@ SELF_TEST_CASES = [
      ".Distinct().ToArray();\n", False),
     ("a validation over the types rather than a set of them",
      CONV + "\nif (typed.All(d => d.Type is { } type && ok(type))) return true;\n", False),
-    ("a projection to something else",
-     CONV + "\nvar k = typed.Where(d => d.Locations is null).ToHashSet();\n", False),
+    # A real projection into a real set, of a real member that is not Type. This is the only row
+    # that pins the pattern to Type: the one that stood here filtered rather than projected, so it
+    # was clean because of `.Locations` and would have stayed clean with the member wildcarded.
+    ("a projection of a different member, into a set",
+     CONV + "\nvar k = typed.Select(d => d.Locations).ToHashSet();\n", False),
+    ("a filter rather than a projection",
+     CONV + "\nvar k = typed.Where(d => d.Type is null).ToHashSet(StringComparer.Ordinal);\n", False),
+    # The binding, as its own row: the same computation in a file that never mentions these
+    # entries is not this computation, and nothing else in the list would notice if it were.
+    ("the shape in a file that never names these entries",
+     "var t = things.Select(d => d.Type).ToHashSet(StringComparer.Ordinal);\n", False),
     ("a Type that is not the projected entry's",
      CONV + "\nvar t = typed.Select(d => other.Type).ToHashSet(StringComparer.Ordinal);\n", False),
 
@@ -305,8 +381,8 @@ def self_test():
             io.open(os.path.join(tmp, rel), "w", encoding="utf-8", newline="").write(body)
             rels.append(rel)
 
-        canonical_hits, found = scan(tmp, rels, canonical_rel)
-        caught = {rel for rel, _, _ in found}
+        canonical_hits, offenders, allowed = scan(tmp, rels, canonical_rel)
+        caught = {rel for rel, _, _, _ in offenders}
 
         for i, (name, _, expected) in enumerate(SELF_TEST_CASES):
             got = f"case{i}.cs" in caught
@@ -324,7 +400,7 @@ def self_test():
               f"expected=found got={'found' if canonical_hits else 'nothing'}")
 
         # And the refusal branch: with the canonical file absent, the control comes back empty.
-        absent_hits, _ = scan(tmp, [r for r in rels if r != canonical_rel], canonical_rel)
+        absent_hits, _, _ = scan(tmp, [r for r in rels if r != canonical_rel], canonical_rel)
         refuses = not absent_hits
         ok &= refuses
         print(f"{'OK    ' if refuses else 'FAILED'} "
@@ -358,7 +434,7 @@ def main():
         capture_output=True, text=True, encoding="utf-8", check=True).stdout.strip()
 
     rels = tracked_sources(root)
-    canonical_hits, found = scan(root, rels, CANONICAL)
+    canonical_hits, offenders, allowed = scan(root, rels, CANONICAL)
 
     print(f"C# files scanned: {len(rels)}")
 
@@ -367,7 +443,7 @@ def main():
         print(f"REFUSED: the computation was found {len(canonical_hits)} time(s) in {CANONICAL},")
         print("and this check needs exactly one - that occurrence is its only control.")
         print(f"If {CANONICAL_MEMBER} MOVED, update CANONICAL near the top of")
-        print(f"  .github/scripts/lint-no-inlined-detail-types.py")
+        print("  .github/scripts/lint-no-inlined-detail-types.py")
         print("If it was REWRITTEN and no longer reads as this computation, update the patterns")
         print("beside it and prove them with --self-test. If a SECOND occurrence appeared in that")
         print("file, one of them is the duplication this check exists to stop.")
@@ -375,23 +451,21 @@ def main():
 
     print(f"Canonical occurrences in {CANONICAL}: {len(canonical_hits)}")
 
-    allowed_hits = [hit for hit in found if hit[0] in ALLOWED]
-    offenders = [hit for hit in found if hit[0] not in ALLOWED]
-
-    # Every allowance is a control. One that matches nothing is stale, and a stale allowance
-    # covers whatever lands at that path next without anybody deciding to.
-    silent = sorted(set(ALLOWED) - {hit[0] for hit in allowed_hits})
-    if silent:
+    # Every marker is a control. One with nothing beneath it allows nothing today and will allow
+    # whatever lands there tomorrow, without anybody deciding to.
+    stale = stale_markers(root, rels, allowed)
+    if stale:
         print()
-        print(f"REFUSED: {len(silent)} allowance(s) matched nothing:")
-        for rel in silent:
-            print(f"  {rel}")
-        print("An allowance nobody needs is one nobody notices going stale. Remove it, or find")
-        print("out why the site it names stopped being an instance of this computation.")
+        print(f"REFUSED: {len(stale)} allowance marker(s) with no occurrence beneath them:")
+        for rel, line in stale:
+            print(f"  {rel}:{line}")
+        print("An allowance nobody needs is one nobody notices going stale, and the next site to")
+        print("land under it inherits a reason written for something else. Remove the marker, or")
+        print("find out why the code beneath it stopped being an instance of this computation.")
         return 1
 
-    for rel, line, form in allowed_hits:
-        print(f"Allowed: {rel}:{line} ({form}) - {ALLOWED[rel]}")
+    for rel, line, form, reason in allowed:
+        print(f"Allowed: {rel}:{line} ({form}) - {reason}")
 
     if not offenders:
         print("No other site recomputes the types an authorization_details array names.")
@@ -399,13 +473,15 @@ def main():
 
     print()
     print(f"The computation is inlined in {len(offenders)} place(s) outside the canonical member:")
-    for rel, line, form in offenders:
+    for rel, line, form, _ in offenders:
         print(f"  {rel}:{line} ({form})")
     print()
     print(f"Call {CANONICAL_MEMBER} instead. Two halves of one comparison living in two files")
     print("drift by a clause and then disagree on the inputs nobody wrote a test for, while both")
-    print("stay green. If this site genuinely cannot call it, add it to ALLOWED with the reason -")
-    print("an allowance is a decision somebody made, and it carries its own control.")
+    print("stay green. If a site genuinely cannot call it, put a comment directly above it saying")
+    print(f"  {ALLOWANCE_MARKER} - <why this one computes it itself>")
+    print("An allowance is a decision somebody made, it sits where the decision applies, and it")
+    print("carries its own control.")
     return 1
 
 

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -71,6 +71,37 @@ jobs:
         run: python .github/scripts/lint-license-headers.py
         timeout-minutes: 3
     timeout-minutes: 5
+  # A C# check in a workflow named for workflows, for the same reason the licence-header job
+  # above is here: the triggers. This file is the one with no path filter, so a job added here
+  # runs on every pull request rather than only on those that happen to touch .github/.
+  inlined-detail-types:
+    name: The authorization_details types are computed in one place
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+        timeout-minutes: 3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+        timeout-minutes: 3
+      # The check uses only the standard library, so there is nothing to install and no
+      # third-party code runs here.
+      #
+      # The self-test runs FIRST and separately. A clean tree is an answer about the world and
+      # about the instrument at once, and one exit code cannot separate them: a pattern broken
+      # by a later edit would leave this job green for good, because there would be nothing left
+      # to find.
+      - name: Prove the check can report a find
+        run: python .github/scripts/lint-no-inlined-detail-types.py --self-test
+        timeout-minutes: 3
+      - name: Check the computation is not inlined
+        run: python .github/scripts/lint-no-inlined-detail-types.py
+        timeout-minutes: 3
+    timeout-minutes: 5
   actionlint:
     name: actionlint (schema + shellcheck)
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,24 @@ repos:
         # The script's own path is in the pattern: a commit editing only KNOWN must re-run the
         # check, or the list is edited by whoever is not looking at what it holds.
         files: (\.cs|\.github/scripts/lint-take-once-consumers\.py)$
+      - id: inlined-detail-types-self-test
+
+        name: "Prove the detail-types check can report a find"
+
+        entry: python .github/scripts/lint-no-inlined-detail-types.py --self-test
+
+        language: python
+
+        pass_filenames: false
+
+        # Only when the check itself is edited, which is where its patterns get broken.
+
+        # A tree walk run on a pattern nothing proved answers about the pattern, not the
+
+        # tree. CI runs this unconditionally; a clone without pre-commit runs no hook at all.
+
+        files: ^\.github/scripts/lint-no-inlined-detail-types\.py$
+
       - id: inlined-detail-types
         name: "Keep the authorization_details types computed in one place"
         entry: python .github/scripts/lint-no-inlined-detail-types.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,16 @@ repos:
         # The script's own path is in the pattern: a commit editing only KNOWN must re-run the
         # check, or the list is edited by whoever is not looking at what it holds.
         files: (\.cs|\.github/scripts/lint-take-once-consumers\.py)$
+      - id: inlined-detail-types
+        name: "Keep the authorization_details types computed in one place"
+        entry: python .github/scripts/lint-no-inlined-detail-types.py
+        language: python
+        pass_filenames: false
+        # The script's own path is in the pattern for the same reason as above: a commit that
+        # edits only the patterns must re-run them, or they are changed by whoever is not
+        # looking at what they still catch. CI runs this unconditionally - a clone with no
+        # pre-commit installed executes no hook at all.
+        files: (\.cs|\.github/scripts/lint-no-inlined-detail-types\.py)$
       - id: no-split-doc-comments
         name: "Block a doc comment that documents two members"
         entry: python .github/scripts/lint-no-split-doc-comments.py

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -172,6 +172,10 @@ public class ConsentConstraintEnforcer(
             if (escapedTypes.Length > 0)
                 throw Violation(culprit, "authorization_details types", escapedTypes);
 
+            // lint-inlined-detail-types: allowed - the grant side of this comparison REFUSES a
+            // typeless entry where AuthorizationDetailTypes.NamedBy DROPS one, and the two guards
+            // above are that refusal. Calling the shared member here would be equivalent ONLY
+            // because those guards ran first, which is a dependency nothing states - see issue 494.
             return typed.Select(detail => detail.Type!).ToHashSet(StringComparer.Ordinal);
         }
     }


### PR DESCRIPTION
Four call sites once computed the same thing: the set of types an `authorization_details` array names. Nothing said so. It surfaced in review, on the fourth copy, and #427 folded them into `AuthorizationDetailTypes.NamedBy` - which closed the duplication and left nothing behind to stop it returning.

This adds that check, and it took two review rounds to become one. Both rounds are recorded below, because what the check now is only makes sense against what it was.

## What it looks for

**The result, not the pipeline.** A projection of an entry to its `Type` whose result becomes a set. How the entries were obtained is not in the pattern at all.

The first version anchored on the conversion followed by the projection in the SAME expression. Every live site in the tree converts in one statement and projects in the next, so it saw none of them: re-inlining #427's exact removal, written the way the file it was removed from writes it, passed clean while the run printed that no other site recomputes it. A check that certifies its own blindness is worse than none.

**A file has to be dealing in these entries at all.** The result shape alone cannot say WHAT was counted - a client-registration validator builds the identical set over its own validators, whose `Type` is the kind each one handles, and the second version refused it. A regular expression cannot infer a sequence's type, so the file is asked what it can answer: does it name these entries, by the conversion or by the typed property the library also exposes. Whole words, so a validator interface and a registration field do not drag their files in. This is a NECESSARY condition, not a sufficient one, and the check says so where a reader will meet it.

## Allowances live at the occurrence

One live site genuinely cannot call the shared member: the grant side of the consent comparison REFUSES a typeless entry where the canonical member DROPS one, and its two guards are that refusal. It carries a marker comment directly above it with the reason.

That was keyed by FILE first, and the second review round showed what it cost: both original spellings of the duplication, planted into that file, were waved through - each printed with a reason written for a different line, exit 0. The check waved through the thing it exists to stop. An allowance has to name the thing it allows, and a file is not a thing.

At the occurrence it covers one place, moves with the code, and a second inlining ten lines below inherits nothing. **Every marker is also a control**: one with no occurrence beneath it REFUSES, because an allowance nobody needs is one nobody notices going stale, and whatever lands there next would inherit somebody else's reasoning.

## The controls, and what makes a green run mean anything

- **The canonical member must match exactly once.** Not at least once: a second occurrence in that file is the duplication rather than a passing run. Its absence refuses with a message naming what to do - the member moved, the member was rewritten, or a second one appeared.
- **Every allowance marker must have an occupant**, as above.
- **The self-test runs as its own CI step, ahead of the tree walk.** One exit code cannot tell a clean tree from a broken pattern, and a pattern broken by a later edit would otherwise leave the job green permanently.
- **An unrecognised argument exits 2** rather than silently walking the tree, so a typo in `--self-test` cannot print a clean result.

## Driven

Both original spellings and the two-statement idiom were planted into real files and each was caught at its planted line; the same two spellings planted into the ALLOWED file are refused rather than waved through. The stale-allowance refusal was driven with a fabricated marker. All three canonical-control failures were driven. Everything restored from copies taken first.

The self-test has teeth on the properties it names: wildcarding the projected member, and accepting `Where` beside `Select`, each fail cases. Round 2 found that neither did - the row named for pinning the member filtered rather than projected, so it was clean for the wrong reason.

## What a green run does NOT say

Each of these is a way to write the computation that this check cannot see, and they are in the script's own docstring so a reader meets them where the decision is made:

- the projection and the set in two different statements;
- a set built by a loop, by `new HashSet<string>(...)`, or by a collection expression;
- a projection whose lambda body is a conditional expression ending in `.Type`;
- entries reached in a file that names neither the conversion nor the type.

No counts appear in this description. Three of them went stale here across two rounds, and a number written once reads as current forever.

Ref #429
