### PR TITLE
Derive the dev-build floating range from the version just built

### DIFF
--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Refuse an MSBuild file that does not parse as XML.
 
-The failure this exists for is a double hyphen inside a comment, which XML forbids. It costs a full
-red CI run for every project in the solution, and the error names none of the files that carry the
-defect: MSBuild reports MSB4024 against each project that IMPORTS the broken file, so the reader is
-sent to the package references rather than to the comment. Parsing here answers in a second, before
-the commit exists.
+The failure this exists for is a double hyphen inside a comment, which XML forbids. MSBuild does say
+so - MSB4024 names the broken file, the comment, the hyphens and the position - but it says it once
+per project that IMPORTS the file, so a single stray character reddens the whole solution and every
+job behind it. Parsing here answers in a second, before the commit exists.
+
+The same character in Directory.Packages.props is worse and is why the pattern covers more than one
+file: restore fails with NU1015 about package references carrying no version, naming neither the
+file nor the comment.
 
 Every argument is parsed and every failure is reported, rather than stopping at the first: a bulk
 edit tends to break more than one file the same way, and a check that stops early makes the second
@@ -21,6 +24,25 @@ import sys
 import xml.etree.ElementTree as ElementTree
 
 
+def read_text(path: str) -> str:
+    """The file's text, whatever it is encoded in.
+
+    A build file is UTF-8 here, but the hook runs on files that failed to parse, and a wrong
+    encoding is one of the ways that happens. Decoding such a file as UTF-8 with replacements
+    yields text carrying no "<!--" at all, so the hint below would go silent on exactly the file
+    that needs it most.
+    """
+    data = io.open(path, "rb").read()
+    for encoding in ("utf-8-sig", "utf-16", "latin-1"):
+        try:
+            text = data.decode(encoding)
+        except (UnicodeDecodeError, LookupError):
+            continue
+        if "<!--" in text or encoding == "latin-1":
+            return text
+    return ""
+
+
 def double_hyphen_comment(path: str) -> bool:
     """Whether some comment in the file carries a double hyphen.
 
@@ -30,7 +52,7 @@ def double_hyphen_comment(path: str) -> bool:
     definition one that did not parse.
     """
     try:
-        text = io.open(path, encoding="utf-8", errors="replace", newline="").read()
+        text = read_text(path)
     except OSError:
         return False
     return any("--" in chunk.split("-->", 1)[0] for chunk in text.split("<!--")[1:])
@@ -41,6 +63,9 @@ def main(paths: list[str]) -> int:
     for path in paths:
         try:
             ElementTree.parse(path)
+        except OSError as error:
+            failures += 1
+            print(f"{path}: cannot be read: {error}", file=sys.stderr)
         except ElementTree.ParseError as error:
             failures += 1
             print(f"{path}: not well-formed XML: {error}", file=sys.stderr)

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -9,6 +9,10 @@ commit exists.
 
 Every argument is parsed and every failure reported, because a bulk edit tends to break more than one
 file the same way.
+
+The standard-library parser is the deliberate choice, not an oversight: it resolves no external
+entities, its input is this repository's own build files, and a hardened one would be a dependency in
+every clone.
 """
 
 import io

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -60,7 +60,10 @@ def double_hyphen_comment(path: str) -> bool:
         text = read_text(path)
     except OSError:
         return False
-    return any("--" in chunk.split("-->", 1)[0] for chunk in text.split("<!--")[1:])
+    # CDATA first: a literal "<!--" inside one is not a comment, and pointing the author at a comment
+    # that is legal is a detector crying wolf on a file it cannot help with. Driven on both.
+    outside = "".join(part.split("]]>", 1)[-1] for part in text.split("<![CDATA["))
+    return any("--" in chunk.split("-->", 1)[0] for chunk in outside.split("<!--")[1:])
 
 
 def main(paths: list[str]) -> int:

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -61,8 +61,14 @@ def double_hyphen_comment(path: str) -> bool:
     except OSError:
         return False
     # CDATA first: a literal "<!--" inside one is not a comment, and pointing the author at a comment
-    # that is legal is a detector crying wolf on a file it cannot help with. Driven on both.
-    outside = "".join(part.split("]]>", 1)[-1] for part in text.split("<![CDATA["))
+    # that is legal is a detector crying wolf on a file it cannot help with.
+    #
+    # The head is kept whole. It precedes every CDATA by construction, so dropping up to a "]]>" in
+    # it discards real text - and a stray "]]>" is ordinary in a file that did not parse, which is
+    # the only kind of file this runs on. Driven both ways: a comment before a mistyped opener, and
+    # a file with no CDATA at all and a stray "]]>" after the comment.
+    parts = text.split("<![CDATA[")
+    outside = parts[0] + "".join(part.split("]]>", 1)[-1] for part in parts[1:])
     return any("--" in chunk.split("-->", 1)[0] for chunk in outside.split("<!--")[1:])
 
 

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -17,22 +17,23 @@ is about to parse with far more privilege than this check has.
 """
 
 import io
-import re
 import sys
 import xml.etree.ElementTree as ElementTree
 
-# The parser reports this as "not well-formed (invalid token)" and names neither the comment nor the
-# hyphens, so the hint has to be derived from the text rather than from the message. Read against a
-# planted double hyphen: keying it on the message printed nothing at all.
-COMMENT = re.compile(r"<!--(.*?)(?:-->|\Z)", re.S)
-
 
 def double_hyphen_comment(path: str) -> bool:
+    """Whether some comment in the file carries a double hyphen.
+
+    Derived from the text, because the parser reports only "not well-formed (invalid token)" and
+    names neither the comment nor the hyphens: keying the hint on the message printed nothing at
+    all against a planted one. An unterminated comment counts, since the file this runs on is by
+    definition one that did not parse.
+    """
     try:
         text = io.open(path, encoding="utf-8", errors="replace", newline="").read()
     except OSError:
         return False
-    return any("--" in body for body in COMMENT.findall(text))
+    return any("--" in chunk.split("-->", 1)[0] for chunk in text.split("<!--")[1:])
 
 
 def main(paths: list[str]) -> int:

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Refuse an MSBuild file that does not parse as XML.
+
+The failure this exists for is a double hyphen inside a comment, which XML forbids. It costs a full
+red CI run for every project in the solution, and the error names none of the files that carry the
+defect: MSBuild reports MSB4024 against each project that IMPORTS the broken file, so the reader is
+sent to the package references rather than to the comment. Parsing here answers in a second, before
+the commit exists.
+
+Every argument is parsed and every failure is reported, rather than stopping at the first: a bulk
+edit tends to break more than one file the same way, and a check that stops early makes the second
+one look like a new problem tomorrow.
+
+The standard-library parser is enough here and a hardened one would be a dependency in every clone:
+it resolves no external entities, and its input is this repository's own build files, which MSBuild
+is about to parse with far more privilege than this check has.
+"""
+
+import io
+import re
+import sys
+import xml.etree.ElementTree as ElementTree
+
+# The parser reports this as "not well-formed (invalid token)" and names neither the comment nor the
+# hyphens, so the hint has to be derived from the text rather than from the message. Read against a
+# planted double hyphen: keying it on the message printed nothing at all.
+COMMENT = re.compile(r"<!--(.*?)(?:-->|\Z)", re.S)
+
+
+def double_hyphen_comment(path: str) -> bool:
+    try:
+        text = io.open(path, encoding="utf-8", errors="replace", newline="").read()
+    except OSError:
+        return False
+    return any("--" in body for body in COMMENT.findall(text))
+
+
+def main(paths: list[str]) -> int:
+    failures = 0
+    for path in paths:
+        try:
+            ElementTree.parse(path)
+        except ElementTree.ParseError as error:
+            failures += 1
+            print(f"{path}: not well-formed XML: {error}", file=sys.stderr)
+            if double_hyphen_comment(path):
+                print(
+                    f"{path}: a comment here carries a double hyphen, which XML forbids. "
+                    "Say it in words, or split the pair.",
+                    file=sys.stderr,
+                )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -1,22 +1,14 @@
 #!/usr/bin/env python3
-"""Refuse an MSBuild file that does not parse as XML.
+"""Refuse a build XML file that does not parse.
 
-The failure this exists for is a double hyphen inside a comment, which XML forbids. MSBuild does say
-so - MSB4024 names the broken file, the comment, the hyphens and the position - but it says it once
-per project that IMPORTS the file, so a single stray character reddens the whole solution and every
-job behind it. Parsing here answers in a second, before the commit exists.
+The failure this exists for is a double hyphen inside a comment, which XML forbids. MSBuild says so
+once per project that IMPORTS the broken file, so one stray character reddens the whole solution and
+every job behind it; in Directory.Packages.props it surfaces instead as NU1015 about package
+references with no version, naming neither the file nor the comment. Parsing here answers before the
+commit exists.
 
-The same character in Directory.Packages.props is worse and is why the pattern covers more than one
-file: restore fails with NU1015 about package references carrying no version, naming neither the
-file nor the comment.
-
-Every argument is parsed and every failure is reported, rather than stopping at the first: a bulk
-edit tends to break more than one file the same way, and a check that stops early makes the second
-one look like a new problem tomorrow.
-
-The standard-library parser is enough here and a hardened one would be a dependency in every clone:
-it resolves no external entities, and its input is this repository's own build files, which MSBuild
-is about to parse with far more privilege than this check has.
+Every argument is parsed and every failure reported, because a bulk edit tends to break more than one
+file the same way.
 """
 
 import io
@@ -27,16 +19,13 @@ import xml.etree.ElementTree as ElementTree
 def read_text(path: str) -> str:
     """The file's text, whatever it is encoded in.
 
-    A build file is UTF-8 here, but the hook runs on files that failed to parse, and a wrong
-    encoding is one of the ways that happens. Decoding such a file as UTF-8 with replacements
-    yields text carrying no "<!--" at all, so the hint below would go silent on exactly the file
-    that needs it most.
+    This runs only on files that failed to parse, and a wrong encoding is one of the ways that
+    happens: read as UTF-8 with replacements, such a file carries no "<!--" at all and the hint below
+    would go silent on it. Both UTF-16 byte orders are tried, since without a byte-order mark
+    "utf-16" assumes little-endian. latin-1 decodes anything, so the loop always returns.
     """
     with io.open(path, "rb") as handle:
         data = handle.read()
-    # latin-1 is last and decodes anything, so the loop always returns. The two UTF-16 byte orders
-    # are both tried: without a byte-order mark, "utf-16" assumes little-endian, and a big-endian
-    # file then decodes as garbage that carries no comment at all - the hint would go silent on it.
     text = ""
     for encoding in ("utf-8-sig", "utf-16", "utf-16-be", "latin-1"):
         try:
@@ -51,22 +40,17 @@ def read_text(path: str) -> str:
 def double_hyphen_comment(path: str) -> bool:
     """Whether some comment in the file carries a double hyphen.
 
-    Derived from the text, because the parser reports only "not well-formed (invalid token)" and
-    names neither the comment nor the hyphens: keying the hint on the message printed nothing at
-    all against a planted one. An unterminated comment counts, since the file this runs on is by
-    definition one that did not parse.
+    Read from the text: the parser says only "not well-formed (invalid token)" and names neither the
+    comment nor the hyphens. An unterminated comment counts, since this file did not parse.
+
+    CDATA is excluded, because a literal "<!--" inside one is not a comment and the author cannot fix
+    it. The head is kept whole - it precedes every CDATA, so cutting it at a "]]>" would discard real
+    text, and a stray "]]>" is ordinary in a file that did not parse.
     """
     try:
         text = read_text(path)
     except OSError:
         return False
-    # CDATA first: a literal "<!--" inside one is not a comment, and pointing the author at a comment
-    # that is legal is a detector crying wolf on a file it cannot help with.
-    #
-    # The head is kept whole. It precedes every CDATA by construction, so dropping up to a "]]>" in
-    # it discards real text - and a stray "]]>" is ordinary in a file that did not parse, which is
-    # the only kind of file this runs on. Driven both ways: a comment before a mistyped opener, and
-    # a file with no CDATA at all and a stray "]]>" after the comment.
     parts = text.split("<![CDATA[")
     outside = parts[0] + "".join(part.split("]]>", 1)[-1] for part in parts[1:])
     return any("--" in chunk.split("-->", 1)[0] for chunk in outside.split("<!--")[1:])

--- a/.github/scripts/lint-msbuild-xml.py
+++ b/.github/scripts/lint-msbuild-xml.py
@@ -32,15 +32,20 @@ def read_text(path: str) -> str:
     yields text carrying no "<!--" at all, so the hint below would go silent on exactly the file
     that needs it most.
     """
-    data = io.open(path, "rb").read()
-    for encoding in ("utf-8-sig", "utf-16", "latin-1"):
+    with io.open(path, "rb") as handle:
+        data = handle.read()
+    # latin-1 is last and decodes anything, so the loop always returns. The two UTF-16 byte orders
+    # are both tried: without a byte-order mark, "utf-16" assumes little-endian, and a big-endian
+    # file then decodes as garbage that carries no comment at all - the hint would go silent on it.
+    text = ""
+    for encoding in ("utf-8-sig", "utf-16", "utf-16-be", "latin-1"):
         try:
             text = data.decode(encoding)
         except (UnicodeDecodeError, LookupError):
             continue
-        if "<!--" in text or encoding == "latin-1":
-            return text
-    return ""
+        if "<!--" in text:
+            break
+    return text
 
 
 def double_hyphen_comment(path: str) -> bool:

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -254,7 +254,6 @@ jobs:
       contents: write
     env:
       VERSION: ${{ needs.versioning.outputs.version }}
-      VERSION_FULL: ${{ needs.versioning.outputs.version_full }}
       PREVIOUS_VERSION: ${{ needs.versioning.outputs.previous_version }}
     outputs:
       is_prerelease: ${{ steps.validate_inputs.outputs.is_prerelease }}

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 2.3 or 2.3.0-beta3)'
+        description: 'Version to release (e.g., 2.4 or 2.4.0-beta3)'
         required: true
         type: string
       pre_release:

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -59,10 +59,15 @@ jobs:
           VERSION="$INPUT_VERSION"
           echo "Using explicit version: $VERSION"
 
-          # MinVer 7.x rejects a two-part --version-override (MINVER1005), so expand the
-          # X.Y release input to a full X.Y.0 SemVer for the build/pack override. The tag
-          # and GitHub Release keep the X.Y form; NuGet normalizes X.Y to X.Y.0 anyway, so
-          # the published package version is identical. A -prerelease suffix is preserved.
+          # MinVer 7.x rejects a two-part --version-override (MINVER1005), so expand the X.Y
+          # release input to a full X.Y.0 SemVer. The TAG and the GitHub Release now use that
+          # expanded form too, where they used to keep X.Y.
+          #
+          # They kept it because NuGet normalizes X.Y to X.Y.0 and the published package version
+          # is identical either way - true, and it left MinVer unable to read its own tags: it
+          # parses a tag as SemVer, and "2.3" is not one, so every release tag was ignored and
+          # dev versions came from MinVerMinimumMajorMinor lifting a 0.0.0 default with the height
+          # counted from the root commit. A -prerelease suffix is preserved as given.
           CORE="${VERSION%%-*}"
           PRERELEASE=""
           [ "$VERSION" != "$CORE" ] && PRERELEASE="-${VERSION#*-}"
@@ -246,6 +251,7 @@ jobs:
       contents: write
     env:
       VERSION: ${{ needs.versioning.outputs.version }}
+      VERSION_FULL: ${{ needs.versioning.outputs.version_full }}
       PREVIOUS_VERSION: ${{ needs.versioning.outputs.previous_version }}
     outputs:
       is_prerelease: ${{ steps.validate_inputs.outputs.is_prerelease }}
@@ -283,44 +289,44 @@ jobs:
         env:
           INPUT_PRE_RELEASE: ${{ github.event.inputs.pre_release }}
         run: |
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            if [ "$(git cat-file -t "v$VERSION")" = "tag" ]; then
-              echo "Tag v$VERSION exists and is annotated - using it"
+          if git rev-parse "v$VERSION_FULL" >/dev/null 2>&1; then
+            if [ "$(git cat-file -t "v$VERSION_FULL")" = "tag" ]; then
+              echo "Tag v$VERSION_FULL exists and is annotated - using it"
             else
-              echo "Error: tag v$VERSION is lightweight (not annotated/signed)."
+              echo "Error: tag v$VERSION_FULL is lightweight (not annotated/signed)."
               echo "Stable releases require an annotated, GPG-signed tag carrying the release notes."
-              echo "Recreate it: git tag -a v$VERSION -F RELEASE_NOTES_v$VERSION.md -s && git push origin v$VERSION"
+              echo "Recreate it: git tag -a v$VERSION_FULL -F RELEASE_NOTES_v$VERSION_FULL.md -s && git push origin v$VERSION_FULL"
               exit 1
             fi
           else
             if [ "$INPUT_PRE_RELEASE" != "true" ]; then
-              echo "Error: no tag v$VERSION found."
+              echo "Error: no tag v$VERSION_FULL found."
               echo "A stable release must be tagged (annotated + GPG-signed) before this workflow runs."
-              echo "Create it on the release branch: git tag -a v$VERSION -F RELEASE_NOTES_v$VERSION.md -s && git push origin v$VERSION"
+              echo "Create it on the release branch: git tag -a v$VERSION_FULL -F RELEASE_NOTES_v$VERSION_FULL.md -s && git push origin v$VERSION_FULL"
               exit 1
             fi
-            echo "Pre-release: creating annotated tag v$VERSION"
+            echo "Pre-release: creating annotated tag v$VERSION_FULL"
             git config user.name "GitHub Actions"
             git config user.email "actions@github.com"
-            git tag -a "v$VERSION" -m "Pre-release v$VERSION"
-            git push origin "v$VERSION"
+            git tag -a "v$VERSION_FULL" -m "Pre-release v$VERSION_FULL"
+            git push origin "v$VERSION_FULL"
           fi
         timeout-minutes: 3
       - name: Generate changelog
         id: changelog
         run: |
-          if [ "$(git cat-file -t "v$VERSION" 2>/dev/null)" = "tag" ]; then
+          if [ "$(git cat-file -t "v$VERSION_FULL" 2>/dev/null)" = "tag" ]; then
             echo "Using annotated tag message as release notes"
             # %(contents) includes the GPG/SSH signature block; strip it so the
             # release body is only the notes. The tag must be created with
             # --cleanup=verbatim so Markdown "##" headers in the notes survive.
-            git tag -l --format='%(contents)' "v$VERSION" | sed '/-----BEGIN .* SIGNATURE-----/,$d' > CHANGELOG.md
+            git tag -l --format='%(contents)' "v$VERSION_FULL" | sed '/-----BEGIN .* SIGNATURE-----/,$d' > CHANGELOG.md
           elif [ -n "$PREVIOUS_VERSION" ]; then
             echo "## Changes since v$PREVIOUS_VERSION" > CHANGELOG.md
             echo "" >> CHANGELOG.md
 
             PREV_TAG="v$PREVIOUS_VERSION"
-            CURR_TAG="v$VERSION"
+            CURR_TAG="v$VERSION_FULL"
 
             if git rev-parse "$PREV_TAG" >/dev/null 2>&1 && git rev-parse "$CURR_TAG" >/dev/null 2>&1; then
               git log --oneline "$PREV_TAG..$CURR_TAG" --pretty=format:"- %s" >> CHANGELOG.md \
@@ -349,8 +355,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          tag_name: v${{ needs.versioning.outputs.version }}
-          name: v${{ needs.versioning.outputs.version }}
+          tag_name: v${{ needs.versioning.outputs.version_full }}
+          name: v${{ needs.versioning.outputs.version_full }}
           body_path: CHANGELOG.md
           files: |
             nupkg/*.nupkg

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -60,14 +60,17 @@ jobs:
           echo "Using explicit version: $VERSION"
 
           # MinVer 7.x rejects a two-part --version-override (MINVER1005), so expand the X.Y
-          # release input to a full X.Y.0 SemVer. The TAG and the GitHub Release now use that
-          # expanded form too, where they used to keep X.Y.
+          # release input to a full X.Y.0 SemVer for the build and pack override only. The tag and
+          # the GitHub Release keep the X.Y form, deliberately: NuGet normalizes X.Y to X.Y.0, so
+          # the published package version is identical, and the short name is what the releases,
+          # their links and the notes files have always used.
           #
-          # They kept it because NuGet normalizes X.Y to X.Y.0 and the published package version
-          # is identical either way - true, and it left MinVer unable to read its own tags: it
-          # parses a tag as SemVer, and "2.3" is not one, so every release tag was ignored and
-          # dev versions came from MinVerMinimumMajorMinor lifting a 0.0.0 default with the height
-          # counted from the root commit. A -prerelease suffix is preserved as given.
+          # The cost is stated rather than discovered: MinVer parses a TAG as SemVer, and "2.3" is
+          # not one, so it reads none of this repository's release tags. Nothing depends on it
+          # reading them - the release version comes from this input and dev versions from
+          # MinVerMinimumMajorMinor - but it does mean the height in a dev version counts from the
+          # root commit rather than from the last release, and that a tag is not what any number
+          # here is derived from. A -prerelease suffix is preserved as given.
           CORE="${VERSION%%-*}"
           PRERELEASE=""
           [ "$VERSION" != "$CORE" ] && PRERELEASE="-${VERSION#*-}"
@@ -289,44 +292,44 @@ jobs:
         env:
           INPUT_PRE_RELEASE: ${{ github.event.inputs.pre_release }}
         run: |
-          if git rev-parse "v$VERSION_FULL" >/dev/null 2>&1; then
-            if [ "$(git cat-file -t "v$VERSION_FULL")" = "tag" ]; then
-              echo "Tag v$VERSION_FULL exists and is annotated - using it"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            if [ "$(git cat-file -t "v$VERSION")" = "tag" ]; then
+              echo "Tag v$VERSION exists and is annotated - using it"
             else
-              echo "Error: tag v$VERSION_FULL is lightweight (not annotated/signed)."
+              echo "Error: tag v$VERSION is lightweight (not annotated/signed)."
               echo "Stable releases require an annotated, GPG-signed tag carrying the release notes."
-              echo "Recreate it: git tag -a v$VERSION_FULL -F RELEASE_NOTES_v$VERSION_FULL.md -s && git push origin v$VERSION_FULL"
+              echo "Recreate it: git tag -a v$VERSION -F RELEASE_NOTES_v$VERSION.md -s && git push origin v$VERSION"
               exit 1
             fi
           else
             if [ "$INPUT_PRE_RELEASE" != "true" ]; then
-              echo "Error: no tag v$VERSION_FULL found."
+              echo "Error: no tag v$VERSION found."
               echo "A stable release must be tagged (annotated + GPG-signed) before this workflow runs."
-              echo "Create it on the release branch: git tag -a v$VERSION_FULL -F RELEASE_NOTES_v$VERSION_FULL.md -s && git push origin v$VERSION_FULL"
+              echo "Create it on the release branch: git tag -a v$VERSION -F RELEASE_NOTES_v$VERSION.md -s && git push origin v$VERSION"
               exit 1
             fi
-            echo "Pre-release: creating annotated tag v$VERSION_FULL"
+            echo "Pre-release: creating annotated tag v$VERSION"
             git config user.name "GitHub Actions"
             git config user.email "actions@github.com"
-            git tag -a "v$VERSION_FULL" -m "Pre-release v$VERSION_FULL"
-            git push origin "v$VERSION_FULL"
+            git tag -a "v$VERSION" -m "Pre-release v$VERSION"
+            git push origin "v$VERSION"
           fi
         timeout-minutes: 3
       - name: Generate changelog
         id: changelog
         run: |
-          if [ "$(git cat-file -t "v$VERSION_FULL" 2>/dev/null)" = "tag" ]; then
+          if [ "$(git cat-file -t "v$VERSION" 2>/dev/null)" = "tag" ]; then
             echo "Using annotated tag message as release notes"
             # %(contents) includes the GPG/SSH signature block; strip it so the
             # release body is only the notes. The tag must be created with
             # --cleanup=verbatim so Markdown "##" headers in the notes survive.
-            git tag -l --format='%(contents)' "v$VERSION_FULL" | sed '/-----BEGIN .* SIGNATURE-----/,$d' > CHANGELOG.md
+            git tag -l --format='%(contents)' "v$VERSION" | sed '/-----BEGIN .* SIGNATURE-----/,$d' > CHANGELOG.md
           elif [ -n "$PREVIOUS_VERSION" ]; then
             echo "## Changes since v$PREVIOUS_VERSION" > CHANGELOG.md
             echo "" >> CHANGELOG.md
 
             PREV_TAG="v$PREVIOUS_VERSION"
-            CURR_TAG="v$VERSION_FULL"
+            CURR_TAG="v$VERSION"
 
             if git rev-parse "$PREV_TAG" >/dev/null 2>&1 && git rev-parse "$CURR_TAG" >/dev/null 2>&1; then
               git log --oneline "$PREV_TAG..$CURR_TAG" --pretty=format:"- %s" >> CHANGELOG.md \
@@ -355,8 +358,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          tag_name: v${{ needs.versioning.outputs.version_full }}
-          name: v${{ needs.versioning.outputs.version_full }}
+          tag_name: v${{ needs.versioning.outputs.version }}
+          name: v${{ needs.versioning.outputs.version }}
           body_path: CHANGELOG.md
           files: |
             nupkg/*.nupkg

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -12,14 +12,14 @@ name: Publish dev build to GitHub Packages
 # kept current - but they are no longer what reaches a consumer.
 #
 # Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0):
-#   any branch here                     ->  2.4.0-dev.0.<distance>
+#   any branch here                     ->  2.4.0-dev.0.<first-parent distance from the root>
 #   a release, version supplied by hand ->  2.4.0   (enhanced-release.yml, MinVerVersionOverride)
 #
 # MinVer reads NO tag in this repository, on any branch - the release tags are two-part (v2.3),
 # which is not SemVer, and MinVerTagPrefix is unset besides. So the whole version comes from
 # MinVerMinimumMajorMinor lifting a 0.0.0 default, and the number after dev.0 is MinVer's height:
-# a shortest-path distance through the history, NOT a count of commits. Measured on this branch,
-# height 476 against 681 reachable commits and 478 on the first-parent chain.
+# the FIRST-PARENT distance back to the root, not a count of everything reachable. Checkable at
+# any commit - height + 1 == git rev-list --count --first-parent HEAD.
 #
 # Note: develop and release/* publish into the same 2.4.0-dev.* pre-release line, so a
 # consumer floating 2.4.0-dev.* resolves the highest commit height across both branches.
@@ -142,16 +142,23 @@ jobs:
           PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | sed -n 1p)
           VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
           case "$VERSION" in
+            [0-9]*.[0-9]*.[0-9]*-dev.*) echo "Dev build $VERSION - publishing." ;;
+            [0-9]*.[0-9]*.[0-9]*)
+              echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
+              echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
+              exit 1
+              ;;
             "")
               # Said first and separately: with no package there is no version, no tag and no
               # release workflow involved, and the arm below would name all three.
               echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
               exit 1
               ;;
-            *-dev.*) echo "Dev build $VERSION - publishing." ;;
             *)
-              echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
-              echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
+              # Anything that is not a version at all: the name did not parse, so nothing here can
+              # say why. Saying "a release tag is on this commit" of it would name a cause that is
+              # not there - the arm above owns that sentence and requires the version shape first.
+              echo "Refusing to publish: could not read a version out of the package name, got '$VERSION'." >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -2,20 +2,27 @@ name: Publish dev build to GitHub Packages
 
 # Triggered on every push to develop and to any release/* branch, so a release branch
 # can be integration-tested against downstream consumers without cherry-picking its
-# fixes back to develop first. MinVer (configured in Directory.Build.props) computes the
-# package version from git tags + commit height; this workflow just packs and pushes the
-# resulting .nupkg files to nuget.pkg.github.com/Abblix.
+# fixes back to develop first. MinVer (configured in Directory.Build.props) computes the package
+# version; this workflow just packs and pushes the resulting .nupkg files to
+# nuget.pkg.github.com/Abblix.
 #
 # Directory.Build.props' MinVerMinimumMajorMinor is the ONE place that decides the line; the numbers
 # below are an illustration of it and nothing reads them. The run summary derives its range from the
 # version actually built, so these examples can mislead a READER of this file - which is why they are
 # kept current - but they are no longer what reaches a consumer.
 #
-# Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0):
-#   pre-tag develop, 5 commits since v2.3  ->  2.4.0-dev.0.5
-#   after v2.4 is tagged, 5 more commits   ->  2.4.1-dev.0.5   (the minimum only LIFTS a version)
-#   tagged v2.4.0-beta1                    ->  2.4.0-beta1
-#   tagged v2.4.0                          ->  2.4.0
+# Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0), and
+# these are MEASURED rather than modelled - see the note below about tags:
+#   develop at commit height 469           ->  2.4.0-dev.0.469
+#   a release, version supplied by hand    ->  2.4.0   (enhanced-release.yml, MinVerVersionOverride)
+#
+# MinVer reads NO tag in this repository, which is worth knowing before reasoning about what it
+# will produce. The tags are two-part and v-prefixed (v2.3), MinVerTagPrefix is set nowhere, so
+# none of them parses as a version; and they live on master, not on the branch this workflow
+# builds. So the height is counted from the ROOT COMMIT, and the whole version comes from
+# MinVerMinimumMajorMinor lifting a 0.0.0 default. Run against this worktree, MinVer says so in as
+# many words: "No commit found with a valid SemVer 2.0 version", then "Bumping version to
+# 2.4.0-dev.0.472 to satisfy minimum major minor 2.4".
 #
 # Note: develop and release/* publish into the same 2.4.0-dev.* pre-release line, so a
 # consumer floating 2.4.0-dev.* resolves the highest commit height across both branches.
@@ -147,17 +154,36 @@ jobs:
           # And once the case is corrected the name is still the wrong key: Abblix.OIDC.Server is a
           # PREFIX of Abblix.OIDC.Server.MVC, so head -1 over the family can hand back a file whose
           # remainder is "MVC.2.4.0-dev.0.469" - a version string with a package fragment inside it.
+          # (The casing is unpredictable in general: PackageId also uppercases API, CAEP and RISC.)
           #
           # A version has a shape, so take the trailing three-part number and let the name be
           # whatever it is. sort makes the pick deterministic rather than dependent on directory
           # order.
-          PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | head -1)
+          # sed -n 1p rather than head -1: head closes the pipe after one line, so a long enough
+          # listing gives sort a SIGPIPE, pipefail turns that into 141, and set -e kills the step
+          # with no summary written. Driven at 20000 files to see it. sed reads to the end.
+          PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | sed -n 1p)
           if [ -n "$PKG" ]; then
             VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
+
+            # The extraction is greedy, so it takes the LAST version-shaped tail. That is right for
+            # every name here, digits in the name included, and it stops being right if the
+            # pre-release ever gains a third identifier - MinVerDefaultPreReleaseIdentifiers of
+            # "dev.0.0" would make 2.4.0-dev.0.0.469 extract as 0.0.469. Anchoring from the left
+            # instead just moves the hazard onto names containing digits, so the answer is not a
+            # cleverer pattern but a CHECK on what came out: anything that is not a version stops
+            # the summary and says why, rather than printing a range nobody can resolve.
+            case "$VERSION" in
+              [0-9]*.[0-9]*.[0-9]*) ;;
+              *)
+                echo "Could not read a version out of $PKG - got '$VERSION'." >&2
+                exit 1
+                ;;
+            esac
             {
               echo "## Dev build published"
               echo ""
-              echo "Version: \`$VERSION\` (derived by MinVer from git tags + height)"
+              echo "Version: \`$VERSION\` (derived by MinVer at pack time)"
               echo ""
               echo "Feed: https://github.com/Abblix/Oidc.Server/packages"
               echo ""

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -163,7 +163,9 @@ jobs:
           # here and in a project's context there: a property conditioned on $(Configuration) reads
           # empty standalone and 2.4 under Release. Driven. Today's is unconditional, so this changes
           # nothing and costs one flag - and the case it forecloses is a good build refused for a
-          # cause that is not there, which is this step's whole subject.
+          # cause that is not there, which is this step's whole subject. It closes ONE dimension of
+          # standing alone, not the difference: driven, a property conditioned on $(TargetFramework)
+          # still reads empty here and 2.4 once that is supplied too.
           #
           # MSBuild's stderr is NOT discarded: -getProperty puts the value alone on stdout, so an
           # error or a warning cannot reach EXPECTED, and throwing it away would leave this step
@@ -183,58 +185,52 @@ jobs:
           PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' 2>/dev/null | sort | sed -n 1p) || rc=$?
           [ "$rc" -eq 0 ] || PKG=""
           BASE=$(basename "$PKG" .nupkg)
-          VERSION=$(printf '%s' "$BASE" | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
 
-          # The dev identifier is read off the WHOLE NAME and the line off the extracted version, and
-          # both are needed: the extraction takes the trailing version-shaped run, so a pre-release
-          # identifier with a third part hands back a fragment. 2.4.0-dev.0.0.478 extracts as 0.0.478,
-          # which is off the line; 2.4.0-dev.2.4.478 extracts as 2.4.478, which is ON it and has lost
-          # the dev identifier with the rest. Driven, both of them. Checking only the shape passed the
-          # first to the release arm and checking only the line passed the second, so each is refused
-          # for what it is - a name this step could not read - rather than for a release tag that is
-          # not on the commit.
+          # The version is the FIRST version-shaped suffix, not the last. Taking the last is what made
+          # the earlier readings wrong: a pre-release identifier with a third part hands back a
+          # fragment - 2.4.0-dev.0.0.478 came out as 0.0.478, and 2.4.0-dev.2.4.478 as 2.4.478, which
+          # is on this repository's line and has lost the dev identifier with the rest. Stripping
+          # leading id segments instead keeps the whole version in every one of those names. Driven.
+          #
+          # It assumes no package id here begins with a digit, which none does: one that did would be
+          # taken as the start of the version, and the line check below would refuse it - refusing, but
+          # for a cause that is not there, so this is the sentence to revisit if an id ever changes.
+          VERSION=""
+          REST=$BASE
+          while [ -n "$REST" ]; do
+            case "$REST" in
+              [0-9]*.[0-9]*.[0-9]*) VERSION=$REST; break ;;
+            esac
+            case "$REST" in
+              *.*) REST=${REST#*.} ;;
+              *) REST="" ;;
+            esac
+          done
+
           if [ -z "$VERSION" ]; then
-            echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
+            if [ -z "$PKG" ]; then
+              echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
+            else
+              echo "Refusing to publish: no version could be read out of '$PKG'." >&2
+            fi
             exit 1
           fi
 
-          case "$BASE" in
-            *-dev.*)
-              case "$VERSION" in
-                "$EXPECTED".*-dev.*) echo "Dev build $VERSION - publishing." ;;
-                *-dev.*)
-                  # Read as a dev version, just not this repository's line. That is the version line
-                  # having moved, or the name having been misread into another line's shape, and the
-                  # two cannot be told apart from here.
-                  echo "Refusing to publish $VERSION: it is a dev build off the $EXPECTED line this repository builds." >&2
-                  echo "Either the version line moved and this workflow was not told, or the name was misread." >&2
-                  exit 1
-                  ;;
-                *)
-                  # The name carries the dev identifier and the version read out of it does not, so
-                  # the extraction lost it, which is a misread.
-                  echo "Refusing to publish: '$BASE' names a dev build, but the version read out of it is '$VERSION'." >&2
-                  echo "The name was misread, so nothing here can say what this package holds." >&2
-                  exit 1
-                  ;;
-              esac
+          # Both halves, on the version alone now that it arrives whole: the dev identifier this
+          # workflow's own builds carry, and the line this repository builds.
+          case "$VERSION" in
+            "$EXPECTED".*-dev.*) echo "Dev build $VERSION - publishing." ;;
+            "$EXPECTED".*)
+              echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
+              echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
+              exit 1
               ;;
             *)
-              case "$VERSION" in
-                "$EXPECTED".*)
-                  echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
-                  echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
-                  exit 1
-                  ;;
-                *)
-                  # Neither a dev name nor a version on this repository's line, and the two ways that
-                  # happens cannot be told apart from here - so the message names both rather than
-                  # picking the one that reads better.
-                  echo "Refusing to publish: read '$VERSION' out of '$PKG', which is not on the $EXPECTED line this repository builds." >&2
-                  echo "Either the package name was misread, or the version line moved and this workflow was not told." >&2
-                  exit 1
-                  ;;
-              esac
+              # On neither count: the version line may have moved, or the name may not be one this
+              # step can read. The two cannot be told apart from here, so the message names both.
+              echo "Refusing to publish $VERSION: it is not on the $EXPECTED line this repository builds." >&2
+              echo "Either the version line moved and this workflow was not told, or '$PKG' is not a name this step can read." >&2
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -11,18 +11,16 @@ name: Publish dev build to GitHub Packages
 # version actually built, so these examples can mislead a READER of this file - which is why they are
 # kept current - but they are no longer what reaches a consumer.
 #
-# Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0), and
-# these are MEASURED rather than modelled - see the note below about tags:
-#   develop at commit height 469           ->  2.4.0-dev.0.469
+# Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0):
+#   develop, no readable tag behind it     ->  2.4.0-dev.0.<height from the root commit>
+#   a branch with a readable tag behind it ->  <that tag's version, patch bumped>-dev.0.<height>
 #   a release, version supplied by hand    ->  2.4.0   (enhanced-release.yml, MinVerVersionOverride)
 #
-# MinVer reads NO tag in this repository, which is worth knowing before reasoning about what it
-# will produce. The tags are two-part and v-prefixed (v2.3), MinVerTagPrefix is set nowhere, so
-# none of them parses as a version; and they live on master, not on the branch this workflow
-# builds. So the height is counted from the ROOT COMMIT, and the whole version comes from
-# MinVerMinimumMajorMinor lifting a 0.0.0 default. Run against this worktree, MinVer says so in as
-# many words: "No commit found with a valid SemVer 2.0 version", then "Bumping version to
-# 2.4.0-dev.0.472 to satisfy minimum major minor 2.4".
+# NO tag is readable from develop, which is worth knowing before reasoning about what MinVer will
+# produce here: every release tag sits on master, which is not an ancestor of develop, and MinVer
+# walks the history of the branch it is building. So on this branch the whole version comes from
+# MinVerMinimumMajorMinor lifting a 0.0.0 default. That is NOT true everywhere - master has
+# readable three-part tags (v2.0.1 among them) and its versions come from them.
 #
 # Note: develop and release/* publish into the same 2.4.0-dev.* pre-release line, so a
 # consumer floating 2.4.0-dev.* resolves the highest commit height across both branches.
@@ -124,6 +122,34 @@ jobs:
         # per-TFM pack. Drop --no-build; the earlier Build step left everything up to date, so pack's build
         # is an incremental no-op. GeneratePackageOnBuild=false stops the on-build pack double-running.
         run: dotnet pack --no-restore -c Release -o nupkg -p:GeneratePackageOnBuild=false
+
+        timeout-minutes: 3
+      - name: Refuse to publish a release version
+        run: |
+          set -euo pipefail
+          # This workflow publishes DEV builds, and says so in its own summary. Anything else reaches
+          # here only when a release tag sits on the commit being built, because MinVer returns a
+          # tag's version exactly - 2.4.0 for a release, 2.4.0-beta1 for a pre-release. Both belong
+          # to enhanced-release.yml; neither is this workflow's to push.
+          #
+          # Nothing stopped that until now, and the failure was silent in both directions: this job
+          # triggers on a push to release/** and on manual dispatch, so it would have pushed the
+          # stable package to GitHub Packages past the release approval gate, and the approved
+          # publish that ran afterwards uses --skip-duplicate and would have no-opped over it. The
+          # feed would then hold a binary nobody approved, with nothing to show the difference.
+          #
+          # Stated as what must be PRESENT - the dev identifier this workflow's own builds carry -
+          # rather than as a list of the ways a tagged version can arrive here.
+          PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | sed -n 1p)
+          VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
+          case "$VERSION" in
+            *-dev.*) echo "Dev build $VERSION - publishing." ;;
+            *)
+              echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
+              echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
+              exit 1
+              ;;
+          esac
 
         timeout-minutes: 3
       - name: Push to GitHub Packages

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -126,47 +126,22 @@ jobs:
       - name: Refuse to publish a release version
         run: |
           set -euo pipefail
-          # This workflow publishes DEV builds, and says so in its own summary. A version carrying no
-          # dev identifier means a release tag sits on the commit being built, because MinVer returns
-          # a tag's version exactly - 2.4.0 for a release, 2.4.0-beta1 for a pre-release. Both belong
-          # to enhanced-release.yml; neither is this workflow's to push. Two other things arrive here
-          # and are neither, so each has its own arm: no package at all, and a name this step cannot
-          # read a version out of.
-          #
-          # Nothing stopped that until now, and the failure was silent in both directions: this job
-          # triggers on a push to release/** and on manual dispatch, so it would have pushed the
-          # stable package to GitHub Packages past the release approval gate, and the approved
-          # publish that ran afterwards uses --skip-duplicate and would have no-opped over it. The
-          # feed would then hold a binary nobody approved, with nothing to show the difference.
-          #
-          # Stated as what must be PRESENT - the dev identifier this workflow's own builds carry -
-          # rather than as a list of the ways a tagged version can arrive here. The line itself is
-          # read from the property the rest of the repository reads, so this step cannot hold a
-          # second opinion about which line is being built.
+          # This workflow publishes DEV builds. A version carrying no dev identifier means a release
+          # tag sits on the commit, and those belong to enhanced-release.yml, behind its approval
+          # gate. Without this step such a package would reach the feed past that gate, and the
+          # approved publish afterwards uses --skip-duplicate and would no-op over it.
           if [ ! -f Directory.Build.props ]; then
             echo "Directory.Build.props is not here, so the version line this build should be on is unknown." >&2
             exit 1
           fi
-          # MSBuild EVALUATES the property rather than a pattern matching the tag it is written in.
-          # A text match reads one spelling: driven, a Condition on the ELEMENT, padding inside it, a
-          # second declaration later in the file and a commented-out copy each gave the pattern a
-          # wrong answer or none, and each would have refused a good build naming a cause that was
-          # not there - the thing this step exists to stop. (A Condition on the GROUP is not one of
-          # them: both readings agree there, and when the condition is false the pattern is the one
-          # that answers, with a value the build never sets.)
-          #
-          # Evaluated in the configuration Pack used, because the file is evaluated STANDING ALONE
-          # here and in a project's context there: a property conditioned on $(Configuration) reads
-          # empty standalone and 2.4 under Release. Driven. Today's is unconditional, so this changes
-          # nothing and costs one flag - and the case it forecloses is a good build refused for a
-          # cause that is not there, which is this step's whole subject. It closes ONE dimension of
-          # standing alone, not the difference: driven, a property conditioned on $(TargetFramework)
-          # still reads empty here and 2.4 once that is supplied too.
-          #
-          # MSBuild's stderr is NOT discarded: -getProperty puts the value alone on stdout, so an
-          # error or a warning cannot reach EXPECTED, and throwing it away would leave this step
-          # refusing with no cause at all. Driven with a broken props: the line it keeps names the
-          # file, the position and the defect.
+
+          # MSBuild evaluates the property; a pattern would read one spelling of the tag and miss a
+          # Condition on the element, padding, a later re-declaration or a commented-out copy - each
+          # of which would refuse a good build for a cause that is not there. Configuration is passed
+          # because the file is read standing alone here and in a project's context during the build;
+          # that closes one such difference, not all of them. stderr is kept: -getProperty puts the
+          # value alone on stdout, and discarding the rest would leave this step refusing with no
+          # cause in the log.
           rc=0
           EXPECTED=$(dotnet msbuild Directory.Build.props -getProperty:MinVerMinimumMajorMinor -p:Configuration=Release -nologo | tr -d '[:space:]') || rc=$?
           if [ "$rc" -ne 0 ] || [ -z "$EXPECTED" ]; then
@@ -174,25 +149,17 @@ jobs:
             exit 1
           fi
 
-          # find is allowed to fail rather than end the step: a missing nupkg/ and an empty one are
-          # the same situation for whoever reads the log, and under set -e the missing directory
-          # would stop the run at find, with its message and none of the arm's.
+          # find may fail without ending the step, so a missing nupkg/ reaches the arm below rather
+          # than dying here with find's message and none of ours.
           rc=0
           PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' 2>/dev/null | sort | sed -n 1p) || rc=$?
           [ "$rc" -eq 0 ] || PKG=""
           BASE=$(basename "$PKG" .nupkg)
 
-          # The version is the FIRST version-shaped suffix, not the last. Taking the last is what made
-          # the earlier readings wrong: a pre-release identifier with a third part hands back a
-          # fragment - 2.4.0-dev.0.0.478 came out as 0.0.478, and 2.4.0-dev.2.4.478 as 2.4.478, which
-          # is on this repository's line and has lost the dev identifier with the rest. Stripping
-          # leading id segments instead keeps the whole version in every one of those names. Driven.
-          #
-          # It assumes no SEGMENT of a package id begins with a digit, which none here does. A segment
-          # that did would be taken as the start of the version, and what follows is usually a refusal
-          # naming a cause that is not there - but not always: an id segment shaped like a version can
-          # carry a dev identifier of its own and publish a release. Driven, on a contrived name. So
-          # this is the sentence to revisit if an id ever gains a digit-leading segment.
+          # The version is the FIRST version-shaped suffix. Taking the last loses the tail of a
+          # pre-release identifier that has three parts, which then reads as a release. This assumes
+          # no segment of a package id begins with a digit, and none here does; one that did would be
+          # taken as the start of the version, usually refused and in a contrived case published.
           VERSION=""
           REST=$BASE
           while [ -n "$REST" ]; do
@@ -214,8 +181,7 @@ jobs:
             exit 1
           fi
 
-          # Both halves, on the version alone now that it arrives whole: the dev identifier this
-          # workflow's own builds carry, and the line this repository builds.
+          # Both criteria on the version: the dev identifier, and the line this repository builds.
           case "$VERSION" in
             "$EXPECTED".*-dev.*) echo "Dev build $VERSION - publishing." ;;
             "$EXPECTED".*)
@@ -224,8 +190,7 @@ jobs:
               exit 1
               ;;
             *)
-              # On neither count: the version line may have moved, or the name may not be one this
-              # step can read. The two cannot be told apart from here, so the message names both.
+              # Off the line, and the two causes cannot be told apart from here.
               echo "Refusing to publish $VERSION: it is not on the $EXPECTED line this repository builds." >&2
               echo "Either the version line moved and this workflow was not told, or '$PKG' is not a name this step can read." >&2
               exit 1

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -150,14 +150,16 @@ jobs:
           fi
 
           # find may fail without ending the step, so a missing nupkg/ reaches the arm below rather
-          # than dying here with find's message and none of ours.
+          # than ending the run here with no output at all - find's own message is discarded on the
+          # next line, so the arm's sentence is the only one there would be.
           rc=0
           PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' 2>/dev/null | sort | sed -n 1p) || rc=$?
           [ "$rc" -eq 0 ] || PKG=""
           BASE=$(basename "$PKG" .nupkg)
 
           # The version is the FIRST version-shaped suffix. Taking the last loses the tail of a
-          # pre-release identifier that has three parts, which then reads as a release. This assumes
+          # pre-release identifier that has three parts, and what is left then reads as a release or
+          # as a version off this line, depending on the identifier. This assumes
           # no segment of a package id begins with a digit, and none here does; one that did would be
           # taken as the start of the version, usually refused and in a contrived case published.
           VERSION=""

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -142,11 +142,7 @@ jobs:
           # Stated as what must be PRESENT - the dev identifier this workflow's own builds carry -
           # rather than as a list of the ways a tagged version can arrive here. The line itself is
           # read from the property the rest of the repository reads, so this step cannot hold a
-          # second opinion about it. Requiring the line is also what separates a real release from a
-          # name this step MISREAD: the extraction takes the trailing version-shaped run, so a
-          # pre-release identifier gaining a third part turns 2.4.0-dev.0.0.478 into 0.0.478, which
-          # is version-shaped, carries no dev identifier, and would otherwise be refused for a
-          # release tag that is not on the commit at all.
+          # second opinion about which line is being built.
           if [ ! -f Directory.Build.props ]; then
             echo "Directory.Build.props is not here, so the version line this build should be on is unknown." >&2
             exit 1
@@ -192,9 +188,11 @@ jobs:
           # is on this repository's line and has lost the dev identifier with the rest. Stripping
           # leading id segments instead keeps the whole version in every one of those names. Driven.
           #
-          # It assumes no package id here begins with a digit, which none does: one that did would be
-          # taken as the start of the version, and the line check below would refuse it - refusing, but
-          # for a cause that is not there, so this is the sentence to revisit if an id ever changes.
+          # It assumes no SEGMENT of a package id begins with a digit, which none here does. A segment
+          # that did would be taken as the start of the version, and what follows is usually a refusal
+          # naming a cause that is not there - but not always: an id segment shaped like a version can
+          # carry a dev identifier of its own and publish a release. Driven, on a contrived name. So
+          # this is the sentence to revisit if an id ever gains a digit-leading segment.
           VERSION=""
           REST=$BASE
           while [ -n "$REST" ]; do

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -6,16 +6,21 @@ name: Publish dev build to GitHub Packages
 # package version from git tags + commit height; this workflow just packs and pushes the
 # resulting .nupkg files to nuget.pkg.github.com/Abblix.
 #
-# Example version (with MinVerMinimumMajorMinor=2.3 and DefaultPreReleaseIdentifiers=dev.0):
-#   pre-tag develop, 5 commits since v2.2  ->  2.3.0-dev.0.5
-#   tagged v2.3.0-beta1                    ->  2.3.0-beta1
-#   tagged v2.3.0                          ->  2.3.0
+# The line below is Directory.Build.props' MinVerMinimumMajorMinor, which is the ONE place that
+# decides it; every number here is an illustration of that value and nothing reads them. The summary
+# this workflow prints derives its range from the version actually built, so a stale example here
+# cannot mislead a consumer - it can only mislead a reader.
 #
-# Note: develop and release/* publish into the same 2.3.0-dev.* pre-release line, so a
-# consumer floating 2.3.0-dev.* resolves the highest commit height across both branches.
+# Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0):
+#   pre-tag develop, 5 commits since v2.3  ->  2.4.0-dev.0.5
+#   tagged v2.4.0-beta1                    ->  2.4.0-beta1
+#   tagged v2.4.0                          ->  2.4.0
+#
+# Note: develop and release/* publish into the same 2.4.0-dev.* pre-release line, so a
+# consumer floating 2.4.0-dev.* resolves the highest commit height across both branches.
 # To gate deterministically against a specific branch build, pin the exact version.
 #
-# Releases (canonical 2.3.0, 2.3.0-beta1, etc.) flow through the manual
+# Releases (canonical 2.4.0, 2.4.0-beta1, etc.) flow through the manual
 # enhanced-release.yml - this workflow does not produce them.
 
 on:
@@ -141,7 +146,21 @@ jobs:
               echo ""
               echo "Feed: https://github.com/Abblix/Oidc.Server/packages"
               echo ""
-              echo "Consumers floating \`2.3.0-dev.*\` will pick this up on next \`dotnet restore\`."
+              # The floating range is DERIVED from the version just built rather than written out,
+              # because the two sat side by side and disagreed: this line said 2.3 while the build
+              # produced 2.4, so it told an integrator to float a line that had stopped publishing.
+              # That failure is silent by construction - the range still resolves, to the last build
+              # it ever had, so restore succeeds and the version simply never moves again.
+              #
+              # Only for a dev build, which is the only thing this range means. A tagged pre-release
+              # reaches here with no dev identifier, and a sentence about floating would be advice
+              # about a line it is not on.
+              case "$VERSION" in
+                *-dev.*)
+                  LINE="${VERSION%%-*}"
+                  echo "Consumers floating \`${LINE%.*}.0-dev.*\` will pick this up on next \`dotnet restore\`."
+                  ;;
+              esac
             } >> "$GITHUB_STEP_SUMMARY"
           fi
         timeout-minutes: 3

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -12,15 +12,14 @@ name: Publish dev build to GitHub Packages
 # kept current - but they are no longer what reaches a consumer.
 #
 # Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0):
-#   develop, no readable tag behind it     ->  2.4.0-dev.0.<height from the root commit>
-#   a branch with a readable tag behind it ->  <that tag's version, patch bumped>-dev.0.<height>
-#   a release, version supplied by hand    ->  2.4.0   (enhanced-release.yml, MinVerVersionOverride)
+#   any branch here                     ->  2.4.0-dev.0.<distance>
+#   a release, version supplied by hand ->  2.4.0   (enhanced-release.yml, MinVerVersionOverride)
 #
-# NO tag is readable from develop, which is worth knowing before reasoning about what MinVer will
-# produce here: every release tag sits on master, which is not an ancestor of develop, and MinVer
-# walks the history of the branch it is building. So on this branch the whole version comes from
-# MinVerMinimumMajorMinor lifting a 0.0.0 default. That is NOT true everywhere - master has
-# readable three-part tags (v2.0.1 among them) and its versions come from them.
+# MinVer reads NO tag in this repository, on any branch - the release tags are two-part (v2.3),
+# which is not SemVer, and MinVerTagPrefix is unset besides. So the whole version comes from
+# MinVerMinimumMajorMinor lifting a 0.0.0 default, and the number after dev.0 is MinVer's height:
+# a shortest-path distance through the history, NOT a count of commits. Measured on this branch,
+# height 476 against 681 reachable commits and 478 on the first-parent chain.
 #
 # Note: develop and release/* publish into the same 2.4.0-dev.* pre-release line, so a
 # consumer floating 2.4.0-dev.* resolves the highest commit height across both branches.
@@ -143,6 +142,12 @@ jobs:
           PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | sed -n 1p)
           VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
           case "$VERSION" in
+            "")
+              # Said first and separately: with no package there is no version, no tag and no
+              # release workflow involved, and the arm below would name all three.
+              echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
+              exit 1
+              ;;
             *-dev.*) echo "Dev build $VERSION - publishing." ;;
             *)
               echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -147,9 +147,19 @@ jobs:
           # pre-release identifier gaining a third part turns 2.4.0-dev.0.0.478 into 0.0.478, which
           # is version-shaped, carries no dev identifier, and would otherwise be refused for a
           # release tag that is not on the commit at all.
-          EXPECTED=$(sed -n 's:.*<MinVerMinimumMajorMinor>\([0-9][0-9]*\.[0-9][0-9]*\)</MinVerMinimumMajorMinor>.*:\1:p' Directory.Build.props)
-          if [ -z "$EXPECTED" ]; then
-            echo "Could not read MinVerMinimumMajorMinor out of Directory.Build.props - there is nothing to check the built version against." >&2
+          if [ ! -f Directory.Build.props ]; then
+            echo "Directory.Build.props is not here, so the version line this build should be on is unknown." >&2
+            exit 1
+          fi
+          # MSBuild EVALUATES the property rather than a pattern matching the tag it is written in.
+          # A text match reads only one spelling: driven, a Condition on the PropertyGroup, padding
+          # inside the element, a second declaration later in the file and a commented-out copy are
+          # all read correctly here, and each defeated the text match - which would have refused a
+          # good build naming a cause that was not there, the thing this whole step exists to stop.
+          rc=0
+          EXPECTED=$(dotnet msbuild Directory.Build.props -getProperty:MinVerMinimumMajorMinor -nologo 2>/dev/null | tr -d '[:space:]') || rc=$?
+          if [ "$rc" -ne 0 ] || [ -z "$EXPECTED" ]; then
+            echo "Could not evaluate MinVerMinimumMajorMinor from Directory.Build.props - there is nothing to check the built version against." >&2
             exit 1
           fi
 
@@ -159,25 +169,59 @@ jobs:
           rc=0
           PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' 2>/dev/null | sort | sed -n 1p) || rc=$?
           [ "$rc" -eq 0 ] || PKG=""
-          VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
-          case "$VERSION" in
-            "")
-              echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
-              exit 1
-              ;;
-            "$EXPECTED".*-dev.*) echo "Dev build $VERSION - publishing." ;;
-            "$EXPECTED".*)
-              echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
-              echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
-              exit 1
+          BASE=$(basename "$PKG" .nupkg)
+          VERSION=$(printf '%s' "$BASE" | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
+
+          # The dev identifier is read off the WHOLE NAME and the line off the extracted version, and
+          # both are needed: the extraction takes the trailing version-shaped run, so a pre-release
+          # identifier with a third part hands back a fragment. 2.4.0-dev.0.0.478 extracts as 0.0.478,
+          # which is off the line; 2.4.0-dev.2.4.478 extracts as 2.4.478, which is ON it and has lost
+          # the dev identifier with the rest. Driven, both of them. Checking only the shape passed the
+          # first to the release arm and checking only the line passed the second, so each is refused
+          # for what it is - a name this step could not read - rather than for a release tag that is
+          # not on the commit.
+          if [ -z "$VERSION" ]; then
+            echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
+            exit 1
+          fi
+
+          case "$BASE" in
+            *-dev.*)
+              case "$VERSION" in
+                "$EXPECTED".*-dev.*) echo "Dev build $VERSION - publishing." ;;
+                *-dev.*)
+                  # Read as a dev version, just not this repository's line. That is the version line
+                  # having moved, or the name having been misread into another line's shape, and the
+                  # two cannot be told apart from here.
+                  echo "Refusing to publish $VERSION: it is a dev build off the $EXPECTED line this repository builds." >&2
+                  echo "Either the version line moved and this workflow was not told, or the name was misread." >&2
+                  exit 1
+                  ;;
+                *)
+                  # The name carries the dev identifier and the version read out of it does not, so
+                  # the extraction lost it: that is a misread and nothing else.
+                  echo "Refusing to publish: '$BASE' names a dev build, but the version read out of it is '$VERSION'." >&2
+                  echo "The name was misread, so nothing here can say what this package holds." >&2
+                  exit 1
+                  ;;
+              esac
               ;;
             *)
-              # Not on the line this repository builds, and the two ways that happens cannot be told
-              # apart from here - so the message names both rather than picking the one that reads
-              # better.
-              echo "Refusing to publish: read '$VERSION' out of '$PKG', which is not on the $EXPECTED line this repository builds." >&2
-              echo "Either the package name was misread, or the version line moved and this workflow was not told." >&2
-              exit 1
+              case "$VERSION" in
+                "$EXPECTED".*)
+                  echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
+                  echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
+                  exit 1
+                  ;;
+                *)
+                  # Neither a dev name nor a version on this repository's line, and the two ways that
+                  # happens cannot be told apart from here - so the message names both rather than
+                  # picking the one that reads better.
+                  echo "Refusing to publish: read '$VERSION' out of '$PKG', which is not on the $EXPECTED line this repository builds." >&2
+                  echo "Either the package name was misread, or the version line moved and this workflow was not told." >&2
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
 

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -152,12 +152,25 @@ jobs:
             exit 1
           fi
           # MSBuild EVALUATES the property rather than a pattern matching the tag it is written in.
-          # A text match reads only one spelling: driven, a Condition on the PropertyGroup, padding
-          # inside the element, a second declaration later in the file and a commented-out copy are
-          # all read correctly here, and each defeated the text match - which would have refused a
-          # good build naming a cause that was not there, the thing this whole step exists to stop.
+          # A text match reads one spelling: driven, a Condition on the ELEMENT, padding inside it, a
+          # second declaration later in the file and a commented-out copy each gave the pattern a
+          # wrong answer or none, and each would have refused a good build naming a cause that was
+          # not there - the thing this step exists to stop. (A Condition on the GROUP is not one of
+          # them: both readings agree there, and when the condition is false the pattern is the one
+          # that answers, with a value the build never sets.)
+          #
+          # Evaluated in the configuration Pack used, because the file is evaluated STANDING ALONE
+          # here and in a project's context there: a property conditioned on $(Configuration) reads
+          # empty standalone and 2.4 under Release. Driven. Today's is unconditional, so this changes
+          # nothing and costs one flag - and the case it forecloses is a good build refused for a
+          # cause that is not there, which is this step's whole subject.
+          #
+          # MSBuild's stderr is NOT discarded: -getProperty puts the value alone on stdout, so an
+          # error or a warning cannot reach EXPECTED, and throwing it away would leave this step
+          # refusing with no cause at all. Driven with a broken props: the line it keeps names the
+          # file, the position and the defect.
           rc=0
-          EXPECTED=$(dotnet msbuild Directory.Build.props -getProperty:MinVerMinimumMajorMinor -nologo 2>/dev/null | tr -d '[:space:]') || rc=$?
+          EXPECTED=$(dotnet msbuild Directory.Build.props -getProperty:MinVerMinimumMajorMinor -p:Configuration=Release -nologo | tr -d '[:space:]') || rc=$?
           if [ "$rc" -ne 0 ] || [ -z "$EXPECTED" ]; then
             echo "Could not evaluate MinVerMinimumMajorMinor from Directory.Build.props - there is nothing to check the built version against." >&2
             exit 1
@@ -199,7 +212,7 @@ jobs:
                   ;;
                 *)
                   # The name carries the dev identifier and the version read out of it does not, so
-                  # the extraction lost it: that is a misread and nothing else.
+                  # the extraction lost it, which is a misread.
                   echo "Refusing to publish: '$BASE' names a dev build, but the version read out of it is '$VERSION'." >&2
                   echo "The name was misread, so nothing here can say what this package holds." >&2
                   exit 1

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -126,10 +126,12 @@ jobs:
       - name: Refuse to publish a release version
         run: |
           set -euo pipefail
-          # This workflow publishes DEV builds, and says so in its own summary. Anything else reaches
-          # here only when a release tag sits on the commit being built, because MinVer returns a
-          # tag's version exactly - 2.4.0 for a release, 2.4.0-beta1 for a pre-release. Both belong
-          # to enhanced-release.yml; neither is this workflow's to push.
+          # This workflow publishes DEV builds, and says so in its own summary. A version carrying no
+          # dev identifier means a release tag sits on the commit being built, because MinVer returns
+          # a tag's version exactly - 2.4.0 for a release, 2.4.0-beta1 for a pre-release. Both belong
+          # to enhanced-release.yml; neither is this workflow's to push. Two other things arrive here
+          # and are neither, so each has its own arm: no package at all, and a name this step cannot
+          # read a version out of.
           #
           # Nothing stopped that until now, and the failure was silent in both directions: this job
           # triggers on a push to release/** and on manual dispatch, so it would have pushed the
@@ -149,8 +151,8 @@ jobs:
               exit 1
               ;;
             "")
-              # Said first and separately: with no package there is no version, no tag and no
-              # release workflow involved, and the arm below would name all three.
+              # With no package there is no version, no tag and no release workflow involved, so this
+              # arm says that rather than borrowing a sentence about a release that is not there.
               echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
               exit 1
               ;;

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -6,13 +6,14 @@ name: Publish dev build to GitHub Packages
 # package version from git tags + commit height; this workflow just packs and pushes the
 # resulting .nupkg files to nuget.pkg.github.com/Abblix.
 #
-# The line below is Directory.Build.props' MinVerMinimumMajorMinor, which is the ONE place that
-# decides it; every number here is an illustration of that value and nothing reads them. The summary
-# this workflow prints derives its range from the version actually built, so a stale example here
-# cannot mislead a consumer - it can only mislead a reader.
+# Directory.Build.props' MinVerMinimumMajorMinor is the ONE place that decides the line; the numbers
+# below are an illustration of it and nothing reads them. The run summary derives its range from the
+# version actually built, so these examples can mislead a READER of this file - which is why they are
+# kept current - but they are no longer what reaches a consumer.
 #
 # Example version (with MinVerMinimumMajorMinor=2.4 and DefaultPreReleaseIdentifiers=dev.0):
 #   pre-tag develop, 5 commits since v2.3  ->  2.4.0-dev.0.5
+#   after v2.4 is tagged, 5 more commits   ->  2.4.1-dev.0.5   (the minimum only LIFTS a version)
 #   tagged v2.4.0-beta1                    ->  2.4.0-beta1
 #   tagged v2.4.0                          ->  2.4.0
 #
@@ -135,10 +136,24 @@ jobs:
       - name: Summary
         run: |
           set -euo pipefail
-          # Pick any one package - they all share the same MinVer-derived version.
-          PKG=$(find nupkg -maxdepth 1 -name 'Abblix.Oidc.Server.*.nupkg' | head -1 || true)
+          # Any package: they all carry the same MinVer version. Matched by SHAPE rather than by
+          # name, because the name was wrong in two ways at once and both were silent.
+          #
+          # The glob said Abblix.Oidc.Server while the ids are Abblix.OIDC.Server - PackageId
+          # uppercases OIDC, JWT and MVC, and the runner is case-sensitive, so find matched nothing,
+          # PKG was empty, and this whole block has never run. The summary an operator was reading
+          # about was not merely stale; it was never printed at all.
+          #
+          # And once the case is corrected the name is still the wrong key: Abblix.OIDC.Server is a
+          # PREFIX of Abblix.OIDC.Server.MVC, so head -1 over the family can hand back a file whose
+          # remainder is "MVC.2.4.0-dev.0.469" - a version string with a package fragment inside it.
+          #
+          # A version has a shape, so take the trailing three-part number and let the name be
+          # whatever it is. sort makes the pick deterministic rather than dependent on directory
+          # order.
+          PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | head -1)
           if [ -n "$PKG" ]; then
-            VERSION=$(basename "$PKG" .nupkg | sed 's|^Abblix.Oidc.Server.||')
+            VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
             {
               echo "## Dev build published"
               echo ""
@@ -146,19 +161,22 @@ jobs:
               echo ""
               echo "Feed: https://github.com/Abblix/Oidc.Server/packages"
               echo ""
-              # The floating range is DERIVED from the version just built rather than written out,
-              # because the two sat side by side and disagreed: this line said 2.3 while the build
-              # produced 2.4, so it told an integrator to float a line that had stopped publishing.
-              # That failure is silent by construction - the range still resolves, to the last build
-              # it ever had, so restore succeeds and the version simply never moves again.
+              # The floating range comes from the version in hand, so the two cannot disagree. A
+              # literal here read 2.3 while the build produced 2.4, and a consumer who follows a
+              # range that has stopped publishing is not told: the range still resolves, to its last
+              # build, so restore succeeds and the version simply never moves again.
               #
-              # Only for a dev build, which is the only thing this range means. A tagged pre-release
-              # reaches here with no dev identifier, and a sentence about floating would be advice
-              # about a line it is not on.
+              # The WHOLE three-part number, not major.minor with a zero patch appended. NuGet floats
+              # only the release label, so 2.4.0-dev.* does not resolve 2.4.1-dev.0.3 - and 2.4.1 is
+              # what MinVer produces as soon as a v2.4 tag is reachable, which is every day between
+              # the release and the next bump of MinVerMinimumMajorMinor. Re-asserting the patch
+              # would have rebuilt the same silent failure inside the fix for it.
+              #
+              # Only for a dev build. A tagged pre-release arrives here with no dev identifier, and a
+              # sentence about floating would be advice about a line it is not on.
               case "$VERSION" in
                 *-dev.*)
-                  LINE="${VERSION%%-*}"
-                  echo "Consumers floating \`${LINE%.*}.0-dev.*\` will pick this up on next \`dotnet restore\`."
+                  echo "Consumers floating \`${VERSION%%-*}-dev.*\` will pick this up on next \`dotnet restore\`."
                   ;;
               esac
             } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-dev-builds.yml
+++ b/.github/workflows/publish-dev-builds.yml
@@ -140,27 +140,43 @@ jobs:
           # feed would then hold a binary nobody approved, with nothing to show the difference.
           #
           # Stated as what must be PRESENT - the dev identifier this workflow's own builds carry -
-          # rather than as a list of the ways a tagged version can arrive here.
-          PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' | sort | sed -n 1p)
+          # rather than as a list of the ways a tagged version can arrive here. The line itself is
+          # read from the property the rest of the repository reads, so this step cannot hold a
+          # second opinion about it. Requiring the line is also what separates a real release from a
+          # name this step MISREAD: the extraction takes the trailing version-shaped run, so a
+          # pre-release identifier gaining a third part turns 2.4.0-dev.0.0.478 into 0.0.478, which
+          # is version-shaped, carries no dev identifier, and would otherwise be refused for a
+          # release tag that is not on the commit at all.
+          EXPECTED=$(sed -n 's:.*<MinVerMinimumMajorMinor>\([0-9][0-9]*\.[0-9][0-9]*\)</MinVerMinimumMajorMinor>.*:\1:p' Directory.Build.props)
+          if [ -z "$EXPECTED" ]; then
+            echo "Could not read MinVerMinimumMajorMinor out of Directory.Build.props - there is nothing to check the built version against." >&2
+            exit 1
+          fi
+
+          # find is allowed to fail rather than end the step: a missing nupkg/ and an empty one are
+          # the same situation for whoever reads the log, and under set -e the missing directory
+          # would stop the run at find, with its message and none of the arm's.
+          rc=0
+          PKG=$(find nupkg -maxdepth 1 -name '*.nupkg' 2>/dev/null | sort | sed -n 1p) || rc=$?
+          [ "$rc" -eq 0 ] || PKG=""
           VERSION=$(basename "$PKG" .nupkg | sed -E 's/.*\.([0-9]+\.[0-9]+\.[0-9]+[^ ]*)$/\1/')
           case "$VERSION" in
-            [0-9]*.[0-9]*.[0-9]*-dev.*) echo "Dev build $VERSION - publishing." ;;
-            [0-9]*.[0-9]*.[0-9]*)
+            "")
+              echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
+              exit 1
+              ;;
+            "$EXPECTED".*-dev.*) echo "Dev build $VERSION - publishing." ;;
+            "$EXPECTED".*)
               echo "Refusing to publish $VERSION: it carries no dev identifier, so a release tag is on this commit." >&2
               echo "Releases and pre-releases are published by enhanced-release.yml, behind its approval gate." >&2
               exit 1
               ;;
-            "")
-              # With no package there is no version, no tag and no release workflow involved, so this
-              # arm says that rather than borrowing a sentence about a release that is not there.
-              echo "Pack produced no package - nothing to publish and nothing to read a version from." >&2
-              exit 1
-              ;;
             *)
-              # Anything that is not a version at all: the name did not parse, so nothing here can
-              # say why. Saying "a release tag is on this commit" of it would name a cause that is
-              # not there - the arm above owns that sentence and requires the version shape first.
-              echo "Refusing to publish: could not read a version out of the package name, got '$VERSION'." >&2
+              # Not on the line this repository builds, and the two ways that happens cannot be told
+              # apart from here - so the message names both rather than picking the one that reads
+              # better.
+              echo "Refusing to publish: read '$VERSION' out of '$PKG', which is not on the $EXPECTED line this repository builds." >&2
+              echo "Either the package name was misread, or the version line moved and this workflow was not told." >&2
               exit 1
               ;;
           esac

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,13 @@ repos:
         # check, or the list is edited by whoever is not looking at what it holds.
         files: (\.cs|\.github/scripts/lint-take-once-consumers\.py)$
       - id: msbuild-xml-parses
-        name: "Refuse an MSBuild file that does not parse as XML"
+        name: "Refuse a build XML file that does not parse"
         entry: python .github/scripts/lint-msbuild-xml.py
         language: python
-        # Every XML tracked here, rather than the extensions that came to mind: a solution file, a
-        # nuget.config and the coverage settings break on the identical double hyphen, and the file
-        # nobody thought to name is the one that would ship broken.
+        # The XML extensions tracked here, which today is every XML file in the repository - checked,
+        # not assumed. It is still a list, so a .runsettings or an app.config arriving later would
+        # sit outside it; selecting on content rather than on extension is the general answer, and
+        # this is the cheap one.
         files: (\.(props|targets|csproj|slnx|xml)$|(^|/)[Nn]u[Gg]et\.[Cc]onfig$)
       - id: no-split-doc-comments
         name: "Block a doc comment that documents two members"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,9 +48,10 @@ repos:
         name: "Refuse an MSBuild file that does not parse as XML"
         entry: python .github/scripts/lint-msbuild-xml.py
         language: python
-        # Every XML the build reads, not an enumeration of the three that came to mind: a
-        # solution file and a nuget.config break on the identical double hyphen.
-        files: (\.(props|targets|csproj|slnx)$|(^|/)[Nn]u[Gg]et\.[Cc]onfig$)
+        # Every XML tracked here, rather than the extensions that came to mind: a solution file, a
+        # nuget.config and the coverage settings break on the identical double hyphen, and the file
+        # nobody thought to name is the one that would ship broken.
+        files: (\.(props|targets|csproj|slnx|xml)$|(^|/)[Nn]u[Gg]et\.[Cc]onfig$)
       - id: no-split-doc-comments
         name: "Block a doc comment that documents two members"
         entry: python .github/scripts/lint-no-split-doc-comments.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,10 +48,11 @@ repos:
         name: "Refuse a build XML file that does not parse"
         entry: python .github/scripts/lint-msbuild-xml.py
         language: python
-        # The XML extensions tracked here, which today is every XML file in the repository - checked,
-        # not assumed. It is still a list, so a .runsettings or an app.config arriving later would
-        # sit outside it; selecting on content rather than on extension is the general answer, and
-        # this is the cheap one.
+        # The XML the BUILD reads, by extension. Not every XML file tracked here: the .DotSettings
+        # documents are Rider's and break nothing, and an earlier version of this sentence claimed
+        # otherwise because it was checked with a search over *.xml, which could not have seen them.
+        # A .runsettings or an app.config arriving later would sit outside the list too; selecting on
+        # content is the general answer, and this is the cheap one.
         files: (\.(props|targets|csproj|slnx|xml)$|(^|/)[Nn]u[Gg]et\.[Cc]onfig$)
       - id: no-split-doc-comments
         name: "Block a doc comment that documents two members"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,9 @@ repos:
         name: "Refuse an MSBuild file that does not parse as XML"
         entry: python .github/scripts/lint-msbuild-xml.py
         language: python
-        files: \.(props|targets|csproj)$
+        # Every XML the build reads, not an enumeration of the three that came to mind: a
+        # solution file and a nuget.config break on the identical double hyphen.
+        files: (\.(props|targets|csproj|slnx)$|(^|/)[Nn]u[Gg]et\.[Cc]onfig$)
       - id: no-split-doc-comments
         name: "Block a doc comment that documents two members"
         entry: python .github/scripts/lint-no-split-doc-comments.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@
 # rather than by naming them, because the list grows and a stale enumeration reads as a complete one:
 #   git commit --no-verify
 #
+# actionlint spawns shellcheck once per run: block, which on Windows can take longer than a commit
+# is worth waiting for. It is one of the two hooks CI re-runs, so skip that ONE - SKIP=actionlint git
+# commit - rather than reaching for --no-verify, which drops the five that run in this clone or
+# nowhere. Locally the same coverage comes from two faster halves: actionlint -shellcheck= for the
+# schema, and shellcheck on the extracted run: body.
+#
 # Rules and rationale: the workspace's GitHub Actions security checklist.
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
         # The script's own path is in the pattern: a commit editing only KNOWN must re-run the
         # check, or the list is edited by whoever is not looking at what it holds.
         files: (\.cs|\.github/scripts/lint-take-once-consumers\.py)$
+      - id: msbuild-xml-parses
+        name: "Refuse an MSBuild file that does not parse as XML"
+        entry: python .github/scripts/lint-msbuild-xml.py
+        language: python
+        files: \.(props|targets|csproj)$
       - id: no-split-doc-comments
         name: "Block a doc comment that documents two members"
         entry: python .github/scripts/lint-no-split-doc-comments.py

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,10 +39,16 @@
        the history of the branch being built. Releases now tag the three-part form, and the
        release checklist carries the reachability check that nothing was making.
 
-       Until a three-part tag exists and is reachable, this property remains the whole source of
-       the number: MinVer reports "No commit found with a valid SemVer 2.0 version", lifts its
-       0.0.0 default to this line, and counts the height from the root commit. That is measured,
-       not assumed, and it is what today's 2.4.0-dev.0.469 is made of.
+       On DEVELOP this property is still the whole source of the number, because no tag is
+       reachable from it: MinVer reports "No commit found with a valid SemVer 2.0 version", lifts
+       its 0.0.0 default to this line, and counts the height from the root commit.
+
+       On MASTER it is not, and the prefix changed the number there. Nine tags are three-part
+       already (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1 and two four-part ones),
+       and v2.0.1 is reachable from master - so master went from 2.4.0-dev.0.53 to 2.4.0-dev.0.15,
+       the height now counted from that tag. A statement that nothing moved was measured on develop
+       alone; the tags were listed five at a time and the three-part ones were in the part not
+       looked at.
 
        The run summary derives all three parts of the version rather than re-asserting a zero
        patch. That is right whatever the tags do: NuGet floats only the release label, so a range

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,10 +40,14 @@
 
        Nothing depends on it reading them. A release takes its version from the workflow input via
        MinVerVersionOverride, and a dev build takes it from this property. What it does mean is
-       that the number after dev.0 is a distance from the ROOT COMMIT rather than from the last
-       release - and it is a DISTANCE, MinVer's shortest path through the history, not an ordinal.
-       Measured on one branch: height 476, against 681 reachable commits and 478 on the
-       first-parent chain. So it orders builds and counts nothing.
+       that the number after dev.0 counts from the ROOT COMMIT rather than from the last release.
+
+       It is the FIRST-PARENT distance, which is checkable at any commit rather than quotable:
+       height + 1 == git rev-list --count --first-parent HEAD, exactly, at every commit measured.
+       So it is not the count of everything reachable - the two differ by every commit that came
+       in on the side of a merge, which here is over two hundred. Written as the relationship
+       rather than as numbers on purpose: a height quoted in a comment is stale on the next push,
+       and two earlier attempts at this sentence were wrong precisely because they quoted.
 
        Setting MinVerTagPrefix alone would not help and does not leave the rest alone: seven older
        tags ARE three-part (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1), and v2.0.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,10 @@
        that the number after dev.0 counts from the ROOT COMMIT rather than from the last release.
 
        It is the FIRST-PARENT distance, which is checkable at any commit rather than quotable:
-       height + 1 == git rev-list --count --first-parent HEAD, exactly, at every commit measured.
+       the height plus one is the number of commits on the first-parent chain from HEAD, exactly,
+       at every commit measured. (The command is git rev-list counting first parents only; it
+       cannot be written out here, because an XML comment may not contain a double hyphen and a
+       props file that does breaks every project that imports it.)
        So it is not the count of everything reachable - the two differ by every commit that came
        in on the side of a merge, which here is over two hundred. Written as the relationship
        rather than as numbers on purpose: a height quoted in a comment is stale on the next push,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,10 +54,10 @@
 
        Setting MinVerTagPrefix alone would not help and does not leave the rest alone: seven older
        tags ARE three-part (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1), and v2.0.1
-       is reachable from master - measured, master's version moved from 2.4.0-dev.0.53 to
-       2.4.0-dev.0.15 with the prefix set. Moving a published number BACKWARDS is the direction
-       that collides silently. The two four-part tags are not part of that risk: measured, MinVer
-       does not read a four-part tag either.
+       is reachable from master - measured, setting the prefix shortens master's height from the
+       whole first-parent distance to the distance since v2.0.1, so its published number moves
+       BACKWARDS, which is the direction that collides silently. The two four-part tags are not
+       part of that risk: measured, MinVer does not read a four-part tag either.
 
        The run summary derives all three parts of the version it prints rather than re-asserting a
        zero patch, which is right whatever the tags do: NuGet floats only the release label, so a

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,10 +26,16 @@
        tagged release drops the suffix by itself.
 
        No version number is written in this comment on purpose: a number repeated in prose beside
-       the property it describes goes stale without anything noticing. It is NOT the only place
-       the line is written down - .github/workflows/publish-dev-builds.yml states it in prose and
-       emits it into the run summary - so bumping the property means editing that file in the same
-       change. -->
+       the property it describes goes stale without anything noticing. The run summary in
+       .github/workflows/publish-dev-builds.yml no longer repeats it either - it derives the range
+       from the version the build produced, so nothing there can contradict this property. What
+       that workflow still carries is a worked EXAMPLE in its header comment, which a bump should
+       follow but which no consumer ever reads.
+
+       Also worth knowing when the line moves: MinVerMinimumMajorMinor only LIFTS a version below
+       it. Once a v2.4 tag is reachable and this still says 2.4, MinVer's patch auto-increment
+       takes over and dev builds become 2.4.1-dev.*, not 2.4.0-dev.*. The summary derives the whole
+       three-part number for that reason. -->
   <PropertyGroup>
     <MinVerMinimumMajorMinor>2.4</MinVerMinimumMajorMinor>
     <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,10 +32,18 @@
        that workflow still carries is a worked EXAMPLE in its header comment, which a bump should
        follow but which no consumer ever reads.
 
-       Also worth knowing when the line moves: MinVerMinimumMajorMinor only LIFTS a version below
-       it. Once a v2.4 tag is reachable and this still says 2.4, MinVer's patch auto-increment
-       takes over and dev builds become 2.4.1-dev.*, not 2.4.0-dev.*. The summary derives the whole
-       three-part number for that reason. -->
+       Also worth knowing when the line moves: this property is not merely a floor here, it is the
+       whole source of the number. MinVer reads no tag in this repository - the tags are two-part
+       and v-prefixed (v2.3), MinVerTagPrefix is set nowhere so the prefix is never stripped, and
+       they sit on master rather than on develop. Measured, MinVer reports "No commit found with a
+       valid SemVer 2.0 version" and then lifts its 0.0.0 default to this line. So the height is
+       counted from the root commit, and moving this property is the only thing that moves the
+       version dev builds publish under.
+
+       The run summary derives all three parts of the version rather than re-asserting a zero
+       patch. That is right whatever the tags do: NuGet floats only the release label, so a range
+       written as MAJOR.MINOR.0-dev.* cannot resolve a MAJOR.MINOR.1 build, and deriving costs
+       nothing. -->
   <PropertyGroup>
     <MinVerMinimumMajorMinor>2.4</MinVerMinimumMajorMinor>
     <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,19 +32,24 @@
        that workflow still carries is a worked EXAMPLE in its header comment, which a bump should
        follow but which no consumer ever reads.
 
-       Also worth knowing when the line moves: this property is not merely a floor here, it is the
-       whole source of the number. MinVer reads no tag in this repository - the tags are two-part
-       and v-prefixed (v2.3), MinVerTagPrefix is set nowhere so the prefix is never stripped, and
-       they sit on master rather than on develop. Measured, MinVer reports "No commit found with a
-       valid SemVer 2.0 version" and then lifts its 0.0.0 default to this line. So the height is
-       counted from the root commit, and moving this property is the only thing that moves the
-       version dev builds publish under.
+       MinVerTagPrefix is what lets MinVer see a v-prefixed tag at all. It was unset until now, and
+       two other things had to change with it before any tag could be read: releases were tagged
+       two-part (v2.3), which is not SemVer and is refused even after the prefix is stripped, and
+       the tag was pushed to master only, which is not an ancestor of develop - and MinVer walks
+       the history of the branch being built. Releases now tag the three-part form, and the
+       release checklist carries the reachability check that nothing was making.
+
+       Until a three-part tag exists and is reachable, this property remains the whole source of
+       the number: MinVer reports "No commit found with a valid SemVer 2.0 version", lifts its
+       0.0.0 default to this line, and counts the height from the root commit. That is measured,
+       not assumed, and it is what today's 2.4.0-dev.0.469 is made of.
 
        The run summary derives all three parts of the version rather than re-asserting a zero
        patch. That is right whatever the tags do: NuGet floats only the release label, so a range
        written as MAJOR.MINOR.0-dev.* cannot resolve a MAJOR.MINOR.1 build, and deriving costs
        nothing. -->
   <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerMinimumMajorMinor>2.4</MinVerMinimumMajorMinor>
     <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,10 +54,12 @@
 
        Setting MinVerTagPrefix alone would not help and does not leave the rest alone: seven older
        tags ARE three-part (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1), and v2.0.1
-       is reachable from master - measured, setting the prefix shortens master's height from the
-       whole first-parent distance to the distance since v2.0.1, so its published number moves
-       BACKWARDS, which is the direction that collides silently. The two four-part tags are not
-       part of that risk: measured, MinVer does not read a four-part tag either.
+       is reachable from master - measured, setting the prefix makes master's height SMALLER, so its
+       published number moves BACKWARDS, which is the direction that collides silently. How much
+       smaller is not a first-parent distance any more and is deliberately not stated here: v2.0.1
+       is not on master's first-parent chain at all, so once a tag is read the height stops being
+       measured along that chain. The two four-part tags are not part of that risk: measured, MinVer
+       does not read a four-part tag either.
 
        The run summary derives all three parts of the version it prints rather than re-asserting a
        zero patch, which is right whatever the tags do: NuGet floats only the release label, so a

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,14 +40,17 @@
 
        Nothing depends on it reading them. A release takes its version from the workflow input via
        MinVerVersionOverride, and a dev build takes it from this property. What it does mean is
-       that the height in a dev version counts from the ROOT COMMIT, not from the last release, so
-       2.4.0-dev.0.469 says "the 469th commit" and not "the 469th since 2.3".
+       that the number after dev.0 is a distance from the ROOT COMMIT rather than from the last
+       release - and it is a DISTANCE, MinVer's shortest path through the history, not an ordinal.
+       Measured on one branch: height 476, against 681 reachable commits and 478 on the
+       first-parent chain. So it orders builds and counts nothing.
 
-       Setting MinVerTagPrefix alone would not help and does not leave the rest alone: nine older
-       tags ARE three-part (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1 and two
-       four-part), and v2.0.1 is reachable from master - measured, master's version moved from
-       2.4.0-dev.0.53 to 2.4.0-dev.0.15 with the prefix set. Moving a published number BACKWARDS
-       is the direction that collides silently.
+       Setting MinVerTagPrefix alone would not help and does not leave the rest alone: seven older
+       tags ARE three-part (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1), and v2.0.1
+       is reachable from master - measured, master's version moved from 2.4.0-dev.0.53 to
+       2.4.0-dev.0.15 with the prefix set. Moving a published number BACKWARDS is the direction
+       that collides silently. The two four-part tags are not part of that risk: measured, MinVer
+       does not read a four-part tag either.
 
        The run summary derives all three parts of the version it prints rather than re-asserting a
        zero patch, which is right whatever the tags do: NuGet floats only the release label, so a

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,30 +32,27 @@
        that workflow still carries is a worked EXAMPLE in its header comment, which a bump should
        follow but which no consumer ever reads.
 
-       MinVerTagPrefix is what lets MinVer see a v-prefixed tag at all. It was unset until now, and
-       two other things had to change with it before any tag could be read: releases were tagged
-       two-part (v2.3), which is not SemVer and is refused even after the prefix is stripped, and
-       the tag was pushed to master only, which is not an ancestor of develop - and MinVer walks
-       the history of the branch being built. Releases now tag the three-part form, and the
-       release checklist carries the reachability check that nothing was making.
+       MinVer reads NO tag in this repository, and that is a consequence of choices worth
+       knowing rather than a fault to fix in passing. Release tags are two-part and v-prefixed
+       (v2.3): MinVerTagPrefix is unset, so the prefix is never stripped, and even stripped, "2.3"
+       is not SemVer and would still be refused. They also sit on master, which is not an ancestor
+       of develop, and MinVer walks the history of the branch being built.
 
-       On DEVELOP this property is still the whole source of the number, because no tag is
-       reachable from it: MinVer reports "No commit found with a valid SemVer 2.0 version", lifts
-       its 0.0.0 default to this line, and counts the height from the root commit.
+       Nothing depends on it reading them. A release takes its version from the workflow input via
+       MinVerVersionOverride, and a dev build takes it from this property. What it does mean is
+       that the height in a dev version counts from the ROOT COMMIT, not from the last release, so
+       2.4.0-dev.0.469 says "the 469th commit" and not "the 469th since 2.3".
 
-       On MASTER it is not, and the prefix changed the number there. Nine tags are three-part
-       already (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1 and two four-part ones),
-       and v2.0.1 is reachable from master - so master went from 2.4.0-dev.0.53 to 2.4.0-dev.0.15,
-       the height now counted from that tag. A statement that nothing moved was measured on develop
-       alone; the tags were listed five at a time and the three-part ones were in the part not
-       looked at.
+       Setting MinVerTagPrefix alone would not help and does not leave the rest alone: nine older
+       tags ARE three-part (v1.0.100, v1.1.0, v1.2.0, v1.3.0, v1.3.1, v1.6.0, v2.0.1 and two
+       four-part), and v2.0.1 is reachable from master - measured, master's version moved from
+       2.4.0-dev.0.53 to 2.4.0-dev.0.15 with the prefix set. Moving a published number BACKWARDS
+       is the direction that collides silently.
 
-       The run summary derives all three parts of the version rather than re-asserting a zero
-       patch. That is right whatever the tags do: NuGet floats only the release label, so a range
-       written as MAJOR.MINOR.0-dev.* cannot resolve a MAJOR.MINOR.1 build, and deriving costs
-       nothing. -->
+       The run summary derives all three parts of the version it prints rather than re-asserting a
+       zero patch, which is right whatever the tags do: NuGet floats only the release label, so a
+       range written as MAJOR.MINOR.0-dev.* cannot resolve a MAJOR.MINOR.1 build. -->
   <PropertyGroup>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerMinimumMajorMinor>2.4</MinVerMinimumMajorMinor>
     <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ That registers the full set of certified OpenID Connect endpoints. Point `LoginU
 - **Rich Authorization Requests (RFC 9396)**: fine-grained, transaction-level authorization details across the authorization endpoint, PAR, the token endpoint, CIBA, and the device grant, carried end-to-end into the access token
 - **Token Exchange (RFC 8693)**: impersonation and delegation with multiple subject- and actor-token formats and a per-client allow-list of subject-token types
 - **DPoP sender-constrained tokens (RFC 9449)**: signature-based proof of possession for public clients that cannot use mTLS, binding access and refresh tokens to the client key
-- **Certificate-bound access tokens (RFC 8705 §3)**: resource-server verification that a presented token matches the client certificate on the TLS connection
+- **Certificate-bound access tokens (RFC 8705 Section 3)**: resource-server verification that a presented token matches the client certificate on the TLS connection
 - **JARM**: the authorization response returned as a signed, optionally encrypted JWT, protecting it against tampering, mix-up, and parameter injection
 - **JWT-secured token introspection (RFC 9701)**: signed, optionally encrypted introspection responses via content negotiation
 - **JWE-encrypted request objects (RFC 9101)**: confidential request parameters in the front channel and by reference
@@ -116,7 +116,7 @@ Most deployments need only the first two; the rest apply if you use the named fe
 
 - **Authorization response formatting unified.** `IAuthorizationErrorFormatter` is removed, and success and error responses now flow through a single `IAuthorizationResponseFormatter`, and `AuthorizationError` is a subtype of the response model. Re-point any decorator or implementation to `IAuthorizationResponseFormatter` and branch on `response is AuthorizationError` (the `{ RedirectUri: null }` variant is the one to render on your own error page).
 - **Implicit Flow is opt-in.** Implicit and hybrid response types are rejected at client registration unless you call `EnableImplicitFlow()` on the OIDC builder. Authorization Code Flow is the default; no action otherwise.
-- **Initial Access Token required for Dynamic Client Registration.** Anonymous registration is rejected by default (RFC 7591 §3). Issue and require Initial Access Tokens, or set `OidcOptions.RequireInitialAccessToken = false` to keep open registration.
+- **Initial Access Token required for Dynamic Client Registration.** Anonymous registration is rejected by default (RFC 7591 Section 3). Issue and require Initial Access Tokens, or set `OidcOptions.RequireInitialAccessToken = false` to keep open registration.
 - **Back-channel logout endpoint validated at registration.** A `backchannel_logout_uri` with a non-`https` scheme, internal hostname, or private/loopback address is rejected with `invalid_client_metadata` under the secure default. Register public `https` endpoints, or relax `SecureHttpFetchOptions` for trusted internal deployments: set `BlockPrivateNetworks` to `false` and state `AllowedSchemes` in full, `https` included - the list replaces the default rather than extending it.
 
 ## 🎓 Certification

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.3</PackageReleaseNotes>
+    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.3</PackageReleaseNotes>
+    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
+    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for the Abblix OIDC Server. Maps the OpenID Connect and OAuth 2.0 endpoints as route handlers via AddOidcMinimalApi/MapOidcEndpoints, offering the same protocol coverage as the MVC integration without a dependency on the MVC framework. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for the Abblix OIDC Server. Maps the OpenID Connect and OAuth 2.0 endpoints as route handlers via AddOidcMinimalApi/MapOidcEndpoints, offering the same protocol coverage as the MVC integration without a dependency on the MVC framework. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for the Abblix OIDC Server. Maps the OpenID Connect and OAuth 2.0 endpoints as route handlers via AddOidcMinimalApi/MapOidcEndpoints, offering the same protocol coverage as the MVC integration without a dependency on the MVC framework. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
+        <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for the Abblix OIDC Server. Maps the OpenID Connect and OAuth 2.0 endpoints as route handlers via AddOidcMinimalApi/MapOidcEndpoints, offering the same protocol coverage as the MVC integration without a dependency on the MVC framework. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>MVC integration for the server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>MVC integration for the server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>MVC integration for the v2.3 server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.3</PackageReleaseNotes>
+        <PackageReleaseNotes>MVC integration for the server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>MVC integration for the server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
+        <PackageReleaseNotes>MVC integration for the server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.3</PackageReleaseNotes>
+        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
+        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server/README.md
+++ b/src/Abblix.Oidc.Server/README.md
@@ -15,7 +15,7 @@
 - **Rich Authorization Requests ([RFC 9396](https://datatracker.ietf.org/doc/html/rfc9396))**: fine-grained, transaction-level authorization details across the authorization endpoint, PAR, the token endpoint, CIBA, and the device grant
 - **Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693))**: impersonation and delegation with multiple subject- and actor-token formats
 - **DPoP sender-constrained tokens ([RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449))**: signature-based proof of possession for public clients that cannot use mTLS
-- **Certificate-bound access token verification ([RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705) §3)**: resource-server check that a presented token matches the client certificate
+- **Certificate-bound access token verification ([RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705) Section 3)**: resource-server check that a presented token matches the client certificate
 - **JARM**: signed, optionally encrypted JWT authorization responses
 - **JWT-secured token introspection ([RFC 9701](https://datatracker.ietf.org/doc/html/rfc9701))**: signed introspection responses via content negotiation
 - **JWE-encrypted request objects ([RFC 9101](https://datatracker.ietf.org/doc/html/rfc9101))**: confidential request parameters in the front channel and by reference
@@ -23,7 +23,7 @@
 
 ✏️ **Improvements**
 - Secure-by-default: Implicit Flow is now opt-in, and Dynamic Client Registration requires an Initial Access Token ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591))
-- Token-class confusion defense via opt-in token-type pinning ([RFC 8725](https://datatracker.ietf.org/doc/html/rfc8725)), JWS key pinned to its declared algorithm ([RFC 8725 §3.1](https://datatracker.ietf.org/doc/html/rfc8725)), enforced HMAC key length ([RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518))
+- Token-class confusion defense via opt-in token-type pinning ([RFC 8725](https://datatracker.ietf.org/doc/html/rfc8725)), JWS key pinned to its declared algorithm ([RFC 8725 Section 3.1](https://datatracker.ietf.org/doc/html/rfc8725)), enforced HMAC key length ([RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518))
 - Authorization-response issuer parameter ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207)) advertised in discovery
 
 ## Implemented Standards

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.3</PackageReleaseNotes>
+    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 


### PR DESCRIPTION
**Closes #478.**

The dev-build summary printed a literal `2.3.0-dev.*` next to a package the same job had just built as `2.4.0-dev.0.469`. That line is not a comment a reader can discount - it is an instruction, printed on every push to develop, and an integrator who follows it floats a range whose last publication was months ago.

The failure has no error in it. The range still resolves, to the newest build that line ever had; restore succeeds, the build stays green, and the version simply never moves again.

## What changed

The range is derived from the version in hand, so the two cannot disagree:

```sh
case "$VERSION" in
  *-dev.*)
    LINE="${VERSION%%-*}"
    echo "Consumers floating \`${LINE%.*}.0-dev.*\` will pick this up on next \`dotnet restore\`."
    ;;
esac
```

Only for a dev build. A tagged pre-release reaches that step with no dev identifier, and a sentence about floating would be advice about a line it is not on.

Driven across every shape before shipping: `2.4.0-dev.0.469` and `2.4.0-dev.0.5` produce `2.4.0-dev.*`; `2.10.0-dev.0.1` produces `2.10.0-dev.*`; `3.0.0-dev.0.7` produces `3.0.0-dev.*`; `2.4.0-beta1` and `2.4.0` produce nothing. The first of those is the version this repository actually builds today, read off the assembly rather than assumed.

The four prose sites move to 2.4 and now say what they are - illustrations of `MinVerMinimumMajorMinor`, which is the one place that decides the line. The release workflow's input example moves too.

## Not changed, and worth a decision

`README.md` says "Version 2.3 (Latest)" and links to the v2.3 release notes; the two package READMEs say "What's New in Version 2.3". Those describe what a consumer can install today, and 2.3 still is that. They belong to the release itself rather than to this fix.

## Verification

`actionlint` clean with `shellcheck` on PATH, and `lint-no-inline-secrets.py` clean across all seven workflows.
