### PR TITLE
Make a deployment-wide security profile a floor

### DIFF
--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -536,10 +536,10 @@ public record OidcOptions
 	public DPoPOptions DPoP { get; set; } = new();
 
 	/// <summary>
-	/// The server-wide default security profile, applied to every client whose own
-	/// <see cref="ClientInfo.SecurityProfile"/> is left unset (<c>null</c>). A single-profile
+	/// The security profile this deployment holds EVERY client to, whatever
+	/// <see cref="ClientInfo.SecurityProfile"/> each one names for itself. A single-profile
 	/// deployment sets this once - for example to <see cref="ClientSecurityProfile.Fapi2"/> - and
-	/// every client is held to the FAPI 2.0 control bundle, whatever profile it names for itself.
+	/// every client is held to the FAPI 2.0 control bundle.
 	/// This is a floor rather than a default: a client can ask for more and no registration can take
 	/// it out from under what is set here. The default <see cref="ClientSecurityProfile.None"/>
 	/// demands nothing, leaving clients governed by their individual metadata flags.

--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -539,10 +539,10 @@ public record OidcOptions
 	/// The server-wide default security profile, applied to every client whose own
 	/// <see cref="ClientInfo.SecurityProfile"/> is left unset (<c>null</c>). A single-profile
 	/// deployment sets this once - for example to <see cref="ClientSecurityProfile.Fapi2"/> - and
-	/// every client without an explicit profile inherits the FAPI 2.0 control bundle; an individual
-	/// client opts out by setting its own profile to <see cref="ClientSecurityProfile.None"/>. The
-	/// default <see cref="ClientSecurityProfile.None"/> leaves unprofiled clients governed by their
-	/// individual metadata flags, so existing deployments are unaffected.
+	/// every client is held to the FAPI 2.0 control bundle, whatever profile it names for itself.
+	/// This is a floor rather than a default: a client can ask for more and no registration can take
+	/// it out from under what is set here. The default <see cref="ClientSecurityProfile.None"/>
+	/// demands nothing, leaving clients governed by their individual metadata flags.
 	/// </summary>
 	public ClientSecurityProfile DefaultSecurityProfile { get; set; } = ClientSecurityProfile.None;
 

--- a/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
+++ b/src/Abblix.Oidc.Server/Common/Configuration/OidcOptions.cs
@@ -542,7 +542,8 @@ public record OidcOptions
 	/// every client is held to the FAPI 2.0 control bundle.
 	/// This is a floor rather than a default: a client can ask for more and no registration can take
 	/// it out from under what is set here. The default <see cref="ClientSecurityProfile.None"/>
-	/// demands nothing, leaving clients governed by their individual metadata flags.
+	/// demands nothing, leaving each client governed by whatever it names for itself, or by its
+	/// individual metadata flags where it names nothing.
 	/// </summary>
 	public ClientSecurityProfile DefaultSecurityProfile { get; set; } = ClientSecurityProfile.None;
 

--- a/src/Abblix.Oidc.Server/Common/Constants/ClientSecurityProfile.cs
+++ b/src/Abblix.Oidc.Server/Common/Constants/ClientSecurityProfile.cs
@@ -24,10 +24,12 @@ namespace Abblix.Oidc.Server.Common.Constants;
 public enum ClientSecurityProfile
 {
     /// <summary>
-    /// No bundled profile: the client is governed only by its individual metadata flags. As a client's
-    /// explicit value this is an opt-out that overrides the server-wide default; as the server-wide
-    /// <see cref="Configuration.OidcOptions.DefaultSecurityProfile"/> it imposes nothing. A client that
-    /// states no preference leaves its profile unset (<c>null</c>) rather than selecting this.
+    /// No bundled profile: nothing is demanded beyond the client's individual metadata flags. As a
+    /// client's explicit value it therefore adds nothing to whatever the deployment already demands,
+    /// and takes nothing away; as the server-wide
+    /// <see cref="Configuration.OidcOptions.DefaultSecurityProfile"/> it demands nothing of anyone. A
+    /// client that states no preference leaves its profile unset (<c>null</c>) rather than selecting
+    /// this.
     /// </summary>
     None = 0,
 

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/Validation/SecurityProfileValidator.cs
@@ -34,7 +34,7 @@ public class SecurityProfileValidator(IOptions<OidcOptions> options) : SyncClien
         var violations = SecurityProfileConsistency.FindViolations(
             context.Request.ResponseTypes,
             context.Request.TokenEndpointAuthMethod,
-            options.Value.DefaultSecurityProfile);
+            SecurityProfileRequirements.Resolve(options.Value.DefaultSecurityProfile));
 
         return violations.Count == 0
             ? null

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -125,17 +125,15 @@ public partial class JwtBearerGrantHandler(
 	/// </summary>
 	/// <remarks>
 	/// The CLIENT's profile decides, falling back to the deployment's, the way every other reader of
-	/// a profile in this codebase resolves one. Reading the server default alone would ignore both
-	/// directions of a per-client setting: a client held to a bounding profile under a server held
-	/// to none would keep the looser window, and a client explicitly opted out under a bounding
-	/// server would not get its opt-out.
+	/// a profile in this codebase resolves one. Reading the server default alone would ignore a
+	/// client that asks for a tighter window than the deployment demands.
 	/// </remarks>
 	private ClockSkew ResolveClockSkew(ClientInfo clientInfo)
 		=> issuerProvider.Options.ResolveClockSkew(Profile(clientInfo));
 
 	/// <summary>
-	/// The control bundle this client is held to - its own profile where it names one, the
-	/// deployment's otherwise, which is how every other reader of a profile here resolves it.
+	/// The control bundle this client is held to: what the deployment demands of everyone,
+	/// tightened by whatever the client names for itself.
 	/// </summary>
 	private SecurityProfileRequirements Profile(ClientInfo clientInfo)
 		=> SecurityProfileRequirements.For(clientInfo, oidcOptions.Value.DefaultSecurityProfile);

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.Logging.cs
@@ -6,7 +6,6 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
-using System.Collections.Generic;
 using Abblix.Oidc.Server.Common.Constants;
 using Microsoft.Extensions.Logging;
 
@@ -22,7 +21,7 @@ partial class SecurityProfileClientAuthenticator
                   + "every client to {DeploymentProfile}: {@Violations}")]
     private partial void LogRegistrationCannotSatisfyProfile(
         string ClientId,
-        string ClientProfile,
+        ClientSecurityProfile ClientProfile,
         ClientSecurityProfile DeploymentProfile,
         IReadOnlyList<string> Violations);
 
@@ -32,4 +31,24 @@ partial class SecurityProfileClientAuthenticator
         Message = "The client {ClientId} names security profile {Profile}, which this server does "
                   + "not define, so it is held to every control this server can demand")]
     private partial void LogProfileIsNotOneThisServerDefines(string ClientId, int Profile);
+
+    /// <remarks>
+    /// A message of its own rather than a sentinel in <c>ClientProfile</c>: the client named
+    /// nothing, so there is no value to carry, and a sentinel would put a string in that field
+    /// which no type protects and which every consumer would have to know by heart.
+    ///
+    /// Its own event id follows from the same reasoning: an absent case selected by an id that is
+    /// PRESENT beats one selected by a missing field, which a consumer cannot tell apart from a
+    /// field dropped somewhere in the pipeline.
+    /// </remarks>
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.RegistrationCannotSatisfyDeploymentProfile,
+        Level = LogLevel.Warning,
+        Message = "The client {ClientId} authenticated, but its registration cannot satisfy the "
+                  + "controls it is held to - it names no profile of its own and this deployment "
+                  + "holds every client to {DeploymentProfile}: {@Violations}")]
+    private partial void LogRegistrationCannotSatisfyDeploymentProfile(
+        string ClientId,
+        ClientSecurityProfile DeploymentProfile,
+        IReadOnlyList<string> Violations);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.Logging.cs
@@ -1,0 +1,35 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System.Collections.Generic;
+using Abblix.Oidc.Server.Common.Constants;
+using Microsoft.Extensions.Logging;
+
+namespace Abblix.Oidc.Server.Features.ClientAuthentication;
+
+partial class SecurityProfileClientAuthenticator
+{
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.RegistrationCannotSatisfyProfile,
+        Level = LogLevel.Warning,
+        Message = "The client {ClientId} authenticated, but its registration cannot satisfy the "
+                  + "controls it is held to - it names {ClientProfile} and this deployment holds "
+                  + "every client to {DeploymentProfile}: {@Violations}")]
+    private partial void LogRegistrationCannotSatisfyProfile(
+        string ClientId,
+        string ClientProfile,
+        ClientSecurityProfile DeploymentProfile,
+        IReadOnlyList<string> Violations);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.ProfileIsNotOneThisServerDefines,
+        Level = LogLevel.Warning,
+        Message = "The client {ClientId} names security profile {Profile}, which this server does "
+                  + "not define, so it is held to every control this server can demand")]
+    private partial void LogProfileIsNotOneThisServerDefines(string ClientId, int Profile);
+}

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -78,7 +78,11 @@ internal partial class SecurityProfileClientAuthenticator(
         if (violations.Count == 0)
             return clientInfo;
 
-        LogRegistrationCannotSatisfyProfile(clientInfo.ClientId, profile, violations);
+        LogRegistrationCannotSatisfyProfile(
+            clientInfo.ClientId,
+            clientInfo.SecurityProfile,
+            options.Value.DefaultSecurityProfile,
+            violations);
         return null;
     }
 
@@ -86,10 +90,12 @@ internal partial class SecurityProfileClientAuthenticator(
         EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.RegistrationCannotSatisfyProfile,
         Level = LogLevel.Warning,
         Message = "The client {ClientId} authenticated, but its registration cannot satisfy the "
-                  + "{Profile} profile it is held to: {@Violations}")]
+                  + "controls it is held to - it names {ClientProfile} and this deployment holds "
+                  + "every client to {DeploymentProfile}: {@Violations}")]
     private partial void LogRegistrationCannotSatisfyProfile(
         string ClientId,
-        ClientSecurityProfile Profile,
+        ClientSecurityProfile? ClientProfile,
+        ClientSecurityProfile DeploymentProfile,
         IReadOnlyList<string> Violations);
 
     [LoggerMessage(

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -7,7 +7,6 @@
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
 using Abblix.Oidc.Server.Common.Configuration;
-using Abblix.Oidc.Server.Common.Constants;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Model;
 using Microsoft.Extensions.Logging;
@@ -78,14 +77,15 @@ internal partial class SecurityProfileClientAuthenticator(
         if (violations.Count == 0)
             return clientInfo;
 
-        // Spelled out rather than passed as a nullable: the generator renders an absent value as
-        // "(null)", which names the shape of a field where the sentence is about a client - and a
-        // client naming nothing is the common case, not the exception.
-        LogRegistrationCannotSatisfyProfile(
-            clientInfo.ClientId,
-            clientInfo.SecurityProfile is { } named ? named.ToString() : "no profile of its own",
-            options.Value.DefaultSecurityProfile,
-            violations);
+        // Two wordings rather than one with an absent value in it: the generator renders a null as
+        // "(null)", which names the shape of a field where the sentence is about a client, and a
+        // sentinel string would put prose where a consumer expects a value it can query.
+        if (clientInfo.SecurityProfile is { } named)
+            LogRegistrationCannotSatisfyProfile(
+                clientInfo.ClientId, named, options.Value.DefaultSecurityProfile, violations);
+        else
+            LogRegistrationCannotSatisfyDeploymentProfile(
+                clientInfo.ClientId, options.Value.DefaultSecurityProfile, violations);
         return null;
     }
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -49,6 +49,10 @@ internal partial class SecurityProfileClientAuthenticator(
         if (clientInfo == null)
             return null;
 
+        // The raw value, because the question below is whether this server DEFINES it - not what
+        // it demands. What the client is held to comes from the combination further down, which
+        // takes the deployment's demands as a floor; this read must not, or an undefined value the
+        // client set would be hidden behind a defined deployment default.
         var profile = clientInfo.SecurityProfile ?? options.Value.DefaultSecurityProfile;
 
         // Said where a client is met after proving who it is. The value cannot be interpreted, so
@@ -69,7 +73,7 @@ internal partial class SecurityProfileClientAuthenticator(
         var violations = SecurityProfileConsistency.FindViolations(
             clientInfo.EffectiveResponseTypes,
             clientInfo.TokenEndpointAuthMethod,
-            profile);
+            SecurityProfileRequirements.For(clientInfo, options.Value.DefaultSecurityProfile));
 
         if (violations.Count == 0)
             return clientInfo;

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs
@@ -78,30 +78,14 @@ internal partial class SecurityProfileClientAuthenticator(
         if (violations.Count == 0)
             return clientInfo;
 
+        // Spelled out rather than passed as a nullable: the generator renders an absent value as
+        // "(null)", which names the shape of a field where the sentence is about a client - and a
+        // client naming nothing is the common case, not the exception.
         LogRegistrationCannotSatisfyProfile(
             clientInfo.ClientId,
-            clientInfo.SecurityProfile,
+            clientInfo.SecurityProfile is { } named ? named.ToString() : "no profile of its own",
             options.Value.DefaultSecurityProfile,
             violations);
         return null;
     }
-
-    [LoggerMessage(
-        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.RegistrationCannotSatisfyProfile,
-        Level = LogLevel.Warning,
-        Message = "The client {ClientId} authenticated, but its registration cannot satisfy the "
-                  + "controls it is held to - it names {ClientProfile} and this deployment holds "
-                  + "every client to {DeploymentProfile}: {@Violations}")]
-    private partial void LogRegistrationCannotSatisfyProfile(
-        string ClientId,
-        ClientSecurityProfile? ClientProfile,
-        ClientSecurityProfile DeploymentProfile,
-        IReadOnlyList<string> Violations);
-
-    [LoggerMessage(
-        EventId = LogEvents.ClientAuth.SecurityProfileClientAuthenticator.ProfileIsNotOneThisServerDefines,
-        Level = LogLevel.Warning,
-        Message = "The client {ClientId} names security profile {Profile}, which this server does "
-                  + "not define, so it is held to every control this server can demand")]
-    private partial void LogProfileIsNotOneThisServerDefines(string ClientId, int Profile);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -384,7 +384,7 @@ public record ClientInfo(string ClientId)
     /// sender-constrained tokens, code-only responses) and prevents the individual toggles above
     /// from weakening it.
     ///
-    /// It can only ADD demands. <see cref="ClientSecurityProfile.None"/> names no controls of its
+    /// It can only tighten. <see cref="ClientSecurityProfile.None"/> names no controls of its
     /// own and therefore changes nothing where the deployment names some: a server-wide profile is
     /// a floor every client stands on, so no registration can take a client out from under it. That
     /// matters because such a registration would not read as a decision to weaken the server, and

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/ClientInfo.cs
@@ -378,15 +378,21 @@ public record ClientInfo(string ClientId)
     public bool TlsClientCertificateBoundAccessTokens { get; set; } = false;
 
     /// <summary>
-    /// The named security profile this client is held to. <see cref="ClientSecurityProfile.Fapi2"/>
-    /// forces the FAPI 2.0 control bundle (PKCE restricted to <c>S256</c>, Pushed Authorization
-    /// Requests, sender-constrained tokens, code-only responses) on the client and prevents the
-    /// individual toggles above from weakening it. <see cref="ClientSecurityProfile.None"/> is an
-    /// explicit opt-out that leaves the client governed by those individual toggles alone, overriding
-    /// any server-wide default. <c>null</c> (the default) means the client states no preference and
-    /// inherits <see cref="Common.Configuration.OidcOptions.DefaultSecurityProfile"/> - which is
-    /// itself <see cref="ClientSecurityProfile.None"/> unless the deployment sets a server-wide
-    /// profile, so existing clients are unaffected.
+    /// A named security profile this client asks to be held to, ON TOP of whatever the deployment
+    /// demands of every client. <see cref="ClientSecurityProfile.Fapi2"/> forces the FAPI 2.0
+    /// control bundle (PKCE restricted to <c>S256</c>, Pushed Authorization Requests,
+    /// sender-constrained tokens, code-only responses) and prevents the individual toggles above
+    /// from weakening it.
+    ///
+    /// It can only ADD demands. <see cref="ClientSecurityProfile.None"/> names no controls of its
+    /// own and therefore changes nothing where the deployment names some: a server-wide profile is
+    /// a floor every client stands on, so no registration can take a client out from under it. That
+    /// matters because such a registration would not read as a decision to weaken the server, and
+    /// one of them is enough to leave a deployment serving a client under none of the controls it
+    /// turned on.
+    ///
+    /// <c>null</c> (the default) states no preference and leaves the client on
+    /// <see cref="Common.Configuration.OidcOptions.DefaultSecurityProfile"/> alone.
     /// </summary>
     public ClientSecurityProfile? SecurityProfile { get; set; }
 

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/OidcOptionsSecurityProfileValidator.cs
@@ -41,6 +41,8 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
 
         foreach (var client in options.Clients)
         {
+            // The raw value, for the definedness question alone. The controls this client is
+            // held to come from the combination below, which takes the deployment's as a floor.
             var effectiveProfile = client.SecurityProfile ?? options.DefaultSecurityProfile;
 
             // The value tested is the EFFECTIVE one, so an undefined default and an undefined
@@ -63,7 +65,7 @@ public class OidcOptionsSecurityProfileValidator : IValidateOptions<OidcOptions>
                      SecurityProfileConsistency.FindViolations(
                          client.EffectiveResponseTypes,
                          client.TokenEndpointAuthMethod,
-                         effectiveProfile))
+                         SecurityProfileRequirements.For(client, options.DefaultSecurityProfile)))
             {
                 failures.Add($"Client '{client.ClientId}': {violation}.");
             }

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileConsistency.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileConsistency.cs
@@ -30,13 +30,20 @@ public static class SecurityProfileConsistency
     /// </summary>
     /// <param name="allowedResponseTypes">The response-type combinations the client is registered for.</param>
     /// <param name="tokenEndpointAuthMethod">How the client authenticates at the token endpoint.</param>
-    /// <param name="profile">The effective profile governing the client.</param>
+    /// <param name="requirements">The control bundle the client is held to, floor included.</param>
+    /// <remarks>
+    /// The BUNDLE rather than a profile name, because a client is held to the deployment's profile
+    /// tightened by its own and no enum value names that combination. Taking a name here would put
+    /// the resolution inside this method, where it would silently undo whichever floor its caller
+    /// had just applied - and the two controls below are the ones nothing else enforces, so the
+    /// gap would show up as a client authenticating with a shared secret under a profile that
+    /// admits no such client.
+    /// </remarks>
     public static IReadOnlyList<string> FindViolations(
         IReadOnlyList<string[]> allowedResponseTypes,
         string tokenEndpointAuthMethod,
-        ClientSecurityProfile profile)
+        SecurityProfileRequirements requirements)
     {
-        var requirements = SecurityProfileRequirements.Resolve(profile);
         var violations = new List<string>();
 
         // RFC 6749 draws the line at whether the client can hold a credential at all, and the

--- a/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientInformation/SecurityProfileRequirements.cs
@@ -335,11 +335,90 @@ public sealed record SecurityProfileRequirements
     };
 
     /// <summary>
-    /// Convenience entry point for the validators: resolves the effective profile for a client and
-    /// returns its control bundle in one call.
+    /// The control bundle a client is actually held to: what the deployment demands of everyone,
+    /// tightened by whatever the client names for itself.
     /// </summary>
+    /// <remarks>
+    /// A deployment-wide profile is a FLOOR, not a default. Turning one on is a statement about
+    /// every client the server serves, so a client cannot step out from under it - it can only ask
+    /// for more. The alternative reading, where a client naming a profile replaces the deployment's,
+    /// makes the server-wide setting a suggestion: one registration would quietly leave a
+    /// FAPI 2.0 deployment serving a client under none of its controls, and nothing about that
+    /// registration would look like a decision to weaken the server.
+    ///
+    /// The combination is per CONTROL rather than a choice between two bundles, because "stricter"
+    /// is not a property a bundle has - one profile can demand sender-constrained tokens while
+    /// another names a tighter clock window, and picking either bundle whole would drop the other's
+    /// demand.
+    /// </remarks>
     /// <param name="client">The client whose effective profile is being resolved.</param>
-    /// <param name="defaultProfile">The server-wide default profile to fall back to.</param>
+    /// <param name="defaultProfile">The profile the deployment holds every client to.</param>
     public static SecurityProfileRequirements For(ClientInfo client, ClientSecurityProfile defaultProfile)
-        => Resolve(client.SecurityProfile ?? defaultProfile);
+    {
+        var deployment = Resolve(defaultProfile);
+
+        return client.SecurityProfile is not { } chosen
+            ? deployment
+            : deployment.TightenedBy(Resolve(chosen));
+    }
+
+    /// <summary>
+    /// This bundle with every control at whichever of the two values concedes less.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each flag is OR-ed, including <see cref="ForbidRefreshTokenRotation"/>, and that one is not a
+    /// slip. It removes a control, but the profile removing it introduces two others in its place -
+    /// so carrying it over is what keeps a profile whole, while AND-ing it would hand rotation back
+    /// to a client under a deployment that had switched it off, dismantling one part of a bundle
+    /// the deployment turned on entire.
+    /// </para>
+    /// <para>
+    /// A ceiling is the SMALLER of the two, and an absent ceiling concedes to a present one: no
+    /// bound cannot cancel a bound. A tolerance is compared half by half, since the two directions
+    /// answer different questions and a profile may tighten one without touching the other.
+    /// </para>
+    /// </remarks>
+    /// <param name="other">The bundle whose demands are added to this one's.</param>
+    private SecurityProfileRequirements TightenedBy(SecurityProfileRequirements other) => new()
+    {
+        RequirePkce = RequirePkce || other.RequirePkce,
+        RequireS256CodeChallenge = RequireS256CodeChallenge || other.RequireS256CodeChallenge,
+        RequirePushedAuthorizationRequests =
+            RequirePushedAuthorizationRequests || other.RequirePushedAuthorizationRequests,
+        RequireSenderConstrainedTokens =
+            RequireSenderConstrainedTokens || other.RequireSenderConstrainedTokens,
+        RequireCodeResponseTypeOnly = RequireCodeResponseTypeOnly || other.RequireCodeResponseTypeOnly,
+        RequireStrictRequestObjectProcessing =
+            RequireStrictRequestObjectProcessing || other.RequireStrictRequestObjectProcessing,
+        RequireConfidentialClient = RequireConfidentialClient || other.RequireConfidentialClient,
+        RequireKeyBasedClientAuthentication =
+            RequireKeyBasedClientAuthentication || other.RequireKeyBasedClientAuthentication,
+        RequireIssuerAudienceInClientAssertion =
+            RequireIssuerAudienceInClientAssertion || other.RequireIssuerAudienceInClientAssertion,
+        ForbidRefreshTokenRotation = ForbidRefreshTokenRotation || other.ForbidRefreshTokenRotation,
+
+        MaxClockSkew = Tighter(MaxClockSkew, other.MaxClockSkew),
+        DefaultClockSkew = new ClockSkew
+        {
+            Past = Shorter(DefaultClockSkew.Past, other.DefaultClockSkew.Past),
+            Future = Shorter(DefaultClockSkew.Future, other.DefaultClockSkew.Future),
+        },
+    };
+
+    /// <summary>
+    /// The tighter of two ceilings, where absence means no ceiling and therefore concedes.
+    /// </summary>
+    private static TimeSpan? Tighter(TimeSpan? left, TimeSpan? right) => (left, right) switch
+    {
+        ({ } a, { } b) => Shorter(a, b),
+        ({ } a, null) => a,
+        (null, { } b) => b,
+        _ => null,
+    };
+
+    /// <summary>
+    /// The shorter of two windows, which is the one granting less.
+    /// </summary>
+    private static TimeSpan Shorter(TimeSpan left, TimeSpan right) => left < right ? left : right;
 }

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -276,8 +276,9 @@ internal static class LogEvents
         }
 
         /// <summary>
-        /// <c>Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs</c> - refuses a
-        /// stored registration that cannot satisfy the profile it is held to (sub-range 3090-3099).
+        /// <c>Features/ClientAuthentication/SecurityProfileClientAuthenticator.cs</c> - the security
+        /// profile a stored registration is held to: what it fails, and what it names
+        /// (sub-range 3090-3099).
         /// </summary>
         public static class SecurityProfileClientAuthenticator
         {
@@ -285,6 +286,14 @@ internal static class LogEvents
 
             public const int RegistrationCannotSatisfyProfile = Base + 1;
             public const int ProfileIsNotOneThisServerDefines = Base + 2;
+
+            /// <summary>
+            /// The same refusal for a client that names no profile of its own. A number of its own
+            /// rather than a second wording under <see cref="RegistrationCannotSatisfyProfile"/>, so
+            /// that the absent case is selected by an id that is PRESENT rather than by the absence
+            /// of a field - and so that this record goes on naming one shape per number.
+            /// </summary>
+            public const int RegistrationCannotSatisfyDeploymentProfile = Base + 3;
         }
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/PushedRequestFetcherTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/PushedRequestFetcherTests.cs
@@ -154,6 +154,7 @@ public class PushedRequestFetcherTests
         var request = CreateRequest();
         var result = await CreateFetcher(defaultSecurityProfile: ClientSecurityProfile.Fapi2).FetchAsync(request);
 
-        Assert.True(result.TryGetFailure(out _));
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ErrorCodes.InvalidRequestObject, error.Error);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/PushedRequestFetcherTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/RequestFetching/PushedRequestFetcherTests.cs
@@ -137,11 +137,12 @@ public class PushedRequestFetcherTests
     }
 
     /// <summary>
-    /// A client that explicitly selects None opts out of a server-wide FAPI 2.0 default, so PAR is not
-    /// imposed and a non-pushed request passes through.
+    /// A client selecting None under a server-wide FAPI 2.0 default is still held to it, so a request
+    /// that was not pushed is refused. The profile requires every authorization flow to start through
+    /// a pushed request, of every client the deployment serves.
     /// </summary>
     [Fact]
-    public async Task FetchAsync_ExplicitNoneOverridesGlobalDefaultFapi2_PassesThrough()
+    public async Task FetchAsync_ExplicitNoneUnderGlobalDefaultFapi2_StillRefuses()
     {
         _clientInfoProvider
             .Setup(p => p.TryFindClientAsync(TestConstants.DefaultClientId))
@@ -153,7 +154,6 @@ public class PushedRequestFetcherTests
         var request = CreateRequest();
         var result = await CreateFetcher(defaultSecurityProfile: ClientSecurityProfile.Fapi2).FetchAsync(request);
 
-        Assert.True(result.TryGetSuccess(out var passed));
-        Assert.Same(request, passed);
+        Assert.True(result.TryGetFailure(out _));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/FlowTypeValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/FlowTypeValidatorTests.cs
@@ -718,11 +718,12 @@ public class FlowTypeValidatorTests
     }
 
     /// <summary>
-    /// A client that explicitly selects None opts out of a server-wide FAPI 2.0 default: the implicit
-    /// response type it is registered for is accepted.
+    /// A client selecting None under a server-wide FAPI 2.0 default is still held to it, so the
+    /// implicit response type it is registered for is refused. The profile permits the authorization
+    /// code alone, and it permits it of every client the deployment serves.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_ExplicitNoneOverridesGlobalDefaultFapi2_AllowsImplicit()
+    public async Task ValidateAsync_ExplicitNoneUnderGlobalDefaultFapi2_StillRefusesImplicit()
     {
         var validator = AllFlowsValidator(ClientSecurityProfile.Fapi2);
         var context = CreateContext(
@@ -732,8 +733,8 @@ public class FlowTypeValidatorTests
 
         var result = await validator.ValidateAsync(context);
 
-        Assert.Null(result);
-        Assert.Equal(FlowTypes.Implicit, context.FlowType);
+        Assert.NotNull(result);
+        Assert.Contains("security profile", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
     }
 
     private static FlowTypeValidator NoneEnabledValidator()

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/PkceValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/PkceValidatorTests.cs
@@ -666,6 +666,8 @@ public class PkceValidatorTests
         var result = await validator.ValidateAsync(context);
 
         Assert.NotNull(result);
+        Assert.Equal(ErrorCodes.InvalidRequest, result.Error);
+        Assert.Contains("S256", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/PkceValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/PkceValidatorTests.cs
@@ -644,11 +644,17 @@ public class PkceValidatorTests
     }
 
     /// <summary>
-    /// A client that explicitly selects None opts out of a server-wide FAPI 2.0 default: the explicit
-    /// profile overrides the default, so the plain method it allows is accepted.
+    /// A client selecting None under a server-wide FAPI 2.0 default is still held to it: a
+    /// deployment-wide profile is a floor, so naming a profile that demands nothing adds nothing and
+    /// takes nothing away. The plain method the client's own toggle allows is refused all the same.
     /// </summary>
+    /// <remarks>
+    /// The registration that would otherwise escape here does not read as a decision to weaken the
+    /// server, which is what makes the floor worth having: one such client is enough to leave a
+    /// deployment serving requests under none of the controls it turned on.
+    /// </remarks>
     [Fact]
-    public async Task ValidateAsync_ExplicitNoneOverridesGlobalDefaultFapi2_AllowsPlain()
+    public async Task ValidateAsync_ExplicitNoneUnderGlobalDefaultFapi2_StillRefusesPlain()
     {
         var validator = CreateValidator(defaultSecurityProfile: ClientSecurityProfile.Fapi2);
         var context = CreateContext(
@@ -659,7 +665,7 @@ public class PkceValidatorTests
 
         var result = await validator.ValidateAsync(context);
 
-        Assert.Null(result);
+        Assert.NotNull(result);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/DPoPTokenEndpointValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/DPoPTokenEndpointValidatorTests.cs
@@ -168,11 +168,13 @@ public class DPoPTokenEndpointValidatorTests
     }
 
     /// <summary>
-    /// A client that explicitly selects None opts out of a server-wide FAPI 2.0 default, so a missing
-    /// proof is accepted (opportunistic) rather than rejected.
+    /// A client selecting None under a server-wide FAPI 2.0 default is still held to it, so a missing
+    /// proof is refused rather than treated as opportunistic. The profile demands a
+    /// sender-constrained token of every client the deployment serves, and a registration naming a
+    /// profile that demands nothing adds nothing to that.
     /// </summary>
     [Fact]
-    public async Task ValidateAsync_MissingHeaderExplicitNoneOverridesGlobalDefaultFapi2_ReturnsNull()
+    public async Task ValidateAsync_MissingHeaderExplicitNoneUnderGlobalDefaultFapi2_StillRefuses()
     {
         _opts.DefaultSecurityProfile = ClientSecurityProfile.Fapi2;
         var context = CreateContext(
@@ -182,7 +184,7 @@ public class DPoPTokenEndpointValidatorTests
 
         var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
-        Assert.Null(error);
+        Assert.NotNull(error);
         Assert.Null(context.ProofKeyThumbprint);
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/DPoPTokenEndpointValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/Validation/DPoPTokenEndpointValidatorTests.cs
@@ -184,8 +184,7 @@ public class DPoPTokenEndpointValidatorTests
 
         var error = await _validator.ValidateAsync(context, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(error);
-        Assert.Null(context.ProofKeyThumbprint);
+        AssertProofRejected(error, context);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -80,6 +80,62 @@ public class SecurityProfileClientAuthenticatorTests
     }
 
     /// <summary>
+    /// The refusal an operator reads names BOTH sides, because the controls come from the two
+    /// together and neither alone says where the requirement came from. A client naming the empty
+    /// profile satisfies it and is refused anyway, which is the line that would otherwise send the
+    /// operator looking at the client's registration for a demand the deployment made.
+    /// </summary>
+    [Fact]
+    public async Task TheRefusal_NamesTheClientsChoiceAndTheDeploymentsFloor()
+    {
+        var logger = new CapturingLogger();
+
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2, logger);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+            SecurityProfile = ClientSecurityProfile.None,
+        });
+
+        await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        var entry = Assert.Single(
+            logger.Entries,
+            e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
+                .RegistrationCannotSatisfyProfile);
+
+        Assert.Contains(nameof(ClientSecurityProfile.None), entry.Message);
+        Assert.Contains(nameof(ClientSecurityProfile.Fapi2), entry.Message);
+    }
+
+    /// <summary>
+    /// And a client naming NO profile - which is most of them - still produces a sentence, rather
+    /// than one with a hole where the name would be. This is the shape the message is read on most
+    /// often, so a placeholder that renders empty for it makes the line worse than saying nothing.
+    /// </summary>
+    [Fact]
+    public async Task TheRefusal_ReadsAsASentenceWhenTheClientNamesNoProfile()
+    {
+        var logger = new CapturingLogger();
+
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2, logger);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+        });
+
+        await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        var entry = Assert.Single(
+            logger.Entries,
+            e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
+                .RegistrationCannotSatisfyProfile);
+
+        Assert.DoesNotContain("null", entry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(ClientSecurityProfile.Fapi2), entry.Message);
+    }
+
+    /// <summary>
     /// And a profile this server does define says nothing, or the line would be noise on every
     /// request rather than a signal about one client.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -104,8 +104,8 @@ public class SecurityProfileClientAuthenticatorTests
             e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
                 .RegistrationCannotSatisfyProfile);
 
-        Assert.Contains(nameof(ClientSecurityProfile.None), entry.Message);
-        Assert.Contains(nameof(ClientSecurityProfile.Fapi2), entry.Message);
+        Assert.Contains($"it names {ClientSecurityProfile.None}", entry.Message);
+        Assert.Contains($"every client to {ClientSecurityProfile.Fapi2}", entry.Message);
     }
 
     /// <summary>
@@ -129,10 +129,70 @@ public class SecurityProfileClientAuthenticatorTests
         var entry = Assert.Single(
             logger.Entries,
             e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
+                .RegistrationCannotSatisfyDeploymentProfile);
+
+        Assert.Contains("it names no profile of its own", entry.Message);
+        Assert.Contains($"every client to {ClientSecurityProfile.Fapi2}", entry.Message);
+    }
+
+    /// <summary>
+    /// The structured field carries the VALUE, not the word: a consumer filtering on the profile a
+    /// client named gets an enum it can compare, rather than a rendering of one.
+    /// </summary>
+    [Fact]
+    public async Task TheRefusal_CarriesTheClientsProfileAsAValue()
+    {
+        var logger = new CapturingLogger();
+
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2, logger);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+            SecurityProfile = ClientSecurityProfile.None,
+        });
+
+        await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        var entry = Assert.Single(
+            logger.Entries,
+            e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
                 .RegistrationCannotSatisfyProfile);
 
-        Assert.DoesNotContain("null", entry.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(nameof(ClientSecurityProfile.Fapi2), entry.Message);
+        Assert.Equal(
+            ClientSecurityProfile.None,
+            Assert.IsType<ClientSecurityProfile>(
+                Assert.Single(entry.Fields, f => f.Key == "ClientProfile").Value));
+    }
+
+    /// <summary>
+    /// And the case where the client named nothing carries no such field at all, under an event id
+    /// of its own. That id is what a consumer selects on: a filter naming an id that is PRESENT
+    /// cannot be satisfied by a field dropped somewhere in the pipeline, which is what asking for an
+    /// absent key would be.
+    /// </summary>
+    [Fact]
+    public async Task TheRefusal_ForAClientNamingNothing_CarriesNoProfileFieldAndItsOwnEventId()
+    {
+        var logger = new CapturingLogger();
+
+        var (authenticator, inner) = CreateAuthenticator(ClientSecurityProfile.Fapi2, logger);
+        Authenticates(inner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+        });
+
+        await authenticator.TryAuthenticateClientAsync(new ClientRequest());
+
+        var entry = Assert.Single(
+            logger.Entries,
+            e => e.EventId == LogEvents.ClientAuth.SecurityProfileClientAuthenticator
+                .RegistrationCannotSatisfyDeploymentProfile);
+
+        Assert.DoesNotContain(entry.Fields, f => f.Key == "ClientProfile");
+        Assert.Equal(
+            ClientSecurityProfile.Fapi2,
+            Assert.IsType<ClientSecurityProfile>(
+                Assert.Single(entry.Fields, f => f.Key == "DeploymentProfile").Value));
     }
 
     /// <summary>
@@ -349,12 +409,25 @@ public class SecurityProfileClientAuthenticatorTests
     }
 
     /// <summary>
-    /// A logger that keeps what it was told. Hand-written rather than mocked because the type under
-    /// test is internal, and a dynamic proxy cannot be built over a generic logger closed on it.
+    /// A logger that keeps what it was told, STATE included. Hand-written rather than mocked because
+    /// the type under test is internal, and a dynamic proxy cannot be built over a generic logger
+    /// closed on it.
     /// </summary>
+    /// <remarks>
+    /// Without the state nothing here can tell an enum in a structured field from prose in it, or
+    /// either from a field that is absent - so a decision about what a field carries would rest on
+    /// reading rather than on a run.
+    ///
+    /// The cast falls back to an empty list, which is what a case asserting a field is ABSENT would
+    /// be satisfied by if the generator's state type ever stopped carrying the interface. What stops
+    /// that is the assertion beside it, naming a field that must be PRESENT on the same entry: it
+    /// goes red on an empty list, so it is the control for the absence rather than a repetition of
+    /// the case above it.
+    /// </remarks>
     private sealed class CapturingLogger : ILogger<SecurityProfileClientAuthenticator>
     {
-        public List<(LogLevel Level, int EventId, string Message)> Entries { get; } = [];
+        public List<(LogLevel Level, int EventId, string Message, IReadOnlyList<KeyValuePair<string, object?>> Fields)>
+            Entries { get; } = [];
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -366,6 +439,10 @@ public class SecurityProfileClientAuthenticatorTests
             TState state,
             Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => Entries.Add((logLevel, eventId.Id, formatter(state, exception)));
+            => Entries.Add((
+                logLevel,
+                eventId.Id,
+                formatter(state, exception),
+                state as IReadOnlyList<KeyValuePair<string, object?>> ?? []));
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/SecurityProfileClientAuthenticatorTests.cs
@@ -231,21 +231,25 @@ public class SecurityProfileClientAuthenticatorTests
     }
 
     /// <summary>
-    /// The client's own profile outranks the server-wide default, in both directions: a client
-    /// naming no profile under a Fapi2 server is held to it, and a client naming none under one is
-    /// not. Without the second half the decorator could be reading the default alone.
+    /// The client's profile adds to the deployment's and never replaces it, in both directions: a
+    /// shared-secret client is refused under a Fapi2 server whether it names the empty profile or
+    /// names none at all, and equally when it names Fapi2 under a server that names nothing.
     /// </summary>
+    /// <remarks>
+    /// The second half is what keeps this from being satisfied by a decorator reading the
+    /// deployment alone; the first is what keeps a registration from stepping out from under it.
+    /// </remarks>
     [Fact]
-    public async Task ClientProfileOverridesTheDefault()
+    public async Task TheClientProfileAddsToTheDefaultRatherThanReplacingIt()
     {
-        var (relaxed, relaxedInner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
-        Authenticates(relaxedInner, new ClientInfo(ClientId)
+        var (underFloor, underFloorInner) = CreateAuthenticator(ClientSecurityProfile.Fapi2);
+        Authenticates(underFloorInner, new ClientInfo(ClientId)
         {
             TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
             SecurityProfile = ClientSecurityProfile.None,
         });
 
-        Assert.NotNull(await relaxed.TryAuthenticateClientAsync(new ClientRequest()));
+        Assert.Null(await underFloor.TryAuthenticateClientAsync(new ClientRequest()));
 
         var (tightened, tightenedInner) = CreateAuthenticator(ClientSecurityProfile.None);
         Authenticates(tightenedInner, new ClientInfo(ClientId)
@@ -255,6 +259,23 @@ public class SecurityProfileClientAuthenticatorTests
         });
 
         Assert.Null(await tightened.TryAuthenticateClientAsync(new ClientRequest()));
+    }
+
+    /// <summary>
+    /// And a shared-secret client under a server naming no profile is accepted, without which the
+    /// case above would be satisfied by a decorator refusing every shared-secret client.
+    /// </summary>
+    [Fact]
+    public async Task NoProfileEitherSide_LeavesASharedSecretClientAlone()
+    {
+        var (unprofiled, unprofiledInner) = CreateAuthenticator(ClientSecurityProfile.None);
+        Authenticates(unprofiledInner, new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+            SecurityProfile = ClientSecurityProfile.None,
+        });
+
+        Assert.NotNull(await unprofiled.TryAuthenticateClientAsync(new ClientRequest()));
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -247,6 +247,36 @@ public class SecurityProfileTests
     }
 
     /// <summary>
+    /// The other control this walk owns, given its own case: a client authenticating with NOTHING is
+    /// the public client the profile excludes, and the floor reaches it too. The case above cannot
+    /// stand for this one - it uses a shared secret, which is a confidential client by RFC 6749 and
+    /// trips the key-based requirement alone, so removing the confidential-client arm would leave it
+    /// green.
+    /// </summary>
+    [Fact]
+    public void OptionsValidator_GlobalDefaultFapi2_ClientNamesNoneAndAuthenticatesWithNothing_Fails()
+    {
+        var options = new OidcOptions
+        {
+            DefaultSecurityProfile = ClientSecurityProfile.Fapi2,
+            Clients =
+            [
+                new ClientInfo(TestConstants.DefaultClientId)
+                {
+                    SecurityProfile = ClientSecurityProfile.None,
+                    AllowedResponseTypes = [[ResponseTypes.Code]],
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.None,
+                },
+            ],
+        };
+
+        var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains("confidential clients only", result.FailureMessage!);
+    }
+
+    /// <summary>
     /// And the same client under a deployment naming no profile starts clean, without which the
     /// case above would be satisfied by a walk refusing every shared-secret client.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -48,13 +48,22 @@ public class SecurityProfileTests
         Assert.True(requirements.RequireStrictRequestObjectProcessing);
     }
 
+    /// <summary>
+    /// A deployment-wide profile is a FLOOR: a client can ask for more and never for less. The row
+    /// that carries the decision is the third - naming a profile that demands nothing, under a
+    /// deployment that demands the FAPI 2.0 bundle, leaves the client held to that bundle.
+    /// </summary>
+    /// <remarks>
+    /// The first two rows keep the case from being satisfied by a resolution that answers the
+    /// strictest bundle whatever it is asked, and the fourth by one that answers the deployment's.
+    /// </remarks>
     [Theory]
     // clientProfile (null = unset), defaultProfile, expected effective
     [InlineData(null, ClientSecurityProfile.None, ClientSecurityProfile.None)]
-    [InlineData(null, ClientSecurityProfile.Fapi2, ClientSecurityProfile.Fapi2)] // unset inherits the default
-    [InlineData(ClientSecurityProfile.None, ClientSecurityProfile.Fapi2, ClientSecurityProfile.None)] // explicit None opts out
-    [InlineData(ClientSecurityProfile.Fapi2, ClientSecurityProfile.None, ClientSecurityProfile.Fapi2)] // client wins
-    public void For_UnsetInheritsDefault_ExplicitWins(
+    [InlineData(null, ClientSecurityProfile.Fapi2, ClientSecurityProfile.Fapi2)] // unset takes the floor
+    [InlineData(ClientSecurityProfile.None, ClientSecurityProfile.Fapi2, ClientSecurityProfile.Fapi2)] // cannot step below it
+    [InlineData(ClientSecurityProfile.Fapi2, ClientSecurityProfile.None, ClientSecurityProfile.Fapi2)] // may rise above it
+    public void For_TakesTheFloorAndWhateverTheClientAddsToIt(
         ClientSecurityProfile? clientProfile,
         ClientSecurityProfile defaultProfile,
         ClientSecurityProfile expected)

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -277,8 +277,9 @@ public class SecurityProfileTests
     }
 
     /// <summary>
-    /// And the same client under a deployment naming no profile starts clean, without which the
-    /// case above would be satisfied by a walk refusing every shared-secret client.
+    /// The control for the shared-secret case: the same client under a deployment naming no profile
+    /// starts clean, without which that case would be satisfied by a walk refusing every
+    /// shared-secret client whatever the deployment demands.
     /// </summary>
     [Fact]
     public void OptionsValidator_NoGlobalDefault_ClientNamesNoneAndUsesASharedSecret_Succeeds()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/SecurityProfileTests.cs
@@ -91,7 +91,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code]],
             ClientAuthenticationMethods.PrivateKeyJwt,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         Assert.Empty(violations);
     }
@@ -106,7 +106,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [["Code"]],
             ClientAuthenticationMethods.PrivateKeyJwt,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         Assert.Empty(violations);
     }
@@ -117,7 +117,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.IdToken]],
             ClientAuthenticationMethods.PrivateKeyJwt,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         Assert.Equal(2, violations.Count);
     }
@@ -128,7 +128,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code], [ResponseTypes.Code, ResponseTypes.IdToken]],
             ClientAuthenticationMethods.PrivateKeyJwt,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         // code is allowed, so only the implicit/hybrid violation remains.
         Assert.Single(violations);
@@ -140,7 +140,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.IdToken]],
             ClientAuthenticationMethods.PrivateKeyJwt,
-            ClientSecurityProfile.None);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.None));
 
         Assert.Empty(violations);
     }
@@ -210,6 +210,68 @@ public class SecurityProfileTests
     }
 
     /// <summary>
+    /// The floor reaches the two controls only this walk enforces. A client naming the empty
+    /// profile under a FAPI 2.0 deployment, registered to authenticate with a shared secret, is
+    /// refused at startup - the profile admits confidential clients authenticating by key, and it
+    /// admits them of every client the deployment serves.
+    /// </summary>
+    /// <remarks>
+    /// These two flags have no other consumer, so a resolution that dropped the floor here would
+    /// show up nowhere else: every request-time validator would refuse such a client while the
+    /// server started clean, leaving the operator to learn it from refusals citing requirements no
+    /// configuration of theirs sets. Worse, the client would go on holding a shared secret while
+    /// the profile switched OFF its refresh token rotation, which is what the two controls this
+    /// walk enforces are there to pay for.
+    /// </remarks>
+    [Fact]
+    public void OptionsValidator_GlobalDefaultFapi2_ClientNamesNoneAndUsesASharedSecret_Fails()
+    {
+        var options = new OidcOptions
+        {
+            DefaultSecurityProfile = ClientSecurityProfile.Fapi2,
+            Clients =
+            [
+                new ClientInfo(TestConstants.DefaultClientId)
+                {
+                    SecurityProfile = ClientSecurityProfile.None,
+                    AllowedResponseTypes = [[ResponseTypes.Code]],
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+                },
+            ],
+        };
+
+        var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains("private key JWT", result.FailureMessage!);
+    }
+
+    /// <summary>
+    /// And the same client under a deployment naming no profile starts clean, without which the
+    /// case above would be satisfied by a walk refusing every shared-secret client.
+    /// </summary>
+    [Fact]
+    public void OptionsValidator_NoGlobalDefault_ClientNamesNoneAndUsesASharedSecret_Succeeds()
+    {
+        var options = new OidcOptions
+        {
+            Clients =
+            [
+                new ClientInfo(TestConstants.DefaultClientId)
+                {
+                    SecurityProfile = ClientSecurityProfile.None,
+                    AllowedResponseTypes = [[ResponseTypes.Code]],
+                    TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretBasic,
+                },
+            ],
+        };
+
+        var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
     /// An unprofiled client inherits the server-wide DefaultSecurityProfile=FAPI 2.0; a hybrid
     /// response type then makes it inconsistent and startup validation fails.
     /// </summary>
@@ -234,11 +296,12 @@ public class SecurityProfileTests
     }
 
     /// <summary>
-    /// A client that explicitly selects None opts out of the server-wide FAPI 2.0 default, so its
-    /// hybrid response type is not constrained and startup validation passes.
+    /// A client naming the empty profile under a server-wide FAPI 2.0 default is refused at startup
+    /// for its hybrid response type, the same as one naming no profile at all. The deployment's
+    /// profile is a floor, and naming a profile that demands nothing adds nothing to it.
     /// </summary>
     [Fact]
-    public void OptionsValidator_ExplicitNoneOverridesGlobalDefault_Succeeds()
+    public void OptionsValidator_ExplicitNoneUnderGlobalDefault_StillFails()
     {
         var options = new OidcOptions
         {
@@ -255,7 +318,7 @@ public class SecurityProfileTests
 
         var result = new OidcOptionsSecurityProfileValidator().Validate(null, options);
 
-        Assert.True(result.Succeeded);
+        Assert.True(result.Failed);
     }
 
     /// <summary>
@@ -269,7 +332,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code]],
             ClientAuthenticationMethods.None,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         Assert.Contains(violations, violation => violation.Contains("confidential clients only"));
     }
@@ -288,7 +351,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code]],
             method,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         Assert.Contains(violations, violation => violation.Contains("mutual TLS or a private key JWT"));
     }
@@ -306,7 +369,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code]],
             method,
-            ClientSecurityProfile.Fapi2);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.Fapi2));
 
         Assert.Empty(violations);
     }
@@ -321,7 +384,7 @@ public class SecurityProfileTests
         var violations = SecurityProfileConsistency.FindViolations(
             [[ResponseTypes.Code]],
             ClientAuthenticationMethods.None,
-            ClientSecurityProfile.None);
+            SecurityProfileRequirements.Resolve(ClientSecurityProfile.None));
 
         Assert.Empty(violations);
     }

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(156, EventIds().Count);
+        Assert.Equal(157, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()


### PR DESCRIPTION
A security profile turned on for the deployment is a statement about every client the server serves. Until now a client could name a profile of its own and replace that bundle entire, so a single registration was enough to leave a FAPI 2.0 deployment serving a client under none of the controls it had turned on — and nothing about that registration read as a decision to weaken the server.

The effective bundle is now the deployment's, tightened by whatever the client asks for. A client can add demands and never remove one.

## Why per control rather than per bundle

"Stricter" is not a property a bundle has. One profile can demand sender-constrained tokens while another names a tighter clock window, so taking either bundle whole would silently drop the other's demand. Each control is combined on its own:

- Every tightening flag is carried over from whichever side sets it.
- The flag that removes a control is carried over too. It removes one control and introduces two others in its place, so keeping it is what keeps a profile whole; dropping it would hand rotation back to a client under a deployment that had switched it off.
- A ceiling is the smaller of the two, and an absent ceiling concedes to a present one — no bound cannot cancel a bound.
- A tolerance is compared half by half, since the two directions answer different questions.

## What the specification says

FAPI 2.0 Security Profile section 5.3.2 addresses every requirement to authorization servers, with no clause naming a subset of clients: "shall only support confidential clients", "shall only issue sender-constrained access tokens", "shall require PKCE with S256 as the code challenge method". The only conditions in that list are about technique ("if using DPoP"), never about who the client is. The document has no notion of a per-client exemption at all.

Section 5.1.2 sets the direction a deployment may deviate in: "further reducing the number of choices may further improve security", and "for a profile to be compliant with this document, the profile shall not remove or override mandatory behaviors, as doing so is likely to invalidate the formal security analysis and reduce security in potentially unpredictable ways".

## Breaking change

A deployment that registered a client specifically to take it out from under the server-wide profile will start receiving refusals for that client. That is the point of the change, and it is described in the release notes as the new behaviour.

Five test cases pinned the previous rule by name and now pin this one. The decisive row is in the profile-resolution table: a client naming the empty profile under a deployment naming FAPI 2.0 resolves to FAPI 2.0.
