### PR TITLE
Refuse a user code past its lifetime, and ask the record rather than the clock

### DIFF
--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
@@ -54,10 +54,9 @@ public record DeviceAuthorizationRequest(
     /// </para>
     /// <para>
     /// Only one of the two boundaries is held. Relaxing THIS one to <c>&gt;=</c> turns two rows red, both
-    /// driving a decision at exactly <c>ExpiresAt</c>. Relaxing the handler's leaves every suite green,
-    /// so a maintainer who reads this as the single place, and edits
-    /// <see cref="Endpoints.Token.Grants.DeviceCodeGrantHandler"/> to match, splits the token endpoint's
-    /// verdict from the verification endpoint's in silence. That gap is on the handler, not here.
+    /// driving a decision at exactly <c>ExpiresAt</c>. Relaxing
+    /// <see cref="Endpoints.Token.Grants.DeviceCodeGrantHandler"/>'s leaves every suite green. That gap
+    /// is on the handler, not here.
     /// </para>
     /// <para>
     /// It hands back the remaining time because the callers that act on the record need it: a decision

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
@@ -33,11 +33,33 @@ public record DeviceAuthorizationRequest(
     public DateTimeOffset? NextPollAt { get; set; }
 
     /// <summary>
-    /// The absolute time when this device authorization request expires (RFC 8628 §3.2 fixed lifetime).
+    /// The absolute time when this device authorization request expires (RFC 8628 Section 3.2 fixed lifetime).
     /// Seeded by the storage on <c>StoreAsync</c> and used to cap the refreshed cache TTL at the remaining
     /// lifetime, so regular polling cannot extend the code.
     /// </summary>
     public DateTimeOffset ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Whether the fixed lifetime still has time left at <paramref name="now"/>, handing back how much.
+    /// </summary>
+    /// <remarks>
+    /// The comparison lives here rather than at each caller because it was written out three times and
+    /// the fourth place was the one that forgot it - user code verification, the step the end user
+    /// reaches first, decided on <see cref="Status"/> alone and answered a full result for a record the
+    /// approval would then refuse.
+    /// <para>
+    /// It hands back the remaining time because the callers that act on the record need it: a decision
+    /// is written with that as the cache TTL, so the code cannot be extended by being decided on.
+    /// </para>
+    /// </remarks>
+    /// <param name="now">The instant to judge against, from the caller's own time provider.</param>
+    /// <param name="remaining">How much lifetime is left; zero or negative when there is none.</param>
+    /// <returns><c>true</c> while the request can still be acted on.</returns>
+    public bool HasLifetimeLeft(DateTimeOffset now, out TimeSpan remaining)
+    {
+        remaining = ExpiresAt - now;
+        return remaining > TimeSpan.Zero;
+    }
 
     /// <summary>
     /// Indicates the current status of the device authorization request.
@@ -52,7 +74,7 @@ public record DeviceAuthorizationRequest(
     public AuthorizedGrant? AuthorizedGrant { get; set; }
 
     /// <summary>
-    /// RFC 9396 §3 Rich Authorization Requests array carried from the original
+    /// RFC 9396 Section 3 Rich Authorization Requests array carried from the original
     /// <c>/device_authorization</c> request. The host's user-verification step reads this
     /// (via <see cref="ValidUserCode"/>) to render structured consent, then threads it into
     /// the <see cref="AuthorizedGrant"/>'s <c>AuthorizationContext</c> when approving;

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
@@ -43,10 +43,16 @@ public record DeviceAuthorizationRequest(
     /// Whether the fixed lifetime still has time left at <paramref name="now"/>, handing back how much.
     /// </summary>
     /// <remarks>
-    /// The comparison lives here rather than at each caller because it was written out three times and
-    /// the fourth place was the one that forgot it - user code verification, the step the end user
-    /// reaches first, decided on <see cref="Status"/> alone and answered a full result for a record the
-    /// approval would then refuse.
+    /// The comparison sits here because it was being written out at each caller, and one of them
+    /// forgot it: user code verification, the step the end user reaches first, decided on
+    /// <see cref="Status"/> alone and answered a full result for a record the approval would then refuse.
+    /// <para>
+    /// It is NOT yet the only place. <c>DeviceCodeGrantHandler</c> still writes both halves out - the
+    /// verdict as <c>now &gt;= ExpiresAt</c> and the remaining time as <c>ExpiresAt - now</c> - and that
+    /// file is outside this change. The two agree today, and nothing holds them to it: changing the
+    /// boundary here to <c>&gt;=</c> is caught by no test anywhere, so a maintainer who reads this as the
+    /// single place can split the token endpoint's verdict from the verification endpoint's in silence.
+    /// </para>
     /// <para>
     /// It hands back the remaining time because the callers that act on the record need it: a decision
     /// is written with that as the cache TTL, so the code cannot be extended by being decided on.

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
@@ -49,9 +49,14 @@ public record DeviceAuthorizationRequest(
     /// <para>
     /// It is NOT yet the only place. <c>DeviceCodeGrantHandler</c> still writes both halves out - the
     /// verdict as <c>now &gt;= ExpiresAt</c> and the remaining time as <c>ExpiresAt - now</c> - and that
-    /// file is outside this change. The two agree today, and nothing holds them to it: changing the
-    /// boundary here to <c>&gt;=</c> is caught by no test anywhere, so a maintainer who reads this as the
-    /// single place can split the token endpoint's verdict from the verification endpoint's in silence.
+    /// file is outside this change. The two agree today, exactly: this predicate is <c>now &lt; ExpiresAt</c>
+    /// and the handler's expiry arm is its complement.
+    /// </para>
+    /// <para>
+    /// Only one of the two boundaries is held. Relaxing THIS one to <c>&gt;=</c> turns two rows red, both
+    /// driving a decision at exactly <c>ExpiresAt</c>. Relaxing the handler's leaves every suite green,
+    /// so a maintainer who reads this as the single place and edits there splits the token endpoint's
+    /// verdict from the verification endpoint's in silence. That gap is on the handler, not here.
     /// </para>
     /// <para>
     /// It hands back the remaining time because the callers that act on the record need it: a decision

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/DeviceAuthorizationRequest.cs
@@ -55,7 +55,8 @@ public record DeviceAuthorizationRequest(
     /// <para>
     /// Only one of the two boundaries is held. Relaxing THIS one to <c>&gt;=</c> turns two rows red, both
     /// driving a decision at exactly <c>ExpiresAt</c>. Relaxing the handler's leaves every suite green,
-    /// so a maintainer who reads this as the single place and edits there splits the token endpoint's
+    /// so a maintainer who reads this as the single place, and edits
+    /// <see cref="Endpoints.Token.Grants.DeviceCodeGrantHandler"/> to match, splits the token endpoint's
     /// verdict from the verification endpoint's in silence. That gap is on the handler, not here.
     /// </para>
     /// <para>

--- a/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
+++ b/src/Abblix.Oidc.Server/Features/DeviceAuthorization/UserCodeVerificationService.cs
@@ -70,6 +70,18 @@ public partial class UserCodeVerificationService(
             return new UserCodeAlreadyUsed();
         }
 
+        // A code past its lifetime is as dead as a used one, and the approval that follows this step
+        // refuses it without a reason - so answering valid here shows the user a consent screen for
+        // nothing. It counts as a FAILURE for the same reason the used code does: success resets the
+        // per-code counter, so one expired-but-pending code would otherwise clear that bucket at will
+        // and its brute-force budget would never fill. InvalidUserCode is what its own contract already
+        // promises for this - "not found or has expired".
+        if (!request.HasLifetimeLeft(timeProvider.GetUtcNow(), out _))
+        {
+            await rateLimiter.RecordFailureAsync(userCode, clientIp);
+            return new InvalidUserCode();
+        }
+
         // Valid user code found and pending - record success to reset counters
         await rateLimiter.RecordSuccessAsync(userCode, clientIp);
         return new ValidUserCode(request.ClientId, request.Scope, request.Resources, request.AuthorizationDetails);
@@ -90,8 +102,7 @@ public partial class UserCodeVerificationService(
 
         // An approval landing after the code's fixed lifetime (RFC 8628 section 3.2) cannot be redeemed, so treat
         // it as a no-op rather than reviving an expired code; this also keeps the refreshed cache TTL positive.
-        var remaining = request.ExpiresAt - timeProvider.GetUtcNow();
-        if (remaining <= TimeSpan.Zero)
+        if (!request.HasLifetimeLeft(timeProvider.GetUtcNow(), out var remaining))
             return false;
 
         // Narrowing is the host's to decide; widening is not. A grant carrying a type the device
@@ -149,8 +160,7 @@ public partial class UserCodeVerificationService(
 
         // A denial after the code's fixed lifetime (RFC 8628 section 3.2) is moot - the code is already unusable, so
         // treat it as a no-op rather than writing a record with a non-positive cache TTL.
-        var remaining = request.ExpiresAt - timeProvider.GetUtcNow();
-        if (remaining <= TimeSpan.Zero)
+        if (!request.HasLifetimeLeft(timeProvider.GetUtcNow(), out var remaining))
             return false;
 
         return await TryDecideAsync(

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -48,8 +48,10 @@ public class UserCodeVerificationServiceTests
     public UserCodeVerificationServiceTests()
     {
         // ExpiresAt is set because it is DateTimeOffset.MinValue otherwise, which is in the past.
-        // These rows are named for canonicalization, and a record that is also expired would let
-        // them go green on the wrong reason once the lifetime is checked.
+        // Measured: leave it unset and all four canonicalization rows go RED once the lifetime is
+        // checked, because verification then answers InvalidUserCode. They are not vacuous - they
+        // measure canonicalization exactly as named - so an expired fixture would break them for a
+        // reason having nothing to do with what they are for.
         var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
         {
             ExpiresAt = Now.AddMinutes(5),
@@ -322,6 +324,61 @@ public class UserCodeVerificationServiceTests
             limiter => limiter.RecordFailureAsync(CanonicalUserCode, It.IsAny<string>()), Times.Once);
         rateLimiter.Verify(
             limiter => limiter.RecordSuccessAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// The approval and the denial refuse a record past its lifetime, and each holds the predicate's
+    /// boundary on its own.
+    /// </summary>
+    /// <remarks>
+    /// Both guards existed before this change and nothing measured either: deleting them at the base
+    /// left the suite green. Now that one predicate decides all three callers, a single edit moves three
+    /// verdicts, so each caller gets a row rather than trusting the one on verification.
+    /// <para>
+    /// The instant chosen is the expiry itself, because that is the boundary a mutation moves: at
+    /// exactly <c>ExpiresAt</c> the lifetime is over, and relaxing the comparison to <c>&gt;=</c> is
+    /// what these rows exist to turn red.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ADecisionOnARecordAtItsExpiry_IsRefused(bool approving)
+    {
+        var expired = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            ExpiresAt = Now,
+        };
+
+        var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
+        storage
+            .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, expired) : null);
+        storage
+            .Setup(store => store.TryGetByDeviceCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == DeviceCode ? expired : null);
+
+        var service = new UserCodeVerificationService(
+            new CapturingLogger<UserCodeVerificationService>(),
+            storage.Object,
+            Mock.Of<IUserCodeRateLimiter>(),
+            new UserCodeNormalizer(Options.Create(DeviceOptions())),
+            Mock.Of<IRequestInfoProvider>(),
+            new FakeTimeProvider(Now));
+
+        var decided = approving
+            ? await service.ApproveAsync(CanonicalUserCode, GrantWith(null))
+            : await service.DenyAsync(CanonicalUserCode);
+
+        Assert.False(decided);
+
+        // The record is untouched, which is the half a bare false does not say: a decision written with
+        // a non-positive cache TTL is what refusing here avoids.
+        Assert.Equal(DeviceAuthorizationStatus.Pending, expired.Status);
+        storage.Verify(
+            store => store.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<DeviceAuthorizationRequest>(), It.IsAny<TimeSpan>()),
+            Times.Never);
     }
 
     private static UserCodeVerificationService BuildService(

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DeviceAuthorization/UserCodeVerificationServiceTests.cs
@@ -47,7 +47,13 @@ public class UserCodeVerificationServiceTests
 
     public UserCodeVerificationServiceTests()
     {
-        var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode);
+        // ExpiresAt is set because it is DateTimeOffset.MinValue otherwise, which is in the past.
+        // These rows are named for canonicalization, and a record that is also expired would let
+        // them go green on the wrong reason once the lifetime is checked.
+        var request = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            ExpiresAt = Now.AddMinutes(5),
+        };
 
         var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
         storage
@@ -259,6 +265,63 @@ public class UserCodeVerificationServiceTests
 
         // And the stale one was left alone, which is what a caller reading it back would rely on.
         Assert.Equal(DeviceAuthorizationStatus.Pending, fromUserCode.Status);
+    }
+
+    /// <summary>
+    /// A record past its lifetime is refused, and the refusal counts as a failed attempt.
+    /// </summary>
+    /// <remarks>
+    /// Verification is the step the end user reaches FIRST, and it was the only one of the three
+    /// deciding on <c>Status</c> alone. Its two siblings on the same record both refuse an expired one,
+    /// so the user was shown a consent screen for a code that <c>ApproveAsync</c> would then refuse
+    /// without a reason.
+    /// <para>
+    /// The rate-limit half is the one with teeth. Answering valid ran <c>RecordSuccessAsync</c>, which
+    /// resets the per-code failure counter - so somebody holding one expired-but-pending code could
+    /// clear that bucket at will and the brute-force budget for it never filled. An expired code is as
+    /// dead as a used one and earns the same treatment.
+    /// </para>
+    /// <para>
+    /// The answer is <see cref="InvalidUserCode"/> rather than a new result type because that type's own
+    /// contract already says so: "was not found or has expired". The gap was the implementation, not the
+    /// vocabulary.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task Verify_OnAPendingRecordPastItsLifetime_RefusesAndCountsAFailure()
+    {
+        var expired = new DeviceAuthorizationRequest(ClientId, ["openid"], null, CanonicalUserCode)
+        {
+            ExpiresAt = Now.AddSeconds(-1),
+        };
+
+        var storage = new Mock<IDeviceAuthorizationStorage>(MockBehavior.Loose);
+        storage
+            .Setup(store => store.TryGetByUserCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync((string code) => code == CanonicalUserCode ? (DeviceCode, expired) : null);
+
+        var rateLimiter = new Mock<IUserCodeRateLimiter>(MockBehavior.Loose);
+        rateLimiter
+            .Setup(limiter => limiter.CheckAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((Result<bool, TimeSpan>)true);
+
+        var service = new UserCodeVerificationService(
+            new CapturingLogger<UserCodeVerificationService>(),
+            storage.Object,
+            rateLimiter.Object,
+            new UserCodeNormalizer(Options.Create(DeviceOptions())),
+            Mock.Of<IRequestInfoProvider>(),
+            new FakeTimeProvider(Now));
+
+        var result = await service.VerifyAsync(CanonicalUserCode);
+
+        Assert.IsType<InvalidUserCode>(result);
+
+        // Both halves, because a refusal that still reset the counter would satisfy the line above.
+        rateLimiter.Verify(
+            limiter => limiter.RecordFailureAsync(CanonicalUserCode, It.IsAny<string>()), Times.Once);
+        rateLimiter.Verify(
+            limiter => limiter.RecordSuccessAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     private static UserCodeVerificationService BuildService(


### PR DESCRIPTION
`UserCodeVerificationService.VerifyAsync` decided on `Status` alone. A device authorization record past its RFC 8628 Section 3.2 lifetime but still `Pending` was answered with a full `ValidUserCode` - client id, scope, resources, authorization details - and the rate limiter was told the attempt SUCCEEDED.

## What it cost

It never let an expired code be redeemed: `ApproveAsync` is the gate and it holds. Two other things:

- **A consent screen for a code that cannot be approved.** The user types the code, sees the client and the scopes, approves, and nothing happens - `ApproveAsync` returns `false` with no reason.
- **A rate-limit reset the code had not earned.** `RecordSuccessAsync` runs on the valid path, so verifying an expired-but-pending code clears the per-code failure counter and that bucket's brute-force budget never fills. How long such a record survives is not measured here and the phrase "at will" was inherited from the issue rather than run; what IS measured is that the state is reachable and durable by another route - `DeviceAuthorizationRequestMapper` reads a stored record with no expiry back as `DateTimeOffset.MinValue`, which is expired and `Pending` indefinitely.

## Why one caller forgot it

The comparison was written out at each caller. `ApproveAsync` and `DenyAsync` both had it; verification, the step the end user reaches FIRST, did not. A comparison repeated at every caller is one a caller can be added without, and this is that.

It is still not in one place. `DeviceCodeGrantHandler` writes both halves out - the verdict as `now >= ExpiresAt`, the remaining time as `ExpiresAt - now` - and that file is outside this change. The record's remarks say so rather than claiming otherwise. The two rows below hold THIS side of that boundary: relaxing the predicate turns both red. The handler's side is held by nothing - relaxing it leaves every suite in the solution green - which is issue #496 and is deliberately not fixed here.

So it moves onto the record as `HasLifetimeLeft(now, out remaining)`. It hands back the remaining time because the two deciding callers need it as the cache TTL - a decision must not extend the code it decides on - and it answers the question in one place.

## The answer is InvalidUserCode, and the repository had already decided that

Not a new result type. `InvalidUserCode`'s own summary reads "the user code was not found **or has expired**". The vocabulary was there; the implementation did not honour it. A new type would also break an exhaustive switch in every host that has one, to say something the existing type already says.

The refusal counts as a FAILURE for rate limiting, the same treatment a used code gets.

## Driven

- The reproduction is commit 1 and the fix is commit 2. Red before, green after, and the test was not edited by the fix.
- The class fixture never set `ExpiresAt`, leaving it at `DateTimeOffset.MinValue` - expired. Invisible while nothing checked the lifetime. Measured with it reverted at head: all four canonicalization rows go RED, because verification then answers `InvalidUserCode` while they assert a valid one. They are not vacuous; the expired fixture would have broken them for a reason having nothing to do with canonicalization. Set to five minutes out in the reproduction commit.
- Mutation: make `HasLifetimeLeft` always answer true. Built to a printed `0 Error(s)`, and it kills three rows at head - the verification row and both decision rows. Restored from a copy taken first.
- Every suite green, nothing failing. One row is skipped in a Key Vault suite, at the base as well as here. No totals given: they move under each merge of the base, and a number written once reads as current forever.

Ref #483

## Round 1

Two statements were false and both have been driven rather than reworded.

The fixture claim was inverted, as recorded above. The record's remarks claimed the comparison now lives in one place while a third caller still writes it out; they now name that caller and say what the split costs.

That cost was measurable and had never been measured: relaxing the boundary in `HasLifetimeLeft` to `>=` survived every suite in the solution. Two rows now drive the approval and the denial at exactly `ExpiresAt`, and the same mutation turns both red. Each also asserts the record is left untouched - a bare `false` does not say that, and not writing is the point, since a decision written past the expiry carries a non-positive cache TTL.

Both of those guards predate this change and nothing measured either: deleting them at the base leaves the suite green. That is debt on develop rather than something this change caused, but one predicate now decides three callers, so one edit moves three verdicts.

## Round 2

One finding, and it was this change's own second edit invalidating its own first.

Round 1 was answered two ways in a single commit: the remarks were rewritten, and the coverage was added. The rewritten remarks said relaxing this predicate's boundary is caught by no test anywhere - and the rows added beside them catch exactly that. The sentence was true when written and false by the end of the commit that wrote it.

It also named the wrong file. The boundary nothing holds is `DeviceCodeGrantHandler`'s: relaxing `now >= ExpiresAt` there leaves every suite green. The remarks now say which of the two is held and which is not, so a maintainer following them goes to the file that needs a row.


