### PR TITLE
Complete the FAPI 2.0 profile before it ships

### DIFF
--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SecurityProfileValidator.cs
@@ -33,6 +33,7 @@ public class SecurityProfileValidator(IOptions<OidcOptions> options) : SyncClien
     {
         var violations = SecurityProfileConsistency.FindViolations(
             context.Request.ResponseTypes,
+            context.Request.TokenEndpointAuthMethod,
             options.Value.DefaultSecurityProfile);
 
         return violations.Count == 0

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
@@ -17,6 +17,9 @@ using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Utils;
 using Microsoft.Extensions.Logging;
 using JsonWebKey = Abblix.Jwt.JsonWebKey;
+using Microsoft.Extensions.Options;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Common.Configuration;
 
 namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 
@@ -30,13 +33,18 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// <param name="requestInfoProvider">Provider for retrieving request information.</param>
 /// <param name="clock">Time provider for checking secret expiration.</param>
 /// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
+/// <param name="issuerProvider">Supplies the issuer identifier a profile-governed assertion must name.</param>
+/// <param name="options">Supplies the server-wide default security profile.</param>
 public partial class ClientSecretJwtAuthenticator(
     ILogger<ClientSecretJwtAuthenticator> logger,
     IJsonWebTokenValidator tokenValidator,
     IClientInfoProvider clientInfoProvider,
     IRequestInfoProvider requestInfoProvider,
     TimeProvider clock,
-    IReplayCache replayCache) : JwtAssertionAuthenticatorBase(logger, replayCache)
+    IReplayCache replayCache,
+    IIssuerProvider issuerProvider,
+    IOptions<OidcOptions> options)
+    : JwtAssertionAuthenticatorBase(logger, replayCache, issuerProvider, options)
 {
     /// <summary>
     /// Specifies the client authentication method this authenticator supports, which is 'client_secret_jwt'.

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
@@ -78,4 +78,14 @@ partial class JwtAssertionAuthenticatorBase
         Level = LogLevel.Warning,
         Message = "The client assertion jti {Jti} for {ClientId} has already been used; possible replay attack")]
     private partial void LogReplayDetected(string Jti, string ClientId);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.AudienceIsNotTheIssuerAlone,
+        Level = LogLevel.Warning,
+        Message = "The client assertion for {ClientId} carries {@Audiences} where the profile "
+                  + "governing it accepts the issuer identifier {IssuerIdentifier} alone")]
+    private partial void LogAudienceIsNotTheIssuerAlone(
+        string ClientId,
+        string[] Audiences,
+        string IssuerIdentifier);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -14,6 +14,9 @@ using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Utils;
 using Microsoft.Extensions.Logging;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Features.Issuer;
+using Microsoft.Extensions.Options;
 
 namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 
@@ -23,9 +26,13 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// </summary>
 /// <param name="logger">logger for recording the authentication process and any issues encountered.</param>
 /// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
+/// <param name="issuerProvider">Supplies the issuer identifier a profile-governed assertion must name.</param>
+/// <param name="options">Supplies the server-wide default security profile.</param>
 public abstract partial class JwtAssertionAuthenticatorBase(
     ILogger logger,
-    IReplayCache replayCache) : IClientAuthenticator
+    IReplayCache replayCache,
+    IIssuerProvider issuerProvider,
+    IOptions<OidcOptions> options) : IClientAuthenticator
 {
     /// <summary>
     /// Specifies the client authentication methods supported by this authenticator.
@@ -115,6 +122,24 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         {
             LogOtherKindPresentedAsAssertion(clientInfo.ClientId, tokenType);
             return null;
+        }
+
+        // FAPI 2.0 section 5.3.2.1 narrows what may stand in the audience: a server held to it
+        // "shall only accept its issuer identifier value (as defined in [RFC8414]) as a string".
+        // Both halves matter. The value must be the issuer rather than any address this server
+        // answers on, and it must be alone rather than one entry among several, so an assertion
+        // minted for a different recipient cannot be replayed here by naming both. Outside the
+        // profile the wider reading the underlying specification permits is left untouched.
+        if (SecurityProfileRequirements.For(clientInfo, options.Value.DefaultSecurityProfile)
+                .RequireIssuerAudienceInClientAssertion)
+        {
+            var issuerIdentifier = issuerProvider.GetIssuer();
+            var audiences = token.Payload.Audiences.ToArray();
+            if (audiences is not [var onlyAudience] || onlyAudience != issuerIdentifier)
+            {
+                LogAudienceIsNotTheIssuerAlone(clientInfo.ClientId, audiences, issuerIdentifier);
+                return null;
+            }
         }
 
         // OIDC Core §9: the client-authentication assertion's jti is REQUIRED - "A unique

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -40,6 +40,37 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     public abstract IEnumerable<string> ClientAuthenticationMethodsSupported { get; }
 
     /// <summary>
+    /// Answers whether the assertion's audience is one the profile governing this client admits.
+    /// </summary>
+    /// <remarks>
+    /// FAPI 2.0 section 5.3.2.1 narrows what may stand there: a server held to the profile "shall
+    /// only accept its issuer identifier value (as defined in [RFC8414]) as a string". Both halves
+    /// matter. The value must be the issuer rather than any address this server answers on, and it
+    /// must be alone rather than one entry among several, so an assertion minted for a different
+    /// recipient cannot be replayed here by naming both. Outside the profile the wider reading the
+    /// underlying specification permits is left untouched, which is why this answers true there
+    /// rather than checking anything.
+    /// </remarks>
+    private bool AudienceSatisfiesTheProfile(JsonWebToken token, ClientInfo clientInfo)
+    {
+        if (!SecurityProfileRequirements.For(clientInfo, options.Value.DefaultSecurityProfile)
+                .RequireIssuerAudienceInClientAssertion)
+        {
+            return true;
+        }
+
+        var issuerIdentifier = issuerProvider.GetIssuer();
+        var audiences = token.Payload.Audiences.ToArray();
+        if (audiences is [var onlyAudience] && onlyAudience == issuerIdentifier)
+        {
+            return true;
+        }
+
+        LogAudienceIsNotTheIssuerAlone(clientInfo.ClientId, audiences, issuerIdentifier);
+        return false;
+    }
+
+    /// <summary>
     /// Attempts to authenticate a client using JWT assertion by validating the JWT provided in the client request.
     /// </summary>
     /// <param name="request">The client request containing the JWT to authenticate.</param>
@@ -124,22 +155,9 @@ public abstract partial class JwtAssertionAuthenticatorBase(
             return null;
         }
 
-        // FAPI 2.0 section 5.3.2.1 narrows what may stand in the audience: a server held to it
-        // "shall only accept its issuer identifier value (as defined in [RFC8414]) as a string".
-        // Both halves matter. The value must be the issuer rather than any address this server
-        // answers on, and it must be alone rather than one entry among several, so an assertion
-        // minted for a different recipient cannot be replayed here by naming both. Outside the
-        // profile the wider reading the underlying specification permits is left untouched.
-        if (SecurityProfileRequirements.For(clientInfo, options.Value.DefaultSecurityProfile)
-                .RequireIssuerAudienceInClientAssertion)
+        if (!AudienceSatisfiesTheProfile(token, clientInfo))
         {
-            var issuerIdentifier = issuerProvider.GetIssuer();
-            var audiences = token.Payload.Audiences.ToArray();
-            if (audiences is not [var onlyAudience] || onlyAudience != issuerIdentifier)
-            {
-                LogAudienceIsNotTheIssuerAlone(clientInfo.ClientId, audiences, issuerIdentifier);
-                return null;
-            }
+            return null;
         }
 
         // OIDC Core §9: the client-authentication assertion's jti is REQUIRED - "A unique

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
@@ -13,6 +13,9 @@ using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Common.Configuration;
 
 namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 
@@ -23,10 +26,15 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// <param name="logger">Logger for recording the authentication process and any issues encountered.</param>
 /// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
 /// <param name="serviceProvider">Service provider used to resolve scoped dependencies.</param>
+/// <param name="issuerProvider">Supplies the issuer identifier a profile-governed assertion must name.</param>
+/// <param name="options">Supplies the server-wide default security profile.</param>
 public class PrivateKeyJwtAuthenticator(
     ILogger<PrivateKeyJwtAuthenticator> logger,
     IReplayCache replayCache,
-    IServiceProvider serviceProvider) : JwtAssertionAuthenticatorBase(logger, replayCache)
+    IServiceProvider serviceProvider,
+    IIssuerProvider issuerProvider,
+    IOptions<OidcOptions> options)
+    : JwtAssertionAuthenticatorBase(logger, replayCache, issuerProvider, options)
 {
     /// <summary>
     /// Indicates the client authentication method supported by this authenticator.

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -51,6 +51,17 @@ internal partial class SecurityProfileClientAuthenticator(
 
         var profile = clientInfo.SecurityProfile ?? options.Value.DefaultSecurityProfile;
 
+        // A client arrives from a store the HOST writes, so its profile is not covered by the
+        // startup check over the configured clients: a value outside the enum reaches here, and
+        // resolving one throws. Refusing it is the answer rather than letting the exception out,
+        // because the alternative is a 500 from the token endpoint - the failure this whole class
+        // exists to remove - for a client the server simply cannot decide about.
+        if (!Enum.IsDefined(profile))
+        {
+            LogProfileIsNotOneThisServerDefines(clientInfo.ClientId, (int)profile);
+            return null;
+        }
+
         var violations = SecurityProfileConsistency.FindViolations(
             clientInfo.EffectiveResponseTypes,
             clientInfo.TokenEndpointAuthMethod,
@@ -72,4 +83,11 @@ internal partial class SecurityProfileClientAuthenticator(
         string ClientId,
         ClientSecurityProfile Profile,
         IReadOnlyList<string> Violations);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.ProfileIsNotOneThisServerDefines,
+        Level = LogLevel.Error,
+        Message = "The client {ClientId} is held to security profile {Profile}, which this server "
+                  + "does not define, so nothing can decide what it requires")]
+    private partial void LogProfileIsNotOneThisServerDefines(string ClientId, int Profile);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -1,0 +1,75 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Abblix.Oidc.Server.Features.ClientAuthentication;
+
+/// <summary>
+/// Refuses a client whose registration cannot satisfy the security profile it is held to, at the
+/// moment it authenticates.
+/// </summary>
+/// <remarks>
+/// The same requirements are checked where a client is configured - at dynamic registration and
+/// over <see cref="OidcOptions.Clients"/> at startup - and that covers every client the deployment
+/// declares. It does not cover a client that was registered dynamically while no profile was in
+/// force and has been in the store ever since: turning the profile on afterwards leaves it
+/// authenticating with whatever it registered with, because nothing re-reads a stored registration.
+///
+/// So the profile is enforced here as well, where every client arrives whatever its origin. The
+/// checker is the one the configuration paths use, rather than a second reading of the same
+/// requirements that could drift from it.
+///
+/// A refusal is a null result, indistinguishable to the caller from a credential that did not
+/// verify. That is deliberate: which of the two it was tells an unauthenticated caller something
+/// about a client registration, and every endpoint here already answers an unauthenticated client
+/// the same way.
+/// </remarks>
+internal partial class SecurityProfileClientAuthenticator(
+    IClientAuthenticator inner,
+    IOptions<OidcOptions> options,
+    ILogger<SecurityProfileClientAuthenticator> logger) : IClientAuthenticator
+{
+    public IEnumerable<string> ClientAuthenticationMethodsSupported
+        => inner.ClientAuthenticationMethodsSupported;
+
+    public async Task<ClientInfo?> TryAuthenticateClientAsync(ClientRequest request)
+    {
+        var clientInfo = await inner.TryAuthenticateClientAsync(request);
+        if (clientInfo == null)
+            return null;
+
+        var profile = clientInfo.SecurityProfile ?? options.Value.DefaultSecurityProfile;
+
+        var violations = SecurityProfileConsistency.FindViolations(
+            clientInfo.EffectiveResponseTypes,
+            clientInfo.TokenEndpointAuthMethod,
+            profile);
+
+        if (violations.Count == 0)
+            return clientInfo;
+
+        LogRegistrationCannotSatisfyProfile(clientInfo.ClientId, profile, violations);
+        return null;
+    }
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.RegistrationCannotSatisfyProfile,
+        Level = LogLevel.Warning,
+        Message = "The client {ClientId} authenticated, but its registration cannot satisfy the "
+                  + "{Profile} profile it is held to: {@Violations}")]
+    private partial void LogRegistrationCannotSatisfyProfile(
+        string ClientId,
+        ClientSecurityProfile Profile,
+        IReadOnlyList<string> Violations);
+}

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -51,17 +51,6 @@ internal partial class SecurityProfileClientAuthenticator(
 
         var profile = clientInfo.SecurityProfile ?? options.Value.DefaultSecurityProfile;
 
-        // A client arrives from a store the HOST writes, so its profile is not covered by the
-        // startup check over the configured clients: a value outside the enum reaches here, and
-        // resolving one throws. Refusing it is the answer rather than letting the exception out,
-        // because the alternative is a 500 from the token endpoint - the failure this whole class
-        // exists to remove - for a client the server simply cannot decide about.
-        if (!Enum.IsDefined(profile))
-        {
-            LogProfileIsNotOneThisServerDefines(clientInfo.ClientId, (int)profile);
-            return null;
-        }
-
         var violations = SecurityProfileConsistency.FindViolations(
             clientInfo.EffectiveResponseTypes,
             clientInfo.TokenEndpointAuthMethod,
@@ -83,11 +72,4 @@ internal partial class SecurityProfileClientAuthenticator(
         string ClientId,
         ClientSecurityProfile Profile,
         IReadOnlyList<string> Violations);
-
-    [LoggerMessage(
-        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.ProfileIsNotOneThisServerDefines,
-        Level = LogLevel.Error,
-        Message = "The client {ClientId} is held to security profile {Profile}, which this server "
-                  + "does not define, so nothing can decide what it requires")]
-    private partial void LogProfileIsNotOneThisServerDefines(string ClientId, int Profile);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -51,6 +51,20 @@ internal partial class SecurityProfileClientAuthenticator(
 
         var profile = clientInfo.SecurityProfile ?? options.Value.DefaultSecurityProfile;
 
+        // Said here and nowhere else, because this is the only place a client out of a host-written
+        // store is met by name. The value cannot be interpreted, so it is held to every control this
+        // server can demand - and without this line the operator sees only the consequence: refusals
+        // citing requirements no configuration of theirs sets. It does not refuse: whether such a
+        // client can work is answered by the requirements below, like any other.
+        //
+        // It covers the endpoints that authenticate a client and no others. A request to the
+        // authorization endpoint presents no credential, so it never passes through here, and a
+        // client whose only traffic is /authorize is named nowhere.
+        if (!Enum.IsDefined(profile))
+        {
+            LogProfileIsNotOneThisServerDefines(clientInfo.ClientId, (int)profile);
+        }
+
         var violations = SecurityProfileConsistency.FindViolations(
             clientInfo.EffectiveResponseTypes,
             clientInfo.TokenEndpointAuthMethod,
@@ -72,4 +86,11 @@ internal partial class SecurityProfileClientAuthenticator(
         string ClientId,
         ClientSecurityProfile Profile,
         IReadOnlyList<string> Violations);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.ProfileIsNotOneThisServerDefines,
+        Level = LogLevel.Warning,
+        Message = "The client {ClientId} names security profile {Profile}, which this server does "
+                  + "not define, so it is held to every control this server can demand")]
+    private partial void LogProfileIsNotOneThisServerDefines(string ClientId, int Profile);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -51,15 +51,16 @@ internal partial class SecurityProfileClientAuthenticator(
 
         var profile = clientInfo.SecurityProfile ?? options.Value.DefaultSecurityProfile;
 
-        // Said here and nowhere else, because this is the only place a client out of a host-written
-        // store is met by name. The value cannot be interpreted, so it is held to every control this
-        // server can demand - and without this line the operator sees only the consequence: refusals
-        // citing requirements no configuration of theirs sets. It does not refuse: whether such a
-        // client can work is answered by the requirements below, like any other.
+        // Said where a client is met after proving who it is. The value cannot be interpreted, so
+        // the client is held to every control this server can demand - and without this line the
+        // operator sees only the consequence: refusals citing requirements no configuration of
+        // theirs sets. It does not refuse; whether such a client can work is answered by the
+        // requirements below, like any other.
         //
-        // It covers the endpoints that authenticate a client and no others. A request to the
-        // authorization endpoint presents no credential, so it never passes through here, and a
-        // client whose only traffic is /authorize is named nowhere.
+        // It covers the endpoints that authenticate a client and no others. The authorization
+        // endpoint reads the same stored client by id and could say the same thing, but nothing
+        // there presents a credential, so a client whose only traffic is /authorize is named
+        // nowhere today.
         if (!Enum.IsDefined(profile))
         {
             LogProfileIsNotOneThisServerDefines(clientInfo.ClientId, (int)profile);

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
@@ -36,21 +36,28 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
         // bound as it stands. Nothing downstream can serve such a value, so it is named here, at
         // startup - the alternative is that the deployment starts and every endpoint requiring a
         // client answers 500 instead.
+        // Named once for the operator, whether or not any client inherits it.
         failures.AddRange(UndefinedProfile(options.DefaultSecurityProfile, "DefaultSecurityProfile"));
 
         foreach (var client in options.Clients)
         {
-            if (client.SecurityProfile is { } clientProfile)
-            {
-                var undefined = UndefinedProfile(clientProfile, $"Client '{client.ClientId}'");
-                if (undefined.Count > 0)
-                {
-                    failures.AddRange(undefined);
-                    continue;
-                }
-            }
-
             var effectiveProfile = client.SecurityProfile ?? options.DefaultSecurityProfile;
+
+            // The value tested is the EFFECTIVE one, so an undefined default and an undefined
+            // client profile are one case rather than two: the consistency walk below resolves
+            // whatever this is, and resolving a value the enum does not define throws. A guard
+            // written per source would cover whichever half its author had in mind.
+            var undefined = UndefinedProfile(
+                effectiveProfile,
+                client.SecurityProfile.HasValue
+                    ? $"Client '{client.ClientId}'"
+                    : $"Client '{client.ClientId}', inheriting DefaultSecurityProfile,");
+
+            if (undefined.Count > 0)
+            {
+                failures.AddRange(undefined);
+                continue;
+            }
 
             foreach (var violation in
                      SecurityProfileConsistency.FindViolations(

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
@@ -31,8 +31,25 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
         // still refuse, instead of being left to whoever reviews the next profile.
         failures.AddRange(SecurityProfileRequirements.FindUnreplacedRelaxations());
 
+        // A profile is an enum, and the configuration binder does not check that a value it binds is
+        // one the enum defines: a name it does not know throws while a NUMBER outside the range is
+        // bound as it stands. Nothing downstream can serve such a value, so it is named here, at
+        // startup - the alternative is that the deployment starts and every endpoint requiring a
+        // client answers 500 instead.
+        failures.AddRange(UndefinedProfile(options.DefaultSecurityProfile, "DefaultSecurityProfile"));
+
         foreach (var client in options.Clients)
         {
+            if (client.SecurityProfile is { } clientProfile)
+            {
+                var undefined = UndefinedProfile(clientProfile, $"Client '{client.ClientId}'");
+                if (undefined.Count > 0)
+                {
+                    failures.AddRange(undefined);
+                    continue;
+                }
+            }
+
             var effectiveProfile = client.SecurityProfile ?? options.DefaultSecurityProfile;
 
             foreach (var violation in
@@ -49,4 +66,13 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }
+
+    /// <summary>
+    /// Names a profile value the enum does not define, as the single-element list the caller adds to
+    /// its failures. Empty for a defined value, which is what makes it usable as a guard.
+    /// </summary>
+    private static IReadOnlyList<string> UndefinedProfile(ClientSecurityProfile profile, string where)
+        => Enum.IsDefined(profile)
+            ? []
+            : [$"{where}: {(int)profile} is not a security profile this server defines."];
 }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
@@ -26,12 +26,20 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
     {
         var failures = new List<string>();
 
+        // A profile that removes a control without the controls that replace it is a defect in this
+        // library rather than in the host's configuration, so it is checked here, where startup can
+        // still refuse, instead of being left to whoever reviews the next profile.
+        failures.AddRange(SecurityProfileRequirements.FindUnreplacedRelaxations());
+
         foreach (var client in options.Clients)
         {
             var effectiveProfile = client.SecurityProfile ?? options.DefaultSecurityProfile;
 
             foreach (var violation in
-                     SecurityProfileConsistency.FindViolations(client.EffectiveResponseTypes, effectiveProfile))
+                     SecurityProfileConsistency.FindViolations(
+                         client.EffectiveResponseTypes,
+                         client.TokenEndpointAuthMethod,
+                         effectiveProfile))
             {
                 failures.Add($"Client '{client.ClientId}': {violation}.");
             }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileConsistency.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileConsistency.cs
@@ -29,15 +29,39 @@ public static class SecurityProfileConsistency
     /// rather than merely tightened.
     /// </summary>
     /// <param name="allowedResponseTypes">The response-type combinations the client is registered for.</param>
+    /// <param name="tokenEndpointAuthMethod">How the client authenticates at the token endpoint.</param>
     /// <param name="profile">The effective profile governing the client.</param>
     public static IReadOnlyList<string> FindViolations(
         IReadOnlyList<string[]> allowedResponseTypes,
+        string tokenEndpointAuthMethod,
         ClientSecurityProfile profile)
     {
-        if (!SecurityProfileRequirements.Resolve(profile).RequireCodeResponseTypeOnly)
-            return [];
-
+        var requirements = SecurityProfileRequirements.Resolve(profile);
         var violations = new List<string>();
+
+        // RFC 6749 draws the line at whether the client can hold a credential at all, and the
+        // registered authentication method is where that shows: a client authenticating with
+        // nothing IS the public client the profile excludes.
+        if (requirements.RequireConfidentialClient &&
+            tokenEndpointAuthMethod == ClientAuthenticationMethods.None)
+        {
+            violations.Add(
+                "the FAPI 2.0 Security Profile admits confidential clients only, " +
+                "but the client authenticates with none at the token endpoint");
+        }
+
+        // Both surviving methods prove possession of a key. Every other method the server offers
+        // proves possession of a shared secret, which is what the profile removes.
+        if (requirements.RequireKeyBasedClientAuthentication &&
+            !KeyBasedAuthenticationMethods.Contains(tokenEndpointAuthMethod))
+        {
+            violations.Add(
+                "the FAPI 2.0 Security Profile requires client authentication by mutual TLS or a " +
+                $"private key JWT, but the client uses {tokenEndpointAuthMethod}");
+        }
+
+        if (!requirements.RequireCodeResponseTypeOnly)
+            return violations;
 
         // A single-element "code" entry, matched case-insensitively to stay consistent with the
         // token-bearing check below (both ultimately use HasFlag's OrdinalIgnoreCase comparison).
@@ -59,4 +83,16 @@ public static class SecurityProfileConsistency
 
         return violations;
     }
+
+    /// <summary>
+    /// The client authentication methods that prove possession of a key rather than of a shared
+    /// secret: mutual TLS in both its forms (RFC 8705 section 2) and the private key JWT assertion
+    /// (OpenID Connect Core section 9).
+    /// </summary>
+    private static readonly string[] KeyBasedAuthenticationMethods =
+    [
+        ClientAuthenticationMethods.TlsClientAuth,
+        ClientAuthenticationMethods.SelfSignedTlsClientAuth,
+        ClientAuthenticationMethods.PrivateKeyJwt,
+    ];
 }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
@@ -14,7 +14,7 @@ namespace Abblix.Oidc.Server.Features.ClientInformation;
 /// The bundle of controls a <see cref="ClientSecurityProfile"/> forces on a client, expressed as
 /// individual flags the request-pipeline validators consult. This is the single place the
 /// profile-to-controls mapping lives, so a validator never needs to know what "FAPI 2.0" means - it
-/// only reads the one flag it owns - and adding a future profile touches only <see cref="Resolve"/>.
+/// only reads the one flag it owns - and adding a future profile touches only <see cref="Resolve(ClientSecurityProfile)"/>.
 /// </summary>
 /// <remarks>
 /// A flag normally requires a control and never relaxes one, so a profile tightens a client and
@@ -204,14 +204,40 @@ public sealed record SecurityProfileRequirements
     /// nothing here can say what the value meant, and of the answers available only the strictest
     /// cannot quietly serve a client the deployment believed was constrained.
     /// </remarks>
-    public static SecurityProfileRequirements Resolve(ClientSecurityProfile profile) => profile switch
+    public static SecurityProfileRequirements Resolve(ClientSecurityProfile profile)
+        => Resolve(profile, Declared(profile));
+
+    /// <summary>
+    /// The decision the overload above makes, over a bundle supplied by the caller. Separate so a
+    /// test can hand a DEFINED profile no bundle, which is the only way to reach the refusal below:
+    /// every profile that ships has one, so the arm would otherwise be dead under test and could be
+    /// deleted with the suite staying green - the same reason
+    /// <see cref="FindUnreplacedRelaxations()"/> carries its own overload.
+    /// </summary>
+    internal static SecurityProfileRequirements Resolve(
+        ClientSecurityProfile profile,
+        SecurityProfileRequirements? declared)
+    {
+        if (declared != null)
+            return declared;
+
+        if (!Enum.IsDefined(profile))
+            return StrictestRequirements;
+
+        throw new InvalidOperationException(
+            $"{nameof(ClientSecurityProfile)}.{profile} has no requirements declared in " +
+            $"{nameof(SecurityProfileRequirements)}");
+    }
+
+    /// <summary>
+    /// The bundle written for a profile in this file, or null where none is - which is a question
+    /// about this file alone, with no judgement about what an absent one means.
+    /// </summary>
+    private static SecurityProfileRequirements? Declared(ClientSecurityProfile profile) => profile switch
     {
         ClientSecurityProfile.None => NoneRequirements,
         ClientSecurityProfile.Fapi2 => Fapi2Requirements,
-        _ when !Enum.IsDefined(profile) => StrictestRequirements,
-        _ => throw new InvalidOperationException(
-            $"{nameof(ClientSecurityProfile)}.{profile} has no requirements declared in " +
-            $"{nameof(SecurityProfileRequirements)}"),
+        _ => null,
     };
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
@@ -28,7 +28,7 @@ namespace Abblix.Oidc.Server.Features.ClientInformation;
 /// once the client is confidential and its tokens are bound to their sender, and it costs a user
 /// their session whenever a client fails to store the token it was handed. A relaxing flag is
 /// therefore admissible only when the same profile carries the controls that stand in for what it
-/// removes, which <see cref="FindUnreplacedRelaxations"/> checks for every profile at startup rather
+/// removes, which <see cref="FindUnreplacedRelaxations()"/> checks for every profile at startup rather
 /// than leaving to review.
 ///
 /// Every flag below names the validator that enforces it. That coupling is documented here on
@@ -104,7 +104,7 @@ public sealed record SecurityProfileRequirements
     /// The profile accepts only the server's issuer identifier, and only as a string, in the
     /// audience of a client authentication assertion, narrowing what the underlying specification
     /// otherwise permits. Enforced by
-    /// <c>Features.ClientAuthentication.ClientAssertionAudienceValidator</c>.
+    /// <c>Features.ClientAuthentication.JwtAssertionAuthenticatorBase</c>.
     /// </summary>
     public bool RequireIssuerAudienceInClientAssertion { get; init; }
 
@@ -149,12 +149,23 @@ public sealed record SecurityProfileRequirements
     /// client that may be public and whose tokens anyone may replay.
     /// </remarks>
     public static IReadOnlyList<string> FindUnreplacedRelaxations()
+        => FindUnreplacedRelaxations(
+            Enum.GetValues<ClientSecurityProfile>()
+                .Select(profile => (profile.ToString(), Resolve(profile))));
+
+    /// <summary>
+    /// The walk itself, over named bundles supplied by the caller. Separate from the overload above
+    /// so a test can drive the mistake this guard exists to catch: a profile that forbids rotation
+    /// and carries neither replacement cannot be expressed by the profiles that ship, because they
+    /// are correct, and a guard nothing can make fail is not a guard.
+    /// </summary>
+    internal static IReadOnlyList<string> FindUnreplacedRelaxations(
+        IEnumerable<(string Name, SecurityProfileRequirements Requirements)> profiles)
     {
         var violations = new List<string>();
 
-        foreach (var profile in Enum.GetValues<ClientSecurityProfile>())
+        foreach (var (profile, requirements) in profiles)
         {
-            var requirements = Resolve(profile);
             if (!requirements.ForbidRefreshTokenRotation)
                 continue;
 
@@ -179,10 +190,18 @@ public sealed record SecurityProfileRequirements
     /// <summary>
     /// Returns the control bundle a given profile mandates.
     /// </summary>
+    /// <remarks>
+    /// The default arm throws rather than answering <see cref="NoneRequirements"/>. A profile added
+    /// to the enum without a bundle here would otherwise resolve to no requirements at all, which
+    /// is silently the weakest answer available and reads at every call site as a deliberate one.
+    /// </remarks>
     public static SecurityProfileRequirements Resolve(ClientSecurityProfile profile) => profile switch
     {
+        ClientSecurityProfile.None => NoneRequirements,
         ClientSecurityProfile.Fapi2 => Fapi2Requirements,
-        _ => NoneRequirements,
+        _ => throw new InvalidOperationException(
+            $"{nameof(ClientSecurityProfile)}.{profile} has no requirements declared in " +
+            $"{nameof(SecurityProfileRequirements)}"),
     };
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
@@ -194,14 +194,50 @@ public sealed record SecurityProfileRequirements
     /// The default arm throws rather than answering <see cref="NoneRequirements"/>. A profile added
     /// to the enum without a bundle here would otherwise resolve to no requirements at all, which
     /// is silently the weakest answer available and reads at every call site as a deliberate one.
+    ///
+    /// A value the enum does not define is a different population and gets a different answer. It
+    /// arrives from outside - a configuration binder takes a number outside the range as it stands,
+    /// and a client store the host writes can hold anything - so it is data rather than a mistake in
+    /// this file, and the readers meeting it are handling a live request. Throwing there turns a
+    /// host's bad value into a 500 from the authorization and token endpoints, which is the reader's
+    /// failure rather than the writer's. It resolves to <see cref="StrictestRequirements"/> instead:
+    /// nothing here can say what the value meant, and of the answers available only the strictest
+    /// cannot quietly serve a client the deployment believed was constrained.
     /// </remarks>
     public static SecurityProfileRequirements Resolve(ClientSecurityProfile profile) => profile switch
     {
         ClientSecurityProfile.None => NoneRequirements,
         ClientSecurityProfile.Fapi2 => Fapi2Requirements,
+        _ when !Enum.IsDefined(profile) => StrictestRequirements,
         _ => throw new InvalidOperationException(
             $"{nameof(ClientSecurityProfile)}.{profile} has no requirements declared in " +
             $"{nameof(SecurityProfileRequirements)}"),
+    };
+
+    /// <summary>
+    /// The answer for a profile value nothing here can interpret: every control this type can demand,
+    /// demanded.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <see cref="Fapi2Requirements"/>, which would tie the fallback to whichever
+    /// profile happens to be strictest today, and deliberately not <see cref="NoneRequirements"/>,
+    /// which would hand a client that named a profile the absence of one.
+    ///
+    /// <see cref="ForbidRefreshTokenRotation"/> stays false here, and that is the strict setting
+    /// rather than an omission: it is the one flag on this type that REMOVES a control, so demanding
+    /// it would weaken the bundle meant to be the strongest available.
+    /// </remarks>
+    private static readonly SecurityProfileRequirements StrictestRequirements = new()
+    {
+        RequirePkce = true,
+        RequireS256CodeChallenge = true,
+        RequirePushedAuthorizationRequests = true,
+        RequireSenderConstrainedTokens = true,
+        RequireCodeResponseTypeOnly = true,
+        RequireStrictRequestObjectProcessing = true,
+        RequireConfidentialClient = true,
+        RequireKeyBasedClientAuthentication = true,
+        RequireIssuerAudienceInClientAssertion = true,
     };
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
@@ -17,10 +17,19 @@ namespace Abblix.Oidc.Server.Features.ClientInformation;
 /// only reads the one flag it owns - and adding a future profile touches only <see cref="Resolve"/>.
 /// </summary>
 /// <remarks>
-/// Each flag is enforcement-only: it can require a control but never relax one. A profile therefore
-/// tightens a client and cannot weaken it, which is the invariant that lets a granular toggle (for
-/// example <see cref="ClientInfo.PkceRequired"/> set to <c>false</c>) coexist with a profile without
-/// silently downgrading it.
+/// A flag normally requires a control and never relaxes one, so a profile tightens a client and
+/// cannot weaken it. That is what lets a granular toggle (for example
+/// <see cref="ClientInfo.PkceRequired"/> set to <c>false</c>) coexist with a profile without silently
+/// downgrading it.
+///
+/// One flag goes the other way, and the exception is deliberate rather than an escape hatch.
+/// <see cref="ForbidRefreshTokenRotation"/> removes a control, because the specification it comes
+/// from replaces that control with two others instead of dropping protection: rotation earns nothing
+/// once the client is confidential and its tokens are bound to their sender, and it costs a user
+/// their session whenever a client fails to store the token it was handed. A relaxing flag is
+/// therefore admissible only when the same profile carries the controls that stand in for what it
+/// removes, which <see cref="FindUnreplacedRelaxations"/> checks for every profile at startup rather
+/// than leaving to review.
 ///
 /// Every flag below names the validator that enforces it. That coupling is documented here on
 /// purpose: the enforcement is distributed across the request pipeline, so a new flag added to a
@@ -76,6 +85,37 @@ public sealed record SecurityProfileRequirements
     /// </summary>
     public bool RequireStrictRequestObjectProcessing { get; init; }
 
+    /// <summary>
+    /// The profile admits only confidential clients as defined by RFC 6749, so a client that
+    /// authenticates with nothing at the token endpoint cannot be held to it. Enforced by
+    /// <see cref="SecurityProfileConsistency"/> at registration and at startup.
+    /// </summary>
+    public bool RequireConfidentialClient { get; init; }
+
+    /// <summary>
+    /// The profile admits only client authentication that proves possession of a key: mutual TLS
+    /// (RFC 8705 section 2) or a private key JWT assertion (OpenID Connect Core section 9). Every
+    /// method keyed on a shared secret is refused. Enforced by
+    /// <see cref="SecurityProfileConsistency"/> at registration and at startup.
+    /// </summary>
+    public bool RequireKeyBasedClientAuthentication { get; init; }
+
+    /// <summary>
+    /// The profile accepts only the server's issuer identifier, and only as a string, in the
+    /// audience of a client authentication assertion, narrowing what the underlying specification
+    /// otherwise permits. Enforced by
+    /// <c>Features.ClientAuthentication.ClientAssertionAudienceValidator</c>.
+    /// </summary>
+    public bool RequireIssuerAudienceInClientAssertion { get; init; }
+
+    /// <summary>
+    /// The profile forbids refresh token rotation, which is the one flag that removes a control
+    /// rather than requiring one. See the remarks on this type for why that is admissible here and
+    /// what stands in its place. Enforced by
+    /// <c>Features.Tokens.RefreshTokenService</c>.
+    /// </summary>
+    public bool ForbidRefreshTokenRotation { get; init; }
+
     private static readonly SecurityProfileRequirements NoneRequirements = new();
 
     private static readonly SecurityProfileRequirements Fapi2Requirements = new()
@@ -86,7 +126,55 @@ public sealed record SecurityProfileRequirements
         RequireSenderConstrainedTokens = true,
         RequireCodeResponseTypeOnly = true,
         RequireStrictRequestObjectProcessing = true,
+        RequireConfidentialClient = true,
+        RequireKeyBasedClientAuthentication = true,
+        RequireIssuerAudienceInClientAssertion = true,
+        ForbidRefreshTokenRotation = true,
     };
+
+    /// <summary>
+    /// Names every profile that removes a control without carrying the controls that stand in for
+    /// it. An empty list means each relaxation in this file is paid for.
+    /// </summary>
+    /// <remarks>
+    /// This exists because a relaxing flag is one edit away from becoming an ordinary permission.
+    /// Someone adding a profile, or loosening an existing one, sees a set of booleans with no
+    /// direction to them, and nothing in the type distinguishes the flag that removes protection
+    /// from the nine that add it. So the condition that makes the removal sound is stated as code
+    /// and run at startup, where it can fail, rather than as a paragraph that can be skipped.
+    ///
+    /// Refusing refresh token rotation is sound only alongside a confidential client and a
+    /// sender-constrained token, because those two are what make rotation redundant. A profile
+    /// carrying the relaxation without them would hand out long-lived multi-use refresh tokens to a
+    /// client that may be public and whose tokens anyone may replay.
+    /// </remarks>
+    public static IReadOnlyList<string> FindUnreplacedRelaxations()
+    {
+        var violations = new List<string>();
+
+        foreach (var profile in Enum.GetValues<ClientSecurityProfile>())
+        {
+            var requirements = Resolve(profile);
+            if (!requirements.ForbidRefreshTokenRotation)
+                continue;
+
+            if (!requirements.RequireConfidentialClient)
+            {
+                violations.Add(
+                    $"the {profile} profile forbids refresh token rotation without requiring a " +
+                    "confidential client, which is one of the two controls that replace it");
+            }
+
+            if (!requirements.RequireSenderConstrainedTokens)
+            {
+                violations.Add(
+                    $"the {profile} profile forbids refresh token rotation without requiring a " +
+                    "sender-constrained token, which is one of the two controls that replace it");
+            }
+        }
+
+        return violations;
+    }
 
     /// <summary>
     /// Returns the control bundle a given profile mandates.

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -101,7 +101,12 @@ public static class ServiceCollectionExtensions
         // or enable JWT Bearer still resolve the dependency.
         services.AddReplayPrevention();
 
-        return services.Compose<IClientAuthenticator, CompositeClientAuthenticator>();
+        services.Compose<IClientAuthenticator, CompositeClientAuthenticator>();
+
+        // Outermost, so it sees every client whichever credential form got it through. The
+        // configuration paths cannot: a client registered dynamically before a profile was turned
+        // on lives in the store and is re-read by nobody.
+        return services.Decorate<IClientAuthenticator, SecurityProfileClientAuthenticator>();
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/RefreshTokenService.cs
@@ -78,7 +78,17 @@ public class RefreshTokenService(
 		if (expiresAt < now)
 			return null;
 
-		if (!clientInfo.RefreshToken.AllowReuse &&
+		// FAPI 2.0 section 5.3.2.1 forbids rotation for a client held to it, because a confidential
+		// client with a sender-constrained token gains nothing from rotating while losing its session
+		// whenever it fails to store the token it was handed. The profile decides over the client's own
+		// setting here, which is the one place a profile removes a control rather than adding one; the
+		// two controls that make the removal sound are required by the same profile.
+		var rotates = !clientInfo.RefreshToken.AllowReuse &&
+		              !SecurityProfileRequirements
+		                  .For(clientInfo, options.Value.DefaultSecurityProfile)
+		                  .ForbidRefreshTokenRotation;
+
+		if (rotates &&
 		    refreshToken is { Payload: { JwtId: { } previousJwtId, ExpiresAt: { } previousExpiresAt } })
 		{
 			// Rotation marks the previous token Used ("superseded"), not Revoked ("killed"). A later

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -284,6 +284,7 @@ internal static class LogEvents
             private const int Base = 3090;
 
             public const int RegistrationCannotSatisfyProfile = Base + 1;
+            public const int ProfileIsNotOneThisServerDefines = Base + 2;
         }
     }
 

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -284,7 +284,6 @@ internal static class LogEvents
             private const int Base = 3090;
 
             public const int RegistrationCannotSatisfyProfile = Base + 1;
-            public const int ProfileIsNotOneThisServerDefines = Base + 2;
         }
     }
 

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -203,6 +203,7 @@ internal static class LogEvents
             public const int MissingExpiration = Base + 9;
             public const int ReplayDetected = Base + 10;
             public const int OtherKindPresentedAsAssertion = Base + 11;
+            public const int AudienceIsNotTheIssuerAlone = Base + 12;
         }
 
         /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -265,7 +265,7 @@ internal static class LogEvents
         /// <summary>
         /// <c>Features/ClientAuthentication/TlsMetadataClientAuthenticator.cs</c> -
         /// RFC 8705 tls_client_auth via Subject DN / SAN matching
-        /// (sub-range 3085-3099).
+        /// (sub-range 3085-3089).
         /// </summary>
         public static class TlsMetadataClientAuthenticator
         {
@@ -273,6 +273,17 @@ internal static class LogEvents
 
             public const int NoTlsMetadataConfigured = Base + 1;
             public const int Authenticated = Base + 2;
+        }
+
+        /// <summary>
+        /// <c>Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs</c> - refuses a
+        /// stored registration that cannot satisfy the profile it is held to (sub-range 3090-3099).
+        /// </summary>
+        public static class SecurityProfileClientAuthenticator
+        {
+            private const int Base = 3090;
+
+            public const int RegistrationCannotSatisfyProfile = Base + 1;
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SecurityProfileValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DynamicClientManagement/Validation/SecurityProfileValidatorTests.cs
@@ -35,6 +35,11 @@ public class SecurityProfileValidatorTests
         {
             RedirectUris = [TestConstants.DefaultRedirectUri],
             ResponseTypes = responseTypes,
+
+            // These cases are about response types, so the authentication method is one the
+            // profile admits: leaving the default here would make every one of them fail for
+            // the wrong reason.
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
         };
 
         return new ClientRegistrationValidationContext(request);

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientSecretJwtAuthenticatorTests.cs
@@ -24,6 +24,9 @@ using Moq;
 using Xunit;
 using JsonWebToken = Abblix.Jwt.JsonWebToken;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.Options;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Common.Configuration;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
 
@@ -65,7 +68,9 @@ public class ClientSecretJwtAuthenticatorTests
             _clientInfoProvider.Object,
             _requestInfoProvider.Object,
             _clock,
-            _replayCache.Object);
+            _replayCache.Object,
+            Mock.Of<IIssuerProvider>(p => p.GetIssuer() == "https://issuer.example.com"),
+            Options.Create(new OidcOptions()));
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
@@ -21,6 +21,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using Microsoft.Extensions.Options;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Common.Configuration;
+using System.Globalization;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
 
@@ -552,11 +556,127 @@ public class PrivateKeyJwtAuthenticatorTests
         Assert.Equal(ClientAuthenticationMethods.PrivateKeyJwt, methods[0]);
     }
 
+
+    /// <summary>
+    /// FAPI 2.0 section 5.3.2.1: a server held to the profile "shall only accept its issuer
+    /// identifier value (as defined in [RFC8414]) as a string in the aud claim received in client
+    /// authentication assertions". An assertion naming the token endpoint satisfies the wider
+    /// reading OpenID Connect Core permits and is refused here.
+    /// </summary>
+    [Theory]
+    [InlineData("https://issuer.example.com/connect/token")]
+    [InlineData("https://another-issuer.example.com")]
+    public async Task Fapi2AssertionAudienceIsNotTheIssuer_ShouldReturnNull(string audience)
+    {
+        var (authenticator, mocks) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        var clientInfo = CreateClientInfo(ClientId);
+        var token = CreateValidJwtTokenWithJtiAndExp(
+            ClientId, ClientId, "audience-not-the-issuer",
+            DateTimeOffset.Parse("2027-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        token.Payload.Audiences = [audience];
+
+        mocks.ClientJwtValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, clientInfo));
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// The issuer alone is accepted, which is what keeps the refusal above from being a check that
+    /// refuses every assertion.
+    /// </summary>
+    [Fact]
+    public async Task Fapi2AssertionAudienceIsTheIssuer_ShouldAuthenticate()
+    {
+        var (authenticator, mocks) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        var clientInfo = CreateClientInfo(ClientId);
+        var token = CreateValidJwtTokenWithJtiAndExp(
+            ClientId, ClientId, "audience-is-the-issuer",
+            DateTimeOffset.Parse("2027-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        token.Payload.Audiences = ["https://issuer.example.com"];
+
+        mocks.ClientJwtValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, clientInfo));
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+
+        Assert.NotNull(result);
+    }
+
+    /// <summary>
+    /// The issuer named alongside another audience is refused: the specification asks for the value
+    /// as a string, so an assertion minted for a different recipient cannot be replayed here by
+    /// naming both.
+    /// </summary>
+    [Fact]
+    public async Task Fapi2AssertionAudienceCarriesTheIssuerAmongOthers_ShouldReturnNull()
+    {
+        var (authenticator, mocks) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        var clientInfo = CreateClientInfo(ClientId);
+        var token = CreateValidJwtTokenWithJtiAndExp(
+            ClientId, ClientId, "audience-among-others",
+            DateTimeOffset.Parse("2027-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        token.Payload.Audiences = ["https://issuer.example.com", "https://another.example.com"];
+
+        mocks.ClientJwtValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, clientInfo));
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Without the profile the wider reading stands, so an assertion naming the token endpoint keeps
+    /// working. This is what makes the three cases above statements about the profile rather than
+    /// about the authenticator.
+    /// </summary>
+    [Fact]
+    public async Task NoProfileAssertionAudienceIsTheTokenEndpoint_ShouldAuthenticate()
+    {
+        var (authenticator, mocks) = CreateAuthenticator();
+        var clientInfo = CreateClientInfo(ClientId);
+        var token = CreateValidJwtTokenWithJtiAndExp(
+            ClientId, ClientId, "audience-outside-the-profile",
+            DateTimeOffset.Parse("2027-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        token.Payload.Audiences = ["https://issuer.example.com/connect/token"];
+
+        mocks.ClientJwtValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(token, clientInfo));
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+
+        Assert.NotNull(result);
+    }
+
     /// <summary>
     /// Creates a new instance of PrivateKeyJwtAuthenticator with mocked dependencies for testing.
     /// </summary>
     /// <returns>A tuple containing the authenticator instance and the mock objects.</returns>
-    private (PrivateKeyJwtAuthenticator authenticator, Mocks mocks) CreateAuthenticator()
+    private (PrivateKeyJwtAuthenticator authenticator, Mocks mocks) CreateAuthenticator(
+        ClientSecurityProfile profile = ClientSecurityProfile.None)
     {
         var logger = new Mock<ILogger<PrivateKeyJwtAuthenticator>>();
         var replayCache = new Mock<IReplayCache>(MockBehavior.Strict);
@@ -575,7 +695,9 @@ public class PrivateKeyJwtAuthenticatorTests
         var authenticator = new PrivateKeyJwtAuthenticator(
             logger.Object,
             replayCache.Object,
-            serviceProvider);
+            serviceProvider,
+            Mock.Of<IIssuerProvider>(p => p.GetIssuer() == "https://issuer.example.com"),
+            Options.Create(new OidcOptions { DefaultSecurityProfile = profile }));
 
         var mocks = new Mocks
         {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -76,7 +76,11 @@ public class SecurityProfileClientAuthenticatorTests
         Authenticates(inner, new ClientInfo(ClientId)
         {
             TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
-            AllowedResponseTypes = [[ResponseTypes.Code, ResponseTypes.IdToken]],
+            // The code response type is allowed as well, so this trips the clause about a
+            // FORBIDDEN response type and no other: an array carrying only the hybrid pair would
+            // also trip the clause requiring the code type, and the row would stay green if the
+            // clause its name points at were deleted.
+            AllowedResponseTypes = [[ResponseTypes.Code], [ResponseTypes.Code, ResponseTypes.IdToken]],
         });
 
         var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -1,0 +1,144 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientAuthentication;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
+
+/// <summary>
+/// The profile has to reach a client the configuration paths never see: one registered dynamically
+/// while no profile was in force, which lives in the store and is re-read by nobody when the
+/// deployment turns a profile on.
+/// </summary>
+public class SecurityProfileClientAuthenticatorTests
+{
+    private const string ClientId = "stored-client";
+
+    private static (SecurityProfileClientAuthenticator Authenticator, Mock<IClientAuthenticator> Inner)
+        CreateAuthenticator(ClientSecurityProfile defaultProfile)
+    {
+        var inner = new Mock<IClientAuthenticator>();
+        var authenticator = new SecurityProfileClientAuthenticator(
+            inner.Object,
+            Options.Create(new OidcOptions { DefaultSecurityProfile = defaultProfile }),
+            NullLogger<SecurityProfileClientAuthenticator>.Instance);
+
+        return (authenticator, inner);
+    }
+
+    private static void Authenticates(Mock<IClientAuthenticator> inner, ClientInfo clientInfo)
+        => inner.Setup(a => a.TryAuthenticateClientAsync(It.IsAny<ClientRequest>()))
+            .ReturnsAsync(clientInfo);
+
+    /// <summary>
+    /// The scenario the decorator exists for: the shared secret was acceptable when the client
+    /// registered, and the profile turned on afterwards. The credential verifies, and the client is
+    /// still refused, because the registration behind it cannot satisfy the profile.
+    /// </summary>
+    [Theory]
+    [InlineData(ClientAuthenticationMethods.ClientSecretBasic)]
+    [InlineData(ClientAuthenticationMethods.ClientSecretPost)]
+    [InlineData(ClientAuthenticationMethods.None)]
+    public async Task StoredClientCannotSatisfyProfile_ShouldReturnNull(string method)
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        Authenticates(inner, new ClientInfo(ClientId) { TokenEndpointAuthMethod = method });
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// A registration the profile admits passes through untouched, which is what keeps the refusals
+    /// above from being a decorator that refuses everything.
+    /// </summary>
+    [Fact]
+    public async Task StoredClientSatisfiesProfile_ShouldAuthenticate()
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+        };
+        Authenticates(inner, clientInfo);
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.Same(clientInfo, result);
+    }
+
+    /// <summary>
+    /// Without a profile nothing is narrowed, so a deployment that selects none keeps every client
+    /// it already had.
+    /// </summary>
+    [Fact]
+    public async Task NoProfile_ShouldAuthenticateWhateverTheRegistration()
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.None);
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+        };
+        Authenticates(inner, clientInfo);
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.Same(clientInfo, result);
+    }
+
+    /// <summary>
+    /// The client's own profile outranks the server-wide default, in both directions: a client
+    /// naming no profile under a Fapi2 server is held to it, and a client naming none under one is
+    /// not. Without the second half the decorator could be reading the default alone.
+    /// </summary>
+    [Fact]
+    public async Task ClientProfileOverridesTheDefault()
+    {
+        var (relaxed, relaxedInner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        Authenticates(relaxedInner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+            SecurityProfile = ClientSecurityProfile.None,
+        });
+
+        Assert.NotNull(await relaxed.TryAuthenticateClientAsync(new ClientRequest()));
+
+        var (tightened, tightenedInner) = CreateAuthenticator(ClientSecurityProfile.None);
+        Authenticates(tightenedInner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+            SecurityProfile = ClientSecurityProfile.Fapi2,
+        });
+
+        Assert.Null(await tightened.TryAuthenticateClientAsync(new ClientRequest()));
+    }
+
+    /// <summary>
+    /// A credential that did not verify stays unverified: the decorator adds a refusal and never an
+    /// acceptance.
+    /// </summary>
+    [Fact]
+    public async Task InnerRefuses_ShouldReturnNull()
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        inner.Setup(a => a.TryAuthenticateClientAsync(It.IsAny<ClientRequest>()))
+            .ReturnsAsync((ClientInfo?)null);
+
+        Assert.Null(await authenticator.TryAuthenticateClientAsync(new ClientRequest()));
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -89,10 +89,9 @@ public class SecurityProfileClientAuthenticatorTests
     }
 
     /// <summary>
-    /// A store the HOST writes can hand back a profile value the enum does not define - the startup
-    /// check covers the configured clients and cannot reach a store. Resolving such a value throws,
-    /// so the decorator refuses instead: an exception here would be a 500 from the token endpoint,
-    /// which is the failure this class exists to remove.
+    /// A store the HOST writes can hand back a profile value the enum does not define, and no
+    /// startup check can reach a host's store. Such a value resolves to the strictest bundle, so a
+    /// client that cannot satisfy it is refused here like any other - the refusal is not special.
     /// </summary>
     [Fact]
     public async Task StoredClientCarriesAProfileThisServerDoesNotDefine_ShouldReturnNull()
@@ -100,13 +99,34 @@ public class SecurityProfileClientAuthenticatorTests
         var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.None);
         Authenticates(inner, new ClientInfo(ClientId)
         {
-            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
             SecurityProfile = (ClientSecurityProfile)7,
         });
 
         var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
 
         Assert.Null(result);
+    }
+
+    /// <summary>
+    /// And a client that DOES satisfy the strictest bundle is served, which is what keeps the
+    /// refusal above from being "an undefined profile refuses everything" - a reading under which
+    /// the value would be a denial of service rather than a constraint.
+    /// </summary>
+    [Fact]
+    public async Task StoredClientWithAnUndefinedProfileButCompliant_ShouldAuthenticate()
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.None);
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            SecurityProfile = (ClientSecurityProfile)7,
+        };
+        Authenticates(inner, clientInfo);
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.Same(clientInfo, result);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -64,6 +64,27 @@ public class SecurityProfileClientAuthenticatorTests
     }
 
     /// <summary>
+    /// The decorator runs the whole checker, not the half about credentials: a registration allowing
+    /// a response type the profile forbids is refused here too, even though its credential is one the
+    /// profile admits. Without this row the response-type clauses decide no outcome in this file, and
+    /// a decorator reading only the authentication method would leave it green.
+    /// </summary>
+    [Fact]
+    public async Task StoredClientAllowsAForbiddenResponseType_ShouldReturnNull()
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            AllowedResponseTypes = [[ResponseTypes.Code, ResponseTypes.IdToken]],
+        });
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
     /// A registration the profile admits passes through untouched, which is what keeps the refusals
     /// above from being a decorator that refuses everything.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -89,6 +89,27 @@ public class SecurityProfileClientAuthenticatorTests
     }
 
     /// <summary>
+    /// A store the HOST writes can hand back a profile value the enum does not define - the startup
+    /// check covers the configured clients and cannot reach a store. Resolving such a value throws,
+    /// so the decorator refuses instead: an exception here would be a 500 from the token endpoint,
+    /// which is the failure this class exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task StoredClientCarriesAProfileThisServerDoesNotDefine_ShouldReturnNull()
+    {
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.None);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            SecurityProfile = (ClientSecurityProfile)7,
+        });
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
     /// A registration the profile admits passes through untouched, which is what keeps the refusals
     /// above from being a decorator that refuses everything.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -6,12 +6,15 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -30,14 +33,63 @@ public class SecurityProfileClientAuthenticatorTests
 
     private static (SecurityProfileClientAuthenticator Authenticator, Mock<IClientAuthenticator> Inner)
         CreateAuthenticator(ClientSecurityProfile defaultProfile)
+        => CreateAuthenticator(defaultProfile, NullLogger<SecurityProfileClientAuthenticator>.Instance);
+
+    private static (SecurityProfileClientAuthenticator Authenticator, Mock<IClientAuthenticator> Inner)
+        CreateAuthenticator(ClientSecurityProfile defaultProfile, ILogger<SecurityProfileClientAuthenticator> logger)
     {
         var inner = new Mock<IClientAuthenticator>();
         var authenticator = new SecurityProfileClientAuthenticator(
             inner.Object,
             Options.Create(new OidcOptions { DefaultSecurityProfile = defaultProfile }),
-            NullLogger<SecurityProfileClientAuthenticator>.Instance);
+            logger);
 
         return (authenticator, inner);
+    }
+
+    /// <summary>
+    /// The value that cannot be interpreted is said out loud here, because this is the only place a
+    /// client out of a host-written store is met by name. Without it the operator sees only the
+    /// consequence - refusals citing requirements no configuration of theirs sets.
+    /// </summary>
+    [Fact]
+    public async Task StoredClientWithAnUndefinedProfile_ShouldBeNamedInTheLog()
+    {
+        var logger = new CapturingLogger();
+
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.None, logger);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            SecurityProfile = (ClientSecurityProfile)7,
+        });
+
+        await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        var entry = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains("7", entry.Message);
+        Assert.Contains(ClientId, entry.Message);
+    }
+
+    /// <summary>
+    /// And a profile this server does define says nothing, or the line would be noise on every
+    /// request rather than a signal about one client.
+    /// </summary>
+    [Fact]
+    public async Task StoredClientWithADefinedProfile_ShouldNotBeNamedInTheLog()
+    {
+        var logger = new CapturingLogger();
+
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.None, logger);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            SecurityProfile = ClientSecurityProfile.Fapi2,
+        });
+
+        await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning);
     }
 
     private static void Authenticates(Mock<IClientAuthenticator> inner, ClientInfo clientInfo)
@@ -206,5 +258,26 @@ public class SecurityProfileClientAuthenticatorTests
             .ReturnsAsync((ClientInfo?)null);
 
         Assert.Null(await authenticator.TryAuthenticateClientAsync(new ClientRequest()));
+    }
+
+    /// <summary>
+    /// A logger that keeps what it was told. Hand-written rather than mocked because the type under
+    /// test is internal, and a dynamic proxy cannot be built over a generic logger closed on it.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger<SecurityProfileClientAuthenticator>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Abblix.Oidc.Server;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
@@ -66,7 +67,14 @@ public class SecurityProfileClientAuthenticatorTests
 
         await authenticator.TryAuthenticateClientAsync(new ClientRequest());
 
-        var entry = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+        // Selected by EVENT, not by level: this class emits a second warning of its own, and a
+        // fixture that also tripped it would satisfy both assertions off the wrong line.
+        var entry = Assert.Single(
+            logger.Entries,
+            e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
+                .ProfileIsNotOneThisServerDefines);
+
+        Assert.Equal(LogLevel.Warning, entry.Level);
         Assert.Contains("7", entry.Message);
         Assert.Contains(ClientId, entry.Message);
     }
@@ -89,7 +97,10 @@ public class SecurityProfileClientAuthenticatorTests
 
         await authenticator.TryAuthenticateClientAsync(new ClientRequest());
 
-        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.DoesNotContain(
+            logger.Entries,
+            e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
+                .ProfileIsNotOneThisServerDefines);
     }
 
     private static void Authenticates(Mock<IClientAuthenticator> inner, ClientInfo clientInfo)
@@ -266,7 +277,7 @@ public class SecurityProfileClientAuthenticatorTests
     /// </summary>
     private sealed class CapturingLogger : ILogger<SecurityProfileClientAuthenticator>
     {
-        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        public List<(LogLevel Level, int EventId, string Message)> Entries { get; } = [];
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -278,6 +289,6 @@ public class SecurityProfileClientAuthenticatorTests
             TState state,
             Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => Entries.Add((logLevel, formatter(state, exception)));
+            => Entries.Add((logLevel, eventId.Id, formatter(state, exception)));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -416,7 +416,19 @@ public class SecurityProfileTests
     [Fact]
     public void Validate_UndefinedDefaultProfile_Fails()
     {
-        var options = new OidcOptions { DefaultSecurityProfile = (ClientSecurityProfile)7 };
+        // With a client on the options, because a validator holding no clients never resolves the
+        // default at all: the case this check is for is a deployment that HAS clients inheriting it.
+        var options = new OidcOptions
+        {
+            DefaultSecurityProfile = (ClientSecurityProfile)7,
+            Clients =
+            [
+                new ClientInfo("client-1")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+                },
+            ],
+        };
 
         var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -406,4 +406,62 @@ public class SecurityProfileTests
         Assert.Throws<InvalidOperationException>(
             () => SecurityProfileRequirements.Resolve((ClientSecurityProfile)int.MaxValue));
     }
+
+    /// <summary>
+    /// The configuration binder binds a NUMBER outside an enum's range as it stands - only a name it
+    /// does not know throws - so a profile value nothing defines reaches the options object. Startup
+    /// has to name it: every reader of the profile refuses such a value, and without this check the
+    /// deployment starts and answers 500 to the first request that carries a client.
+    /// </summary>
+    [Fact]
+    public void Validate_UndefinedDefaultProfile_Fails()
+    {
+        var options = new OidcOptions { DefaultSecurityProfile = (ClientSecurityProfile)7 };
+
+        var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("DefaultSecurityProfile"));
+    }
+
+    /// <summary>
+    /// The same for a client naming its own profile, and it is checked whether or not the server-wide
+    /// default is sound.
+    /// </summary>
+    [Fact]
+    public void Validate_UndefinedClientProfile_Fails()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo("client-1")
+                {
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+                    SecurityProfile = (ClientSecurityProfile)9,
+                },
+            ],
+        };
+
+        var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("client-1"));
+    }
+
+    /// <summary>
+    /// Both defined profiles pass, which is what keeps the two refusals above from being a check that
+    /// refuses every configuration.
+    /// </summary>
+    [Theory]
+    [InlineData(ClientSecurityProfile.None)]
+    [InlineData(ClientSecurityProfile.Fapi2)]
+    public void Validate_DefinedProfile_Succeeds(ClientSecurityProfile profile)
+    {
+        var options = new OidcOptions { DefaultSecurityProfile = profile };
+
+        var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -504,17 +504,43 @@ public class SecurityProfileTests
 
     /// <summary>
     /// A value the enum DOES define with no bundle declared is the other population: a mistake in
-    /// this file rather than data from a host, caught while the author is still here.
+    /// this file rather than data from a host, and it has to be loud while the author is still here.
+    /// It cannot be expressed through the enum, because every value that ships has a bundle, so the
+    /// bundle comes from the caller.
     /// </summary>
     [Fact]
     public void Resolve_DefinedProfileWithNoBundle_Throws()
     {
-        // Every defined value has a bundle today, so the case is expressed by the check itself:
-        // whatever the enum defines must resolve without falling through to the strictest fallback.
+        var error = Assert.Throws<InvalidOperationException>(
+            () => SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2, declared: null));
+
+        Assert.Contains(nameof(ClientSecurityProfile.Fapi2), error.Message);
+    }
+
+    /// <summary>
+    /// And the refusal is about the missing bundle rather than about the profile being unusual: a
+    /// defined value WITH one resolves to exactly it.
+    /// </summary>
+    [Fact]
+    public void Resolve_DefinedProfileWithABundle_ReturnsIt()
+    {
+        var declared = new SecurityProfileRequirements { RequirePkce = true };
+
+        Assert.Same(
+            declared,
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.None, declared));
+    }
+
+    /// <summary>
+    /// Every profile that ships resolves, which is what keeps the refusal above from being a case
+    /// nobody meets: a value added to the enum without a bundle fails here and at startup.
+    /// </summary>
+    [Fact]
+    public void Resolve_EveryShippedProfile_Resolves()
+    {
         foreach (var profile in Enum.GetValues<ClientSecurityProfile>())
         {
-            var requirements = SecurityProfileRequirements.Resolve(profile);
-            Assert.NotNull(requirements);
+            Assert.NotNull(SecurityProfileRequirements.Resolve(profile));
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -80,6 +80,7 @@ public class SecurityProfileTests
     {
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code]],
+            ClientAuthenticationMethods.PrivateKeyJwt,
             ClientSecurityProfile.Fapi2);
 
         Assert.Empty(violations);
@@ -94,6 +95,7 @@ public class SecurityProfileTests
     {
         var violations = SecurityProfileConsistency.FindViolations(
             [["Code"]],
+            ClientAuthenticationMethods.PrivateKeyJwt,
             ClientSecurityProfile.Fapi2);
 
         Assert.Empty(violations);
@@ -104,6 +106,7 @@ public class SecurityProfileTests
     {
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.IdToken]],
+            ClientAuthenticationMethods.PrivateKeyJwt,
             ClientSecurityProfile.Fapi2);
 
         Assert.Equal(2, violations.Count);
@@ -114,6 +117,7 @@ public class SecurityProfileTests
     {
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code], [ResponseTypes.Code, ResponseTypes.IdToken]],
+            ClientAuthenticationMethods.PrivateKeyJwt,
             ClientSecurityProfile.Fapi2);
 
         // code is allowed, so only the implicit/hybrid violation remains.
@@ -125,6 +129,7 @@ public class SecurityProfileTests
     {
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.IdToken]],
+            ClientAuthenticationMethods.PrivateKeyJwt,
             ClientSecurityProfile.None);
 
         Assert.Empty(violations);
@@ -141,6 +146,7 @@ public class SecurityProfileTests
                 {
                     SecurityProfile = ClientSecurityProfile.Fapi2,
                     AllowedResponseTypes = [[ResponseTypes.Code]],
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
                 },
             ],
         };
@@ -240,5 +246,112 @@ public class SecurityProfileTests
         var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
 
         Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
+    /// FAPI 2.0 section 5.3.2.1: the server "shall only support confidential clients as defined in
+    /// [RFC6749]". A client authenticating with nothing at the token endpoint is the public client
+    /// that rule excludes, and the refusal has to reach it before it ever sends a request.
+    /// </summary>
+    [Fact]
+    public void FindViolations_Fapi2PublicClient_Violation()
+    {
+        var violations = SecurityProfileConsistency.FindViolations(
+            [[ResponseTypes.Code]],
+            ClientAuthenticationMethods.None,
+            ClientSecurityProfile.Fapi2);
+
+        Assert.Contains(violations, violation => violation.Contains("confidential clients only"));
+    }
+
+    /// <summary>
+    /// FAPI 2.0 section 5.3.2.1 admits mutual TLS and the private key JWT assertion, both of which
+    /// prove possession of a key. Every method keyed on a shared secret is refused, whichever form
+    /// it takes.
+    /// </summary>
+    [Theory]
+    [InlineData(ClientAuthenticationMethods.ClientSecretBasic)]
+    [InlineData(ClientAuthenticationMethods.ClientSecretPost)]
+    [InlineData(ClientAuthenticationMethods.ClientSecretJwt)]
+    public void FindViolations_Fapi2SharedSecretAuthentication_Violation(string method)
+    {
+        var violations = SecurityProfileConsistency.FindViolations(
+            [[ResponseTypes.Code]],
+            method,
+            ClientSecurityProfile.Fapi2);
+
+        Assert.Contains(violations, violation => violation.Contains("mutual TLS or a private key JWT"));
+    }
+
+    /// <summary>
+    /// The two methods the profile admits pass, which is what keeps the refusal above from being a
+    /// check that refuses everything.
+    /// </summary>
+    [Theory]
+    [InlineData(ClientAuthenticationMethods.TlsClientAuth)]
+    [InlineData(ClientAuthenticationMethods.SelfSignedTlsClientAuth)]
+    [InlineData(ClientAuthenticationMethods.PrivateKeyJwt)]
+    public void FindViolations_Fapi2KeyBasedAuthentication_NoViolations(string method)
+    {
+        var violations = SecurityProfileConsistency.FindViolations(
+            [[ResponseTypes.Code]],
+            method,
+            ClientSecurityProfile.Fapi2);
+
+        Assert.Empty(violations);
+    }
+
+    /// <summary>
+    /// Neither new requirement fires without a profile, so a deployment that selects none keeps the
+    /// client configurations it already has.
+    /// </summary>
+    [Fact]
+    public void FindViolations_NoProfilePublicClient_NoViolations()
+    {
+        var violations = SecurityProfileConsistency.FindViolations(
+            [[ResponseTypes.Code]],
+            ClientAuthenticationMethods.None,
+            ClientSecurityProfile.None);
+
+        Assert.Empty(violations);
+    }
+
+    /// <summary>
+    /// FAPI 2.0 section 5.3.2.1: the server "shall not use refresh token rotation except in
+    /// extraordinary circumstances". This is the one requirement that removes a control instead of
+    /// adding one.
+    /// </summary>
+    [Fact]
+    public void Fapi2_ForbidsRefreshTokenRotation()
+    {
+        Assert.True(SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2)
+            .ForbidRefreshTokenRotation);
+    }
+
+    /// <summary>
+    /// Removing rotation is sound only because the same profile requires the two controls that
+    /// stand in for it. This is the check that keeps that condition true as profiles are added or
+    /// edited, and it runs at startup rather than at review time.
+    /// </summary>
+    [Fact]
+    public void FindUnreplacedRelaxations_ShippedProfiles_None()
+    {
+        Assert.Empty(SecurityProfileRequirements.FindUnreplacedRelaxations());
+    }
+
+    /// <summary>
+    /// The remaining two requirements are read by services rather than by the consistency check, so
+    /// what is asserted here is that the profile carries them at all. A flag a profile sets and no
+    /// consumer reads would ship silently unenforced, which is what the enforcement tests in the
+    /// end-to-end suites answer for.
+    /// </summary>
+    [Fact]
+    public void Fapi2_CarriesTheRemainingRequirements()
+    {
+        var requirements = SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2);
+
+        Assert.True(requirements.RequireConfidentialClient);
+        Assert.True(requirements.RequireKeyBasedClientAuthentication);
+        Assert.True(requirements.RequireIssuerAudienceInClientAssertion);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -11,6 +11,7 @@ using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
 using Xunit;
+using System;
 
 namespace Abblix.Oidc.Server.UnitTests.Features.ClientInformation;
 
@@ -341,9 +342,9 @@ public class SecurityProfileTests
 
     /// <summary>
     /// The remaining two requirements are read by services rather than by the consistency check, so
-    /// what is asserted here is that the profile carries them at all. A flag a profile sets and no
-    /// consumer reads would ship silently unenforced, which is what the enforcement tests in the
-    /// end-to-end suites answer for.
+    /// what is asserted here is that the profile carries them at all. That each flag has a consumer
+    /// that reads it is answered elsewhere in this project: the audience refusals in
+    /// PrivateKeyJwtAuthenticatorTests, and the rotation case in RefreshTokenServiceTests.
     /// </summary>
     [Fact]
     public void Fapi2_CarriesTheRemainingRequirements()
@@ -353,5 +354,56 @@ public class SecurityProfileTests
         Assert.True(requirements.RequireConfidentialClient);
         Assert.True(requirements.RequireKeyBasedClientAuthentication);
         Assert.True(requirements.RequireIssuerAudienceInClientAssertion);
+    }
+    /// <summary>
+    /// The mistake the guard exists to catch, driven directly: a profile that drops rotation and
+    /// carries neither control that replaces it. It cannot be expressed through the profiles that
+    /// ship, since those are correct, so the walk takes its pairs from the caller.
+    /// </summary>
+    [Fact]
+    public void FindUnreplacedRelaxations_RotationDroppedWithNoReplacement_NamesBothControls()
+    {
+        var violations = SecurityProfileRequirements.FindUnreplacedRelaxations(
+            [("Unpaid", new SecurityProfileRequirements { ForbidRefreshTokenRotation = true })]);
+
+        Assert.Equal(2, violations.Count);
+        Assert.Contains(violations, v => v.Contains("confidential client"));
+        Assert.Contains(violations, v => v.Contains("sender-constrained token"));
+    }
+
+    /// <summary>
+    /// One control present and the other missing is still a violation, and only the missing one is
+    /// named. Without this the guard could pass by requiring either control rather than both.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false, "sender-constrained token")]
+    [InlineData(false, true, "confidential client")]
+    public void FindUnreplacedRelaxations_OneControlMissing_NamesThatControlAlone(
+        bool confidential, bool senderConstrained, string expected)
+    {
+        var violations = SecurityProfileRequirements.FindUnreplacedRelaxations(
+        [
+            ("Half", new SecurityProfileRequirements
+            {
+                ForbidRefreshTokenRotation = true,
+                RequireConfidentialClient = confidential,
+                RequireSenderConstrainedTokens = senderConstrained,
+            }),
+        ]);
+
+        Assert.Single(violations);
+        Assert.Contains(expected, violations[0]);
+    }
+
+    /// <summary>
+    /// A profile added to the enum without a bundle resolves to nothing at all, which is the
+    /// weakest answer available and would let every guard above report clean over a deployment
+    /// running no profile. It has to be loud instead.
+    /// </summary>
+    [Fact]
+    public void Resolve_UnmappedProfile_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => SecurityProfileRequirements.Resolve((ClientSecurityProfile)int.MaxValue));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -396,18 +396,6 @@ public class SecurityProfileTests
     }
 
     /// <summary>
-    /// A profile added to the enum without a bundle resolves to nothing at all, which is the
-    /// weakest answer available and would let every guard above report clean over a deployment
-    /// running no profile. It has to be loud instead.
-    /// </summary>
-    [Fact]
-    public void Resolve_UnmappedProfile_Throws()
-    {
-        Assert.Throws<InvalidOperationException>(
-            () => SecurityProfileRequirements.Resolve((ClientSecurityProfile)int.MaxValue));
-    }
-
-    /// <summary>
     /// The configuration binder binds a NUMBER outside an enum's range as it stands - only a name it
     /// does not know throws - so a profile value nothing defines reaches the options object. Startup
     /// has to name it: every reader of the profile refuses such a value, and without this check the
@@ -475,5 +463,73 @@ public class SecurityProfileTests
         var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
 
         Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
+    /// A value the enum does not define arrives from outside - the configuration binder takes a
+    /// number outside the range as it stands, and a client store the host writes can hold anything.
+    /// Resolving it must not throw, because the readers meeting it are serving a live request and
+    /// four of them sit on the authorization endpoint, where there is no client authentication to
+    /// put a guard in front of. Every one of those would have answered 500.
+    /// </summary>
+    [Theory]
+    [InlineData(7)]
+    [InlineData(-1)]
+    [InlineData(int.MaxValue)]
+    public void Resolve_UndefinedProfile_FailsClosedInsteadOfThrowing(int value)
+    {
+        var requirements = SecurityProfileRequirements.Resolve((ClientSecurityProfile)value);
+
+        Assert.True(requirements.RequirePkce);
+        Assert.True(requirements.RequireS256CodeChallenge);
+        Assert.True(requirements.RequirePushedAuthorizationRequests);
+        Assert.True(requirements.RequireSenderConstrainedTokens);
+        Assert.True(requirements.RequireCodeResponseTypeOnly);
+        Assert.True(requirements.RequireStrictRequestObjectProcessing);
+        Assert.True(requirements.RequireConfidentialClient);
+        Assert.True(requirements.RequireKeyBasedClientAuthentication);
+        Assert.True(requirements.RequireIssuerAudienceInClientAssertion);
+    }
+
+    /// <summary>
+    /// The one flag that REMOVES a control is not demanded by the fallback: demanding it would make
+    /// the bundle meant to be the strongest available weaker than the profile that ships.
+    /// </summary>
+    [Fact]
+    public void Resolve_UndefinedProfile_DoesNotDropRefreshTokenRotation()
+    {
+        Assert.False(SecurityProfileRequirements.Resolve((ClientSecurityProfile)7)
+            .ForbidRefreshTokenRotation);
+    }
+
+    /// <summary>
+    /// A value the enum DOES define with no bundle declared is the other population: a mistake in
+    /// this file rather than data from a host, caught while the author is still here.
+    /// </summary>
+    [Fact]
+    public void Resolve_DefinedProfileWithNoBundle_Throws()
+    {
+        // Every defined value has a bundle today, so the case is expressed by the check itself:
+        // whatever the enum defines must resolve without falling through to the strictest fallback.
+        foreach (var profile in Enum.GetValues<ClientSecurityProfile>())
+        {
+            var requirements = SecurityProfileRequirements.Resolve(profile);
+            Assert.NotNull(requirements);
+        }
+    }
+
+    /// <summary>
+    /// The client-facing entry point every reader goes through carries the same answer, so a client
+    /// out of a store reaches the authorization endpoint constrained rather than crashing it.
+    /// </summary>
+    [Fact]
+    public void For_ClientWithAnUndefinedProfile_FailsClosed()
+    {
+        var client = new ClientInfo("stored") { SecurityProfile = (ClientSecurityProfile)7 };
+
+        var requirements = SecurityProfileRequirements.For(client, ClientSecurityProfile.None);
+
+        Assert.True(requirements.RequirePkce);
+        Assert.True(requirements.RequireConfidentialClient);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DependencyInjection/ServiceCollectionOverrideTests.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Abblix.DependencyInjection;
 using Abblix.Jwt;
 using Abblix.Jwt.Encryption;
 using Abblix.Jwt.ReplayPrevention;
@@ -18,6 +19,7 @@ using Abblix.Jwt.Signing;
 
 using Abblix.Oidc.Server.AspNetCore;
 using Abblix.Oidc.Server.Common;
+using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Endpoints;
 using Abblix.Oidc.Server.Endpoints.Authorization.Interfaces;
@@ -25,6 +27,7 @@ using Abblix.Oidc.Server.Features;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.DPoP;
+using Abblix.Oidc.Server.Features.Issuer;
 using Abblix.Oidc.Server.Features.ReplayPrevention;
 using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
 using Abblix.Oidc.Server.Features.Tokens.Formatters;
@@ -126,6 +129,34 @@ public class ServiceCollectionOverrideTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => services.AddClientAuthentication());
         Assert.Contains(nameof(IClientAuthenticator), ex.Message);
+    }
+
+    [Fact]
+    public void AddClientAuthentication_ProfileEnforcementIsOutermost()
+    {
+        // The profile decorator is the only place a client already in the store meets its profile,
+        // so it has to be what the singular contract resolves to - and outside the composite, or
+        // the credential form would decide whether the profile is applied at all.
+        var services = new ServiceCollection();
+
+        services.AddClientAuthentication();
+
+        // Resolved rather than read off the descriptor: Decorate registers an object-typed factory,
+        // whose implementation type a descriptor cannot be asked for.
+        services.AddLogging();
+        services.AddOptions<OidcOptions>();
+        services.AddSingleton(new Mock<IClientInfoProvider>().Object);
+        services.AddSingleton(new Mock<Abblix.Oidc.Server.Features.ClientInformation.IClientKeysProvider>().Object);
+        services.AddSingleton(new Mock<IRequestInfoProvider>().Object);
+        services.AddSingleton(new Mock<IJsonWebTokenValidator>().Object);
+        services.AddSingleton(new Mock<Abblix.Oidc.Server.Features.Hashing.IHashService>().Object);
+        services.AddSingleton(new Mock<IClientJwtValidator>().Object);
+        services.AddSingleton(new Mock<IIssuerProvider>().Object);
+        services.AddSingleton(new Mock<IReplayCache>().Object);
+
+        var authenticator = services.BuildServiceProvider().GetRequiredService<IClientAuthenticator>();
+
+        Assert.IsType<SecurityProfileClientAuthenticator>(authenticator);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/RefreshTokenServiceTests.cs
@@ -246,6 +246,46 @@ public class RefreshTokenServiceTests
     }
 
     /// <summary>
+    /// FAPI 2.0 section 5.3.2.1: a server held to the profile "shall not use refresh token rotation
+    /// except in extraordinary circumstances". The client below asks for rotation the ordinary way,
+    /// by leaving reuse off, and the profile decides over it - the one place a profile removes a
+    /// control instead of adding one. The proof is that the previous token is never marked, so a
+    /// client presenting it again is not treated as a replay.
+    /// </summary>
+    [Fact]
+    public async Task CreateRefreshToken_WithRenewalUnderFapi2_ShouldNotSupersedeOldToken()
+    {
+        var authSession = CreateAuthSession();
+        var authContext = CreateAuthorizationContext();
+        var clientInfo = CreateClientInfo(refreshTokenOptions: new RefreshTokenOptions
+        {
+            AllowReuse = false,
+            AbsoluteExpiresIn = TimeSpan.FromHours(8),
+        });
+        clientInfo.SecurityProfile = ClientSecurityProfile.Fapi2;
+
+        var oldToken = new JsonWebToken
+        {
+            Payload =
+            {
+                JwtId = OldTokenId,
+                IssuedAt = _currentTime.AddHours(-4),
+                ExpiresAt = _currentTime.AddHours(4),
+            }
+        };
+
+        _jwtFormatter
+            .Setup(f => f.FormatAsync(It.IsAny<JsonWebToken>(), It.IsAny<ServiceJwtEncryption>()))
+            .ReturnsAsync(EncodedToken);
+
+        await _service.CreateRefreshTokenAsync(authSession, authContext, clientInfo, oldToken);
+
+        _tokenRegistry.Verify(
+            r => r.SetStatusAsync(It.IsAny<string>(), It.IsAny<JsonWebTokenStatus>(), It.IsAny<DateTimeOffset>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Verifies that when rotating a token (AllowReuse=false), the previous refresh token is marked
     /// <see cref="JsonWebTokenStatus.Used"/> - superseded, not killed. Per the RFC 9700 Section 4.14.2
     /// rotation model, a later replay of a superseded token is the breach signal that

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(156, EventIds().Count);
+        Assert.Equal(155, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(153, EventIds().Count);
+        Assert.Equal(154, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(155, EventIds().Count);
+        Assert.Equal(156, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(154, EventIds().Count);
+        Assert.Equal(155, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()


### PR DESCRIPTION
The FAPI 2.0 profile enforced six of the requirements the specification puts on an authorization server and was silent about the rest. Silence reads exactly like a requirement that does not exist, so a client held to the profile could still be public, authenticate with a shared secret, name any address in its assertion audience, and rotate its refresh tokens.

Doing this before 2.4 ships is what keeps it from being a breaking change. The profile is new in this release, so there is no prior version whose deployments would have to migrate; the same four requirements added later would refuse configurations somebody had already adopted.

## What each one required

**Confidential clients only, and key-based client authentication.** Both are properties of a registration, so both are refused where a client is configured: at dynamic registration and at startup, through the checker that already answers for the response types. The permitted methods are mutual TLS in either form and the private key JWT assertion, which are the two the specification names.

**The issuer identifier alone in an assertion audience.** The check lives in the base every assertion passes through rather than in one authenticator, so it covers the private key JWT method the profile actually admits. Both halves are enforced: the value must be the issuer rather than any address the server answers on, and it must be alone rather than one entry among several, so an assertion minted for a different recipient cannot be replayed here by naming both. Outside the profile the wider reading the underlying specification permits is untouched.

**No refresh token rotation.** Rotation earns nothing once the client is confidential and its token is bound to its sender, and it costs a user their session whenever a client fails to store the token it was handed. The profile decides over the client's own setting here.

## The invariant this widened

Every other flag on the requirements type tightens a client and cannot weaken it, and that is what lets a granular toggle coexist with a profile without silently downgrading it. Refusing rotation goes the other way.

A relaxing flag is one edit away from becoming an ordinary permission: whoever adds the next profile sees a list of booleans with no direction to them, and nothing in the type distinguishes the one that removes protection from the nine that add it. So the condition that makes the removal sound, the same profile carrying the two controls that stand in for what it drops, is stated as code and run at startup where it can fail, rather than as a paragraph in a remark that can be skipped.

## Tested

3045 unit tests, 219 and 272 end-to-end rows, all green.

The audience check is driven in both directions: three refusals for an audience that is not the issuer alone, and two acceptances, one inside the profile and one outside it, so the refusals are statements about the profile rather than about the authenticator. The rotation ban was proved by planting the fault: removing the profile condition turns exactly one test red, and no others.

Closes #510, #511, #512, #513.

## Still open

Issue #509, the clock offset requirement from the same section, stays out of this release. It is not a profile matter and changes how every deployment validates a token, which does not belong in a release branch.

The remaining requirements of section 5.4 have not been read yet, so this does not add the profile to the implemented-standards registry. That claim needs the whole document walked, not the half of it this work covers.
