### PR TITLE
Bind a push-delivered ID Token to the request it answers

### DIFF
--- a/src/Abblix.Jwt/JwtClaimTypes.cs
+++ b/src/Abblix.Jwt/JwtClaimTypes.cs
@@ -262,6 +262,36 @@ public static class JwtClaimTypes
     public const string AccessTokenHash = IanaClaimTypes.AtHash;
 
     /// <summary>
+    /// The identifier of the backchannel authentication request this ID Token answers, carried so a
+    /// push notification cannot be replayed against a different request.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 10.3.1 phrases this alongside the hashes - "the OP MUST include the hash
+    /// value of the Access Token and the auth_req_id ... using the at_hash and
+    /// urn:openid:params:jwt:claim:auth_req_id claims respectively" - but its own worked example beside
+    /// that sentence carries the identifier VERBATIM, matching the <c>auth_req_id</c> field of the same
+    /// notification body. The example is what a client compares against, and its own requirement is to
+    /// check that this claim MATCHES the identifier it asked about, which a hash would not let it do.
+    /// <para>
+    /// Required in push mode only, which the same paragraph says outright. Poll and ping clients redeem
+    /// at the token endpoint holding the identifier already.
+    /// </para>
+    /// </remarks>
+    public const string AuthenticationRequestId = "urn:openid:params:jwt:claim:auth_req_id";
+
+    /// <summary>
+    /// The hash of the refresh token delivered beside this ID Token, computed the same way
+    /// <see cref="AccessTokenHash"/> is.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 10.3.1: "In case a Refresh Token is sent to the Client, the hash value of
+    /// it MUST also be added to the ID token using the urn:openid:params:jwt:claim:rt_hash claim", and
+    /// the same sentence points at OpenID Connect Core 1.0 Section 3.1.3.6 for the calculation - the one
+    /// <c>at_hash</c> uses. Push mode only, and only when a refresh token is actually sent.
+    /// </remarks>
+    public const string RefreshTokenHash = "urn:openid:params:jwt:claim:rt_hash";
+
+    /// <summary>
     /// The 'iat' (issued at) claim identifies the time at which the JWT was issued.
     /// It is expressed as the number of seconds since the Unix epoch.
     /// This claim can be used to determine the age of the JWT.

--- a/src/Abblix.Jwt/JwtClaimTypes.cs
+++ b/src/Abblix.Jwt/JwtClaimTypes.cs
@@ -287,7 +287,8 @@ public static class JwtClaimTypes
     /// CIBA Core 1.0 Section 10.3.1: "In case a Refresh Token is sent to the Client, the hash value of
     /// it MUST also be added to the ID token using the urn:openid:params:jwt:claim:rt_hash claim", and
     /// the same sentence points at OpenID Connect Core 1.0 Section 3.1.3.6 for the calculation - the one
-    /// <c>at_hash</c> uses. Push mode only, and only when a refresh token is actually sent.
+    /// <c>at_hash</c> uses. Required in push mode only, which is what the paragraph says - it does not
+    /// forbid the claim elsewhere - and only when a refresh token is actually sent.
     /// </remarks>
     public const string RefreshTokenHash = "urn:openid:params:jwt:claim:rt_hash";
 

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ValidTokenRequest.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ValidTokenRequest.cs
@@ -34,10 +34,11 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 /// request (RFC 9449 Section 6.1), when the client presented a valid DPoP proof; otherwise <c>null</c>.
 /// </param>
 /// <param name="PushDeliveryOf">The <c>auth_req_id</c> this request delivers in CIBA push mode, or
-/// <c>null</c> for every other caller. Nothing downstream can infer it: poll and ping redeem at the
-/// token endpoint with the same grant type and the same identifier, so only the push path itself knows,
-/// and CIBA Core 1.0 Section 10.3.1 requires the ID Token's extra bindings there and nowhere else.
-/// </param>
+/// <c>null</c> for every other caller. It is stated rather than derived: the delivery mode is reachable
+/// from <see cref="ClientInfo"/>, but deriving it would put CIBA's rules inside the path every grant
+/// type takes, and the push caller holds the identifier anyway. See
+/// <see cref="Features.Tokens.PushDeliveryBindings"/> for what it turns into and why the claims are
+/// required there and nowhere else.</param>
 public record ValidTokenRequest(
     TokenRequest Model,
     AuthorizedGrant AuthorizedGrant,

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ValidTokenRequest.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Interfaces/ValidTokenRequest.cs
@@ -31,7 +31,13 @@ namespace Abblix.Oidc.Server.Endpoints.Token.Interfaces;
 /// <param name="ClientCertificate">The client X.509 certificate presented at the token endpoint for
 /// mutual-TLS client authentication (RFC 8705), when applicable; otherwise <c>null</c>.</param>
 /// <param name="ProofKeyThumbprint">The RFC 7638 JWK thumbprint of the DPoP proof key bound to the
-/// request (RFC 9449 §6.1), when the client presented a valid DPoP proof; otherwise <c>null</c>.</param>
+/// request (RFC 9449 Section 6.1), when the client presented a valid DPoP proof; otherwise <c>null</c>.
+/// </param>
+/// <param name="PushDeliveryOf">The <c>auth_req_id</c> this request delivers in CIBA push mode, or
+/// <c>null</c> for every other caller. Nothing downstream can infer it: poll and ping redeem at the
+/// token endpoint with the same grant type and the same identifier, so only the push path itself knows,
+/// and CIBA Core 1.0 Section 10.3.1 requires the ID Token's extra bindings there and nowhere else.
+/// </param>
 public record ValidTokenRequest(
     TokenRequest Model,
     AuthorizedGrant AuthorizedGrant,
@@ -39,7 +45,8 @@ public record ValidTokenRequest(
     ScopeDefinition[] Scope,
     ResourceDefinition[] Resources,
     X509Certificate2? ClientCertificate = null,
-    string? ProofKeyThumbprint = null)
+    string? ProofKeyThumbprint = null,
+    string? PushDeliveryOf = null)
 {
     /// <summary>
     /// Builds the validated request from a populated <see cref="TokenValidationContext"/>, taking

--- a/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
@@ -162,13 +162,22 @@ public class TokenRequestProcessor(
 
 		if (mayIssueDerivedTokens && authContext.Scope.HasFlag(Scopes.OpenId))
 		{
+			// The bindings exist only when the caller IS the push path, which is the one place that
+			// knows: poll and ping arrive here with the same grant type and the same identifier, so the
+			// request cannot be asked. The refresh token is read from the response because it was minted
+			// above - the order matters and is why it can be hashed at all.
+			var pushBindings = request.PushDeliveryOf is { } authenticationRequestId
+				? new PushDeliveryBindings(authenticationRequestId, response.RefreshToken?.EncodedJwt)
+				: null;
+
 			response.IdToken = await identityTokenService.CreateIdentityTokenAsync(
 				request.AuthorizedGrant.AuthSession,
 				authContext,
 				clientInfo,
 				false,
 				null,
-				accessToken.EncodedJwt);
+				accessToken.EncodedJwt,
+				pushBindings);
 		}
 
 		return response;

--- a/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
@@ -162,10 +162,13 @@ public class TokenRequestProcessor(
 
 		if (mayIssueDerivedTokens && authContext.Scope.HasFlag(Scopes.OpenId))
 		{
-			// The bindings exist only when the caller IS the push path, which is the one place that
-			// knows: poll and ping arrive here with the same grant type and the same identifier, so the
-			// request cannot be asked. The refresh token is read from the response because it was minted
-			// above - the order matters and is why it can be hashed at all.
+			// The bindings exist only when the caller says it IS the push path. The mode could be read
+			// off clientInfo instead, and is not, so that this method does not have to know CIBA's
+			// delivery rules to serve every other grant type - see PushDeliveryBindings.
+			//
+			// The refresh token is read from the RESPONSE because it was minted above. That order is
+			// load-bearing: assembling these bindings before the branch that mints it silently drops
+			// rt_hash from every push notification that carries one.
 			var pushBindings = request.PushDeliveryOf is { } authenticationRequestId
 				? new PushDeliveryBindings(authenticationRequestId, response.RefreshToken?.EncodedJwt)
 				: null;

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -146,12 +146,16 @@ public partial class PushModeCompletionHandler(
             AuthenticationRequestId = authenticationRequestId,
         };
 
+        // Says out loud that this is a push delivery, because nothing downstream can tell: poll and ping
+        // reach the token endpoint with the same grant type and the same identifier. It is what turns on
+        // the two bindings CIBA Core 1.0 Section 10.3.1 requires here and nowhere else.
         var validTokenRequest = new ValidTokenRequest(
             tokenRequest,
             request.AuthorizedGrant,
             clientInfo,
             [],
-            []);
+            [],
+            PushDeliveryOf: authenticationRequestId);
 
         var tokenResult = await tokenRequestProcessor.ProcessAsync(validTokenRequest);
 

--- a/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
+++ b/src/Abblix.Oidc.Server/Features/BackChannelAuthentication/AuthenticationNotifiers/PushModeCompletionHandler.cs
@@ -146,9 +146,10 @@ public partial class PushModeCompletionHandler(
             AuthenticationRequestId = authenticationRequestId,
         };
 
-        // Says out loud that this is a push delivery, because nothing downstream can tell: poll and ping
-        // reach the token endpoint with the same grant type and the same identifier. It is what turns on
-        // the two bindings CIBA Core 1.0 Section 10.3.1 requires here and nowhere else.
+        // Says out loud that this is a push delivery, and hands over the identifier in the same breath.
+        // It is what turns on the two bindings CIBA Core 1.0 Section 10.3.1 requires here and nowhere
+        // else. Stated rather than left to be derived downstream, for the reasons PushDeliveryBindings
+        // sets out.
         var validTokenRequest = new ValidTokenRequest(
             tokenRequest,
             request.AuthorizedGrant,

--- a/src/Abblix.Oidc.Server/Features/Tokens/IIdentityTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/IIdentityTokenService.cs
@@ -41,6 +41,10 @@ public interface IIdentityTokenService
     /// <param name="accessToken">An optional access token provided to include the `at_hash` claim in the identity token,
     /// which is a hash of the token. This parameter is used when the identity token is issued alongside an access token.
     /// </param>
+    /// <param name="pushBindings">The CIBA push notification this token travels in, or
+    /// <see langword="null"/> when it does not. Non-null adds the two bindings Section 10.3.1 requires
+    /// there and nowhere else - the request identifier verbatim, and the refresh token's hash when one
+    /// is sent.</param>
     /// <returns>A task that, upon completion, yields an <see cref="EncodedJsonWebToken"/> that represents the newly
     /// generated identity token, encoded and ready for transmission to the client.</returns>
     /// <remarks>
@@ -53,5 +57,6 @@ public interface IIdentityTokenService
 		ClientInfo clientInfo,
 		bool includeUserClaims,
 		string? authorizationCode,
-		string? accessToken);
+		string? accessToken,
+		PushDeliveryBindings? pushBindings = null);
 }

--- a/src/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -56,6 +56,9 @@ internal class IdentityTokenService(
 	/// <param name="authorizationCode">Authorization code to generate `c_hash`, validating the code's integrity.
 	/// </param>
 	/// <param name="accessToken">Access token to generate `at_hash`, ensuring the token's integrity.</param>
+	/// <param name="pushBindings">The CIBA push notification this token travels in, or <c>null</c> when it
+	/// does not. Non-null adds the two bindings Section 10.3.1 requires in push mode: the request
+	/// identifier verbatim, and the refresh token's hash when one is sent.</param>
 	/// <returns>A task that resolves to an <see cref="EncodedJsonWebToken"/>, representing the identity token.
 	/// </returns>
 	/// <remarks>
@@ -69,7 +72,8 @@ internal class IdentityTokenService(
 		ClientInfo clientInfo,
 		bool includeUserClaims,
 		string? authorizationCode,
-		string? accessToken)
+		string? accessToken,
+		PushDeliveryBindings? pushBindings = null)
 	{
 		var scope = authContext.Scope;
 		if (!includeUserClaims && !clientInfo.ForceUserClaimsInIdentityToken)
@@ -134,7 +138,8 @@ internal class IdentityTokenService(
 			identityToken,
 			clientInfo.IdentityTokenSignedResponseAlgorithm,
 			authorizationCode,
-			accessToken);
+			accessToken,
+			pushBindings);
 
 		var jwt = await jwtFormatter.FormatAsync(
 			identityToken,
@@ -153,7 +158,8 @@ internal class IdentityTokenService(
 		JsonWebToken identityToken,
 		string signingAlgorithm,
 		string? authorizationCode,
-		string? accessToken)
+		string? accessToken,
+		PushDeliveryBindings? pushBindings)
 	{
 		// OIDC Core 1.0 section 3.3.2.11 (c_hash) and section 3.1.3.6 (at_hash): both are the left-most
 		// half of the value's digest, taken with the hash JWA pairs with this token's own signing 'alg'.
@@ -161,6 +167,20 @@ internal class IdentityTokenService(
 		// sides must agree on is not something to write twice.
 		AddHashClaim(identityToken, signingAlgorithm, JwtClaimTypes.CodeHash, authorizationCode);
 		AddHashClaim(identityToken, signingAlgorithm, JwtClaimTypes.AccessTokenHash, accessToken);
+
+		if (pushBindings is null)
+			return;
+
+		// CIBA Core 1.0 Section 10.3.1, push mode only. The identifier goes in VERBATIM despite the
+		// sentence being phrased about hashes: the worked example beside it carries the plain value, and
+		// the client's own requirement is to check this claim MATCHES the identifier it asked about,
+		// which it could not do against a digest.
+		identityToken.Payload[JwtClaimTypes.AuthenticationRequestId] = pushBindings.AuthenticationRequestId;
+
+		// The refresh token's hash is a hash, by the same recipe as at_hash, and only when one is sent -
+		// "In case a Refresh Token is sent to the Client".
+		AddHashClaim(
+			identityToken, signingAlgorithm, JwtClaimTypes.RefreshTokenHash, pushBindings.RefreshToken);
 	}
 
 	private static void AddHashClaim(

--- a/src/Abblix.Oidc.Server/Features/Tokens/PushDeliveryBindings.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/PushDeliveryBindings.cs
@@ -1,0 +1,35 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+namespace Abblix.Oidc.Server.Features.Tokens;
+
+/// <summary>
+/// What a CIBA push notification's ID Token must bind itself to, so the notification cannot be replayed
+/// against a different request.
+/// </summary>
+/// <remarks>
+/// Its presence is what says "this delivery is a push". CIBA Core 1.0 Section 10.3.1 requires these
+/// claims in push mode and says so in as many words - "Note that these claims are only required in Push
+/// mode" - so a null here is a poll or a ping, or a flow that is not CIBA at all, and those ID Tokens
+/// are left exactly as they were.
+/// <para>
+/// The reason the mode has to be carried rather than inferred: poll and ping redeem at the token
+/// endpoint with the same grant type and the same identifier, so nothing in the request itself
+/// distinguishes them. Only the caller that IS the push path knows.
+/// </para>
+/// <para>
+/// Push is also the one mode where the client never asked for these tokens by holding the identifier in
+/// its own hand. A poll client sends the identifier and reads the answer to that call; a push client
+/// receives an unsolicited body and has nothing tying its three parts together but this.
+/// </para>
+/// </remarks>
+/// <param name="AuthenticationRequestId">The <c>auth_req_id</c> this delivery answers, carried into the
+/// ID Token verbatim.</param>
+/// <param name="RefreshToken">The refresh token travelling in the same notification, or
+/// <see langword="null"/> when none is sent - in which case the specification asks for no hash.</param>
+public record PushDeliveryBindings(string AuthenticationRequestId, string? RefreshToken);

--- a/src/Abblix.Oidc.Server/Features/Tokens/PushDeliveryBindings.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/PushDeliveryBindings.cs
@@ -18,9 +18,14 @@ namespace Abblix.Oidc.Server.Features.Tokens;
 /// mode" - so a null here is a poll or a ping, or a flow that is not CIBA at all, and those ID Tokens
 /// are left exactly as they were.
 /// <para>
-/// The reason the mode has to be carried rather than inferred: poll and ping redeem at the token
-/// endpoint with the same grant type and the same identifier, so nothing in the request itself
-/// distinguishes them. Only the caller that IS the push path knows.
+/// The mode is CARRIED rather than inferred, and that is a choice rather than a necessity. It could be
+/// derived - the client's registered delivery mode is on the request, and combined with the grant type
+/// it identifies a push delivery. Two things argue against deriving it. The token processor would have
+/// to know CIBA's delivery rules to make that judgement, which couples the path every grant type takes
+/// to the semantics of one of them. And the derivation is a conjunction whose two halves are right for
+/// different reasons, so a later change to either silently moves who gets these claims - whereas the
+/// caller that IS the push path states the fact directly, and hands over the identifier it already
+/// holds in the same breath.
 /// </para>
 /// <para>
 /// Push is also the one mode where the client never asked for these tokens by holding the identifier in

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/BackChannelAuthenticationTests.cs
@@ -225,6 +225,20 @@ public class BackChannelAuthenticationTests(TestFactory factory) : TestBase(fact
         Assert.Equal(TokenTypes.Bearer, payload["token_type"]!.GetValue<string>());
         Assert.True(payload["expires_in"]!.GetValue<int>() > 0);
 
+        // The binding CIBA Core 1.0 Section 10.3.1 requires in push mode, asserted where a client reads
+        // it. Without it the three parts of this body - the identifier, the access token and the ID
+        // Token - sit beside each other with nothing tying the first to the last, and a client following
+        // its own MUST to check that this claim matches the identifier it asked about cannot accept the
+        // notification at all.
+        //
+        // Read out of the delivered ID Token rather than out of storage, because storage would prove
+        // only that the value was known. Asserted as the literal claim name a client reads off the wire,
+        // for the reason the refusal tests give: comparing a constant with itself lets a rename pass.
+        var idToken = DecodeJwtPayload(payload["id_token"]!.GetValue<string>());
+        Assert.Equal(
+            authRequestId,
+            idToken["urn:openid:params:jwt:claim:auth_req_id"]!.GetValue<string>());
+
         // And the request is gone. That removal is this library's choice rather than a requirement -
         // CIBA Core 1.0 section 10.3.1 says nothing about what the OP keeps - and the reason is that
         // this client is finished with it: the tokens are delivered and it will never come to the token

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestProcessorTests.cs
@@ -226,6 +226,135 @@ public class TokenRequestProcessorTests
     }
 
     /// <summary>
+    /// A push delivery's ID Token is built with the refresh token that was just minted, not without one.
+    /// </summary>
+    /// <remarks>
+    /// The ORDER is the thing under test. The refresh token is minted a few lines above the ID Token and
+    /// read out of the response, so assembling the bindings anywhere earlier hands the token service a
+    /// null refresh token - and CIBA Core 1.0 Section 10.3.1 requires the hash of it in push mode
+    /// whenever one is sent. Hoisting that assembly above the mint compiles, and without this row the
+    /// whole solution stays green while every push notification carrying a refresh token silently drops
+    /// the claim.
+    /// <para>
+    /// Asserted on what the token service RECEIVES rather than on what comes back, because the claim is
+    /// written inside that service and a response-level assertion would pass on a binding built from
+    /// nothing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ForAPushDelivery_BindsTheRefreshTokenThatWasJustMinted()
+    {
+        // Arrange
+        var scopes = new[] { Scopes.OpenId, Scopes.OfflineAccess };
+        var request = CreateValidTokenRequest(scopes) with { PushDeliveryOf = "the-auth-req-id" };
+        var accessToken = CreateAccessToken();
+        var refreshToken = CreateRefreshToken();
+        var idToken = CreateIdToken();
+        var authContext = new AuthorizationContext(TestConstants.DefaultClientId, scopes, null);
+
+        _contextEvaluator
+            .Setup(e => e.EvaluateAuthorizationContext(request))
+            .Returns(authContext);
+
+        _accessTokenService
+            .Setup(s => s.CreateAccessTokenAsync(
+                It.IsAny<AuthSession>(),
+                authContext,
+                request.ClientInfo))
+            .ReturnsAsync(accessToken);
+
+        _refreshTokenService
+            .Setup(s => s.CreateRefreshTokenAsync(
+                It.IsAny<AuthSession>(),
+                It.IsAny<AuthorizationContext>(),
+                request.ClientInfo,
+                null))
+            .ReturnsAsync(refreshToken);
+
+        PushDeliveryBindings? captured = null;
+        _identityTokenService
+            .Setup(s => s.CreateIdentityTokenAsync(
+                It.IsAny<AuthSession>(),
+                authContext,
+                request.ClientInfo,
+                false,
+                null,
+                accessToken.EncodedJwt,
+                It.IsAny<PushDeliveryBindings?>()))
+            .Callback((AuthSession _, AuthorizationContext _, ClientInfo _, bool _, string? _, string? _,
+                PushDeliveryBindings? bindings) => captured = bindings)
+            .ReturnsAsync(idToken);
+
+        // Act
+        await _processor.ProcessAsync(request);
+
+        // Assert
+        Assert.NotNull(captured);
+        Assert.Equal("the-auth-req-id", captured!.AuthenticationRequestId);
+        Assert.Equal(refreshToken.EncodedJwt, captured.RefreshToken);
+    }
+
+    /// <summary>
+    /// Without a push delivery the token service is handed no bindings at all.
+    /// </summary>
+    /// <remarks>
+    /// The control for the row above: the same scopes and the same refresh token, and the only difference
+    /// is that nobody declared a push. Section 10.3.1 requires these claims in push mode, and a poll or
+    /// ping client holds the identifier already.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_WithoutAPushDelivery_PassesNoBindings()
+    {
+        // Arrange
+        var scopes = new[] { Scopes.OpenId, Scopes.OfflineAccess };
+        var request = CreateValidTokenRequest(scopes);
+        var accessToken = CreateAccessToken();
+        var refreshToken = CreateRefreshToken();
+        var idToken = CreateIdToken();
+        var authContext = new AuthorizationContext(TestConstants.DefaultClientId, scopes, null);
+
+        _contextEvaluator
+            .Setup(e => e.EvaluateAuthorizationContext(request))
+            .Returns(authContext);
+
+        _accessTokenService
+            .Setup(s => s.CreateAccessTokenAsync(
+                It.IsAny<AuthSession>(),
+                authContext,
+                request.ClientInfo))
+            .ReturnsAsync(accessToken);
+
+        _refreshTokenService
+            .Setup(s => s.CreateRefreshTokenAsync(
+                It.IsAny<AuthSession>(),
+                It.IsAny<AuthorizationContext>(),
+                request.ClientInfo,
+                null))
+            .ReturnsAsync(refreshToken);
+
+        var captured = new PushDeliveryBindings("not-set", null);
+        _identityTokenService
+            .Setup(s => s.CreateIdentityTokenAsync(
+                It.IsAny<AuthSession>(),
+                authContext,
+                request.ClientInfo,
+                false,
+                null,
+                accessToken.EncodedJwt,
+                It.IsAny<PushDeliveryBindings?>()))
+            .Callback((AuthSession _, AuthorizationContext _, ClientInfo _, bool _, string? _, string? _,
+                PushDeliveryBindings? bindings) => captured = bindings!)
+            .ReturnsAsync(idToken);
+
+        // Act
+        await _processor.ProcessAsync(request);
+
+        // Assert. Seeded with a non-null value first, so "nothing was passed" cannot be confused with
+        // "the callback never ran".
+        Assert.Null(captured);
+    }
+
+    /// <summary>
     /// Verifies both ID token and refresh token are created with both scopes.
     /// Tests complete OIDC flow with offline access.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/TokenRequestProcessorTests.cs
@@ -301,6 +301,13 @@ public class TokenRequestProcessorTests
     /// The control for the row above: the same scopes and the same refresh token, and the only difference
     /// is that nobody declared a push. Section 10.3.1 requires these claims in push mode, and a poll or
     /// ping client holds the identifier already.
+    /// <para>
+    /// It is not the only thing holding that property, and calling it "the control" without this would
+    /// overstate it. Building the bindings unconditionally turns four rows red: this one and three that
+    /// predate the branch, whose Moq setups name the six-argument call and so bake in a null binding.
+    /// What this row adds is saying the property out loud, where those three hold it as a side effect
+    /// of how they were arranged.
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task ProcessAsync_WithoutAPushDelivery_PassesNoBindings()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -114,13 +114,10 @@ public class IdentityTokenServiceTests
     /// A digest would leave the client nothing to compare.
     /// </para>
     /// <para>
-    /// The refresh hash is asserted against the shared calculator, which pins the algorithm argument, the
-    /// source value and the claim name - the three things this row is for. It does NOT pin the digest:
-    /// both sides are computed by the same code, so a change inside the calculator moves them together
-    /// and this row stays green. That is not a gap. <c>HashCalculatorTests</c> in the Jwt suite holds the
-    /// digest against the literals OpenID Connect Core prints in its own worked examples, which is
-    /// stronger than any value computed here would be - a hand-computed literal agrees with the code
-    /// that produced it, while those agree with the document.
+    /// All three literals below are the specification's own, taken from the worked example in that same section: the
+    /// identifier, the refresh token, and the hash it prints for that token. So the digest is asserted
+    /// against the DOCUMENT rather than against this implementation - change the calculation and this
+    /// row goes red, where a value recomputed here would have moved with it and stayed green.
     /// </para>
     /// </remarks>
     [Fact]
@@ -142,7 +139,8 @@ public class IdentityTokenServiceTests
             .ReturnsAsync(EncodedToken);
 
         const string authenticationRequestId = "1c266114-a1be-4252-8ad1-04986c5b9ac1";
-        const string refreshToken = "4bwc0ESC-IAhflf-ACC-vjD-ltc11ne-8gFPfA2Kx16";
+        const string refreshToken = "4bwc0ESC_IAhflf-ACC_vjD_ltc11ne-8gFPfA2Kx16";
+        const string refreshTokenHash = "sHahCuSpXCRg5mkDDvvr4w";
 
         // Act
         await _service.CreateIdentityTokenAsync(
@@ -157,7 +155,7 @@ public class IdentityTokenServiceTests
             capturedToken!.Payload[JwtClaimTypes.AuthenticationRequestId]!.GetValue<string>());
 
         Assert.Equal(
-            HashCalculator.Compute(SigningAlgorithms.RS256, refreshToken),
+            refreshTokenHash,
             capturedToken.Payload[JwtClaimTypes.RefreshTokenHash]!.GetValue<string>());
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -102,6 +102,134 @@ public class IdentityTokenServiceTests
     }
 
     /// <summary>
+    /// A push delivery binds the ID Token to the request it answers and to the refresh token beside it.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 10.3.1: the OP MUST include the auth_req_id in the ID Token, and the hash
+    /// of the refresh token when one is sent. Without these, a push client that follows its own MUST -
+    /// check that the claim matches the identifier it asked about - rejects every notification.
+    /// <para>
+    /// The identifier goes in VERBATIM. The sentence is phrased about hashes, and the worked example
+    /// beside it carries the plain value, matching the auth_req_id field of the same notification body.
+    /// A digest would leave the client nothing to compare.
+    /// </para>
+    /// <para>
+    /// The refresh hash is asserted against the shared calculator rather than a literal, because that
+    /// calculator is what the client side uses too - a literal would let the two drift apart while both
+    /// stayed green.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task CreateIdentityToken_ForAPushDelivery_BindsTheRequestAndTheRefreshToken()
+    {
+        // Arrange
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo();
+
+        _userClaimsProvider
+            .Setup(p => p.GetUserClaimsAsync(authSession, authContext.Scope, null, clientInfo))
+            .ReturnsAsync(CreateUserClaims());
+
+        JsonWebToken? capturedToken = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
+            .ReturnsAsync(EncodedToken);
+
+        const string authenticationRequestId = "1c266114-a1be-4252-8ad1-04986c5b9ac1";
+        const string refreshToken = "4bwc0ESC-IAhflf-ACC-vjD-ltc11ne-8gFPfA2Kx16";
+
+        // Act
+        await _service.CreateIdentityTokenAsync(
+            authSession, authContext, clientInfo, true, null, null,
+            new PushDeliveryBindings(authenticationRequestId, refreshToken));
+
+        // Assert
+        Assert.NotNull(capturedToken);
+
+        Assert.Equal(
+            authenticationRequestId,
+            capturedToken!.Payload[JwtClaimTypes.AuthenticationRequestId]!.GetValue<string>());
+
+        Assert.Equal(
+            HashCalculator.Compute(SigningAlgorithms.RS256, refreshToken),
+            capturedToken.Payload[JwtClaimTypes.RefreshTokenHash]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Without a refresh token there is no hash to give, and the claim is absent rather than empty.
+    /// </summary>
+    /// <remarks>
+    /// The specification asks for it only "in case a Refresh Token is sent to the Client". An empty or
+    /// invented value would read to a client as a binding it can check, and fail.
+    /// </remarks>
+    [Fact]
+    public async Task CreateIdentityToken_ForAPushDeliveryWithoutARefreshToken_OmitsOnlyThatHash()
+    {
+        // Arrange
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo();
+
+        _userClaimsProvider
+            .Setup(p => p.GetUserClaimsAsync(authSession, authContext.Scope, null, clientInfo))
+            .ReturnsAsync(CreateUserClaims());
+
+        JsonWebToken? capturedToken = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
+            .ReturnsAsync(EncodedToken);
+
+        // Act
+        await _service.CreateIdentityTokenAsync(
+            authSession, authContext, clientInfo, true, null, null,
+            new PushDeliveryBindings("some-request", RefreshToken: null));
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.NotNull(capturedToken!.Payload[JwtClaimTypes.AuthenticationRequestId]);
+        Assert.Null(capturedToken.Payload[JwtClaimTypes.RefreshTokenHash]);
+    }
+
+    /// <summary>
+    /// The control, and it is what keeps the two rows above from being a rule about every ID Token: a
+    /// delivery that is not a push carries neither claim.
+    /// </summary>
+    /// <remarks>
+    /// Section 10.3.1 closes its paragraph with "Note that these claims are only required in Push mode",
+    /// and a poll or ping client holds the identifier already - it sent it to get here. Without this row,
+    /// adding the claims unconditionally would leave every other row in this file green.
+    /// </remarks>
+    [Fact]
+    public async Task CreateIdentityToken_WithoutAPushDelivery_CarriesNeitherBinding()
+    {
+        // Arrange
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo();
+
+        _userClaimsProvider
+            .Setup(p => p.GetUserClaimsAsync(authSession, authContext.Scope, null, clientInfo))
+            .ReturnsAsync(CreateUserClaims());
+
+        JsonWebToken? capturedToken = null;
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), clientInfo, It.IsAny<ClientJwtEncryption>()))
+            .Callback<JsonWebToken, ClientInfo, ClientJwtEncryption>((jwt, _, _) => capturedToken = jwt)
+            .ReturnsAsync(EncodedToken);
+
+        // Act
+        await _service.CreateIdentityTokenAsync(authSession, authContext, clientInfo, true, null, null);
+
+        // Assert
+        Assert.NotNull(capturedToken);
+        Assert.Null(capturedToken!.Payload[JwtClaimTypes.AuthenticationRequestId]);
+        Assert.Null(capturedToken.Payload[JwtClaimTypes.RefreshTokenHash]);
+    }
+
+    /// <summary>
     /// Verifies that CreateIdentityTokenAsync generates correct timestamps and issuer.
     /// </summary>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -114,9 +114,11 @@ public class IdentityTokenServiceTests
     /// A digest would leave the client nothing to compare.
     /// </para>
     /// <para>
-    /// The refresh hash is asserted against the shared calculator rather than a literal, because that
-    /// calculator is what the client side uses too - a literal would let the two drift apart while both
-    /// stayed green.
+    /// The refresh hash is asserted against the shared calculator, which pins the algorithm argument, the
+    /// source value and the claim name - the three things this row is for. It does NOT pin the digest:
+    /// a change inside the calculator moves both sides together and this row stays green. A literal
+    /// would catch that and is the stronger assertion against it; the calculator is used here because a
+    /// literal would have to be recomputed by hand for every signing algorithm the row might take.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/IdentityTokenServiceTests.cs
@@ -116,9 +116,11 @@ public class IdentityTokenServiceTests
     /// <para>
     /// The refresh hash is asserted against the shared calculator, which pins the algorithm argument, the
     /// source value and the claim name - the three things this row is for. It does NOT pin the digest:
-    /// a change inside the calculator moves both sides together and this row stays green. A literal
-    /// would catch that and is the stronger assertion against it; the calculator is used here because a
-    /// literal would have to be recomputed by hand for every signing algorithm the row might take.
+    /// both sides are computed by the same code, so a change inside the calculator moves them together
+    /// and this row stays green. That is not a gap. <c>HashCalculatorTests</c> in the Jwt suite holds the
+    /// digest against the literals OpenID Connect Core prints in its own worked examples, which is
+    /// stronger than any value computed here would be - a hand-computed literal agrees with the code
+    /// that produced it, while those agree with the document.
     /// </para>
     /// </remarks>
     [Fact]


### PR DESCRIPTION
In push mode the ID Token must bind itself to the request it answers, and this server bound it to nothing. A client that follows its own requirement - check that the claim matches the `auth_req_id` it asked about - rejects every notification it receives, so this is the difference between a push client working and not working rather than a conformance footnote.

## What the specification says, read at the section

CIBA Core 1.0 Section 10.3.1, "Successful Token Delivery":

> In order to bind together the ID Token, the Access Token, and the auth_req_id, the OP MUST include the hash value of the Access Token and the auth_req_id within the ID Token using the at_hash and urn:openid:params:jwt:claim:auth_req_id claims respectively. In case a Refresh Token is sent to the Client, the hash value of it MUST also be added to the ID token using the urn:openid:params:jwt:claim:rt_hash claim.

`at_hash` was already there. The two CIBA-specific bindings were not.

The same paragraph closes with "Note that these claims are only required in Push mode", so poll and ping are left exactly as they were. Those clients hold the identifier already - they sent it to get here, and they read the answer to their own call.

## The identifier goes in verbatim, and the example is why

The sentence is phrased about hashes, which reads as though the identifier should be hashed too. The worked example printed beside it carries the plain value, identical to the `auth_req_id` field of the same notification body. That is also the only form the client's own requirement can be met against: it must check the claim MATCHES the identifier it asked about, which it cannot do against a digest.

The refresh hash is genuinely a hash, computed by the recipe `at_hash` uses - the same sentence points at OpenID Connect Core 1.0 Section 3.1.3.6 - and only when a refresh token is actually sent.

## Push has to declare itself

The mode is CARRIED rather than derived, and that is a choice. It could be derived: the client's registered delivery mode is on the request and `clientInfo` is already in scope where the bindings are assembled, and combined with the grant type it identifies a push delivery exactly - a push-registered client is refused at the token endpoint by `PushModeGrantProcessor`, which CIBA Core states normatively as well. Two things argue against deriving it. The token processor would have to know CIBA's delivery rules to serve every other grant type. And the derivation is a conjunction whose halves are right for different reasons, so a later change to either silently moves who gets these claims - while the caller that IS the push path states the fact directly and hands over the identifier it already holds. It therefore carries the identifier on the validated request, and the processor turns that into the bindings the token service applies.

The refresh token is read from the response rather than passed in, because it is minted before the ID Token. That order is what makes the hash computable at all, and it is why the bindings are assembled at the processor rather than at the caller.

## Driven

Five unit rows and one end-to-end assertion. Three rows sit at the identity token service and two at the token processor. Every one is pinned by a plant that turns it red, driven and restored from a copy taken first:

| plant | where | rows that die |
|---|---|---|
| the identifier replaced by a literal | identity token service | the binding row, and the end-to-end row |
| the refresh hash not computed | identity token service | the binding row, on its other assertion |
| the refresh hash given a stand-in when none was sent | identity token service | the no-refresh-token row, alone |
| the bindings applied without a push | identity token service | the identity-service control row, alone |
| the bindings assembled ABOVE the refresh mint | token processor | the row asserting the binding carries the token just minted, alone |
| the bindings built unconditionally | token processor | the processor control row, plus three that predate the branch |
| `PushDeliveryOf` never set by the push handler | push completion handler | the end-to-end row |
| the digest slice taken from the wrong half | shared hash calculator | the binding row, plus three rows in the Jwt suite |

The mapping is not one plant per row and the table does not pretend otherwise: two plants land on the binding row, and the processor control shares its property with three older rows whose mock setups name the six-argument call and so bake a null binding in. What the new row adds there is saying the property out loud rather than holding it by arrangement.

The hoist above the refresh mint is the one that matters most: before those processor rows existed it compiled clean and left the whole solution green, silently dropping a Section 10.3.1 MUST from every push notification carrying a refresh token.

Every plant built to a printed `0 Error(s)` before it counted, and each was restored from a copy taken first. One further plant - inverting the push guard - was refused by the compiler rather than the analyzer: with the guard reversed the dereference below it is possibly-null, which is the nullable analysis holding the shape for free.

The end-to-end assertion reads the claim out of the delivered notification, which is where a client reads it, and names it as the literal a client sees rather than through the constant that builds it.

Ref #437

## Public surface

`IIdentityTokenService.CreateIdentityTokenAsync` gains an optional parameter and `ValidTokenRequest`'s primary constructor changes arity. Optional parameters help a CALLER and do nothing for an IMPLEMENTER: a host that implements the public interface itself stops compiling, and a pre-compiled host assembly breaks at load. `TryAddScoped` makes replacing that service a supported scenario, so this belongs in the release notes rather than passing unmentioned.


