### PR TITLE
Move the Shared Signals stream packages to the commercial licence

### DIFF
--- a/.github/scripts/lint-license-headers.py
+++ b/.github/scripts/lint-license-headers.py
@@ -39,9 +39,6 @@ OPEN_PACKAGES = frozenset((
     'Abblix.SecurityEvents.CAEP',
     'Abblix.SecurityEvents.RISC',
     'Abblix.SecurityEvents.MinimalApi',
-    'Abblix.SharedSignals',
-    'Abblix.SharedSignals.Redis',
-    'Abblix.SharedSignals.MinimalApi',
 ))
 
 # A test project is named after what it exercises, so stripping the suffix yields the

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -16,10 +16,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Security Identity AspNetCore Minimal-API dotnet Continuous-Access-Evaluation Zero-Trust Stream-Management Webhook OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
     <PackageIcon>Abblix.png</PackageIcon>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
     <!-- Deterministic builds for reproducible binaries -->
     <Deterministic>true</Deterministic>
@@ -50,7 +50,7 @@
 
   <ItemGroup>
     <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
-    <None Include="..\..\LICENSES\Apache-2.0.txt" Pack="true" PackagePath="LICENSE.txt" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj.DotSettings
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj.DotSettings
@@ -1,9 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Abblix OIDC Server Library&#xD;
-SPDX-FileCopyrightText: Copyright (c) Abblix LLP&#xD;
-SPDX-License-Identifier: Apache-2.0&#xD;
-&#xD;
-Licensed under the Apache License, Version 2.0. You may obtain a copy at&#xD;
-http://www.apache.org/licenses/LICENSE-2.0</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
-</wpf:ResourceDictionary>

--- a/src/Abblix.SharedSignals.MinimalApi/README.md
+++ b/src/Abblix.SharedSignals.MinimalApi/README.md
@@ -108,7 +108,7 @@ Abblix.SharedSignals.MinimalAPI maps the routes of [Abblix.SharedSignals](https:
 
 ## License
 
-Abblix.SharedSignals.MinimalAPI is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
+See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointOptions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointOptions.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Jwt;
 using Microsoft.AspNetCore.Http;

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.Logging.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals;
 using Microsoft.Extensions.Logging;

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Delivery;
 using Abblix.SharedSignals.Model;

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -16,10 +16,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET Redis Outbox Event-Stream Transmitter Security Identity dotnet Continuous-Access-Evaluation Zero-Trust Scale-Out Distributed Replica-Safe RFC8935 RFC8936 OIDC</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
     <PackageIcon>Abblix.png</PackageIcon>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
     <!-- Deterministic builds for reproducible binaries -->
     <Deterministic>true</Deterministic>
@@ -48,7 +48,7 @@
 
   <ItemGroup>
     <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
-    <None Include="..\..\LICENSES\Apache-2.0.txt" Pack="true" PackagePath="LICENSE.txt" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj.DotSettings
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj.DotSettings
@@ -1,9 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Abblix OIDC Server Library&#xD;
-SPDX-FileCopyrightText: Copyright (c) Abblix LLP&#xD;
-SPDX-License-Identifier: Apache-2.0&#xD;
-&#xD;
-Licensed under the Apache License, Version 2.0. You may obtain a copy at&#xD;
-http://www.apache.org/licenses/LICENSE-2.0</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
-</wpf:ResourceDictionary>

--- a/src/Abblix.SharedSignals.Redis/README.md
+++ b/src/Abblix.SharedSignals.Redis/README.md
@@ -99,7 +99,7 @@ Abblix.SharedSignals.Redis is the outbox implementation for [Abblix.SharedSignal
 
 ## License
 
-Abblix.SharedSignals.Redis is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
+See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals.Redis/RedisDeliveryLease.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisDeliveryLease.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Transmitter;
 using StackExchange.Redis;

--- a/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisEventOutbox.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Abblix.SharedSignals.Redis/RedisOutboxOptions.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisOutboxOptions.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Redis;
 

--- a/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
+++ b/src/Abblix.SharedSignals.Redis/RedisStreamStore.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals.Redis/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.DependencyInjection;
 using Abblix.SharedSignals.Infrastructure;

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -16,10 +16,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Abblix Shared-Signals SSF OpenID Security-Event-Token SET RFC8935 RFC8936 CAEP RISC Event-Stream Transmitter Receiver Push Poll Webhook Security Identity dotnet Continuous-Access-Evaluation Zero-Trust Session-Revocation Stream-Management OIDC OAuth2</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
     <PackageIcon>Abblix.png</PackageIcon>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
     <!-- Deterministic builds for reproducible binaries -->
     <Deterministic>true</Deterministic>
@@ -52,7 +52,7 @@
 
   <ItemGroup>
     <None Include="..\..\Abblix.png" Link="Abblix.png" Pack="true" PackagePath="" />
-    <None Include="..\..\LICENSES\Apache-2.0.txt" Pack="true" PackagePath="LICENSE.txt" />
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="" />
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj.DotSettings
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj.DotSettings
@@ -1,9 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Abblix OIDC Server Library&#xD;
-SPDX-FileCopyrightText: Copyright (c) Abblix LLP&#xD;
-SPDX-License-Identifier: Apache-2.0&#xD;
-&#xD;
-Licensed under the Apache License, Version 2.0. You may obtain a copy at&#xD;
-http://www.apache.org/licenses/LICENSE-2.0</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
-</wpf:ResourceDictionary>

--- a/src/Abblix.SharedSignals/Events/SharedSignalsEventTypes.cs
+++ b/src/Abblix.SharedSignals/Events/SharedSignalsEventTypes.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Abstractions;
 using Abblix.SecurityEvents.Events;

--- a/src/Abblix.SharedSignals/Events/StreamUpdatedEventPayload.cs
+++ b/src/Abblix.SharedSignals/Events/StreamUpdatedEventPayload.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Events;

--- a/src/Abblix.SharedSignals/Events/VerificationEventPayload.cs
+++ b/src/Abblix.SharedSignals/Events/VerificationEventPayload.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Events;

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.DependencyInjection;
 using Abblix.SecurityEvents.Delivery;

--- a/src/Abblix.SharedSignals/LogEvents.cs
+++ b/src/Abblix.SharedSignals/LogEvents.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals;
 

--- a/src/Abblix.SharedSignals/Model/AddSubjectRequest.cs
+++ b/src/Abblix.SharedSignals/Model/AddSubjectRequest.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Subjects;

--- a/src/Abblix.SharedSignals/Model/CreateStreamRequest.cs
+++ b/src/Abblix.SharedSignals/Model/CreateStreamRequest.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SharedSignals.Model.Delivery;

--- a/src/Abblix.SharedSignals/Model/Delivery/PollDeliveryMethod.cs
+++ b/src/Abblix.SharedSignals/Model/Delivery/PollDeliveryMethod.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 

--- a/src/Abblix.SharedSignals/Model/Delivery/PushDeliveryMethod.cs
+++ b/src/Abblix.SharedSignals/Model/Delivery/PushDeliveryMethod.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 

--- a/src/Abblix.SharedSignals/Model/Delivery/StreamDeliveryMethod.cs
+++ b/src/Abblix.SharedSignals/Model/Delivery/StreamDeliveryMethod.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 

--- a/src/Abblix.SharedSignals/Model/Delivery/StreamDeliveryMethodJsonConverter.cs
+++ b/src/Abblix.SharedSignals/Model/Delivery/StreamDeliveryMethodJsonConverter.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/src/Abblix.SharedSignals/Model/RemoveSubjectRequest.cs
+++ b/src/Abblix.SharedSignals/Model/RemoveSubjectRequest.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Subjects;

--- a/src/Abblix.SharedSignals/Model/StreamConfiguration.cs
+++ b/src/Abblix.SharedSignals/Model/StreamConfiguration.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SharedSignals.Model.Delivery;

--- a/src/Abblix.SharedSignals/Model/StreamMemberNames.cs
+++ b/src/Abblix.SharedSignals/Model/StreamMemberNames.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Model;
 

--- a/src/Abblix.SharedSignals/Model/StreamStatus.cs
+++ b/src/Abblix.SharedSignals/Model/StreamStatus.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 

--- a/src/Abblix.SharedSignals/Model/StreamStatuses.cs
+++ b/src/Abblix.SharedSignals/Model/StreamStatuses.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Model;
 

--- a/src/Abblix.SharedSignals/Model/TransmitterConfiguration.cs
+++ b/src/Abblix.SharedSignals/Model/TransmitterConfiguration.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;

--- a/src/Abblix.SharedSignals/Model/UpdateStreamRequest.cs
+++ b/src/Abblix.SharedSignals/Model/UpdateStreamRequest.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SharedSignals.Model.Delivery;

--- a/src/Abblix.SharedSignals/Model/VerificationRequest.cs
+++ b/src/Abblix.SharedSignals/Model/VerificationRequest.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 

--- a/src/Abblix.SharedSignals/README.md
+++ b/src/Abblix.SharedSignals/README.md
@@ -118,7 +118,7 @@ Abblix.SharedSignals sits on [Abblix.SecurityEvents](https://www.nuget.org/packa
 
 ## License
 
-Abblix.SharedSignals is licensed under the [Apache License 2.0](https://github.com/Abblix/Oidc.Server/blob/master/LICENSES/Apache-2.0.txt).
+See [LICENSE.md](https://github.com/Abblix/Oidc.Server/blob/master/LICENSE.md).
 
 ## Contacts
 

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/CriticalSubjectMembersStep.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/CriticalSubjectMembersStep.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using Abblix.SecurityEvents.Subjects;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/ForbidSubStep.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/ForbidSubStep.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Jwt;
 using Abblix.SecurityEvents.Validation;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/JwksKeyResolutionOptionsExtensions.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/JwksKeyResolutionOptionsExtensions.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Infrastructure;
 using Abblix.SharedSignals.Model;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/PollClientExtensions.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/PollClientExtensions.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Delivery;
 using Abblix.SharedSignals.Model.Delivery;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/SharedSignalsValidationOptions.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/SharedSignalsValidationOptions.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using Abblix.SecurityEvents.Validation;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamIssuerStep.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamIssuerStep.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Validation;
 

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamManagementClient.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamManagementClient.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Http.Json;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamManagementClientFactory.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamManagementClientFactory.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Model;
 

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamManagementTransport.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/StreamManagementTransport.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Receiver.SecurityEvent;
 

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/TransmitterConfigurationClient.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/TransmitterConfigurationClient.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net.Http.Json;
 using System.Net.Mime;

--- a/src/Abblix.SharedSignals/Receiver/SecurityEvent/TransmitterConfigurationTransport.cs
+++ b/src/Abblix.SharedSignals/Receiver/SecurityEvent/TransmitterConfigurationTransport.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Receiver.SecurityEvent;
 

--- a/src/Abblix.SharedSignals/SsfScopes.cs
+++ b/src/Abblix.SharedSignals/SsfScopes.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals;
 

--- a/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ConfigurationStreamStore.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;

--- a/src/Abblix.SharedSignals/Transmitter/ConfiguredStream.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ConfiguredStream.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/DistributedCacheEventOutbox.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Collections.Concurrent;
 using System.Text.Json;

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.Logging.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/EventDispatcher.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents;
 using Abblix.SecurityEvents.Abstractions;

--- a/src/Abblix.SharedSignals/Transmitter/IDeliveryLease.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IDeliveryLease.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/IEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IEventOutbox.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/IEventSharingPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IEventSharingPolicy.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/IStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/IStreamStore.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/InMemoryEventOutbox.cs
+++ b/src/Abblix.SharedSignals/Transmitter/InMemoryEventOutbox.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Collections.Concurrent;
 

--- a/src/Abblix.SharedSignals/Transmitter/InMemoryStreamStore.cs
+++ b/src/Abblix.SharedSignals/Transmitter/InMemoryStreamStore.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Collections.Concurrent;
 

--- a/src/Abblix.SharedSignals/Transmitter/ManagementResult.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ManagementResult.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 

--- a/src/Abblix.SharedSignals/Transmitter/OutboxItem.cs
+++ b/src/Abblix.SharedSignals/Transmitter/OutboxItem.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 

--- a/src/Abblix.SharedSignals/Transmitter/PollEndpointHandler.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PollEndpointHandler.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Delivery;
 using Abblix.SharedSignals.Model;

--- a/src/Abblix.SharedSignals/Transmitter/PollEndpointLocator.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PollEndpointLocator.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/ProcessLocalDeliveryLease.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ProcessLocalDeliveryLease.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Collections.Concurrent;
 

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryPassOutcome.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryPassOutcome.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.Logging.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryScheduler.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Model.Delivery;
 using Microsoft.Extensions.Hosting;

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.Logging.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.Logging.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliverySender.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Http.Headers;

--- a/src/Abblix.SharedSignals/Transmitter/PushDeliveryTransport.cs
+++ b/src/Abblix.SharedSignals/Transmitter/PushDeliveryTransport.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressPolicy.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Sockets;

--- a/src/Abblix.SharedSignals/Transmitter/ReceiverAddressValidatingHandler.cs
+++ b/src/Abblix.SharedSignals/Transmitter/ReceiverAddressValidatingHandler.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Utils;
 

--- a/src/Abblix.SharedSignals/Transmitter/SecurityEventDescriptor.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SecurityEventDescriptor.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Events;
 using Abblix.SecurityEvents.Subjects;

--- a/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SharedSignalsTransmitterOptions.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Nodes;
 using Abblix.SharedSignals.Model;

--- a/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamManagementService.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using Abblix.SecurityEvents.Subjects;

--- a/src/Abblix.SharedSignals/Transmitter/StreamState.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamState.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Serialization;
 using Abblix.SecurityEvents.Subjects;

--- a/src/Abblix.SharedSignals/Transmitter/StreamSubject.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamSubject.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Subjects;
 

--- a/src/Abblix.SharedSignals/Transmitter/StreamSubjectsMode.cs
+++ b/src/Abblix.SharedSignals/Transmitter/StreamSubjectsMode.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 namespace Abblix.SharedSignals.Transmitter;
 

--- a/src/Abblix.SharedSignals/Transmitter/SubjectMatcher.cs
+++ b/src/Abblix.SharedSignals/Transmitter/SubjectMatcher.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepProfileMetadataTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Nodes;
 using Abblix.Jwt;

--- a/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ManagementRefusalTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Http.Json;

--- a/tests/Abblix.SharedSignals.E2E.Tests/PollDeliveryByDefaultTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/PollDeliveryByDefaultTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Http.Json;

--- a/tests/Abblix.SharedSignals.E2E.Tests/ScopeEnforcementTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/ScopeEnforcementTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Http.Json;

--- a/tests/Abblix.SharedSignals.E2E.Tests/SharedSignalsEndToEndTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/SharedSignalsEndToEndTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Runtime.CompilerServices;

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisDeliveryLeaseTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisDeliveryLeaseTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Tests.Shared;
 using Xunit;

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisEventOutboxTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Transmitter;
 using Abblix.Tests.Shared;

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/RedisStreamStoreTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CaepInteropProfileDispatchTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json.Nodes;
 using Abblix.Jwt;

--- a/tests/Abblix.SharedSignals.UnitTests/ConfigurationHostStoresTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ConfigurationHostStoresTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Abstractions;
 using Abblix.SecurityEvents.Subjects;

--- a/tests/Abblix.SharedSignals.UnitTests/CriticalStepDeclarationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/CriticalStepDeclarationTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Runtime.CompilerServices;
 using Abblix.DependencyInjection;

--- a/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/EventDispatcherTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents;
 using Abblix.SecurityEvents.Abstractions;

--- a/tests/Abblix.SharedSignals.UnitTests/JwksKeyResolutionOptionsExtensionsTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/JwksKeyResolutionOptionsExtensionsTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Infrastructure;
 using Abblix.SharedSignals.Model;

--- a/tests/Abblix.SharedSignals.UnitTests/PollClientTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PollClientTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/PollEndpointLocatorTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PollEndpointLocatorTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Transmitter;
 using Xunit;

--- a/tests/Abblix.SharedSignals.UnitTests/ProcessLocalDeliveryLeaseTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ProcessLocalDeliveryLeaseTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Transmitter;
 using Microsoft.Extensions.Time.Testing;

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliveryResilienceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliveryResilienceTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Tests.Shared;
 using Abblix.SecurityEvents.Infrastructure;

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliverySchedulerTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliverySchedulerTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using Abblix.SecurityEvents.Delivery;

--- a/tests/Abblix.SharedSignals.UnitTests/PushDeliverySsrfWiringTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/PushDeliverySsrfWiringTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using Abblix.SecurityEvents.Infrastructure;

--- a/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ReceiverAddressPolicyTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Sockets;

--- a/tests/Abblix.SharedSignals.UnitTests/ReceiverTransportResilienceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/ReceiverTransportResilienceTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SecurityEvents.Abstractions;
 using Abblix.SecurityEvents.Delivery;

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsEventPayloadTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsEventPayloadTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsReceiverProfileTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsReceiverProfileTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SharedSignalsServiceCollectionTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/tests/Abblix.SharedSignals.UnitTests/SsfScopesTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SsfScopesTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Xunit;
 

--- a/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamAddressAtRegistrationTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Sockets;

--- a/tests/Abblix.SharedSignals.UnitTests/StreamConfigurationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamConfigurationTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/StreamDeliveryMethodTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamDeliveryMethodTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using Abblix.SharedSignals.Model.Delivery;

--- a/tests/Abblix.SharedSignals.UnitTests/StreamManagementClientTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamManagementClientTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamManagementServiceTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using Abblix.SecurityEvents;

--- a/tests/Abblix.SharedSignals.UnitTests/StreamStatusTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamStatusTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/StreamSubjectRequestTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StreamSubjectRequestTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/StubHttpHandler.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/StubHttpHandler.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Mime;

--- a/tests/Abblix.SharedSignals.UnitTests/SubjectMatcherTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/SubjectMatcherTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using Abblix.SecurityEvents.Subjects;

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterConfigurationClientTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterConfigurationClientTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Mime;

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterConfigurationTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterConfigurationTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterDeliveryTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
 using System.Net.Mime;

--- a/tests/Abblix.SharedSignals.UnitTests/TransmitterStoreTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/TransmitterStoreTests.cs
@@ -1,9 +1,10 @@
 ﻿// Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.SharedSignals.Model;
 using Abblix.SharedSignals.Model.Delivery;

--- a/tests/Abblix.SharedSignals.UnitTests/VerificationRequestTests.cs
+++ b/tests/Abblix.SharedSignals.UnitTests/VerificationRequestTests.cs
@@ -1,9 +1,10 @@
 // Abblix OIDC Server Library
 // SPDX-FileCopyrightText: Copyright (c) Abblix LLP
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
 //
-// Licensed under the Apache License, Version 2.0. You may obtain a copy at
-// http://www.apache.org/licenses/LICENSE-2.0
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Text.Json;
 using System.Text.Json.Nodes;


### PR DESCRIPTION
## What changes

The three Shared Signals stream packages - `Abblix.SharedSignals`, `Abblix.SharedSignals.Redis` and `Abblix.SharedSignals.MinimalApi` - move from the Apache-2.0 expression to the commercial licence, consistently across every place a package declares one:

- manifests: `PackageLicenseFile` instead of `PackageLicenseExpression`, licence acceptance required, `LICENSE.md` packed;
- the SPDX header in all 70 source files of those packages;
- the License section of each README, which is packed and becomes the package page;
- the per-project IDE header templates, deleted rather than edited, so nothing stamps the previous header into the next file added or the next Code Cleanup run. Commercial projects inherit the solution-level template, which already carries that header.

## Scope

The open boundary stays where compatibility lives: the security event token and its wire. `Abblix.SecurityEvents` with its CAEP and RISC profiles and its adapter stay Apache-2.0, as do `Abblix.Utils`, `Abblix.DependencyInjection` and `Abblix.Jwt`.

No dependency of the published server changes licence. `Abblix.Oidc.Server` references `Utils`, `DependencyInjection`, `Jwt` and `SecurityEvents`, and does not reference any of the three packages in this change.

## Verification

Each package was built and its `.nupkg` opened: `LICENSE.md` is inside, the manifest carries `<license type="file">LICENSE.md</license>` with `requireLicenseAcceptance` set, and the packed README no longer states the previous licence.

A search across the three project trees returns no occurrence of the previous licence. The same search over a neighbouring Apache-licensed package returns 92 files, so the search does reach what it is pointed at. Seven per-project header templates remain in `src`, one for each package that stays open.
