### PR TITLE
Declare on every SSF route the statuses it answers

### DIFF
--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -273,12 +273,19 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         WarnIfOutsideTheCaepProfile(endpoints.ServiceProvider, options);
         var advertisedPrefix = AdvertisedPrefixOf(endpointOptions);
 
-        return endpoints.MapGet(
+        // Answers 200 and only 200: it takes no parameter to get wrong and no credentials to lack -
+        // discovery has to work before a receiver has any. Declared all the same, because an
+        // undeclared status is INFERRED into the document rather than left out, and an inference that
+        // happens to be right is indistinguishable from one that is not.
+        var document = endpoints.MapGet(
             endpointOptions.ConfigurationDocumentRoute.HasValue
                 ? endpointOptions.ConfigurationDocumentRoute.Value
                 : TransmitterConfiguration.WellKnownAddress(issuer).AbsolutePath,
             (SharedSignalsTransmitterOptions current, PollEndpointLocator pollEndpoints) =>
                 Results.Json(ConfigurationDocumentOf(current, pollEndpoints, advertisedPrefix)));
+
+        document.AnswersWithBody<TransmitterConfiguration>(StatusCodes.Status200OK);
+        return document;
     }
 
     /// <summary>

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Net.Mime;
 using System.Text.Json.Nodes;
 
 namespace Abblix.SharedSignals.MinimalApi;
@@ -127,17 +128,89 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         // stand in this place asserted the bound without its condition.
         group.AddEndpointFilter(EnforceScopeAsync);
 
-        group.MapPost(Routes.Stream, CreateStreamAsync).RequiresScope(SsfScopes.Manage);
-        group.MapGet(Routes.Stream, GetStreamsAsync).RequiresScope(SsfScopes.Read);
-        group.MapPatch(Routes.Stream, UpdateStreamAsync).RequiresScope(SsfScopes.Manage);
-        group.MapPut(Routes.Stream, ReplaceStreamAsync).RequiresScope(SsfScopes.Manage);
-        group.MapDelete(Routes.Stream, DeleteStreamAsync).RequiresScope(SsfScopes.Manage);
-        group.MapGet(Routes.Status, GetStatusAsync).RequiresScope(SsfScopes.Read);
-        group.MapPost(Routes.Status, UpdateStatusAsync).RequiresScope(SsfScopes.Manage);
-        group.MapPost(Routes.AddSubject, AddSubjectAsync).RequiresScope(SsfScopes.Manage);
-        group.MapPost(Routes.RemoveSubject, RemoveSubjectAsync).RequiresScope(SsfScopes.Manage);
-        group.MapPost(Routes.Verify, RequestVerificationAsync).RequiresScope(SsfScopes.Manage);
-        group.MapPost($"{Routes.Poll}/{{streamId}}", PollAsync).RequiresScope(SsfScopes.Read);
+        // The two refusals that belong to the GROUP rather than to any handler: 401 where nothing named
+        // the caller, 403 where the caller was named and its token carries neither scope the route
+        // needs. Declared once here, so a route added later inherits them instead of restating them.
+        group.Answers(StatusCodes.Status401Unauthorized, StatusCodes.Status403Forbidden);
+
+        group.MapPost(Routes.Stream, CreateStreamAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers<StreamConfiguration>(StatusCodes.Status201Created)
+            .Answers(StatusCodes.Status400BadRequest, StatusCodes.Status409Conflict);
+
+        // The read is the one route whose success carries two shapes: the configuration when
+        // "stream_id" names a stream, an array of them when it names none (SSF 1.0 Section 8.1.1.2).
+        // A response type is one type, so this declares the status without one rather than picking
+        // the half that would make a generated client wrong on the other.
+        group.MapGet(Routes.Stream, GetStreamsAsync)
+            .RequiresScope(SsfScopes.Read)
+            .Answers(StatusCodes.Status200OK, StatusCodes.Status404NotFound);
+
+        group.MapPatch(Routes.Stream, UpdateStreamAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers<StreamConfiguration>(StatusCodes.Status200OK)
+            .Answers(
+                StatusCodes.Status202Accepted,
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status404NotFound);
+
+        group.MapPut(Routes.Stream, ReplaceStreamAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers<StreamConfiguration>(StatusCodes.Status200OK)
+            .Answers(
+                StatusCodes.Status202Accepted,
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status404NotFound);
+
+        group.MapDelete(Routes.Stream, DeleteStreamAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers(
+                StatusCodes.Status204NoContent,
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status404NotFound);
+
+        group.MapGet(Routes.Status, GetStatusAsync)
+            .RequiresScope(SsfScopes.Read)
+            .Answers<StreamStatus>(StatusCodes.Status200OK)
+            .Answers(StatusCodes.Status400BadRequest, StatusCodes.Status404NotFound);
+
+        group.MapPost(Routes.Status, UpdateStatusAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers<StreamStatus>(StatusCodes.Status200OK)
+            .Answers(
+                StatusCodes.Status202Accepted,
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status404NotFound);
+
+        // Adding a subject answers 200 with no body (SSF 1.0 Section 8.1.3.2), so the success is
+        // declared as a status rather than as a shape.
+        group.MapPost(Routes.AddSubject, AddSubjectAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers(
+                StatusCodes.Status200OK,
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status409Conflict);
+
+        group.MapPost(Routes.RemoveSubject, RemoveSubjectAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers(
+                StatusCodes.Status204NoContent,
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status409Conflict);
+
+        group.MapPost(Routes.Verify, RequestVerificationAsync)
+            .RequiresScope(SsfScopes.Manage)
+            .Answers(
+                StatusCodes.Status204NoContent,
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status409Conflict,
+                StatusCodes.Status429TooManyRequests);
+
+        group.MapPost($"{Routes.Poll}/{{streamId}}", PollAsync)
+            .RequiresScope(SsfScopes.Read)
+            .Answers<PollResponse>(StatusCodes.Status200OK)
+            .Answers(StatusCodes.Status404NotFound);
 
         // Said out loud because a stream STORES its poll address: the transmitter mints it at create time
         // and a receiver polls it for as long as the stream lives, so an address that does not lead back
@@ -629,9 +702,41 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// <summary>
     /// Records which scope a route requires, so the filter below can read it back off the endpoint.
     /// </summary>
-    private static void RequiresScope<TBuilder>(this TBuilder builder, string scope)
+    private static TBuilder RequiresScope<TBuilder>(this TBuilder builder, string scope)
         where TBuilder : IEndpointConventionBuilder
-        => builder.WithMetadata(new RequiredScope(scope));
+    {
+        builder.WithMetadata(new RequiredScope(scope));
+        return builder;
+    }
+
+    /// <summary>
+    /// Records the statuses a route answers, so a client generated from this surface has a branch for
+    /// every answer it can meet and none for an answer it cannot.
+    /// </summary>
+    /// <remarks>
+    /// Bodiless on purpose: the Stream Management API defines no error body - SSF 1.0 Section 8.1 gives
+    /// its outcomes as status codes and nothing else - so a refusal carries its explanation in the
+    /// <c>WWW-Authenticate</c> challenge. The overload taking a type is for the successes that do carry
+    /// one.
+    /// </remarks>
+    private static void Answers<TBuilder>(this TBuilder builder, params int[] statusCodes)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        foreach (var statusCode in statusCodes)
+        {
+            builder.WithMetadata(new ProducesResponseTypeMetadata(statusCode));
+        }
+    }
+
+    /// <summary>
+    /// Records a status whose response carries a body, and the type of that body.
+    /// </summary>
+    private static RouteHandlerBuilder Answers<TBody>(this RouteHandlerBuilder builder, int statusCode)
+    {
+        builder.WithMetadata(new ProducesResponseTypeMetadata(
+            statusCode, typeof(TBody), [MediaTypeNames.Application.Json]));
+        return builder;
+    }
 
     private sealed record RequiredScope(string Scope);
 

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -135,8 +135,11 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
 
         group.MapPost(Routes.Stream, CreateStreamAsync)
             .RequiresScope(SsfScopes.Manage)
-            .Answers<StreamConfiguration>(StatusCodes.Status201Created)
-            .Answers(StatusCodes.Status400BadRequest, StatusCodes.Status409Conflict);
+            .AnswersWithBody<StreamConfiguration>(StatusCodes.Status201Created)
+            .Answers(
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status409Conflict,
+                StatusCodes.Status415UnsupportedMediaType);
 
         // The read is the one route whose success carries two shapes: the configuration when
         // "stream_id" names a stream, an array of them when it names none (SSF 1.0 Section 8.1.1.2).
@@ -148,19 +151,21 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
 
         group.MapPatch(Routes.Stream, UpdateStreamAsync)
             .RequiresScope(SsfScopes.Manage)
-            .Answers<StreamConfiguration>(StatusCodes.Status200OK)
+            .AnswersWithBody<StreamConfiguration>(StatusCodes.Status200OK)
             .Answers(
                 StatusCodes.Status202Accepted,
                 StatusCodes.Status400BadRequest,
-                StatusCodes.Status404NotFound);
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status415UnsupportedMediaType);
 
         group.MapPut(Routes.Stream, ReplaceStreamAsync)
             .RequiresScope(SsfScopes.Manage)
-            .Answers<StreamConfiguration>(StatusCodes.Status200OK)
+            .AnswersWithBody<StreamConfiguration>(StatusCodes.Status200OK)
             .Answers(
                 StatusCodes.Status202Accepted,
                 StatusCodes.Status400BadRequest,
-                StatusCodes.Status404NotFound);
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status415UnsupportedMediaType);
 
         group.MapDelete(Routes.Stream, DeleteStreamAsync)
             .RequiresScope(SsfScopes.Manage)
@@ -171,16 +176,17 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
 
         group.MapGet(Routes.Status, GetStatusAsync)
             .RequiresScope(SsfScopes.Read)
-            .Answers<StreamStatus>(StatusCodes.Status200OK)
+            .AnswersWithBody<StreamStatus>(StatusCodes.Status200OK)
             .Answers(StatusCodes.Status400BadRequest, StatusCodes.Status404NotFound);
 
         group.MapPost(Routes.Status, UpdateStatusAsync)
             .RequiresScope(SsfScopes.Manage)
-            .Answers<StreamStatus>(StatusCodes.Status200OK)
+            .AnswersWithBody<StreamStatus>(StatusCodes.Status200OK)
             .Answers(
                 StatusCodes.Status202Accepted,
                 StatusCodes.Status400BadRequest,
-                StatusCodes.Status404NotFound);
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status415UnsupportedMediaType);
 
         // Adding a subject answers 200 with no body (SSF 1.0 Section 8.1.3.2), so the success is
         // declared as a status rather than as a shape.
@@ -190,27 +196,35 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
                 StatusCodes.Status200OK,
                 StatusCodes.Status400BadRequest,
                 StatusCodes.Status404NotFound,
-                StatusCodes.Status409Conflict);
+                StatusCodes.Status409Conflict,
+                StatusCodes.Status415UnsupportedMediaType);
 
         group.MapPost(Routes.RemoveSubject, RemoveSubjectAsync)
             .RequiresScope(SsfScopes.Manage)
             .Answers(
                 StatusCodes.Status204NoContent,
+                StatusCodes.Status400BadRequest,
                 StatusCodes.Status404NotFound,
-                StatusCodes.Status409Conflict);
+                StatusCodes.Status409Conflict,
+                StatusCodes.Status415UnsupportedMediaType);
 
         group.MapPost(Routes.Verify, RequestVerificationAsync)
             .RequiresScope(SsfScopes.Manage)
             .Answers(
                 StatusCodes.Status204NoContent,
+                StatusCodes.Status400BadRequest,
                 StatusCodes.Status404NotFound,
                 StatusCodes.Status409Conflict,
+                StatusCodes.Status415UnsupportedMediaType,
                 StatusCodes.Status429TooManyRequests);
 
         group.MapPost($"{Routes.Poll}/{{streamId}}", PollAsync)
             .RequiresScope(SsfScopes.Read)
-            .Answers<PollResponse>(StatusCodes.Status200OK)
-            .Answers(StatusCodes.Status404NotFound);
+            .AnswersWithBody<PollResponse>(StatusCodes.Status200OK)
+            .Answers(
+                StatusCodes.Status400BadRequest,
+                StatusCodes.Status404NotFound,
+                StatusCodes.Status415UnsupportedMediaType);
 
         // Said out loud because a stream STORES its poll address: the transmitter mints it at create time
         // and a receiver polls it for as long as the stream lives, so an address that does not lead back
@@ -715,23 +729,35 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// </summary>
     /// <remarks>
     /// Bodiless on purpose: the Stream Management API defines no error body - SSF 1.0 Section 8.1 gives
-    /// its outcomes as status codes and nothing else - so a refusal carries its explanation in the
-    /// <c>WWW-Authenticate</c> challenge. The overload taking a type is for the successes that do carry
-    /// one.
+    /// its outcomes as status codes and nothing else. <see cref="AnswersWithBody{TBody}"/> is for the
+    /// successes that do carry one.
+    /// <para>
+    /// Only THREE of the refusals say anything beyond their status. 400, 401 and 403 are built as a
+    /// challenge and carry a <c>WWW-Authenticate</c> line naming the reason; 202, 404, 409 and 429 go
+    /// through <see cref="Render{TBody}"/> as a bare status, and the description their
+    /// <c>ManagementResult</c> carried is dropped there - it exists for the operator's logs, not for
+    /// the wire. So a receiver diagnosing one of those four has the status and nothing else.
+    /// </para>
     /// </remarks>
     private static void Answers<TBuilder>(this TBuilder builder, params int[] statusCodes)
         where TBuilder : IEndpointConventionBuilder
     {
         foreach (var statusCode in statusCodes)
         {
-            builder.WithMetadata(new ProducesResponseTypeMetadata(statusCode));
+            // typeof(void), not the parameterless form. A response type whose Type is null is
+            // DISCARDED by the API description pipeline every OpenAPI generator reads, and the
+            // operation then falls back to an inferred 200 - so the declaration reaches the endpoint,
+            // reads correct at the call site, and publishes nothing. void is how the framework's own
+            // Produces(int) says "this status carries no body".
+            builder.WithMetadata(new ProducesResponseTypeMetadata(statusCode, typeof(void)));
         }
     }
 
     /// <summary>
     /// Records a status whose response carries a body, and the type of that body.
     /// </summary>
-    private static RouteHandlerBuilder Answers<TBody>(this RouteHandlerBuilder builder, int statusCode)
+    private static RouteHandlerBuilder AnswersWithBody<TBody>(
+        this RouteHandlerBuilder builder, int statusCode)
     {
         builder.WithMetadata(new ProducesResponseTypeMetadata(
             statusCode, typeof(TBody), [MediaTypeNames.Application.Json]));

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -732,11 +732,19 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// its outcomes as status codes and nothing else. <see cref="AnswersWithBody{TBody}"/> is for the
     /// successes that do carry one.
     /// <para>
-    /// Only THREE of the refusals say anything beyond their status. 400, 401 and 403 are built as a
-    /// challenge and carry a <c>WWW-Authenticate</c> line naming the reason; 202, 404, 409 and 429 go
-    /// through <see cref="Render{TBody}"/> as a bare status, and the description their
-    /// <c>ManagementResult</c> carried is dropped there - it exists for the operator's logs, not for
-    /// the wire. So a receiver diagnosing one of those four has the status and nothing else.
+    /// A refusal says something beyond its status exactly when it is built as a
+    /// <see cref="ChallengeResult"/>, which carries a <c>WWW-Authenticate</c> line naming the reason.
+    /// Three places build one: <see cref="Unauthenticated"/>, <see cref="EnforceScopeAsync"/> and
+    /// <see cref="MissingRequiredParameter"/>. Everything else is a bare status - anything rendered by
+    /// <see cref="Render{TBody}"/>, whose <c>ManagementResult</c> description is dropped there because
+    /// it exists for the operator's logs rather than for the wire, and the framework's own refusals
+    /// besides.
+    /// </para>
+    /// <para>
+    /// Said as a property rather than as a list of codes on purpose: 400 is on BOTH sides of it. The
+    /// one for a required parameter that names nothing is a challenge, and the one for a delivery
+    /// method this transmitter cannot serve is bare, so any enumeration by status code is wrong about
+    /// one of them whichever side it puts 400 on.
     /// </para>
     /// </remarks>
     private static void Answers<TBuilder>(this TBuilder builder, params int[] statusCodes)

--- a/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
@@ -302,6 +302,8 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         await Record("DELETE", StreamRoute, "/ssf/stream");
         await Record("DELETE", StreamRoute, $"/ssf/stream?stream_id={_streamId}");
 
+        await Record("GET", DocumentRoute, DocumentRoute);
+
         answers.AddRange(await DriveEveryRouteAsync(receiverId: null));
         answers.AddRange(await DriveEveryRouteAsync(receiverId: _ => Receiver, grantedScopes: _ => []));
 
@@ -349,6 +351,7 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
     private const string RemoveSubjectRoute = "/ssf/subjects:remove";
     private const string VerifyRoute = "/ssf/verify";
     private const string PollRoute = "/ssf/poll/{streamId}";
+    private const string DocumentRoute = "/.well-known/ssf-configuration";
 
     private string _streamId = string.Empty;
 
@@ -383,6 +386,12 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         ("POST", RemoveSubjectRoute),
         ("POST", VerifyRoute),
         ("POST", PollRoute),
+
+        // Mapped by the same call and deliberately OUTSIDE the group, because discovery must answer
+        // before a receiver has credentials. In scope here for exactly that reason: a route excused
+        // from the comparison is a route whose document nobody checks, and this one used to publish an
+        // inferred 200 while the eleven beside it were being made to state theirs.
+        ("GET", DocumentRoute),
     ];
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
@@ -51,6 +51,12 @@ namespace Abblix.SharedSignals.E2E.Tests;
 /// named exemption is where a declaration nobody drives goes to live.
 /// </para>
 /// <para>
+/// One framework status is outside all of this and stays there: 405 to a wrong method, which every
+/// management path answers. It belongs to no route, because no endpoint matched - which is also why an
+/// OpenAPI document has no operation to declare it on. That is a category exemption like the one this
+/// file refuses elsewhere, so it is written down rather than left to be noticed.
+/// </para>
+/// <para>
 /// The statuses the FRAMEWORK answers are driven too - 415 to a wrong media type, 400 to a body that
 /// does not bind - rather than left out as "not this package's". A receiver meets them on these routes,
 /// so its client needs a branch for them whoever produced them, and the moment they are excused by
@@ -110,6 +116,17 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
                 disagreements.Add(
                     $"{method} {pattern} declares {string.Join(", ", swallowed)} and publishes "
                         + $"{string.Join(", ", published.Order())}");
+            }
+
+            // And the other direction, which is what the original defect actually looked like: an
+            // operation publishing a status nobody declared, INFERRED by the pipeline because the
+            // declarations it was given were thrown away. Unreachable today only because every route
+            // here publishes something, and that is a property of the group rather than of this check.
+            var invented = published.Except(declared).Order().ToList();
+            if (invented.Count > 0)
+            {
+                disagreements.Add(
+                    $"{method} {pattern} publishes {string.Join(", ", invented)} and declares no such thing");
             }
 
             var undeclared = sent.Except(declared).Order().ToList();
@@ -255,6 +272,10 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         // What the framework answers before this package's code runs. Driven rather than exempted:
         // a body-bound route answers these to a caller who got the media type or the JSON wrong, and a
         // status a receiver can meet is a status its client needs a branch for, whoever produced it.
+        // Without a stream the poll path collapses to /ssf/poll/, whose answer is a 404 that route
+        // already declares - so the two rows meant for it would vanish with the suite still green.
+        Assert.NotEmpty(_streamId);
+
         foreach (var (method, pattern, path) in BodyBoundRoutes())
         {
             using (var wrongType = new HttpRequestMessage(new HttpMethod(method), path)

--- a/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
@@ -181,93 +181,93 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
 
         // Created, and the identifier every row below names.
         using (var created = await client.PostAsJsonAsync(
-            "/ssf/stream", new { delivery = PushDelivery, events_requested = new[] { SomeEvent } }, ct))
+            StreamRoute, new { delivery = PushDelivery, events_requested = new[] { SomeEvent } }, ct))
         {
-            answers.Add(new Answer("POST", StreamRoute, (int)created.StatusCode));
+            answers.Add(new Answer(HttpMethods.Post, StreamRoute, (int)created.StatusCode));
             var configuration = await created.Content.ReadFromJsonAsync<StreamConfiguration>(ct);
             Assert.NotNull(configuration);
             _streamId = configuration.StreamId;
         }
 
         // A second stream for a receiver this transmitter allows one stream: 409 by policy.
-        await Record("POST", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Post, StreamRoute, StreamRoute,
             new { delivery = PushDelivery, events_requested = new[] { SomeEvent } });
 
         // A delivery method this transmitter does not serve: refused where the proposal is read.
-        await Record("POST", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Post, StreamRoute, StreamRoute,
             new { delivery = new { method = "urn:example:carrier-pigeon" } });
 
-        await Record("GET", StreamRoute, "/ssf/stream");
-        await Record("GET", StreamRoute, "/ssf/stream?stream_id=no-such-stream");
+        await Record(HttpMethods.Get, StreamRoute, StreamRoute);
+        await Record(HttpMethods.Get, StreamRoute, $"{StreamRoute}?stream_id={MissingStream}");
 
-        await Record("PATCH", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Patch, StreamRoute, StreamRoute,
             new { stream_id = _streamId, events_requested = new[] { SomeEvent } });
-        await Record("PATCH", StreamRoute, "/ssf/stream", new { stream_id = "no-such-stream" });
-        await Record("PATCH", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Patch, StreamRoute, StreamRoute, new { stream_id = MissingStream });
+        await Record(HttpMethods.Patch, StreamRoute, StreamRoute,
             new { stream_id = _streamId, delivery = new { method = "urn:example:carrier-pigeon" } });
 
-        await Record("PUT", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Put, StreamRoute, StreamRoute,
             new { stream_id = _streamId, delivery = PushDelivery, events_requested = new[] { SomeEvent } });
-        await Record("PUT", StreamRoute, "/ssf/stream", new { stream_id = "no-such-stream", delivery = PushDelivery });
+        await Record(HttpMethods.Put, StreamRoute, StreamRoute, new { stream_id = MissingStream, delivery = PushDelivery });
 
         // Replace with no delivery at all: a replacement states the whole configuration, so an absent
         // member is a request to serve nothing rather than a member left as it was.
-        await Record("PUT", StreamRoute, "/ssf/stream", new { stream_id = _streamId });
+        await Record(HttpMethods.Put, StreamRoute, StreamRoute, new { stream_id = _streamId });
 
-        await Record("GET", StatusRoute, $"/ssf/status?stream_id={_streamId}");
-        await Record("GET", StatusRoute, "/ssf/status?stream_id=no-such-stream");
-        await Record("GET", StatusRoute, "/ssf/status");
+        await Record(HttpMethods.Get, StatusRoute, $"{StatusRoute}?stream_id={_streamId}");
+        await Record(HttpMethods.Get, StatusRoute, $"{StatusRoute}?stream_id={MissingStream}");
+        await Record(HttpMethods.Get, StatusRoute, StatusRoute);
 
-        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "paused" });
-        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = "no-such-stream", status = "paused" });
-        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "asleep" });
+        await Record(HttpMethods.Post, StatusRoute, StatusRoute, new { stream_id = _streamId, status = "paused" });
+        await Record(HttpMethods.Post, StatusRoute, StatusRoute, new { stream_id = MissingStream, status = "paused" });
+        await Record(HttpMethods.Post, StatusRoute, StatusRoute, new { stream_id = _streamId, status = "asleep" });
 
         // Back to enabled: verification below dispatches an event, and a paused stream is a different
         // question from the one this row asks.
-        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "enabled" });
+        await Record(HttpMethods.Post, StatusRoute, StatusRoute, new { stream_id = _streamId, status = "enabled" });
 
         var subject = new { format = "opaque", id = "subject-1" };
-        await Record("POST", AddSubjectRoute, "/ssf/subjects:add", new { stream_id = _streamId, subject });
-        await Record("POST", AddSubjectRoute, "/ssf/subjects:add",
-            new { stream_id = "no-such-stream", subject });
+        await Record(HttpMethods.Post, AddSubjectRoute, AddSubjectRoute, new { stream_id = _streamId, subject });
+        await Record(HttpMethods.Post, AddSubjectRoute, AddSubjectRoute,
+            new { stream_id = MissingStream, subject });
 
         // A complex subject naming no member agrees with every event, so it is refused where it arrives.
-        await Record("POST", AddSubjectRoute, "/ssf/subjects:add",
+        await Record(HttpMethods.Post, AddSubjectRoute, AddSubjectRoute,
             new { stream_id = _streamId, subject = new { format = "complex" } });
 
-        await Record("POST", RemoveSubjectRoute, "/ssf/subjects:remove", new { stream_id = _streamId, subject });
-        await Record("POST", RemoveSubjectRoute, "/ssf/subjects:remove",
-            new { stream_id = "no-such-stream", subject });
+        await Record(HttpMethods.Post, RemoveSubjectRoute, RemoveSubjectRoute, new { stream_id = _streamId, subject });
+        await Record(HttpMethods.Post, RemoveSubjectRoute, RemoveSubjectRoute,
+            new { stream_id = MissingStream, subject });
 
-        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = "no-such-stream" });
+        await Record(HttpMethods.Post, VerifyRoute, VerifyRoute, new { stream_id = MissingStream });
 
         // Contention on verification is driven FIRST, while the stream has never been verified: once
         // it has, every later request is throttled before it reaches the write, and the answer that
         // needs the lost write becomes unreachable through this route for the rest of the run.
         store.Refuse = true;
-        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = _streamId });
+        await Record(HttpMethods.Post, VerifyRoute, VerifyRoute, new { stream_id = _streamId });
         store.Refuse = false;
 
-        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = _streamId });
+        await Record(HttpMethods.Post, VerifyRoute, VerifyRoute, new { stream_id = _streamId });
 
         // The second request inside the stream's minimum interval is the throttle.
-        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = _streamId });
+        await Record(HttpMethods.Post, VerifyRoute, VerifyRoute, new { stream_id = _streamId });
 
-        await Record("POST", PollRoute, $"/ssf/poll/{_streamId}", new { maxEvents = 1, returnImmediately = true });
-        await Record("POST", PollRoute, "/ssf/poll/no-such-stream", new { maxEvents = 1, returnImmediately = true });
+        await Record(HttpMethods.Post, PollRoute, $"{PollPathPrefix}/{_streamId}", new { maxEvents = 1, returnImmediately = true });
+        await Record(HttpMethods.Post, PollRoute, $"{PollPathPrefix}/{MissingStream}", new { maxEvents = 1, returnImmediately = true });
 
         // From here the store refuses the conditional write, so every path that ends in one reports
         // that nothing was written - as 202 where repeating the call is the way forward, and as 409
         // where the caller is being told someone else is changing the stream.
         store.Refuse = true;
 
-        await Record("PATCH", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Patch, StreamRoute, StreamRoute,
             new { stream_id = _streamId, events_requested = new[] { SomeEvent } });
-        await Record("PUT", StreamRoute, "/ssf/stream",
+        await Record(HttpMethods.Put, StreamRoute, StreamRoute,
             new { stream_id = _streamId, delivery = PushDelivery, events_requested = new[] { SomeEvent } });
-        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "paused" });
-        await Record("POST", AddSubjectRoute, "/ssf/subjects:add", new { stream_id = _streamId, subject });
-        await Record("POST", RemoveSubjectRoute, "/ssf/subjects:remove", new { stream_id = _streamId, subject });
+        await Record(HttpMethods.Post, StatusRoute, StatusRoute, new { stream_id = _streamId, status = "paused" });
+        await Record(HttpMethods.Post, AddSubjectRoute, AddSubjectRoute, new { stream_id = _streamId, subject });
+        await Record(HttpMethods.Post, RemoveSubjectRoute, RemoveSubjectRoute, new { stream_id = _streamId, subject });
 
         store.Refuse = false;
 
@@ -300,11 +300,11 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         }
 
         // Deletion last: every row above needs the stream.
-        await Record("DELETE", StreamRoute, "/ssf/stream?stream_id=no-such-stream");
-        await Record("DELETE", StreamRoute, "/ssf/stream");
-        await Record("DELETE", StreamRoute, $"/ssf/stream?stream_id={_streamId}");
+        await Record(HttpMethods.Delete, StreamRoute, $"{StreamRoute}?stream_id={MissingStream}");
+        await Record(HttpMethods.Delete, StreamRoute, StreamRoute);
+        await Record(HttpMethods.Delete, StreamRoute, $"{StreamRoute}?stream_id={_streamId}");
 
-        await Record("GET", DocumentRoute, DocumentRoute);
+        await Record(HttpMethods.Get, DocumentRoute, DocumentRoute);
 
         answers.AddRange(await DriveEveryRouteAsync(receiverId: null));
         answers.AddRange(await DriveEveryRouteAsync(receiverId: _ => Receiver, grantedScopes: _ => []));
@@ -359,22 +359,26 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
     private const string AddSubjectRoute = "/ssf/subjects:add";
     private const string RemoveSubjectRoute = "/ssf/subjects:remove";
     private const string VerifyRoute = "/ssf/verify";
-    private const string PollRoute = "/ssf/poll/{streamId}";
+    private const string PollRoute = $"{PollPathPrefix}/{{streamId}}";
     private const string DocumentRoute = "/.well-known/ssf-configuration";
+    private const string PollPathPrefix = "/ssf/poll";
+
+    /// <summary>A stream identifier this receiver has none of, so every lookup under it misses.</summary>
+    private const string MissingStream = "no-such-stream";
 
     private string _streamId = string.Empty;
 
     /// <summary>The routes that bind a body, which is where the framework's own refusals live.</summary>
     private List<(string Method, string Pattern, string Path)> BodyBoundRoutes() =>
     [
-        ("POST", StreamRoute, "/ssf/stream"),
-        ("PATCH", StreamRoute, "/ssf/stream"),
-        ("PUT", StreamRoute, "/ssf/stream"),
-        ("POST", StatusRoute, "/ssf/status"),
-        ("POST", AddSubjectRoute, "/ssf/subjects:add"),
-        ("POST", RemoveSubjectRoute, "/ssf/subjects:remove"),
-        ("POST", VerifyRoute, "/ssf/verify"),
-        ("POST", PollRoute, $"/ssf/poll/{_streamId}"),
+        (HttpMethods.Post, StreamRoute, StreamRoute),
+        (HttpMethods.Patch, StreamRoute, StreamRoute),
+        (HttpMethods.Put, StreamRoute, StreamRoute),
+        (HttpMethods.Post, StatusRoute, StatusRoute),
+        (HttpMethods.Post, AddSubjectRoute, AddSubjectRoute),
+        (HttpMethods.Post, RemoveSubjectRoute, RemoveSubjectRoute),
+        (HttpMethods.Post, VerifyRoute, VerifyRoute),
+        (HttpMethods.Post, PollRoute, $"{PollPathPrefix}/{_streamId}"),
     ];
 
     /// <summary>
@@ -384,23 +388,23 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
     /// </summary>
     private static List<(string Method, string Pattern)> MappedRoutes() =>
     [
-        ("POST", StreamRoute),
-        ("GET", StreamRoute),
-        ("PATCH", StreamRoute),
-        ("PUT", StreamRoute),
-        ("DELETE", StreamRoute),
-        ("GET", StatusRoute),
-        ("POST", StatusRoute),
-        ("POST", AddSubjectRoute),
-        ("POST", RemoveSubjectRoute),
-        ("POST", VerifyRoute),
-        ("POST", PollRoute),
+        (HttpMethods.Post, StreamRoute),
+        (HttpMethods.Get, StreamRoute),
+        (HttpMethods.Patch, StreamRoute),
+        (HttpMethods.Put, StreamRoute),
+        (HttpMethods.Delete, StreamRoute),
+        (HttpMethods.Get, StatusRoute),
+        (HttpMethods.Post, StatusRoute),
+        (HttpMethods.Post, AddSubjectRoute),
+        (HttpMethods.Post, RemoveSubjectRoute),
+        (HttpMethods.Post, VerifyRoute),
+        (HttpMethods.Post, PollRoute),
 
         // Mapped by the same call and deliberately OUTSIDE the group, because discovery must answer
         // before a receiver has credentials. In scope here for exactly that reason: a route excused
         // from the comparison is a route whose document nobody checks, and this one used to publish an
         // inferred 200 while the eleven beside it were being made to state theirs.
-        ("GET", DocumentRoute),
+        (HttpMethods.Get, DocumentRoute),
     ];
 
     /// <summary>

--- a/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
@@ -52,7 +52,7 @@ namespace Abblix.SharedSignals.E2E.Tests;
 /// </para>
 /// <para>
 /// One framework status is outside all of this and stays there: 405 to a wrong method, which every
-/// management path answers. It belongs to no route, because no endpoint matched - which is also why an
+/// path on this surface answers. It belongs to no route, because no endpoint matched - which is also why an
 /// OpenAPI document has no operation to declare it on. That is a category exemption like the one this
 /// file refuses elsewhere, so it is written down rather than left to be noticed.
 /// </para>
@@ -88,7 +88,9 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         var answered = await DriveEveryOutcomeAsync();
 
         // A route that answered nothing would satisfy "declared covers answered" while proving no part
-        // of it, so the drive is required to have reached all eleven routes before anything is judged.
+        // of it, so the drive is required to have reached every route in the table below before
+        // anything is judged. No count is written here: the table is what says how many there are, and
+        // a number beside it is a second place to keep in step.
         var routes = MappedRoutes();
         var reached = answered.Select(answer => (answer.Method, answer.Pattern)).ToHashSet();
         Assert.True(
@@ -311,10 +313,16 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
     }
 
     /// <summary>
-    /// One request per route against a host that refuses all of them for the same reason - nobody was
-    /// named, or nobody was granted the scope. Both refusals belong to the group rather than to any
-    /// handler, so they are driven over every route rather than sampled.
+    /// One request per route against a host that names nobody, or grants no scope. Both refusals
+    /// belong to the GROUP rather than to any handler, so they are driven over every route rather than
+    /// sampled.
     /// </summary>
+    /// <remarks>
+    /// Not every route here is refused, and the one that is not is the point of driving all of them.
+    /// The configuration document is mapped outside that group and answers 200 to a caller with no
+    /// identity and no scope - which is what discovery is for, and what would break silently if the
+    /// group ever grew to cover it.
+    /// </remarks>
     private async Task<List<Answer>> DriveEveryRouteAsync(
         Func<HttpContext, string?>? receiverId,
         Func<HttpContext, IReadOnlyCollection<string>>? grantedScopes = null)
@@ -330,7 +338,8 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
             using var request = new HttpRequestMessage(new HttpMethod(method), path);
 
             // A body every bodied route will BIND: a malformed one is refused by the framework before
-            // this package runs, which is a different answer from the one being driven here.
+            // this package runs, which is a different answer from the one being driven here. The
+            // routes that bind no body at all - the reads, and the configuration document - ignore it.
             request.Content = JsonContent.Create(new
             {
                 stream_id = "some-stream",

--- a/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
@@ -7,6 +7,8 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using System.Net;
+using System.Net.Mime;
+using System.Text;
 using System.Net.Http.Json;
 using Abblix.Jwt;
 using Abblix.SecurityEvents.Infrastructure;
@@ -17,6 +19,7 @@ using Abblix.SharedSignals.Transmitter;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,6 +49,12 @@ namespace Abblix.SharedSignals.E2E.Tests;
 /// <see cref="RefusingUpdates"/> is for - a store that takes every call except the write, so the retry
 /// loop ends with nothing written. Without it those answers could only be exempted by name, and a
 /// named exemption is where a declaration nobody drives goes to live.
+/// </para>
+/// <para>
+/// The statuses the FRAMEWORK answers are driven too - 415 to a wrong media type, 400 to a body that
+/// does not bind - rather than left out as "not this package's". A receiver meets them on these routes,
+/// so its client needs a branch for them whoever produced them, and the moment they are excused by
+/// category the excuse covers whatever else falls into it.
 /// </para>
 /// <para>
 /// What the drive cannot do is find a status nobody thought to reach: an answer neither driven nor
@@ -91,6 +100,17 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
                 .ToHashSet();
 
             var declared = DeclaredBy(method, pattern);
+            var published = PublishedBy(method, pattern);
+
+            // Attached and published are two facts. The first is what this file used to check alone,
+            // and it stays green over a declaration the description pipeline throws away.
+            var swallowed = declared.Except(published).Order().ToList();
+            if (swallowed.Count > 0)
+            {
+                disagreements.Add(
+                    $"{method} {pattern} declares {string.Join(", ", swallowed)} and publishes "
+                        + $"{string.Join(", ", published.Order())}");
+            }
 
             var undeclared = sent.Except(declared).Order().ToList();
             if (undeclared.Count > 0)
@@ -232,6 +252,30 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
 
         store.Refuse = false;
 
+        // What the framework answers before this package's code runs. Driven rather than exempted:
+        // a body-bound route answers these to a caller who got the media type or the JSON wrong, and a
+        // status a receiver can meet is a status its client needs a branch for, whoever produced it.
+        foreach (var (method, pattern, path) in BodyBoundRoutes())
+        {
+            using (var wrongType = new HttpRequestMessage(new HttpMethod(method), path)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Text.Plain),
+            })
+            {
+                using var refused = await client.SendAsync(wrongType, ct);
+                answers.Add(new Answer(method, pattern, (int)refused.StatusCode));
+            }
+
+            using (var malformed = new HttpRequestMessage(new HttpMethod(method), path)
+            {
+                Content = new StringContent("{", Encoding.UTF8, MediaTypeNames.Application.Json),
+            })
+            {
+                using var refused = await client.SendAsync(malformed, ct);
+                answers.Add(new Answer(method, pattern, (int)refused.StatusCode));
+            }
+        }
+
         // Deletion last: every row above needs the stream.
         await Record("DELETE", StreamRoute, "/ssf/stream?stream_id=no-such-stream");
         await Record("DELETE", StreamRoute, "/ssf/stream");
@@ -287,6 +331,19 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
 
     private string _streamId = string.Empty;
 
+    /// <summary>The routes that bind a body, which is where the framework's own refusals live.</summary>
+    private List<(string Method, string Pattern, string Path)> BodyBoundRoutes() =>
+    [
+        ("POST", StreamRoute, "/ssf/stream"),
+        ("PATCH", StreamRoute, "/ssf/stream"),
+        ("PUT", StreamRoute, "/ssf/stream"),
+        ("POST", StatusRoute, "/ssf/status"),
+        ("POST", AddSubjectRoute, "/ssf/subjects:add"),
+        ("POST", RemoveSubjectRoute, "/ssf/subjects:remove"),
+        ("POST", VerifyRoute, "/ssf/verify"),
+        ("POST", PollRoute, $"/ssf/poll/{_streamId}"),
+    ];
+
     /// <summary>
     /// The routes this surface maps, as the pair a request is addressed by. Written out rather than
     /// read off the endpoint table, because the table is one of the two things being compared and a
@@ -307,6 +364,33 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         ("POST", PollRoute),
     ];
 
+    /// <summary>
+    /// The statuses a route publishes, taken from the API description the framework builds - which is
+    /// what an OpenAPI document is generated from, and therefore the only place the declaration becomes
+    /// something a client author can see.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT the endpoint's raw metadata. Metadata reaching the endpoint and metadata
+    /// surviving into a document are two facts, and the second is the one the ticket is about: a
+    /// response type the description pipeline discards leaves the endpoint carrying a declaration
+    /// nobody downstream ever reads, which reads exactly like a declaration that works.
+    /// </remarks>
+    private HashSet<int> PublishedBy(string method, string pattern)
+    {
+        var described = _descriptions
+            .SelectMany(group => group.Items)
+            .Where(item =>
+                string.Equals("/" + item.RelativePath?.Split('?')[0], pattern, StringComparison.Ordinal)
+                && string.Equals(item.HttpMethod, method, StringComparison.Ordinal))
+            .ToList();
+
+        // Not described is a failure rather than an empty answer, for the reason DeclaredBy states.
+        Assert.NotEmpty(described);
+
+        return [.. described.SelectMany(item => item.SupportedResponseTypes)
+            .Select(response => response.StatusCode)];
+    }
+
     /// <summary>The statuses a route declares, read back off its own metadata.</summary>
     private HashSet<int> DeclaredBy(string method, string pattern)
     {
@@ -324,6 +408,8 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
 
     private IReadOnlyList<Endpoint> _endpoints = [];
 
+    private IReadOnlyList<ApiDescriptionGroup> _descriptions = [];
+
     private sealed record Answer(string Method, string Pattern, int StatusCode);
 
     private async Task<WebApplication> StartAsync(
@@ -333,6 +419,7 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Logging.ClearProviders();
+        builder.Services.AddEndpointsApiExplorer();
 
         builder.Services.AddSecurityEvents(o =>
             o.SigningKeySource = _ => Task.FromResult<JsonWebKey>(
@@ -363,6 +450,8 @@ public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
         await app.StartAsync();
 
         _endpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints;
+        _descriptions = app.Services
+            .GetRequiredService<IApiDescriptionGroupCollectionProvider>().ApiDescriptionGroups.Items;
         return app;
     }
 

--- a/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/TheSurfaceDeclaresEveryStatusItAnswersTests.cs
@@ -1,0 +1,399 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Net;
+using System.Net.Http.Json;
+using Abblix.Jwt;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.MinimalApi;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Abblix.SharedSignals.E2E.Tests;
+
+/// <summary>
+/// Every status this surface answers is declared by the route that answers it, and every status a
+/// route declares is one this suite has seen it answer.
+/// </summary>
+/// <remarks>
+/// A status sent and not declared, and one declared and never sent, are the same lie read from the two
+/// ends. The first leaves a generated client with no branch for an answer it will meet; the second gives
+/// it a branch nothing reaches, which is then maintained forever on the strength of the document.
+/// <para>
+/// Both halves are asserted, and both are MEASURED rather than read: what a route answers comes from
+/// driving a real request through a real host, and what it declares is read back off the endpoint's own
+/// metadata. Nothing here parses the mapping source, because the mapping is what is under test.
+/// </para>
+/// <para>
+/// The consequence to accept is that this file has to drive every status, including the two that a
+/// route reaches only when its conditional write LOSES: 202 where repeating the call is the way
+/// forward, 409 where the caller is told someone else is changing the stream. That is what
+/// <see cref="RefusingUpdates"/> is for - a store that takes every call except the write, so the retry
+/// loop ends with nothing written. Without it those answers could only be exempted by name, and a
+/// named exemption is where a declaration nobody drives goes to live.
+/// </para>
+/// <para>
+/// What the drive cannot do is find a status nobody thought to reach: an answer neither driven nor
+/// declared agrees with itself. Verification is the case that proves the cost - its lost-write answer
+/// is reachable only BEFORE the stream has ever been verified, because afterwards the throttle refuses
+/// first, so the row that reaches it has to come before the two that verify normally.
+/// </para>
+/// </remarks>
+public sealed class TheSurfaceDeclaresEveryStatusItAnswersTests
+{
+    private const string Issuer = "https://transmitter.example";
+    private const string SomeEvent = "https://tenant.example.com/events/membership-changed";
+    private const string Receiver = "receiver-1";
+    private const string PushMethod = "urn:ietf:rfc:8935";
+
+    private static readonly object PushDelivery = new
+    {
+        method = PushMethod,
+        endpoint_url = "https://receiver.example/events",
+    };
+
+    [Fact]
+    public async Task EveryRoute_DeclaresExactlyTheStatusesItAnswers()
+    {
+        var answered = await DriveEveryOutcomeAsync();
+
+        // A route that answered nothing would satisfy "declared covers answered" while proving no part
+        // of it, so the drive is required to have reached all eleven routes before anything is judged.
+        var routes = MappedRoutes();
+        var reached = answered.Select(answer => (answer.Method, answer.Pattern)).ToHashSet();
+        Assert.True(
+            routes.All(reached.Contains),
+            "the drive never reached: "
+                + string.Join(", ", routes.Where(route => !reached.Contains(route))
+                    .Select(route => $"{route.Method} {route.Pattern}")));
+
+        var disagreements = new List<string>();
+        foreach (var (method, pattern) in routes)
+        {
+            var sent = answered
+                .Where(answer => answer.Method == method && answer.Pattern == pattern)
+                .Select(answer => answer.StatusCode)
+                .ToHashSet();
+
+            var declared = DeclaredBy(method, pattern);
+
+            var undeclared = sent.Except(declared).Order().ToList();
+            if (undeclared.Count > 0)
+            {
+                disagreements.Add(
+                    $"{method} {pattern} answers {string.Join(", ", undeclared)} without declaring it");
+            }
+
+            var unsent = declared.Except(sent).Order().ToList();
+            if (unsent.Count > 0)
+            {
+                disagreements.Add(
+                    $"{method} {pattern} declares {string.Join(", ", unsent)} and this suite never saw it");
+            }
+        }
+
+        Assert.True(
+            disagreements.Count == 0,
+            $"routes {routes.Count}, answers driven {answered.Count}, disagreements "
+                + $"{disagreements.Count}:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, disagreements));
+    }
+
+    /// <summary>
+    /// Drives one request per outcome each route can produce, and records the status that came back.
+    /// The expectation is not asserted here on purpose: what a route answers is what this method
+    /// MEASURES, and an assertion would turn a wrong guess of mine into a failure about the surface.
+    /// </summary>
+    private async Task<List<Answer>> DriveEveryOutcomeAsync()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var answers = new List<Answer>();
+
+        await using var host = await StartAsync(_ => Receiver);
+        var store = Assert.IsType<RefusingUpdates>(host.Services.GetRequiredService<IStreamStore>());
+        var client = host.GetTestClient();
+
+        async Task Record(string method, string pattern, string path, object? body = null)
+        {
+            using var request = new HttpRequestMessage(new HttpMethod(method), path);
+            if (body is not null)
+            {
+                request.Content = JsonContent.Create(body);
+            }
+
+            using var response = await client.SendAsync(request, ct);
+            answers.Add(new Answer(method, pattern, (int)response.StatusCode));
+        }
+
+        // Created, and the identifier every row below names.
+        using (var created = await client.PostAsJsonAsync(
+            "/ssf/stream", new { delivery = PushDelivery, events_requested = new[] { SomeEvent } }, ct))
+        {
+            answers.Add(new Answer("POST", StreamRoute, (int)created.StatusCode));
+            var configuration = await created.Content.ReadFromJsonAsync<StreamConfiguration>(ct);
+            Assert.NotNull(configuration);
+            _streamId = configuration.StreamId;
+        }
+
+        // A second stream for a receiver this transmitter allows one stream: 409 by policy.
+        await Record("POST", StreamRoute, "/ssf/stream",
+            new { delivery = PushDelivery, events_requested = new[] { SomeEvent } });
+
+        // A delivery method this transmitter does not serve: refused where the proposal is read.
+        await Record("POST", StreamRoute, "/ssf/stream",
+            new { delivery = new { method = "urn:example:carrier-pigeon" } });
+
+        await Record("GET", StreamRoute, "/ssf/stream");
+        await Record("GET", StreamRoute, "/ssf/stream?stream_id=no-such-stream");
+
+        await Record("PATCH", StreamRoute, "/ssf/stream",
+            new { stream_id = _streamId, events_requested = new[] { SomeEvent } });
+        await Record("PATCH", StreamRoute, "/ssf/stream", new { stream_id = "no-such-stream" });
+        await Record("PATCH", StreamRoute, "/ssf/stream",
+            new { stream_id = _streamId, delivery = new { method = "urn:example:carrier-pigeon" } });
+
+        await Record("PUT", StreamRoute, "/ssf/stream",
+            new { stream_id = _streamId, delivery = PushDelivery, events_requested = new[] { SomeEvent } });
+        await Record("PUT", StreamRoute, "/ssf/stream", new { stream_id = "no-such-stream", delivery = PushDelivery });
+
+        // Replace with no delivery at all: a replacement states the whole configuration, so an absent
+        // member is a request to serve nothing rather than a member left as it was.
+        await Record("PUT", StreamRoute, "/ssf/stream", new { stream_id = _streamId });
+
+        await Record("GET", StatusRoute, $"/ssf/status?stream_id={_streamId}");
+        await Record("GET", StatusRoute, "/ssf/status?stream_id=no-such-stream");
+        await Record("GET", StatusRoute, "/ssf/status");
+
+        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "paused" });
+        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = "no-such-stream", status = "paused" });
+        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "asleep" });
+
+        // Back to enabled: verification below dispatches an event, and a paused stream is a different
+        // question from the one this row asks.
+        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "enabled" });
+
+        var subject = new { format = "opaque", id = "subject-1" };
+        await Record("POST", AddSubjectRoute, "/ssf/subjects:add", new { stream_id = _streamId, subject });
+        await Record("POST", AddSubjectRoute, "/ssf/subjects:add",
+            new { stream_id = "no-such-stream", subject });
+
+        // A complex subject naming no member agrees with every event, so it is refused where it arrives.
+        await Record("POST", AddSubjectRoute, "/ssf/subjects:add",
+            new { stream_id = _streamId, subject = new { format = "complex" } });
+
+        await Record("POST", RemoveSubjectRoute, "/ssf/subjects:remove", new { stream_id = _streamId, subject });
+        await Record("POST", RemoveSubjectRoute, "/ssf/subjects:remove",
+            new { stream_id = "no-such-stream", subject });
+
+        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = "no-such-stream" });
+
+        // Contention on verification is driven FIRST, while the stream has never been verified: once
+        // it has, every later request is throttled before it reaches the write, and the answer that
+        // needs the lost write becomes unreachable through this route for the rest of the run.
+        store.Refuse = true;
+        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = _streamId });
+        store.Refuse = false;
+
+        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = _streamId });
+
+        // The second request inside the stream's minimum interval is the throttle.
+        await Record("POST", VerifyRoute, "/ssf/verify", new { stream_id = _streamId });
+
+        await Record("POST", PollRoute, $"/ssf/poll/{_streamId}", new { maxEvents = 1, returnImmediately = true });
+        await Record("POST", PollRoute, "/ssf/poll/no-such-stream", new { maxEvents = 1, returnImmediately = true });
+
+        // From here the store refuses the conditional write, so every path that ends in one reports
+        // that nothing was written - as 202 where repeating the call is the way forward, and as 409
+        // where the caller is being told someone else is changing the stream.
+        store.Refuse = true;
+
+        await Record("PATCH", StreamRoute, "/ssf/stream",
+            new { stream_id = _streamId, events_requested = new[] { SomeEvent } });
+        await Record("PUT", StreamRoute, "/ssf/stream",
+            new { stream_id = _streamId, delivery = PushDelivery, events_requested = new[] { SomeEvent } });
+        await Record("POST", StatusRoute, "/ssf/status", new { stream_id = _streamId, status = "paused" });
+        await Record("POST", AddSubjectRoute, "/ssf/subjects:add", new { stream_id = _streamId, subject });
+        await Record("POST", RemoveSubjectRoute, "/ssf/subjects:remove", new { stream_id = _streamId, subject });
+
+        store.Refuse = false;
+
+        // Deletion last: every row above needs the stream.
+        await Record("DELETE", StreamRoute, "/ssf/stream?stream_id=no-such-stream");
+        await Record("DELETE", StreamRoute, "/ssf/stream");
+        await Record("DELETE", StreamRoute, $"/ssf/stream?stream_id={_streamId}");
+
+        answers.AddRange(await DriveEveryRouteAsync(receiverId: null));
+        answers.AddRange(await DriveEveryRouteAsync(receiverId: _ => Receiver, grantedScopes: _ => []));
+
+        return answers;
+    }
+
+    /// <summary>
+    /// One request per route against a host that refuses all of them for the same reason - nobody was
+    /// named, or nobody was granted the scope. Both refusals belong to the group rather than to any
+    /// handler, so they are driven over every route rather than sampled.
+    /// </summary>
+    private async Task<List<Answer>> DriveEveryRouteAsync(
+        Func<HttpContext, string?>? receiverId,
+        Func<HttpContext, IReadOnlyCollection<string>>? grantedScopes = null)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var host = await StartAsync(receiverId, grantedScopes);
+        var client = host.GetTestClient();
+        var answers = new List<Answer>();
+
+        foreach (var (method, pattern) in MappedRoutes())
+        {
+            var path = pattern.Replace("{streamId}", "some-stream", StringComparison.Ordinal);
+            using var request = new HttpRequestMessage(new HttpMethod(method), path);
+
+            // A body every bodied route will BIND: a malformed one is refused by the framework before
+            // this package runs, which is a different answer from the one being driven here.
+            request.Content = JsonContent.Create(new
+            {
+                stream_id = "some-stream",
+                status = "enabled",
+                subject = new { format = "opaque", id = "subject-1" },
+            });
+
+            using var response = await client.SendAsync(request, ct);
+            answers.Add(new Answer(method, pattern, (int)response.StatusCode));
+        }
+
+        return answers;
+    }
+
+    private const string StreamRoute = "/ssf/stream";
+    private const string StatusRoute = "/ssf/status";
+    private const string AddSubjectRoute = "/ssf/subjects:add";
+    private const string RemoveSubjectRoute = "/ssf/subjects:remove";
+    private const string VerifyRoute = "/ssf/verify";
+    private const string PollRoute = "/ssf/poll/{streamId}";
+
+    private string _streamId = string.Empty;
+
+    /// <summary>
+    /// The routes this surface maps, as the pair a request is addressed by. Written out rather than
+    /// read off the endpoint table, because the table is one of the two things being compared and a
+    /// route both sides derive from it cannot disagree with itself.
+    /// </summary>
+    private static List<(string Method, string Pattern)> MappedRoutes() =>
+    [
+        ("POST", StreamRoute),
+        ("GET", StreamRoute),
+        ("PATCH", StreamRoute),
+        ("PUT", StreamRoute),
+        ("DELETE", StreamRoute),
+        ("GET", StatusRoute),
+        ("POST", StatusRoute),
+        ("POST", AddSubjectRoute),
+        ("POST", RemoveSubjectRoute),
+        ("POST", VerifyRoute),
+        ("POST", PollRoute),
+    ];
+
+    /// <summary>The statuses a route declares, read back off its own metadata.</summary>
+    private HashSet<int> DeclaredBy(string method, string pattern)
+    {
+        var endpoint = _endpoints.OfType<RouteEndpoint>().FirstOrDefault(candidate =>
+            string.Equals(candidate.RoutePattern.RawText, pattern, StringComparison.Ordinal)
+            && candidate.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods
+                .Contains(method, StringComparer.Ordinal) is true);
+
+        // Not found is a failure rather than an empty answer: an empty set would satisfy the
+        // "answers what it declares" half exactly as a correct declaration does.
+        Assert.NotNull(endpoint);
+
+        return [.. endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().Select(one => one.StatusCode)];
+    }
+
+    private IReadOnlyList<Endpoint> _endpoints = [];
+
+    private sealed record Answer(string Method, string Pattern, int StatusCode);
+
+    private async Task<WebApplication> StartAsync(
+        Func<HttpContext, string?>? receiverId = null,
+        Func<HttpContext, IReadOnlyCollection<string>>? grantedScopes = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddSecurityEvents(o =>
+            o.SigningKeySource = _ => Task.FromResult<JsonWebKey>(
+                JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)));
+
+        builder.Services.AddSharedSignalsTransmitter(new SharedSignalsTransmitterOptions
+        {
+            Issuer = Issuer,
+            EventsSupported = [SomeEvent],
+            JwksUri = new Uri($"{Issuer}/jwks"),
+
+            // Long enough that the second verification request inside one test run is throttled by
+            // the clock rather than by luck.
+            MinVerificationInterval = TimeSpan.FromHours(1),
+        });
+
+        builder.Services.Replace(ServiceDescriptor.Singleton<IStreamStore>(
+            _ => new RefusingUpdates(new InMemoryStreamStore())));
+
+        builder.Services.AddSingleton(new SharedSignalsEndpointOptions
+        {
+            ReceiverIdSelector = receiverId ?? (_ => null),
+            GrantedScopesSelector = grantedScopes,
+        });
+
+        var app = builder.Build();
+        app.MapSharedSignalsTransmitterEndpoints();
+        await app.StartAsync();
+
+        _endpoints = app.Services.GetRequiredService<EndpointDataSource>().Endpoints;
+        return app;
+    }
+
+    /// <summary>
+    /// A store that takes every call except the conditional write, so a change reaches the end of the
+    /// retry loop with nothing written - which is the only way the contention answers are reachable
+    /// through a real request.
+    /// </summary>
+    private sealed class RefusingUpdates(IStreamStore inner) : IStreamStore
+    {
+        public bool Refuse { get; set; }
+
+        public Task<bool> TryCreateAsync(StreamState stream, CancellationToken cancellationToken = default)
+            => inner.TryCreateAsync(stream, cancellationToken);
+
+        public Task<StreamState?> FindAsync(
+            string receiverId, string streamId, CancellationToken cancellationToken = default)
+            => inner.FindAsync(receiverId, streamId, cancellationToken);
+
+        public Task<IReadOnlyList<StreamState>> ListAsync(
+            string receiverId, CancellationToken cancellationToken = default)
+            => inner.ListAsync(receiverId, cancellationToken);
+
+        public Task<IReadOnlyList<StreamState>> ListAllAsync(CancellationToken cancellationToken = default)
+            => inner.ListAllAsync(cancellationToken);
+
+        public Task<bool> UpdateAsync(StreamState stream, CancellationToken cancellationToken = default)
+            => Refuse ? Task.FromResult(false) : inner.UpdateAsync(stream, cancellationToken);
+
+        public Task<bool> DeleteAsync(
+            string receiverId, string streamId, CancellationToken cancellationToken = default)
+            => inner.DeleteAsync(receiverId, streamId, cancellationToken);
+    }
+}


### PR DESCRIPTION
## What is wrong

Not one route of the Stream Management surface declared a single response status. A host that generates an OpenAPI document from this group therefore published 200 for every one of them, inferred from a handler return type of `IResult`, which says nothing.

Three of the divergences were reported from a live deployment:

- `DELETE /ssf/stream` and `GET /ssf/status` answer 400 when `stream_id` names nothing, and the document had no 400.
- Every route answers 401 when nothing identifies the caller, and the document had no 401 anywhere.
- `POST /ssf/stream` answers 201, and the document promised 200.

A status sent and not declared, and one declared and never sent, are the same lie read from opposite ends: the first leaves a generated client with no branch for an answer it will meet, the second gives it a branch nothing reaches.

## 201 or 200

The specification settles it. SSF 1.0 section 8.1.1.1: on a valid create request the transmitter "responds with a '201 Created' response containing a JSON [RFC7159] representation of the stream's configuration in the body", and the worked example beside it answers 201. So the code was right and the document was wrong.

## What this changes

Each route declares the statuses it answers. Refusals are declared without a body type, because the Stream Management API defines no error body - section 8.1 gives its outcomes as status codes and nothing else. Three of them say more than their status: 400, 401 and 403 are built as a challenge and carry a `WWW-Authenticate` line naming the reason. The other four - 202, 404, 409 and 429 - go out as a bare status, and the description their result carried is dropped on the way, so a receiver diagnosing a 409 has the status and nothing else.

401 and 403 belong to the group rather than to any handler and are declared once there, so a route added later inherits them.

The configuration document is in scope too, although it is mapped outside that group. It answers 200 and only 200 - it takes no parameter to get wrong and needs no credentials, because discovery has to work before a receiver has any - and it was publishing that 200 as an inference rather than as a statement, which is the same defect on the one route nobody was comparing.

One declaration is deliberately incomplete. `GET /ssf/stream` returns a configuration when `stream_id` names one and an array when it names none (section 8.1.1.2). A response type is one type, so its 200 is declared without one rather than picking the half that would make a generated client wrong on the other.

## The declarations have to reach a document, not just an endpoint

A first review round caught the whole thing being inert. `ProducesResponseTypeMetadata(int)` leaves its
`Type` null, and the API description pipeline every OpenAPI generator reads DISCARDS a response type
with a null type, then falls back to inferring 200 from the handler. So the declarations reached the
endpoints, read correct at the call site, and published nothing - and `DELETE /ssf/stream`,
`POST /ssf/subjects:remove` and `POST /ssf/verify` went on publishing a 200 they never answer.

`typeof(void)` is how the framework's own `Produces(int)` says a status carries no body, and that is
what these now pass. The test grew the second half it was missing: it reads the PUBLISHED set out of
the description pipeline as well as the attached metadata, so a declaration the pipeline throws away is
a failure rather than a silence.

Driving the framework's own refusals rather than excusing them added two more statuses nothing
declared: 415 on all eight routes that bind a body, and 400 from body binding on `subjects:remove`,
`verify` and `poll`, where no business path produces one. The comment that excused them said they
belong to the framework rather than to this package - true, and irrelevant: a receiver meets them on
these routes, so its client needs a branch for them whoever produced them.

## How each status was established

By driving it, not by reading the code. The first commit adds a test that sends a real request for every outcome each route can produce, records what came back, reads what the route declares off its own metadata, and requires the two sets to be equal. Equality in both directions: declaring a status nothing reaches fails just as loudly as answering one nothing declares.

That costs the test a way to reach the answers a route gives only when its conditional write loses - 202 where repeating the call is the way forward, 409 where the caller is told somebody else is changing the stream. A store that takes every call except the write makes them reachable, which keeps them from becoming an exemption written in prose.

Driving them found one the report did not have: `POST /ssf/verify` answers 409 on a lost write, and it is reachable only before the stream has ever been verified, because afterwards the throttle refuses first.

Three regressions were planted and each turns the suite red: a declared status nothing answers, an answer nothing declares, and the null-typed metadata, which reproduces every publish divergence at once.

## Verification

- `Abblix.SharedSignals.E2E.Tests`: 76 passed, 78 answers driven across every route this call maps.
- `Abblix.SharedSignals.UnitTests`: 216 passed.
- Whole solution builds across all target frameworks.

## For the consumer

A downstream host regenerates its committed OpenAPI document once this ships. Nothing in the package's public surface changes, and no behaviour changes - only what the routes say about themselves.
