### PR TITLE
Give a pairwise CIBA client the sector its delivery mode names

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ValidClientRegistrationRequest.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Interfaces/ValidClientRegistrationRequest.cs
@@ -13,9 +13,10 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Interfaces;
 
 /// <summary>
 /// A registration request whose metadata has passed all validators, paired with the
-/// resolved <c>sector_identifier</c> derived either from <c>sector_identifier_uri</c>
-/// or from the registered redirect URIs (used for pairwise PPID computation per
-/// OIDC Core §8.1).
+/// resolved <c>sector_identifier</c> - derived from <c>sector_identifier_uri</c>, from the
+/// registered redirect URIs, or for a backchannel client that registered none from the URI its
+/// delivery mode names (used for pairwise PPID computation per OIDC Core Section 8.1 and
+/// CIBA Core 1.0 Section 4).
 /// </summary>
 /// <param name="Model">The validated registration request.</param>
 /// <param name="SectorIdentifier">The host portion to use as the pairwise sector identifier,

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -82,9 +82,10 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
         // identifier, and where a sector_identifier_uri is registered the endpoint "must be included in
         // the list of URIs pointed to by" it. Poll and ping put the jwks_uri in both of those roles
         // instead, so neither rule reaches a ping registration - which is why they cannot be enforced
-        // beside the HTTPS check, whose arm covers ping and push alike. Neither is implemented anywhere:
-        // SubjectTypeValidator, in this same pipeline, fetches the sector document for redirect_uris
-        // alone. That is a gap rather than a decision, tracked as issue 480.
+        // beside the HTTPS check, whose arm covers ping and push alike. Both ARE implemented, by
+        // SubjectTypeValidator in this same pipeline: it fetches the sector document and checks it for
+        // whichever URI the registered mode names, and takes the sector from that same URI when no
+        // sector_identifier_uri was supplied.
         //
         // The remaining Section 4 rule for this parameter, "REQUIRED if the token delivery mode is set
         // to ping or push", IS implemented - by the switch above, in the words of the refusal it returns.

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/BackChannelAuthenticationValidator.cs
@@ -84,8 +84,10 @@ public class BackChannelAuthenticationValidator(IJsonWebTokenValidator jwtValida
         // instead, so neither rule reaches a ping registration - which is why they cannot be enforced
         // beside the HTTPS check, whose arm covers ping and push alike. Both ARE implemented, by
         // SubjectTypeValidator in this same pipeline: it fetches the sector document and checks it for
-        // whichever URI the registered mode names, and takes the sector from that same URI when no
-        // sector_identifier_uri was supplied.
+        // whichever URI the registered mode names, and takes the sector from that same URI when the client
+        // registered neither a sector_identifier_uri nor a redirect URI. Both absences, not one: a push
+        // client that registered redirect URIs takes its sector from those, and this endpoint then plays no
+        // part in the sector at all.
         //
         // The remaining Section 4 rule for this parameter, "REQUIRED if the token delivery mode is set
         // to ping or push", IS implemented - by the switch above, in the words of the refusal it returns.

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.Logging.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.Logging.cs
@@ -16,6 +16,6 @@ partial class SubjectTypeValidator
     [LoggerMessage(
         EventId = LogEvents.DynamicClientManagement.SubjectTypeValidator.SectorIdentifierMissingUris,
         Level = LogLevel.Warning,
-        Message = "The following registered redirect URIs are missing from the document at {SectorIdentifierUri}: {@MissingUris}")]
+        Message = "The following registered URIs are missing from the document at {SectorIdentifierUri}: {@MissingUris}")]
     private partial void LogSectorIdentifierMissingUris(Sanitized SectorIdentifierUri, Uri[] MissingUris);
 }

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -17,10 +17,13 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 
 /// <summary>
 /// Validates the OIDC Core Section 8 <c>subject_type</c> metadata and computes the pairwise sector
-/// identifier per OIDC Core Section 8.1: when <c>pairwise</c> is requested, either a supplied
-/// <c>sector_identifier_uri</c> (HTTPS, JSON document of redirect URIs) is dereferenced and
-/// cross-checked against the registered <c>redirect_uris</c>, or all redirect URIs must
-/// share a single host. The resolved host is stored on the context for later persistence.
+/// identifier. When <c>pairwise</c> is requested, a supplied <c>sector_identifier_uri</c> (HTTPS) is
+/// dereferenced and every URI the registration is required to have listed there is checked against
+/// its contents; otherwise the host is taken from the registered URIs, which must agree on one.
+/// Which URIs those are depends on the registration: the redirect URIs (OIDC Core Section 8.1), and
+/// for a backchannel client the one CIBA Core 1.0 Section 4 puts in their place - the
+/// <c>jwks_uri</c> in poll and ping, the <c>backchannel_client_notification_endpoint</c> in push.
+/// The resolved host is stored on the context for later persistence.
 /// </summary>
 /// <param name="logger">Logger used for warnings about sector-identifier mismatches.</param>
 /// <param name="secureHttpFetcher">SSRF-protected fetcher for the sector identifier document.</param>
@@ -187,14 +190,18 @@ public partial class SubjectTypeValidator(
                 + "push mode. None of these was registered");
         }
 
-        // The scheme is checked here rather than left to BackChannelAuthenticationValidator, which
-        // enforces the same rule for the notification endpoint but is registered AFTER this validator -
-        // so at this point the value has been through no scheme check at all, and this branch is about
-        // to take a sector identity from its host.
-        if (sectorUri.Scheme != Uri.UriSchemeHttps)
+        // Absoluteness is checked rather than assumed, and both halves matter. A registration body
+        // is attacker-shaped JSON: [AbsoluteUri] is honoured by the form binder, not by the JSON
+        // deserializer, so a relative "/jwks" arrives intact and every Uri member below it - Scheme,
+        // Host - throws rather than returning anything. And the scheme is checked HERE because for
+        // poll and ping nothing else ever checks the jwks_uri's: BackChannelAuthenticationValidator
+        // enforces the specification's "It MUST be an HTTPS URL" for the notification endpoint alone,
+        // and is registered after this validator besides. Delete this and https stops being required
+        // of the value a poll client's whole sector is derived from.
+        if (!sectorUri.IsAbsoluteUri || sectorUri.Scheme != Uri.UriSchemeHttps)
         {
             return ErrorFactory.InvalidClientMetadata(
-                "The URI a pairwise sector identifier is taken from must use the https scheme");
+                "The URI a pairwise sector identifier is taken from must be an absolute https URI");
         }
 
         context.SectorIdentifier = sectorUri.Host;

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -19,10 +19,12 @@ namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 /// Validates the OIDC Core Section 8 <c>subject_type</c> metadata and computes the pairwise sector
 /// identifier. When <c>pairwise</c> is requested, a supplied <c>sector_identifier_uri</c> (HTTPS) is
 /// dereferenced and every URI the registration is required to have listed there is checked against
-/// its contents; otherwise the host is taken from the registered URIs, which must agree on one.
-/// Which URIs those are depends on the registration: the redirect URIs (OIDC Core Section 8.1), and
-/// for a backchannel client the one CIBA Core 1.0 Section 4 puts in their place - the
-/// <c>jwks_uri</c> in poll and ping, the <c>backchannel_client_notification_endpoint</c> in push.
+/// its contents; otherwise the host is taken from the registered redirect URIs, which must agree on
+/// one (OIDC Core Section 8.1). A backchannel client that registered NO redirect URI takes its host
+/// instead from the URI CIBA Core 1.0 Section 4 puts in their place - the <c>jwks_uri</c> in poll and
+/// ping, the <c>backchannel_client_notification_endpoint</c> in push. Registering both is allowed and
+/// they need not agree: the redirect URIs decide, and the backchannel URI is only ever the sector of a
+/// client that has none.
 /// The resolved host is stored on the context for later persistence.
 /// </summary>
 /// <param name="logger">Logger used for warnings about sector-identifier mismatches.</param>

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -9,6 +9,7 @@
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.SecureHttpFetch;
+using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.Logging;
 using static Abblix.Oidc.Server.Model.ClientRegistrationRequest;
 
@@ -57,13 +58,10 @@ public partial class SubjectTypeValidator(
         if (contentResult.TryGetFailure(out var contentError))
             return contentError;
 
-        // A client registering no redirect URIs satisfies the subset check below with nothing to check:
-        // the rule is that everything it registered must appear in the sector document, and it registered
-        // nothing. Passing an empty set says that, where passing null would only ask the question again.
         var error = ValidateSectorIdentifierContent(
             sectorIdentifierUri,
             contentResult.GetSuccess(),
-            context.Request.RedirectUris ?? []);
+            RequiredInSectorDocument(context.Request));
 
         if (error != null)
             return error;
@@ -93,32 +91,73 @@ public partial class SubjectTypeValidator(
     }
 
     /// <summary>
+    /// The URIs this registration must have listed in its sector identifier document.
+    /// </summary>
+    /// <remarks>
+    /// OIDC Core Section 8.1 puts the redirect URIs there. CIBA Core 1.0 Section 4 adds two more and
+    /// says which one by delivery mode: "In CIBA Poll and Ping modes the jwks_uri is used in place of
+    /// the redirect_uri. In CIBA Push mode the backchannel_client_notification_endpoint is used in
+    /// place of the redirect_uri", and the sector document "can contain jwks_uris and
+    /// backchannel_client_notification_endpoints as well as redirect_uri".
+    /// <para>
+    /// Each entry is conditional on the mode that names it, so a registration with no delivery mode
+    /// contributes exactly what it did before this existed. A URI the client did not register
+    /// contributes nothing - the subset check asks whether what was REGISTERED appears in the
+    /// document, so an absent value has nothing to be missing.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<Uri> RequiredInSectorDocument(ClientRegistrationRequest request)
+    {
+        // A client registering no redirect URIs satisfies the subset check with nothing to check: the
+        // rule is that everything it registered must appear in the sector document, and it registered
+        // nothing. Yielding nothing says that, where a null would only ask the question again.
+        foreach (var redirectUri in request.RedirectUris ?? [])
+            yield return redirectUri;
+
+        switch (request.BackChannelTokenDeliveryMode)
+        {
+            case BackchannelTokenDeliveryModes.Push
+                when request.BackChannelClientNotificationEndpoint is {} notificationEndpoint:
+                yield return notificationEndpoint;
+                break;
+
+            case BackchannelTokenDeliveryModes.Poll or BackchannelTokenDeliveryModes.Ping
+                when request.JwksUri is {} jwksUri:
+                yield return jwksUri;
+                break;
+        }
+    }
+
+    /// <summary>
     /// Validates the content fetched from sector identifier URI.
     /// </summary>
     private OidcError? ValidateSectorIdentifierContent(
         Uri sectorIdentifierUri,
         Uri[] sectorIdentifierContent,
-        IEnumerable<Uri> redirectUris)
+        IEnumerable<Uri> requiredUris)
     {
         if (sectorIdentifierContent.Any(uri => uri.Scheme != Uri.UriSchemeHttps))
         {
-            return ErrorFactory.InvalidClientMetadata("All schemes in the redirect URIs must be https");
+            return ErrorFactory.InvalidClientMetadata("All schemes in the sector identifier document must be https");
         }
 
-        // OIDC Core §8.1 / OIDC Registration §5: the values of the registered redirect_uris MUST be
-        // included in the elements of the sector identifier document - the subset check goes from the
-        // registration towards the document, not the other way around. The document is intentionally
-        // shareable across several clients of the same sector, so it may list URIs this client did not
-        // register. The inverted check (document minus registration) both rejected such legitimate
-        // shared documents and let a client register a redirect URI absent from the document - i.e.
-        // claim a sector it does not belong to, breaking pairwise subject isolation.
-        var missingUris = redirectUris.Except(sectorIdentifierContent).ToArray();
+        // OIDC Core §8.1 / OIDC Registration §5: the registered values MUST be included in the elements
+        // of the sector identifier document - the subset check goes from the registration towards the
+        // document, not the other way around. The document is intentionally shareable across several
+        // clients of the same sector, so it may list URIs this client did not register. The inverted
+        // check (document minus registration) both rejected such legitimate shared documents and let a
+        // client register a URI absent from the document - i.e. claim a sector it does not belong to,
+        // breaking pairwise subject isolation.
+        var missingUris = requiredUris.Except(sectorIdentifierContent).ToArray();
         if (missingUris.Length > 0)
         {
             LogSectorIdentifierMissingUris(sectorIdentifierUri, missingUris);
 
+            // The missing values are named individually. A message saying "redirect URIs" to a client
+            // whose notification endpoint was the omission sends its author to the wrong metadata.
             return ErrorFactory.InvalidClientMetadata(
-                $"One or more registered redirect URIs are not listed in the document fetched from the {Parameters.SectorIdentifierUri}");
+                $"These registered URIs are not listed in the document fetched from the "
+                + $"{Parameters.SectorIdentifierUri}: {string.Join(", ", (object[])missingUris)}");
         }
 
         return null;

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidator.cs
@@ -16,8 +16,8 @@ using static Abblix.Oidc.Server.Model.ClientRegistrationRequest;
 namespace Abblix.Oidc.Server.Endpoints.DynamicClientManagement.Validation;
 
 /// <summary>
-/// Validates the OIDC Core §8 <c>subject_type</c> metadata and computes the pairwise sector
-/// identifier per OIDC Core §8.1: when <c>pairwise</c> is requested, either a supplied
+/// Validates the OIDC Core Section 8 <c>subject_type</c> metadata and computes the pairwise sector
+/// identifier per OIDC Core Section 8.1: when <c>pairwise</c> is requested, either a supplied
 /// <c>sector_identifier_uri</c> (HTTPS, JSON document of redirect URIs) is dereferenced and
 /// cross-checked against the registered <c>redirect_uris</c>, or all redirect URIs must
 /// share a single host. The resolved host is stored on the context for later persistence.
@@ -141,7 +141,7 @@ public partial class SubjectTypeValidator(
             return ErrorFactory.InvalidClientMetadata("All schemes in the sector identifier document must be https");
         }
 
-        // OIDC Core §8.1 / OIDC Registration §5: the registered values MUST be included in the elements
+        // OIDC Core Section 8.1 / OIDC Registration Section 5: the registered values MUST be included in the elements
         // of the sector identifier document - the subset check goes from the registration towards the
         // document, not the other way around. The document is intentionally shareable across several
         // clients of the same sector, so it may list URIs this client did not register. The inverted
@@ -169,19 +169,66 @@ public partial class SubjectTypeValidator(
     private static OidcError? Validate(ClientRegistrationValidationContext context)
     {
         var redirectUris = context.Request.RedirectUris;
+        if (redirectUris is { Length: > 0 })
+            return ValidateFromRedirectUris(context, redirectUris);
 
-        // Without a redirect URI there is no host, and the host is what a pairwise identifier is derived
-        // from when no sector identifier URI was registered - so this combination cannot be honoured and
-        // is refused rather than worked around. It is reachable: a client asking only for a grant type
-        // that needs no redirection registers none, which the redirect URI validator correctly permits,
-        // and it arrives here with the list absent or empty.
-        if (redirectUris is not { Length: > 0 })
+        // A client asking only for a grant type that needs no redirection registers no redirect URI,
+        // which the redirect URI validator correctly permits, so it arrives here with the list absent
+        // or empty. CIBA Core 1.0 Section 4 says where its host comes from instead: "In CIBA Poll and
+        // Ping modes the jwks_uri is used in place of the redirect_uri. In CIBA Push mode the
+        // backchannel_client_notification_endpoint is used in place of the redirect_uri."
+        var sectorUri = SectorUriForDeliveryMode(context.Request);
+        if (sectorUri == null)
         {
             return ErrorFactory.InvalidClientMetadata(
-                "The client specified pairwise subject type without a sector identifier URI, which needs "
-                + "a redirect URI to take the host from, and none was registered");
+                "The client specified pairwise subject type without a sector identifier URI, so the host "
+                + "is taken from a registered URI: a redirect URI, or for a backchannel client the "
+                + "jwks_uri in poll and ping modes and the backchannel_client_notification_endpoint in "
+                + "push mode. None of these was registered");
         }
 
+        // The scheme is checked here rather than left to BackChannelAuthenticationValidator, which
+        // enforces the same rule for the notification endpoint but is registered AFTER this validator -
+        // so at this point the value has been through no scheme check at all, and this branch is about
+        // to take a sector identity from its host.
+        if (sectorUri.Scheme != Uri.UriSchemeHttps)
+        {
+            return ErrorFactory.InvalidClientMetadata(
+                "The URI a pairwise sector identifier is taken from must use the https scheme");
+        }
+
+        context.SectorIdentifier = sectorUri.Host;
+        return null;
+    }
+
+    /// <summary>
+    /// The URI whose host is the sector for a backchannel client that registered no redirect URI,
+    /// or <c>null</c> when the registration names none.
+    /// </summary>
+    /// <remarks>
+    /// A registration with no delivery mode yields null here and is refused, which is what this method
+    /// did before it could answer anything else. The absent-mode arm returns null rather than throwing
+    /// because an absent mode is a valid non-backchannel registration, not an unhandled case.
+    /// </remarks>
+    private static Uri? SectorUriForDeliveryMode(ClientRegistrationRequest request)
+        => request.BackChannelTokenDeliveryMode switch
+        {
+            BackchannelTokenDeliveryModes.Push => request.BackChannelClientNotificationEndpoint,
+
+            // Ping registers a notification endpoint too, and its sector is still the jwks_uri: Section 4
+            // groups ping with poll for this, and only push with the notification endpoint.
+            BackchannelTokenDeliveryModes.Poll or BackchannelTokenDeliveryModes.Ping => request.JwksUri,
+
+            _ => null,
+        };
+
+    /// <summary>
+    /// Takes the sector from the registered redirect URIs, which must be https and share one host.
+    /// </summary>
+    private static OidcError? ValidateFromRedirectUris(
+        ClientRegistrationValidationContext context,
+        Uri[] redirectUris)
+    {
         if (redirectUris.Any(uri => uri.Scheme != Uri.UriSchemeHttps))
         {
             return ErrorFactory.InvalidClientMetadata("All schemes in the redirect URIs must be https");

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
@@ -155,9 +155,9 @@ public class SubjectTypeConverter : ISubjectTypeConverter
         => uri.IsAbsoluteUri && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
 
     /// <summary>
-    /// The sector a backchannel client takes from the URI CIBA Core 1.0 Section 4 puts in the redirect URI's
-    /// place, or <c>null</c> when this client is not one, registered a redirect URI, or named a URI whose host
-    /// names nothing.
+    /// The sector host a backchannel client takes from the URI CIBA Core 1.0 Section 4 puts in the redirect
+    /// URI's place. Present only for a client that registered no redirect URI at all and whose mode names an
+    /// absolute http(s) URI; <c>null</c> in every other case, whatever makes it one.
     /// </summary>
     private static string? BackchannelSectorHost(ClientInfo clientInfo)
         => clientInfo.RedirectUris.Length == 0 &&
@@ -167,16 +167,22 @@ public class SubjectTypeConverter : ISubjectTypeConverter
             : null;
 
     /// <summary>
-    /// The URI whose host is the sector for a backchannel client that registered no redirect URI, or
-    /// <c>null</c> when this client is not one.
+    /// The URI CIBA Core 1.0 Section 4 puts in the redirect URI's place for this client's delivery mode,
+    /// or <c>null</c> when the mode names none.
     /// </summary>
     /// <remarks>
+    /// Naming a URI is not the same as having a sector from it: whether its host is used is the caller's
+    /// question, and <see cref="BackchannelSectorHost"/> answers it. Reading this summary as "the sector"
+    /// is what sends somebody debugging a client keyed on its client id into the switch below rather than
+    /// into the filter above.
+    /// <para>
     /// The same order the registration validator resolves, so a statically configured client and a
-    /// dynamically registered one bind to the same sector rather than to whichever path reached them.
-    /// A mode this server does not implement returns null and takes the client_id fallback. Nothing
-    /// refuses such a mode on a statically configured client - the registration validator only sees
-    /// requests that came over the network - so that client authenticates normally through whatever
-    /// other grant it holds, and keeps the per-client sector it had before this method existed.
+    /// dynamically registered one bind to the same sector rather than to whichever path reached them. A
+    /// mode this server does not implement returns null here. Nothing refuses such a mode on a statically
+    /// configured client - the registration validator only sees requests that came over the network - so
+    /// that client authenticates normally through whatever other grant it holds, and keeps the per-client
+    /// sector it had before this method existed.
+    /// </para>
     /// </remarks>
     private static Uri? BackchannelSectorUri(ClientInfo clientInfo)
         => clientInfo.BackChannelTokenDeliveryMode switch

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
@@ -127,19 +127,44 @@ public class SubjectTypeConverter : ISubjectTypeConverter
     /// clients would silently share one sector and seal identical pseudonyms for the same user, defeating the
     /// isolation this subject type exists to provide. Such clients keep per-client isolation via the client_id
     /// fallback.
+    /// <para>
+    /// The backchannel URI is held to the same test, by the same predicate, because a sector is a sector
+    /// whichever URI it came from: a jwks_uri spelled com.example.one:/keys parses as an absolute URI with an
+    /// EMPTY host, and an empty host is not null, so the client_id fallback below never fires and every such
+    /// client shares one sector. An http(s) URI cannot arrive that way - Uri refuses to construct http:/keys at
+    /// all - so one predicate covers both the empty host and the relative URI, which would otherwise throw on
+    /// Scheme rather than fall through to anything.
+    /// </para>
     /// </remarks>
     private static byte[] Sector(ClientInfo clientInfo)
     {
         var sector =
             clientInfo.SectorIdentifier ??
-            clientInfo.RedirectUris.FirstOrDefault(redirectUri =>
-                redirectUri.Scheme == Uri.UriSchemeHttp ||
-                redirectUri.Scheme == Uri.UriSchemeHttps)?.Host ??
-            (clientInfo.RedirectUris.Length == 0 ? BackchannelSectorUri(clientInfo)?.Host : null) ??
+            clientInfo.RedirectUris.FirstOrDefault(IsWebUri)?.Host ??
+            BackchannelSectorHost(clientInfo) ??
             clientInfo.ClientId;
 
         return Encoding.UTF8.GetBytes(sector);
     }
+
+    /// <summary>
+    /// Whether a URI's host names a sector at all: the web clients OIDC Core Section 8.1 had in mind, and
+    /// nothing else.
+    /// </summary>
+    private static bool IsWebUri(Uri uri)
+        => uri.IsAbsoluteUri && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+
+    /// <summary>
+    /// The sector a backchannel client takes from the URI CIBA Core 1.0 Section 4 puts in the redirect URI's
+    /// place, or <c>null</c> when this client is not one, registered a redirect URI, or named a URI whose host
+    /// names nothing.
+    /// </summary>
+    private static string? BackchannelSectorHost(ClientInfo clientInfo)
+        => clientInfo.RedirectUris.Length == 0 &&
+           BackchannelSectorUri(clientInfo) is { } sectorUri &&
+           IsWebUri(sectorUri)
+            ? sectorUri.Host
+            : null;
 
     /// <summary>
     /// The URI whose host is the sector for a backchannel client that registered no redirect URI, or

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
@@ -109,12 +109,14 @@ public class SubjectTypeConverter : ISubjectTypeConverter
     /// The sector the pseudonym is bound to (OIDC Core Section 8.1), as associated-data bytes.
     /// </summary>
     /// <remarks>
-    /// When no sector_identifier_uri was provided, the sector is the host component of the registered redirect_uri.
-    /// A client_id fallback would produce identifiers that silently change when the same application is
+    /// When no sector_identifier_uri was provided, the sector is the host component of the registered redirect_uri,
+    /// and for a backchannel client that registered none it is the host of the URI CIBA Core 1.0 Section 4 puts in
+    /// the redirect URI's place - the jwks_uri in poll and ping, the backchannel_client_notification_endpoint in
+    /// push. A client_id fallback would produce identifiers that silently change when the same application is
     /// re-registered under a new client id, defeating the stability pairwise identifiers give a sector; it affects
     /// only statically configured clients, since DCR-registered pairwise clients always get SectorIdentifier
-    /// computed at registration time, and remains the last resort for clients with no redirect URIs at all (e.g.
-    /// pure client_credentials configurations). The host is meaningful only for http(s) redirect URIs - the web
+    /// computed at registration time, and remains the last resort for a client with none of those URIs (e.g. a pure
+    /// client_credentials configuration). The host is meaningful only for http(s) redirect URIs - the web
     /// clients Core Section 8.1 had in mind. Native custom-scheme redirects (RFC 8252 Section 7.1) must not reach
     /// the host branch: the single-slash form (com.example.app:/oauth2redirect) parses with an EMPTY host, and the
     /// authority form (app-one://callback) puts an arbitrary path-like segment into Host - either way unrelated
@@ -129,8 +131,27 @@ public class SubjectTypeConverter : ISubjectTypeConverter
             clientInfo.RedirectUris.FirstOrDefault(redirectUri =>
                 redirectUri.Scheme == Uri.UriSchemeHttp ||
                 redirectUri.Scheme == Uri.UriSchemeHttps)?.Host ??
+            BackchannelSectorUri(clientInfo)?.Host ??
             clientInfo.ClientId;
 
         return Encoding.UTF8.GetBytes(sector);
     }
+
+    /// <summary>
+    /// The URI whose host is the sector for a backchannel client that registered no redirect URI, or
+    /// <c>null</c> when this client is not one.
+    /// </summary>
+    /// <remarks>
+    /// The same order the registration validator resolves, so a statically configured client and a
+    /// dynamically registered one bind to the same sector rather than to whichever path reached them.
+    /// A mode this server does not implement returns null and takes the client_id fallback, which is a
+    /// per-client sector - wrong for nobody, since no such client can authenticate.
+    /// </remarks>
+    private static Uri? BackchannelSectorUri(ClientInfo clientInfo)
+        => clientInfo.BackChannelTokenDeliveryMode switch
+        {
+            BackchannelTokenDeliveryModes.Push => clientInfo.BackChannelClientNotificationEndpoint,
+            BackchannelTokenDeliveryModes.Poll or BackchannelTokenDeliveryModes.Ping => clientInfo.JwksUri,
+            _ => null,
+        };
 }

--- a/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
+++ b/src/Abblix.Oidc.Server/Features/PairwiseIdentifiers/SubjectTypeConverter.cs
@@ -110,9 +110,13 @@ public class SubjectTypeConverter : ISubjectTypeConverter
     /// </summary>
     /// <remarks>
     /// When no sector_identifier_uri was provided, the sector is the host component of the registered redirect_uri,
-    /// and for a backchannel client that registered none it is the host of the URI CIBA Core 1.0 Section 4 puts in
-    /// the redirect URI's place - the jwks_uri in poll and ping, the backchannel_client_notification_endpoint in
-    /// push. A client_id fallback would produce identifiers that silently change when the same application is
+    /// and for a backchannel client that registered NO redirect URI at all it is the host of the URI CIBA Core 1.0
+    /// Section 4 puts in the redirect URI's place - the jwks_uri in poll and ping, the
+    /// backchannel_client_notification_endpoint in push. "No redirect URI at all" rather than "no usable one", so
+    /// that the custom-scheme case below keeps the client_id fallback the paragraph promises it: a native client
+    /// registers redirect URIs whose host is meaningless, and letting those fall through to a shared jwks host
+    /// would merge unrelated apps into one sector, which is the collision this whole method exists to prevent.
+    /// A client_id fallback would produce identifiers that silently change when the same application is
     /// re-registered under a new client id, defeating the stability pairwise identifiers give a sector; it affects
     /// only statically configured clients, since DCR-registered pairwise clients always get SectorIdentifier
     /// computed at registration time, and remains the last resort for a client with none of those URIs (e.g. a pure
@@ -131,7 +135,7 @@ public class SubjectTypeConverter : ISubjectTypeConverter
             clientInfo.RedirectUris.FirstOrDefault(redirectUri =>
                 redirectUri.Scheme == Uri.UriSchemeHttp ||
                 redirectUri.Scheme == Uri.UriSchemeHttps)?.Host ??
-            BackchannelSectorUri(clientInfo)?.Host ??
+            (clientInfo.RedirectUris.Length == 0 ? BackchannelSectorUri(clientInfo)?.Host : null) ??
             clientInfo.ClientId;
 
         return Encoding.UTF8.GetBytes(sector);
@@ -144,8 +148,10 @@ public class SubjectTypeConverter : ISubjectTypeConverter
     /// <remarks>
     /// The same order the registration validator resolves, so a statically configured client and a
     /// dynamically registered one bind to the same sector rather than to whichever path reached them.
-    /// A mode this server does not implement returns null and takes the client_id fallback, which is a
-    /// per-client sector - wrong for nobody, since no such client can authenticate.
+    /// A mode this server does not implement returns null and takes the client_id fallback. Nothing
+    /// refuses such a mode on a statically configured client - the registration validator only sees
+    /// requests that came over the network - so that client authenticates normally through whatever
+    /// other grant it holds, and keeps the per-client sector it had before this method existed.
     /// </remarks>
     private static Uri? BackchannelSectorUri(ClientInfo clientInfo)
         => clientInfo.BackChannelTokenDeliveryMode switch

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
@@ -39,8 +39,8 @@ public class SubjectTypeValidatorTests
     }
 
     /// <summary>
-    /// A pairwise client that registered no redirect URI and no sector identifier URI is refused, not
-    /// crashed on.
+    /// A pairwise client that registered no redirect URI, no sector identifier URI and no backchannel
+    /// delivery mode is refused, not crashed on.
     /// </summary>
     /// <remarks>
     /// The sibling of the redirect URI validator's own null case, and reachable for the same reason from
@@ -553,21 +553,26 @@ public class SubjectTypeValidatorTests
     }
 
     /// <summary>
-    /// A pairwise poll or ping client that registered neither a sector identifier URI nor a jwks_uri
-    /// is refused.
+    /// A pairwise poll or ping client with no sector identifier URI, no redirect URI and no
+    /// jwks_uri is refused.
     /// </summary>
     /// <remarks>
-    /// CIBA Core 1.0 Section 4 requires exactly this pair: "the RP must provide either a
-    /// sector_identifier_uri or a jwks_uri at the registration phase when the
-    /// urn:openid:params:grant-type:ciba grant type is registered", and separately that an OP
-    /// supporting PPIDs "MUST check if a valid jwks_uri is set when the subject_type is pairwise".
-    /// Without one there is no host to derive a sector from, and a client id would make the
-    /// identifiers per-client where the specification makes them per-sector.
+    /// All three absences are load-bearing, and the name says so because the narrower reading is
+    /// what this row actually holds. CIBA Core 1.0 Section 4 asks for more than this - "it MUST
+    /// check if a valid jwks_uri is set when the subject_type is pairwise" is unconditional, so a
+    /// poll client that registered a redirect URI and no jwks_uri is accepted here and should not
+    /// be. That gap is not this change's to close and is recorded rather than implied by a row
+    /// whose name promises it.
+    /// <para>
+    /// What this row does hold: with none of the three, there is no host to derive a sector from,
+    /// and falling back to the client id would make the identifiers per-client where the
+    /// specification makes them per-sector.
+    /// </para>
     /// </remarks>
     [Theory]
     [InlineData(BackchannelTokenDeliveryModes.Poll)]
     [InlineData(BackchannelTokenDeliveryModes.Ping)]
-    public async Task ValidateAsync_PairwisePollOrPingWithNoJwksUri_ShouldReturnError(string deliveryMode)
+    public async Task ValidateAsync_PairwisePollOrPingWithNoUriAtAll_ShouldReturnError(string deliveryMode)
     {
         // Arrange
         var context = CreateContext(
@@ -616,20 +621,62 @@ public class SubjectTypeValidatorTests
     /// The URI a sector is taken from must be https, the same rule the redirect URI branch applies.
     /// </summary>
     /// <remarks>
-    /// BackChannelAuthenticationValidator enforces the specification's "It MUST be an HTTPS URL" for
-    /// the notification endpoint, but it is registered AFTER this validator, so at this point the value
-    /// has been through no scheme check - and this branch is about to take a sector identity from its
-    /// host.
+    /// Push is the weaker case and poll is the one that matters: for the notification endpoint
+    /// BackChannelAuthenticationValidator enforces the specification's "It MUST be an HTTPS URL"
+    /// as well, just later in the pipeline, whereas for the jwks_uri NOTHING else in the
+    /// registration pipeline checks the scheme at all. Both are driven, so that a reader who
+    /// reorders the validators cannot delete this check on the strength of the duplicate.
     /// </remarks>
-    [Fact]
-    public async Task ValidateAsync_CibaSectorUriOverHttp_ShouldReturnError()
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Push)]
+    [InlineData(BackchannelTokenDeliveryModes.Poll)]
+    [InlineData(BackchannelTokenDeliveryModes.Ping)]
+    public async Task ValidateAsync_CibaSectorUriOverHttp_ShouldReturnError(string deliveryMode)
     {
         // Arrange
+        var overHttp = new Uri("http://client.example.com/callback");
+        var isPush = deliveryMode == BackchannelTokenDeliveryModes.Push;
         var context = CreateContext(
             redirectUris: [],
             subjectType: SubjectTypes.Pairwise,
-            deliveryMode: BackchannelTokenDeliveryModes.Push,
-            notificationEndpoint: new Uri("http://notify.example.com/callback"));
+            deliveryMode: deliveryMode,
+            notificationEndpoint: isPush ? overHttp : null,
+            jwksUri: isPush ? null : overHttp);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+        Assert.Null(context.SectorIdentifier);
+    }
+    /// <summary>
+    /// A relative URI where the sector's host would come from is refused, not dereferenced.
+    /// </summary>
+    /// <remarks>
+    /// A registration body is attacker-shaped JSON, and <c>[AbsoluteUri]</c> does not reach it: the
+    /// attribute is honoured by the form binder rather than by the JSON deserializer, so "/jwks"
+    /// arrives intact. Every <see cref="Uri"/> member this branch then reads - Scheme, Host - throws
+    /// <see cref="InvalidOperationException"/> on a relative value rather than returning anything, so
+    /// what the client meets is a fault instead of the refusal it should be. The redirect-URI branch
+    /// never had this exposure: it only ever sees values that survived
+    /// <c>RedirectUrisValidator</c>.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Push)]
+    [InlineData(BackchannelTokenDeliveryModes.Poll)]
+    public async Task ValidateAsync_RelativeCibaSectorUri_IsRefusedRatherThanDereferenced(string deliveryMode)
+    {
+        // Arrange
+        var relative = new Uri("/jwks", UriKind.Relative);
+        var isPush = deliveryMode == BackchannelTokenDeliveryModes.Push;
+        var context = CreateContext(
+            redirectUris: [],
+            subjectType: SubjectTypes.Pairwise,
+            deliveryMode: deliveryMode,
+            notificationEndpoint: isPush ? relative : null,
+            jwksUri: isPush ? null : relative);
 
         // Act
         var result = await _validator.ValidateAsync(context);

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
@@ -65,13 +65,19 @@ public class SubjectTypeValidatorTests
     private ClientRegistrationValidationContext CreateContext(
         Uri[] redirectUris,
         string? subjectType = SubjectTypes.Public,
-        Uri? sectorIdentifierUri = null)
+        Uri? sectorIdentifierUri = null,
+        string? deliveryMode = null,
+        Uri? notificationEndpoint = null,
+        Uri? jwksUri = null)
     {
         var request = new ClientRegistrationRequest
         {
             RedirectUris = redirectUris,
             SubjectType = subjectType,
-            SectorIdentifierUri = sectorIdentifierUri
+            SectorIdentifierUri = sectorIdentifierUri,
+            BackChannelTokenDeliveryMode = deliveryMode,
+            BackChannelClientNotificationEndpoint = notificationEndpoint,
+            JwksUri = jwksUri
         };
 
         return new ClientRegistrationValidationContext(request);
@@ -388,5 +394,128 @@ public class SubjectTypeValidatorTests
 
         // Assert
         Assert.Equal("sector.example.com", context.SectorIdentifier);
+    }
+    /// <summary>
+    /// A CIBA client's sector document must list the URI its delivery mode uses in place of the
+    /// redirect URI, and each mode names a different one.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 4: "In CIBA Poll and Ping modes the jwks_uri is used in place of the
+    /// redirect_uri. In CIBA Push mode the backchannel_client_notification_endpoint is used in place
+    /// of the redirect_uri", and the document "can contain jwks_uris and
+    /// backchannel_client_notification_endpoints as well as redirect_uri". The membership check is
+    /// what stops a client claiming a sector it does not belong to, so an unchecked URI is a client
+    /// receiving identifiers computed from somebody else's host.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Push, true, false)]
+    [InlineData(BackchannelTokenDeliveryModes.Push, false, true)]
+    [InlineData(BackchannelTokenDeliveryModes.Poll, true, false)]
+    [InlineData(BackchannelTokenDeliveryModes.Poll, false, true)]
+    [InlineData(BackchannelTokenDeliveryModes.Ping, true, false)]
+    [InlineData(BackchannelTokenDeliveryModes.Ping, false, true)]
+    public async Task ValidateAsync_CibaSectorDocument_MustListTheUriTheModeNames(
+        string deliveryMode, bool listedInDocument, bool expectError)
+    {
+        // Arrange
+        var sectorUri = new Uri("https://sector.example.com/sector.json");
+        var modeUri = new Uri($"https://client.example.com/{deliveryMode}");
+
+        _secureHttpFetcher
+            .Setup(f => f.FetchAsync<Uri[]>(sectorUri))
+            .ReturnsAsync(Result<Uri[], OidcError>.Success(
+                listedInDocument ? [modeUri] : [new Uri("https://client.example.com/something-else")]));
+
+        var isPush = deliveryMode == BackchannelTokenDeliveryModes.Push;
+        var context = CreateContext(
+            redirectUris: [],
+            subjectType: SubjectTypes.Pairwise,
+            sectorIdentifierUri: sectorUri,
+            deliveryMode: deliveryMode,
+            notificationEndpoint: isPush ? modeUri : null,
+            jwksUri: isPush ? null : modeUri);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        if (expectError)
+        {
+            Assert.NotNull(result);
+            Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+        }
+        else
+        {
+            Assert.Null(result);
+            Assert.Equal("sector.example.com", context.SectorIdentifier);
+        }
+    }
+
+    /// <summary>
+    /// A registration with no delivery mode is not asked for either CIBA URI, even when it has them.
+    /// </summary>
+    /// <remarks>
+    /// The requirement is written per mode, so making it unconditional would refuse a plain pairwise
+    /// client that happens to publish a jwks_uri - which OIDC Core has never required to be listed.
+    /// This row is what stops the two arms above from widening into every registration.
+    /// </remarks>
+    [Fact]
+    public async Task ValidateAsync_PairwiseWithNoDeliveryMode_DoesNotRequireTheCibaUris()
+    {
+        // Arrange
+        var sectorUri = new Uri("https://sector.example.com/sector.json");
+        var redirectUri = new Uri("https://client.example.com/callback");
+
+        _secureHttpFetcher
+            .Setup(f => f.FetchAsync<Uri[]>(sectorUri))
+            .ReturnsAsync(Result<Uri[], OidcError>.Success([redirectUri]));
+
+        var context = CreateContext(
+            redirectUris: [redirectUri],
+            subjectType: SubjectTypes.Pairwise,
+            sectorIdentifierUri: sectorUri,
+            deliveryMode: null,
+            notificationEndpoint: new Uri("https://client.example.com/notify"),
+            jwksUri: new Uri("https://client.example.com/jwks"));
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal("sector.example.com", context.SectorIdentifier);
+    }
+
+    /// <summary>
+    /// The refusal names the URI that was missing, rather than calling everything a redirect URI.
+    /// </summary>
+    /// <remarks>
+    /// A message saying "redirect URIs" to a client whose notification endpoint was the omission sends
+    /// its author to the wrong piece of metadata, and the sector document is edited by a person.
+    /// </remarks>
+    [Fact]
+    public async Task ValidateAsync_MissingNotificationEndpoint_NamesItInTheMessage()
+    {
+        // Arrange
+        var sectorUri = new Uri("https://sector.example.com/sector.json");
+        var notificationEndpoint = new Uri("https://client.example.com/notify");
+
+        _secureHttpFetcher
+            .Setup(f => f.FetchAsync<Uri[]>(sectorUri))
+            .ReturnsAsync(Result<Uri[], OidcError>.Success([]));
+
+        var context = CreateContext(
+            redirectUris: [],
+            subjectType: SubjectTypes.Pairwise,
+            sectorIdentifierUri: sectorUri,
+            deliveryMode: BackchannelTokenDeliveryModes.Push,
+            notificationEndpoint: notificationEndpoint);
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains(notificationEndpoint.OriginalString, result.ErrorDescription);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SubjectTypeValidatorTests.cs
@@ -518,4 +518,125 @@ public class SubjectTypeValidatorTests
         Assert.NotNull(result);
         Assert.Contains(notificationEndpoint.OriginalString, result.ErrorDescription);
     }
+    /// <summary>
+    /// With no sector identifier URI and no redirect URI, the sector is the host of the URI the
+    /// delivery mode names.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 4: the jwks_uri stands in for the redirect URI in poll and ping, the
+    /// backchannel_client_notification_endpoint in push. Ping registers a notification endpoint as
+    /// well and its sector is still the jwks_uri, which is why ping is grouped with poll here and not
+    /// with push - a row that exists to catch the grouping being done by "has a notification endpoint"
+    /// instead of by mode.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Push, "notify.example.com")]
+    [InlineData(BackchannelTokenDeliveryModes.Poll, "keys.example.com")]
+    [InlineData(BackchannelTokenDeliveryModes.Ping, "keys.example.com")]
+    public async Task ValidateAsync_CibaWithNoRedirectUri_TakesTheSectorFromTheModesUri(
+        string deliveryMode, string expectedSector)
+    {
+        // Arrange
+        var context = CreateContext(
+            redirectUris: [],
+            subjectType: SubjectTypes.Pairwise,
+            deliveryMode: deliveryMode,
+            notificationEndpoint: new Uri("https://notify.example.com/callback"),
+            jwksUri: new Uri("https://keys.example.com/jwks"));
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal(expectedSector, context.SectorIdentifier);
+    }
+
+    /// <summary>
+    /// A pairwise poll or ping client that registered neither a sector identifier URI nor a jwks_uri
+    /// is refused.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 4 requires exactly this pair: "the RP must provide either a
+    /// sector_identifier_uri or a jwks_uri at the registration phase when the
+    /// urn:openid:params:grant-type:ciba grant type is registered", and separately that an OP
+    /// supporting PPIDs "MUST check if a valid jwks_uri is set when the subject_type is pairwise".
+    /// Without one there is no host to derive a sector from, and a client id would make the
+    /// identifiers per-client where the specification makes them per-sector.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Poll)]
+    [InlineData(BackchannelTokenDeliveryModes.Ping)]
+    public async Task ValidateAsync_PairwisePollOrPingWithNoJwksUri_ShouldReturnError(string deliveryMode)
+    {
+        // Arrange
+        var context = CreateContext(
+            redirectUris: [],
+            subjectType: SubjectTypes.Pairwise,
+            deliveryMode: deliveryMode,
+            notificationEndpoint: new Uri("https://notify.example.com/callback"));
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+    }
+
+    /// <summary>
+    /// A registered redirect URI still decides the sector, even for a client that also registered a
+    /// backchannel delivery mode.
+    /// </summary>
+    /// <remarks>
+    /// The order matters beyond correctness: the pairwise pseudonym is sealed with the sector as
+    /// associated data, so moving a client's sector invalidates every identifier already issued to it.
+    /// Putting the CIBA URIs BELOW the redirect URI is what keeps every client that has one where it
+    /// was.
+    /// </remarks>
+    [Fact]
+    public async Task ValidateAsync_CibaClientWithARedirectUri_KeepsTheRedirectUriHost()
+    {
+        // Arrange
+        var context = CreateContext(
+            redirectUris: [new Uri("https://app.example.com/callback")],
+            subjectType: SubjectTypes.Pairwise,
+            deliveryMode: BackchannelTokenDeliveryModes.Push,
+            notificationEndpoint: new Uri("https://notify.example.com/callback"));
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal("app.example.com", context.SectorIdentifier);
+    }
+
+    /// <summary>
+    /// The URI a sector is taken from must be https, the same rule the redirect URI branch applies.
+    /// </summary>
+    /// <remarks>
+    /// BackChannelAuthenticationValidator enforces the specification's "It MUST be an HTTPS URL" for
+    /// the notification endpoint, but it is registered AFTER this validator, so at this point the value
+    /// has been through no scheme check - and this branch is about to take a sector identity from its
+    /// host.
+    /// </remarks>
+    [Fact]
+    public async Task ValidateAsync_CibaSectorUriOverHttp_ShouldReturnError()
+    {
+        // Arrange
+        var context = CreateContext(
+            redirectUris: [],
+            subjectType: SubjectTypes.Pairwise,
+            deliveryMode: BackchannelTokenDeliveryModes.Push,
+            notificationEndpoint: new Uri("http://notify.example.com/callback"));
+
+        // Act
+        var result = await _validator.ValidateAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidClientMetadata, result.Error);
+        Assert.Null(context.SectorIdentifier);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
@@ -320,6 +320,7 @@ public class SubjectTypeConverterTests
 
         Assert.Equal(expectedLength, pairwise.Length);
     }
+
     /// <summary>
     /// Two backchannel clients of one sector that registered no redirect URI still derive the same
     /// pairwise subject, taking the host from the URI their delivery mode names.
@@ -423,6 +424,7 @@ public class SubjectTypeConverterTests
 
         Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
     }
+
     /// <summary>
     /// Two native clients that publish keys on one host stay in separate sectors.
     /// </summary>
@@ -454,6 +456,7 @@ public class SubjectTypeConverterTests
 
         Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
     }
+
     /// <summary>
     /// Two backchannel clients whose keys sit on one host, named by a scheme that is not the web's, stay in
     /// separate sectors.
@@ -482,6 +485,26 @@ public class SubjectTypeConverterTests
             jwksUri: new Uri("com.example.two:/keys"));
 
         Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
+    }
+
+    /// <summary>
+    /// The same for a relative REDIRECT URI, which is the arm that carried this exposure first.
+    /// </summary>
+    /// <remarks>
+    /// The redirect arm gained its absoluteness guard by sharing the predicate rather than by being
+    /// fixed, so nothing recorded the change: a statically configured client with <c>/cb</c> faulted on
+    /// every token before and falls back to the client id now. A shared predicate is pinned at one arm
+    /// and diverges at the other by a deliberate edit, which is exactly what this row refuses.
+    /// </remarks>
+    [Fact]
+    public void Convert_ClientWithARelativeRedirectUri_FallsBackRatherThanFaulting()
+    {
+        var converter = CreateConverter();
+
+        var client = CreatePairwiseClient("client-a", redirectUris: [new Uri("/cb", UriKind.Relative)]);
+        var withNoRedirectUri = CreatePairwiseClient("client-a");
+
+        Assert.Equal(converter.Convert(Subject, withNoRedirectUri), converter.Convert(Subject, client));
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
@@ -423,4 +423,35 @@ public class SubjectTypeConverterTests
 
         Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
     }
+    /// <summary>
+    /// Two native clients that publish keys on one host stay in separate sectors.
+    /// </summary>
+    /// <remarks>
+    /// The redirect-URI branch above only considers http(s) URIs, so a native client registering
+    /// <c>com.example.app:/oauth2redirect</c> falls PAST it - and would land on the backchannel URI
+    /// if that branch did not first require that no redirect URI was registered at all. Two
+    /// unrelated apps whose keys sit on one hosting provider would then seal identical pseudonyms
+    /// for the same person, which is exactly the collision the custom-scheme paragraph exists to
+    /// prevent. The existing custom-scheme row cannot see this: it registers no delivery mode, so
+    /// the branch it would have to pass through is never entered.
+    /// </remarks>
+    [Fact]
+    public void Convert_NativeClientsSharingAJwksHost_StayInSeparateSectors()
+    {
+        var converter = CreateConverter();
+
+        var clientA = CreatePairwiseClient(
+            "client-a",
+            redirectUris: [new Uri("com.example.one:/oauth2redirect")],
+            deliveryMode: BackchannelTokenDeliveryModes.Poll,
+            jwksUri: new Uri("https://keys.example.com/a.jwks"));
+
+        var clientB = CreatePairwiseClient(
+            "client-b",
+            redirectUris: [new Uri("app-two://callback")],
+            deliveryMode: BackchannelTokenDeliveryModes.Poll,
+            jwksUri: new Uri("https://keys.example.com/b.jwks"));
+
+        Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
@@ -16,7 +16,7 @@ namespace Abblix.Oidc.Server.UnitTests.Features.PairwiseIdentifiers;
 
 /// <summary>
 /// Unit tests for <see cref="SubjectTypeConverter"/> verifying pairwise subject derivation per
-/// OIDC Core §8.1, in particular the sector identifier fallback chain for statically configured
+/// OIDC Core Section 8.1, in particular the sector identifier fallback chain for statically configured
 /// clients without an explicit sector identifier.
 /// </summary>
 public class SubjectTypeConverterTests
@@ -31,15 +31,21 @@ public class SubjectTypeConverterTests
     private static ClientInfo CreatePairwiseClient(
         string clientId,
         string? sectorIdentifier = null,
-        Uri[]? redirectUris = null) => new(clientId)
+        Uri[]? redirectUris = null,
+        string? deliveryMode = null,
+        Uri? notificationEndpoint = null,
+        Uri? jwksUri = null) => new(clientId)
     {
         SubjectType = SubjectTypes.Pairwise,
         SectorIdentifier = sectorIdentifier,
         RedirectUris = redirectUris ?? [],
+        BackChannelTokenDeliveryMode = deliveryMode,
+        BackChannelClientNotificationEndpoint = notificationEndpoint,
+        JwksUri = jwksUri,
     };
 
     /// <summary>
-    /// OIDC Core §8.1: without an explicit sector identifier the sector is the host component of
+    /// OIDC Core Section 8.1: without an explicit sector identifier the sector is the host component of
     /// the registered redirect_uri - two statically configured clients of the same sector must
     /// derive the same pairwise subject. The previous client_id fallback broke exactly this.
     /// </summary>
@@ -70,11 +76,11 @@ public class SubjectTypeConverterTests
     }
 
     /// <summary>
-    /// Custom-scheme redirect URIs of native clients (RFC 8252 §7.1) carry no meaningful host:
+    /// Custom-scheme redirect URIs of native clients (RFC 8252 Section 7.1) carry no meaningful host:
     /// the single-slash form parses with an empty Host, and the authority form puts an arbitrary
     /// path-like segment there - either would merge unrelated clients into one shared sector,
     /// giving them identical pairwise subjects and defeating the isolation pairwise subject
-    /// types exist to provide (OIDC Core §8.1). The client_id fallback applies instead.
+    /// types exist to provide (OIDC Core Section 8.1). The client_id fallback applies instead.
     /// </summary>
     [Theory]
     [InlineData("com.example.one:/oauth2redirect", "com.example.two:/oauth2redirect")]
@@ -104,7 +110,7 @@ public class SubjectTypeConverterTests
 
     /// <summary>
     /// A pairwise subject is stable: the same (subject, sector) always seals to the same value, so a client sees a
-    /// consistent identifier for the user across logins - the core stability guarantee of OIDC Core §8.1.
+    /// consistent identifier for the user across logins - the core stability guarantee of OIDC Core Section 8.1.
     /// </summary>
     [Fact]
     public void Convert_SameSubjectAndClient_IsDeterministic()
@@ -135,7 +141,7 @@ public class SubjectTypeConverterTests
     /// <summary>
     /// Sector, not client id, determines the identifier: two distinct clients sharing an explicit sector_identifier
     /// seal the same subject to the same value, so a sector's back-ends see one consistent identifier (OIDC Core
-    /// §8.1).
+    /// Section 8.1).
     /// </summary>
     [Fact]
     public void Convert_SameExplicitSectorIdentifier_DifferentClients_ProduceSameSubject()
@@ -180,7 +186,7 @@ public class SubjectTypeConverterTests
 
     /// <summary>
     /// A public client's subject is not transformed: Convert returns it unchanged, so the client sees the real
-    /// subject (OIDC Core §8, the public subject type).
+    /// subject (OIDC Core Section 8, the public subject type).
     /// </summary>
     [Fact]
     public void Convert_PublicClient_ReturnsSubjectUnchanged()
@@ -313,5 +319,108 @@ public class SubjectTypeConverterTests
         var pairwise = converter.Convert(subject, client);
 
         Assert.Equal(expectedLength, pairwise.Length);
+    }
+    /// <summary>
+    /// Two backchannel clients of one sector that registered no redirect URI still derive the same
+    /// pairwise subject, taking the host from the URI their delivery mode names.
+    /// </summary>
+    /// <remarks>
+    /// CIBA Core 1.0 Section 4 puts the jwks_uri in the redirect URI's place for poll and ping, and the
+    /// backchannel_client_notification_endpoint for push. Without this the client_id fallback was
+    /// reached, making identifiers per-client where the specification makes them per-sector - which is
+    /// the whole point of a sector, so two genuinely-one-deployment clients could not recognise a user
+    /// as the same person.
+    /// </remarks>
+    [Theory]
+    [InlineData(BackchannelTokenDeliveryModes.Push)]
+    [InlineData(BackchannelTokenDeliveryModes.Poll)]
+    [InlineData(BackchannelTokenDeliveryModes.Ping)]
+    public void Convert_BackchannelClientsOfOneSector_DeriveTheSameSubject(string deliveryMode)
+    {
+        var converter = CreateConverter();
+        var isPush = deliveryMode == BackchannelTokenDeliveryModes.Push;
+
+        ClientInfo Client(string clientId, string path) => CreatePairwiseClient(
+            clientId,
+            deliveryMode: deliveryMode,
+            notificationEndpoint: isPush ? new Uri($"https://one.example.com/{path}") : null,
+            jwksUri: isPush ? null : new Uri($"https://one.example.com/{path}"));
+
+        Assert.Equal(
+            converter.Convert(Subject, Client("client-a", "a")),
+            converter.Convert(Subject, Client("client-b", "b")));
+    }
+
+    /// <summary>
+    /// A ping client's sector is its jwks_uri, not its notification endpoint.
+    /// </summary>
+    /// <remarks>
+    /// Ping registers both, so grouping it by "has a notification endpoint" instead of by the mode the
+    /// specification names is the plausible mistake, and it is invisible to every test where the two
+    /// hosts agree. These two clients share a jwks_uri host and differ on the notification endpoint, so
+    /// only the correct grouping makes them one sector.
+    /// </remarks>
+    [Fact]
+    public void Convert_PingClient_TakesTheSectorFromTheJwksUriNotTheNotificationEndpoint()
+    {
+        var converter = CreateConverter();
+
+        var clientA = CreatePairwiseClient(
+            "client-a",
+            deliveryMode: BackchannelTokenDeliveryModes.Ping,
+            notificationEndpoint: new Uri("https://notify-a.example.com/cb"),
+            jwksUri: new Uri("https://keys.example.com/a.jwks"));
+
+        var clientB = CreatePairwiseClient(
+            "client-b",
+            deliveryMode: BackchannelTokenDeliveryModes.Ping,
+            notificationEndpoint: new Uri("https://notify-b.example.com/cb"),
+            jwksUri: new Uri("https://keys.example.com/b.jwks"));
+
+        Assert.Equal(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
+    }
+
+    /// <summary>
+    /// A registered redirect URI still decides the sector for a client that also has a delivery mode.
+    /// </summary>
+    /// <remarks>
+    /// The order is what keeps every already-issued pseudonym openable: the sector is the seal's
+    /// associated data, so a client whose sector moves loses every identifier it ever handed out. Only
+    /// clients that had NO redirect URI - and whose sector was therefore the client id - change here.
+    /// </remarks>
+    [Fact]
+    public void Convert_BackchannelClientWithARedirectUri_KeepsTheRedirectUriSector()
+    {
+        var converter = CreateConverter();
+
+        var backchannel = CreatePairwiseClient(
+            "client-a",
+            redirectUris: [new Uri("https://app.example.com/cb")],
+            deliveryMode: BackchannelTokenDeliveryModes.Push,
+            notificationEndpoint: new Uri("https://notify.example.com/cb"));
+
+        var plain = CreatePairwiseClient("client-b", redirectUris: [new Uri("https://app.example.com/cb")]);
+
+        Assert.Equal(converter.Convert(Subject, backchannel), converter.Convert(Subject, plain));
+    }
+
+    /// <summary>
+    /// With no delivery mode the client id is still the last resort, and two such clients stay apart.
+    /// </summary>
+    /// <remarks>
+    /// This is what stops the new fallback from widening: a client that registered a jwks_uri without
+    /// any backchannel mode is an ordinary client publishing its keys, and merging two of them into one
+    /// sector would seal identical pseudonyms for unrelated parties.
+    /// </remarks>
+    [Fact]
+    public void Convert_NoDeliveryMode_StillFallsBackToTheClientId()
+    {
+        var converter = CreateConverter();
+        var jwksUri = new Uri("https://keys.example.com/jwks");
+
+        var clientA = CreatePairwiseClient("client-a", jwksUri: jwksUri);
+        var clientB = CreatePairwiseClient("client-b", jwksUri: jwksUri);
+
+        Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/PairwiseIdentifiers/SubjectTypeConverterTests.cs
@@ -454,4 +454,58 @@ public class SubjectTypeConverterTests
 
         Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
     }
+    /// <summary>
+    /// Two backchannel clients whose keys sit on one host, named by a scheme that is not the web's, stay in
+    /// separate sectors.
+    /// </summary>
+    /// <remarks>
+    /// The host branch is filtered to http(s) for a reason that reads as being about redirect URIs and is
+    /// not: a URI spelled <c>com.example.one:/keys</c> is absolute, and its Host is the EMPTY STRING rather
+    /// than null - so a chain that reaches for the client id when the host is missing never gets there, and
+    /// every client naming such a URI shares the one empty sector. Measured, not reasoned: before the
+    /// filter reached this arm these two clients sealed the identical pseudonym for one user. The row above
+    /// cannot see it, because it comes in through the redirect URIs.
+    /// </remarks>
+    [Fact]
+    public void Convert_BackchannelClientsWithNonWebKeyUris_StayInSeparateSectors()
+    {
+        var converter = CreateConverter();
+
+        var clientA = CreatePairwiseClient(
+            "client-a",
+            deliveryMode: BackchannelTokenDeliveryModes.Poll,
+            jwksUri: new Uri("com.example.one:/keys"));
+
+        var clientB = CreatePairwiseClient(
+            "client-b",
+            deliveryMode: BackchannelTokenDeliveryModes.Poll,
+            jwksUri: new Uri("com.example.two:/keys"));
+
+        Assert.NotEqual(converter.Convert(Subject, clientA), converter.Convert(Subject, clientB));
+    }
+
+    /// <summary>
+    /// A statically configured client whose key URI is relative still gets an identifier, rather than
+    /// faulting on every token it is issued.
+    /// </summary>
+    /// <remarks>
+    /// The registration validator refuses this shape, and it only ever sees requests that came over the
+    /// network - a client written into configuration reaches the converter unrefused. <see cref="Uri.Host"/>
+    /// throws on a relative URI rather than returning anything, so the fault would land on token issuance,
+    /// far from the file that caused it.
+    /// </remarks>
+    [Fact]
+    public void Convert_BackchannelClientWithARelativeKeyUri_FallsBackRatherThanFaulting()
+    {
+        var converter = CreateConverter();
+
+        var client = CreatePairwiseClient(
+            "client-a",
+            deliveryMode: BackchannelTokenDeliveryModes.Poll,
+            jwksUri: new Uri("/jwks", UriKind.Relative));
+
+        var withNoKeyUri = CreatePairwiseClient("client-a");
+
+        Assert.Equal(converter.Convert(Subject, withNoKeyUri), converter.Convert(Subject, client));
+    }
 }


### PR DESCRIPTION
A pairwise CIBA client could not get a correct sector identifier by any route. The
registration validator refused it outright, the sector document check ignored the two
entries CIBA adds, and a statically configured one silently fell back to its client id.
Three commits, one per site.

## What the specification says

CIBA Core 1.0 Section 4, retrieved and read rather than recalled. Three sentences carry
this change:

> In CIBA Poll and Ping modes the jwks_uri is used in place of the redirect_uri. In CIBA
> Push mode the backchannel_client_notification_endpoint is used in place of the
> redirect_uri.

> This specification extends the purpose of the sector_identifier_uri such that it can
> contain jwks_uris and backchannel_client_notification_endpoints as well as redirect_uri.

> the RP must provide either a sector_identifier_uri or a jwks_uri at the registration
> phase when the urn:openid:params:grant-type:ciba grant type is registered

Ping is grouped with poll, not with push. It registers a notification endpoint as well -
that parameter is REQUIRED for ping and push alike - but its sector is still the jwks_uri.
Grouping by "has a notification endpoint" is the plausible mistake and it has a row of its
own in each of the two test files.

## The three sites

**The sector document was checked for redirect_uris alone.** It now also carries the
notification endpoint for push and the jwks_uri for poll and ping, each conditional on the
mode that names it - so a registration with no delivery mode is asked for exactly what it
was asked for before. The refusal names the missing values individually; "one or more
registered redirect URIs are not listed" sent to a client whose notification endpoint was
the omission points its author at the wrong metadata.

**A pairwise client with no redirect URI was refused.** The refusal's own comment named
the reachable case - "a client asking only for a grant type that needs no redirection" -
which is a CIBA client, and RedirectUrisValidator does permit it: redirect URIs are
required only for authorization_code, implicit and refresh_token. So a legitimate
registration was being turned away. The host now comes from the URI the mode names, and
the refusal that remains is the specification's own, a pairwise poll or ping client with
neither a sector_identifier_uri nor a jwks_uri.

**A statically configured client fell through to its client id.** SubjectTypeConverter now
consults the same two URIs in the same order before that last resort.

## The consequence, stated rather than buried

Commit three changes the sector for one population: a statically configured pairwise
client with a backchannel delivery mode, no http(s) redirect URI, and a jwks_uri or
notification endpoint. The pairwise pseudonym is sealed with the sector as associated
data, so a sector change makes every already-issued identifier fail to open - that user
looks like a new user.

The population cannot have been created through dynamic registration, because commit two's
refusal is what has been rejecting it; it exists only where a host wrote it into
configuration. It is also not avoidable while fixing the defect: the identifiers are wrong
precisely because the sector is wrong. This belongs in the release notes.

The redirect URI stays FIRST at both sites for the same reason - every client that has one
keeps the sector it has.

## Driven

Fourteen plants, each built to a printed `0 Error(s)` before it counted and each restored
from a copy taken first. Baseline before and after every plant: 2945 rows, 0 failed.

| plant | rows that die |
|---|---|
| the push arm dropped from the required set | the push refusal rows, and the message row |
| the poll/ping arm dropped | the poll and ping refusal rows |
| the mode condition dropped, both URIs always required | the no-delivery-mode row, alone |
| the sector URI itself put into the required set | five methods, three of which predate this change |
| push resolves to no sector URI | one row |
| poll/ping resolves to no sector URI | two rows |
| ping grouped with push | two rows, in two methods |
| the CIBA branch hoisted above the redirect URI | the row holding existing sectors in place |
| the https check removed | one row |
| the refusal removed | four rows, two of which predate this change |
| the whole URL taken instead of the host | four rows, in two methods |
| ping grouped with push, in the converter | two rows |
| the jwks_uri consulted without asking the mode | the client-id fallback row |
| the backchannel branch hoisted above the redirect URI, in the converter | one row |

Two further plants were refused by the analyzer rather than by the tests: blanking every
switch arm trips S3923, and deleting the call to the resolver trips S1144. Recorded because
a plant that cannot be driven is not evidence from the suite - it is the shape being held
by something else.

## Not in this change

- No migration for the population named above. If one is wanted it is its own issue.
- No check that the client PROVED ownership of its jwks_uri. Section 4 asks for that
  separately, through private_key_jwt or self-signed mutual TLS, and it is a requirement
  about authentication method rather than about the sector.
- The pairwise seal, the salt and ConvertBack are untouched.

Fixes #480
