### PR TITLE
Let a client be held to the clock tolerance its own profile allows

### DIFF
--- a/src/Abblix.Jwt/ClockSkew.cs
+++ b/src/Abblix.Jwt/ClockSkew.cs
@@ -98,6 +98,45 @@ public readonly record struct ClockSkew
     public static implicit operator ClockSkew(TimeSpan symmetric) => new() { Past = symmetric, Future = symmetric };
 
     /// <summary>
+    /// Why a token's timestamps are refused at <paramref name="now"/>, or null where this tolerance
+    /// admits them.
+    /// </summary>
+    /// <remarks>
+    /// The comparison belongs here rather than to whoever validates, because more than one caller
+    /// asks it: a token is checked once against the tolerance it arrived under, and again wherever a
+    /// tighter one turns out to apply. Two copies would part company on the boundaries, which is
+    /// where they are least likely to be noticed - expiry is compared with <c>&lt;=</c>, so a token
+    /// exactly its whole tolerance past the end is already expired, while one exactly the whole
+    /// tolerance ahead is still accepted.
+    ///
+    /// The order is deliberate: a token both post-dated and expired answers "not yet valid", which
+    /// is what its sender meant to send and what tells them so.
+    /// </remarks>
+    /// <param name="now">The instant the timestamps are judged against.</param>
+    /// <param name="notBefore">When the token says it starts, if it says.</param>
+    /// <param name="expiresAt">When the token says it ends, if it says.</param>
+    /// <param name="issuedAt">When the token says it was minted, if it says.</param>
+    public string? WhyRefused(
+        DateTimeOffset now,
+        DateTimeOffset? notBefore,
+        DateTimeOffset? expiresAt,
+        DateTimeOffset? issuedAt)
+    {
+        var future = now + Future;
+
+        if (notBefore.HasValue && future < notBefore.Value.ToUniversalTime())
+            return "Token not yet valid";
+
+        if (expiresAt.HasValue && expiresAt.Value.ToUniversalTime() <= now - Past)
+            return "Token has expired";
+
+        if (issuedAt.HasValue && future < issuedAt.Value.ToUniversalTime())
+            return "Token issued in the future";
+
+        return null;
+    }
+
+    /// <summary>
     /// This tolerance with neither direction exceeding <paramref name="ceiling"/>, or unchanged
     /// where there is no ceiling to hold it to.
     /// </summary>

--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -664,19 +664,11 @@ internal class JsonWebTokenValidator(
         // Whatever bound the caller is held to has already been applied to the value it handed
         // over: a ceiling arriving as a second field is a ceiling somebody forgets to pass, and the
         // omission would read as a caller entitled to be looser rather than as the mistake it is.
-        var skew = parameters.ClockSkew;
-        var future = utcNow + skew.Future;
+        var refusal = parameters.ClockSkew.WhyRefused(utcNow, notBefore, expiresAt, issuedAt);
 
-        if (notBefore.HasValue && future < notBefore.Value.ToUniversalTime())
-            return new JwtValidationError(JwtError.InvalidToken, "Token not yet valid");
-
-        if (expiresAt.HasValue && expiresAt.Value.ToUniversalTime() <= utcNow - skew.Past)
-            return new JwtValidationError(JwtError.InvalidToken, "Token has expired");
-
-        if (issuedAt.HasValue && future < issuedAt.Value.ToUniversalTime())
-            return new JwtValidationError(JwtError.InvalidToken, "Token issued in the future");
-
-        return token;
+        return refusal is null
+            ? token
+            : new JwtValidationError(JwtError.InvalidToken, refusal);
     }
 
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/ClientSecretJwtAuthenticator.cs
@@ -44,7 +44,7 @@ public partial class ClientSecretJwtAuthenticator(
     IReplayCache replayCache,
     IIssuerProvider issuerProvider,
     IOptions<OidcOptions> options)
-    : JwtAssertionAuthenticatorBase(logger, replayCache, issuerProvider, options)
+    : JwtAssertionAuthenticatorBase(logger, replayCache, issuerProvider, options, clock)
 {
     /// <summary>
     /// Specifies the client authentication method this authenticator supports, which is 'client_secret_jwt'.
@@ -170,7 +170,7 @@ public partial class ClientSecretJwtAuthenticator(
             yield break;
         }
 
-        var utcNow = clock.GetUtcNow();
+        var utcNow = Clock.GetUtcNow();
         foreach (var clientSecret in client.ClientSecrets)
         {
             if (clientSecret.ExpiresAt.HasValue && clientSecret.ExpiresAt.Value < utcNow)

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
@@ -80,6 +80,13 @@ partial class JwtAssertionAuthenticatorBase
     private partial void LogReplayDetected(string Jti, string ClientId);
 
     [LoggerMessage(
+        EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.TimestampsOutsideTheClientsProfile,
+        Level = LogLevel.Warning,
+        Message = "The assertion from {ClientId} passed the deployment's clock tolerance but not the "
+                  + "one the client's own security profile allows: {Refusal}")]
+    private partial void LogTimestampsOutsideTheClientsProfile(string ClientId, string Refusal);
+
+    [LoggerMessage(
         EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.AudienceIsNotTheIssuerAlone,
         Level = LogLevel.Warning,
         Message = "The client assertion for {ClientId} carries {@Audiences} where the profile "

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -228,9 +228,9 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     /// the claim was granted.
     /// </summary>
     /// <remarks>
-    /// Its own method because the reservation is irreversible, and a method ending in the spend
-    /// cannot grow a check underneath it by accident: anything added to the caller lands before the
-    /// call rather than after it.
+    /// Its own method because the reservation is irreversible, and a method ending in the spend is
+    /// where a check added later is least likely to land underneath it: the natural place to add one
+    /// in the caller is before the call.
     /// </remarks>
     /// <param name="token">The assertion whose identifier is being claimed.</param>
     /// <param name="clientInfo">The client the assertion authenticates.</param>

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -28,12 +28,20 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// <param name="replayCache">Replay cache that records assertion jti values and atomically rejects reuse.</param>
 /// <param name="issuerProvider">Supplies the issuer identifier a profile-governed assertion must name.</param>
 /// <param name="options">Supplies the server-wide default security profile.</param>
+/// <param name="timeProvider">Judges the assertion's timestamps against the client's own profile.</param>
 public abstract partial class JwtAssertionAuthenticatorBase(
     ILogger logger,
     IReplayCache replayCache,
     IIssuerProvider issuerProvider,
-    IOptions<OidcOptions> options) : IClientAuthenticator
+    IOptions<OidcOptions> options,
+    TimeProvider timeProvider) : IClientAuthenticator
 {
+    /// <summary>
+    /// The clock this class judges an assertion's timestamps by, exposed so a derived authenticator
+    /// reads the same instant rather than capturing a second copy of the same dependency.
+    /// </summary>
+    protected TimeProvider Clock => timeProvider;
+
     /// <summary>
     /// Specifies the client authentication methods supported by this authenticator.
     /// </summary>
@@ -46,6 +54,41 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     /// </summary>
     protected SecurityProfileRequirements DefaultProfileRequirements
         => SecurityProfileRequirements.Resolve(options.Value.DefaultSecurityProfile);
+
+    /// <summary>
+    /// Answers whether the assertion's timestamps sit inside the window the profile governing THIS
+    /// CLIENT allows, which the validator could not ask: the client is identified from the assertion
+    /// it is validating, so its profile is not known until the validation has finished.
+    /// </summary>
+    /// <remarks>
+    /// The first pass ran under the deployment's own window, which is the widest any client can be
+    /// given - a deployment-wide profile is a floor and a client may only tighten it. So this
+    /// narrows and never widens, and a client asking for the deployment's profile or for nothing at
+    /// all reaches the same answer twice.
+    ///
+    /// Placed before the identifier is reserved, because a reservation is spent and cannot be given
+    /// back: a refusal after it would burn the assertion's own identifier on a request this check
+    /// was going to reject.
+    /// </remarks>
+    /// <param name="token">The assertion whose timestamps are being judged.</param>
+    /// <param name="clientInfo">The client the assertion authenticates.</param>
+    private bool TimestampsSatisfyTheClientsOwnProfile(JsonWebToken token, ClientInfo clientInfo)
+    {
+        var refusal = SecurityProfileRequirements
+            .For(clientInfo, options.Value.DefaultSecurityProfile)
+            .ClockSkewOrDefault()
+            .WhyRefused(
+                timeProvider.GetUtcNow(),
+                token.Payload.NotBefore,
+                token.Payload.ExpiresAt,
+                token.Payload.IssuedAt);
+
+        if (refusal is null)
+            return true;
+
+        LogTimestampsOutsideTheClientsProfile(clientInfo.ClientId, refusal);
+        return false;
+    }
 
     /// <summary>
     /// Answers whether the assertion's audience is one the profile governing this client admits.
@@ -164,6 +207,11 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         }
 
         if (!AudienceSatisfiesTheProfile(token, clientInfo))
+        {
+            return null;
+        }
+
+        if (!TimestampsSatisfyTheClientsOwnProfile(token, clientInfo))
         {
             return null;
         }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -63,8 +63,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     /// <remarks>
     /// The first pass ran under the deployment's own window, which is the widest any client can be
     /// given - a deployment-wide profile is a floor and a client may only tighten it. So this
-    /// narrows and never widens, and a client asking for the deployment's profile or for nothing at
-    /// all reaches the same answer twice.
+    /// narrows and never widens.
     ///
     /// Placed before the identifier is reserved, because a reservation is spent and cannot be given
     /// back: a refusal after it would burn the assertion's own identifier on a request this check

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -215,6 +215,27 @@ public abstract partial class JwtAssertionAuthenticatorBase(
             return null;
         }
 
+        if (!await ReserveTheAssertionAsync(token, clientInfo))
+        {
+            return null;
+        }
+
+        return clientInfo;
+    }
+
+    /// <summary>
+    /// Claims the assertion's identifier so it cannot be presented a second time, answering whether
+    /// the claim was granted.
+    /// </summary>
+    /// <remarks>
+    /// Its own method because the reservation is irreversible, and a method ending in the spend
+    /// cannot grow a check underneath it by accident: anything added to the caller lands before the
+    /// call rather than after it.
+    /// </remarks>
+    /// <param name="token">The assertion whose identifier is being claimed.</param>
+    /// <param name="clientInfo">The client the assertion authenticates.</param>
+    private async Task<bool> ReserveTheAssertionAsync(JsonWebToken token, ClientInfo clientInfo)
+    {
         // OIDC Core §9: the client-authentication assertion's jti is REQUIRED - "A unique
         // identifier for the token, which can be used to prevent reuse of the token". Reject an
         // assertion without it: single-use replay protection is impossible without a unique id,
@@ -223,7 +244,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         if (token is not { Payload.JwtId: { } jwtId })
         {
             LogMissingJti(clientInfo.ClientId);
-            return null;
+            return false;
         }
 
         // RFC 7523 §3: the assertion MUST contain an 'exp' claim that limits the window during
@@ -233,7 +254,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         if (token is not { Payload.ExpiresAt: { } expiresAt })
         {
             LogMissingExpiration(clientInfo.ClientId);
-            return null;
+            return false;
         }
 
         // Single atomic reserve-and-check: record the jti and treat "already present" as a replay.
@@ -242,10 +263,10 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         if (!await replayCache.TryReserveAsync(jwtId, expiresAt))
         {
             LogReplayDetected(jwtId, clientInfo.ClientId);
-            return null;
+            return false;
         }
 
-        return clientInfo;
+        return true;
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/PrivateKeyJwtAuthenticator.cs
@@ -28,13 +28,15 @@ namespace Abblix.Oidc.Server.Features.ClientAuthentication;
 /// <param name="serviceProvider">Service provider used to resolve scoped dependencies.</param>
 /// <param name="issuerProvider">Supplies the issuer identifier a profile-governed assertion must name.</param>
 /// <param name="options">Supplies the server-wide default security profile.</param>
+/// <param name="timeProvider">Judges the assertion's timestamps against the client's own profile.</param>
 public class PrivateKeyJwtAuthenticator(
     ILogger<PrivateKeyJwtAuthenticator> logger,
     IReplayCache replayCache,
     IServiceProvider serviceProvider,
     IIssuerProvider issuerProvider,
-    IOptions<OidcOptions> options)
-    : JwtAssertionAuthenticatorBase(logger, replayCache, issuerProvider, options)
+    IOptions<OidcOptions> options,
+    TimeProvider timeProvider)
+    : JwtAssertionAuthenticatorBase(logger, replayCache, issuerProvider, options, timeProvider)
 {
     /// <summary>
     /// Indicates the client authentication method supported by this authenticator.

--- a/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
+++ b/src/Abblix.Oidc.Server/Features/ServiceCollectionExtensions.cs
@@ -430,6 +430,11 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddClientJwt(this IServiceCollection services)
     {
         services.TryAddSingleton<IClientJwtValidator, ClientJwtValidator>();
+
+        // The validator judges a client JWT's timestamps against this clock. Registered here rather
+        // than relied upon from elsewhere: this method is public and a host may call it on a
+        // collection that has nothing else of ours in it.
+        services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<IClientJwtFormatter, ClientJwtFormatter>();
         services.TryAddSingleton<IResponseJwtBuilder, ResponseJwtBuilder>();
         return services;

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.Logging.cs
@@ -37,6 +37,13 @@ partial class ClientJwtValidator
     private partial void LogValidationSucceeded(string ClientId);
 
     [LoggerMessage(
+        EventId = LogEvents.Tokens.ClientJwtValidator.TimestampsOutsideTheClientsProfile,
+        Level = LogLevel.Warning,
+        Message = "The token from {ClientId} passed the deployment's clock tolerance but not the one "
+                  + "the client's own security profile allows: {Refusal}")]
+    private partial void LogTimestampsOutsideTheClientsProfile(string ClientId, string Refusal);
+
+    [LoggerMessage(
         EventId = LogEvents.Tokens.ClientJwtValidator.AudienceValidationFailed,
         Level = LogLevel.Warning,
         Message = "Audience validation failed, token audiences: {@Audiences}, expected requestUri: {RequestUri} or issuer: {Issuer}")]

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
@@ -130,21 +130,27 @@ public partial class ClientJwtValidator(
         // token being validated and is not known until that has finished. A client naming a profile
         // of its own may be held to a tighter one, and this is the first line where there is a client
         // to ask. It only narrows: a deployment-wide profile is a floor, so no client's window is
-        // wider than the one already applied, and a client naming nothing reaches the same answer
-        // twice.
-        var refusal = SecurityProfileRequirements
-            .For(context.ClientInfo, oidcOptions.Value.DefaultSecurityProfile)
-            .ClockSkewOrDefault()
-            .WhyRefused(
-                timeProvider.GetUtcNow(),
-                validatedToken.Payload.NotBefore,
-                validatedToken.Payload.ExpiresAt,
-                validatedToken.Payload.IssuedAt);
-
-        if (refusal != null)
+        // wider than the one already applied.
+        //
+        // Under the same flag as the pass above, and not merely for symmetry: a caller that opted
+        // out of time handling must not meet the timestamp accessors either, since they throw on a
+        // value outside the range DateTimeOffset can hold.
+        if (options.HasFlag(ValidationOptions.ValidateLifetime))
         {
-            LogTimestampsOutsideTheClientsProfile(context.ClientInfo.ClientId, refusal);
-            return new JwtValidationError(JwtError.InvalidToken, refusal);
+            var refusal = SecurityProfileRequirements
+                .For(context.ClientInfo, oidcOptions.Value.DefaultSecurityProfile)
+                .ClockSkewOrDefault()
+                .WhyRefused(
+                    timeProvider.GetUtcNow(),
+                    validatedToken.Payload.NotBefore,
+                    validatedToken.Payload.ExpiresAt,
+                    validatedToken.Payload.IssuedAt);
+
+            if (refusal != null)
+            {
+                LogTimestampsOutsideTheClientsProfile(context.ClientInfo.ClientId, refusal);
+                return new JwtValidationError(JwtError.InvalidToken, refusal);
+            }
         }
 
         LogValidationSucceeded(context.ClientInfo.ClientId);

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
@@ -132,9 +132,10 @@ public partial class ClientJwtValidator(
         // to ask. It only narrows: a deployment-wide profile is a floor, so no client's window is
         // wider than the one already applied.
         //
-        // Under the same flag as the pass above, and not merely for symmetry: a caller that opted
-        // out of time handling must not meet the timestamp accessors either, since they throw on a
-        // value outside the range DateTimeOffset can hold.
+        // The same flag the pass above reads, because the caller's options are handed to it
+        // unchanged where the validation parameters are built. Not symmetry for its own sake: a
+        // caller that opted out of time handling must not meet the timestamp accessors either,
+        // since they throw on a value outside the range DateTimeOffset can hold.
         if (options.HasFlag(ValidationOptions.ValidateLifetime))
         {
             var refusal = SecurityProfileRequirements

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
@@ -38,8 +38,10 @@ namespace Abblix.Oidc.Server.Features.Tokens.Validation;
 /// <param name="issuerProvider">Provides the authorization server's issuer identifier for audience validation.</param>
 /// <param name="serviceKeysProvider">Provides the server's own private keys used to decrypt request
 /// objects that the client encrypted to the server (RFC 9101 section 6.1).</param>
-/// <param name="oidcOptions">Carries the security profile whose bound on how far ahead a token
-/// may be dated this validator applies.</param>
+/// <param name="oidcOptions">Carries the security profile every client is held to, and the default
+/// a client without one of its own falls back to.</param>
+/// <param name="timeProvider">Judges the token's timestamps against the client's own profile, once
+/// the client is known.</param>
 [SuppressMessage("SonarQube", "S107:Methods should not have too many parameters",
     Justification = "Every dependency is used: two resolve the client and its keys, two the server's own address and keys, and the options carry the security profile whose tolerance this validator applies. Splitting the class is a separate question from the profile it now reads.")]
 public partial class ClientJwtValidator(
@@ -50,7 +52,8 @@ public partial class ClientJwtValidator(
     IClientKeysProvider clientJwksProvider,
     IIssuerProvider issuerProvider,
     IAuthServiceKeysProvider serviceKeysProvider,
-    IOptions<OidcOptions> oidcOptions) : IClientJwtValidator
+    IOptions<OidcOptions> oidcOptions,
+    TimeProvider timeProvider) : IClientJwtValidator
 {
     private SecurityProfileRequirements Profile
         => SecurityProfileRequirements.Resolve(oidcOptions.Value.DefaultSecurityProfile);
@@ -121,6 +124,27 @@ public partial class ClientJwtValidator(
         {
             LogClientNotDetermined();
             return new JwtValidationError(JwtError.InvalidToken, "Unable to determine client from JWT");
+        }
+
+        // The pass above ran under the DEPLOYMENT's window, because the client is identified from the
+        // token being validated and is not known until that has finished. A client naming a profile
+        // of its own may be held to a tighter one, and this is the first line where there is a client
+        // to ask. It only narrows: a deployment-wide profile is a floor, so no client's window is
+        // wider than the one already applied, and a client naming nothing reaches the same answer
+        // twice.
+        var refusal = SecurityProfileRequirements
+            .For(context.ClientInfo, oidcOptions.Value.DefaultSecurityProfile)
+            .ClockSkewOrDefault()
+            .WhyRefused(
+                timeProvider.GetUtcNow(),
+                validatedToken.Payload.NotBefore,
+                validatedToken.Payload.ExpiresAt,
+                validatedToken.Payload.IssuedAt);
+
+        if (refusal != null)
+        {
+            LogTimestampsOutsideTheClientsProfile(context.ClientInfo.ClientId, refusal);
+            return new JwtValidationError(JwtError.InvalidToken, refusal);
         }
 
         LogValidationSucceeded(context.ClientInfo.ClientId);

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -204,6 +204,7 @@ internal static class LogEvents
             public const int ReplayDetected = Base + 10;
             public const int OtherKindPresentedAsAssertion = Base + 11;
             public const int AudienceIsNotTheIssuerAlone = Base + 12;
+            public const int TimestampsOutsideTheClientsProfile = Base + 13;
         }
 
         /// <summary>
@@ -362,6 +363,7 @@ internal static class LogEvents
             public const int ClientNotDetermined = Base + 3;
             public const int ValidationSucceeded = Base + 4;
             public const int AudienceValidationFailed = Base + 5;
+            public const int TimestampsOutsideTheClientsProfile = Base + 6;
         }
 
         /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAssertionMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAssertionMayTightenItselfTests.cs
@@ -179,6 +179,20 @@ public class ClientAssertionMayTightenItselfTests
         Assert.NotNull(result);
     }
 
+    /// <summary>
+    /// The forward direction accepts an <c>nbf</c> inside the tighter window, without which the
+    /// refusal above would be satisfied by a clause refusing on the mere presence of the claim.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_KeepsANotBeforeInsideItsOwnWindow()
+    {
+        var result = await Authenticate(
+            ClientSecurityProfile.Fapi2,
+            notBefore: Now.AddSeconds(5));
+
+        Assert.NotNull(result);
+    }
+
     private async Task<ClientInfo?> Authenticate(
         ClientSecurityProfile? clientProfile,
         DateTimeOffset? issuedAt = null,

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAssertionMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAssertionMayTightenItselfTests.cs
@@ -13,13 +13,13 @@ using Abblix.Jwt;
 using Abblix.Jwt.ReplayPrevention;
 using Abblix.Oidc.Server.Common.Configuration;
 using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Common.Interfaces;
 using Abblix.Oidc.Server.Features.ClientAuthentication;
 using Abblix.Oidc.Server.Features.ClientInformation;
 using Abblix.Oidc.Server.Features.Issuer;
-using Abblix.Oidc.Server.Features.Tokens.Validation;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
-using Microsoft.Extensions.DependencyInjection;
+using Abblix.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -33,8 +33,12 @@ namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
 /// deployment's. A client asking to be held to a tighter profile could not be heard on this path.
 /// </summary>
 /// <remarks>
-/// The answer is a second pass once the client is known. These cases are about that pass: every
-/// assertion here carries the identifier and the expiry the specification demands and names the
+/// The subject is <see cref="ClientSecretJwtAuthenticator"/> rather than its sibling, because this is
+/// where the base class's second pass is the ONLY one: it validates through
+/// <see cref="IJsonWebTokenValidator"/> directly, while <see cref="PrivateKeyJwtAuthenticator"/> goes
+/// through the client JWT validator, which now performs the same check itself.
+///
+/// Every assertion here carries the identifier and the expiry the specification demands and names the
 /// issuer as its audience, so the only thing separating acceptance from refusal is which profile the
 /// client names for itself.
 /// </remarks>
@@ -42,15 +46,19 @@ public class ClientAssertionMayTightenItselfTests
 {
     private const string ClientId = "tightening_client";
     private static readonly string Issuer = TestConstants.DefaultIssuer.ToString();
-    private const string JwtAssertion = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+    private const string JwtAssertion = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
 
     private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
     /// <summary>
-    /// Dated ahead of every profile this server carries, and inside the window a deployment holding
-    /// clients to nothing grants.
+    /// Beyond every profile this server carries, and inside the window a deployment holding clients
+    /// to nothing grants.
     /// </summary>
-    private static readonly TimeSpan AheadOfEveryProfileButNone = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan BeyondEveryProfileButNone = TimeSpan.FromMinutes(1);
+
+    private readonly Mock<IJsonWebTokenValidator> tokenValidator = new(MockBehavior.Strict);
+    private readonly Mock<IClientInfoProvider> clientInfoProvider = new(MockBehavior.Strict);
+    private readonly Mock<IReplayCache> replayCache = new(MockBehavior.Strict);
 
     /// <summary>
     /// The case this exists for: a client naming FAPI 2.0 under a deployment naming nothing is held
@@ -58,14 +66,11 @@ public class ClientAssertionMayTightenItselfTests
     /// second pass this assertion authenticated the client.
     /// </summary>
     [Fact]
-    public async Task AClientNamingFapi2_IsHeldToItUnderADeploymentNamingNothing()
+    public async Task AClientNamingFapi2_IsHeldToItsOwnForwardWindow()
     {
-        var (authenticator, replayCache) = CreateAuthenticator();
-
         var result = await Authenticate(
-            authenticator,
             ClientSecurityProfile.Fapi2,
-            Now + AheadOfEveryProfileButNone);
+            issuedAt: Now + BeyondEveryProfileButNone);
 
         Assert.Null(result);
 
@@ -82,51 +87,145 @@ public class ClientAssertionMayTightenItselfTests
     /// above would be satisfied by a pass refusing every assertion dated ahead at all.
     /// </summary>
     [Fact]
-    public async Task AClientNamingNothing_KeepsTheDeploymentsWindow()
+    public async Task AClientNamingNothing_KeepsTheDeploymentsForwardWindow()
     {
-        var (authenticator, _) = CreateAuthenticator();
-
         var result = await Authenticate(
-            authenticator,
             clientProfile: null,
-            issuedAt: Now + AheadOfEveryProfileButNone);
+            issuedAt: Now + BeyondEveryProfileButNone);
 
         Assert.NotNull(result);
     }
 
     /// <summary>
-    /// And an assertion inside the tighter window authenticates the FAPI client too, or the case
+    /// The backward half, which is the larger of the two shifts: FAPI 2.0 grants a token no life at
+    /// all past the expiry its issuer chose, where a deployment naming nothing grants minutes.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_IsHeldToItsOwnExpiry()
+    {
+        var result = await Authenticate(
+            ClientSecurityProfile.Fapi2,
+            expiresAt: Now.AddSeconds(-1));
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// And the same expired assertion from a client naming nothing authenticates, which is what
+    /// makes the case above a statement about the profile rather than about expiry.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingNothing_KeepsTheDeploymentsExpiryTolerance()
+    {
+        var result = await Authenticate(
+            clientProfile: null,
+            expiresAt: Now.AddSeconds(-1));
+
+        Assert.NotNull(result);
+    }
+
+    /// <summary>
+    /// The forward direction reaches <c>nbf</c> as well as <c>iat</c>: FAPI 2.0 section 5.3.2.1
+    /// names both, and this is the clause that answers for the first of them.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_IsHeldToItsOwnWindowOnNotBefore()
+    {
+        var result = await Authenticate(
+            ClientSecurityProfile.Fapi2,
+            notBefore: Now + BeyondEveryProfileButNone);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// And the same post-dated assertion from a client naming nothing authenticates.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingNothing_KeepsTheDeploymentsWindowOnNotBefore()
+    {
+        var result = await Authenticate(
+            clientProfile: null,
+            notBefore: Now + BeyondEveryProfileButNone);
+
+        Assert.NotNull(result);
+    }
+
+    /// <summary>
+    /// A client naming the empty profile is not heard either way: it cannot loosen what the
+    /// deployment demands, and it demands nothing of its own.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingTheEmptyProfile_IsTreatedAsNamingNothing()
+    {
+        var result = await Authenticate(
+            ClientSecurityProfile.None,
+            issuedAt: Now + BeyondEveryProfileButNone);
+
+        Assert.NotNull(result);
+    }
+
+    /// <summary>
+    /// And an assertion inside the tighter window authenticates the FAPI client too, or the cases
     /// above would be satisfied by a pass refusing every assertion from a client naming a profile.
     /// </summary>
     [Fact]
     public async Task AClientNamingFapi2_KeepsAnAssertionInsideItsOwnWindow()
     {
-        var (authenticator, _) = CreateAuthenticator();
-
         var result = await Authenticate(
-            authenticator,
             ClientSecurityProfile.Fapi2,
-            Now.AddSeconds(5));
+            issuedAt: Now.AddSeconds(5));
 
         Assert.NotNull(result);
     }
 
-    private readonly Mock<IClientJwtValidator> validator = new(MockBehavior.Strict);
-
     private async Task<ClientInfo?> Authenticate(
-        PrivateKeyJwtAuthenticator authenticator,
         ClientSecurityProfile? clientProfile,
-        DateTimeOffset issuedAt)
+        DateTimeOffset? issuedAt = null,
+        DateTimeOffset? expiresAt = null,
+        DateTimeOffset? notBefore = null)
     {
         var clientInfo = new ClientInfo(ClientId)
         {
-            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretJwt,
             SecurityProfile = clientProfile,
         };
 
-        validator
-            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
-            .ReturnsAsync(new ValidJsonWebToken(CreateAssertion(issuedAt), clientInfo));
+        clientInfoProvider
+            .Setup(p => p.TryFindClientAsync(ClientId))
+            .ReturnsAsync(clientInfo);
+
+        var token = CreateAssertion(issuedAt, expiresAt, notBefore);
+
+        // The real validator drives these callbacks, and the assertion path depends on what they
+        // leave behind: the issuer callback is what resolves the client into the validation context.
+        tokenValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationParameters>()))
+            .Returns(new Func<string, ValidationParameters, Task<Result<JsonWebToken, JwtValidationError>>>(
+                async (_, parameters) =>
+                {
+                    if (parameters.ValidateIssuer != null)
+                        await parameters.ValidateIssuer(ClientId);
+
+                    return token;
+                }));
+
+        replayCache
+            .Setup(r => r.TryReserveAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(true);
+
+        var requestInfoProvider = new Mock<IRequestInfoProvider>();
+        requestInfoProvider.Setup(p => p.RequestUri).Returns(Issuer);
+
+        var authenticator = new ClientSecretJwtAuthenticator(
+            Mock.Of<ILogger<ClientSecretJwtAuthenticator>>(),
+            tokenValidator.Object,
+            clientInfoProvider.Object,
+            requestInfoProvider.Object,
+            new FixedClock(Now),
+            replayCache.Object,
+            Mock.Of<IIssuerProvider>(p => p.GetIssuer() == Issuer),
+            Options.Create(new OidcOptions { DefaultSecurityProfile = ClientSecurityProfile.None }));
 
         return await authenticator.TryAuthenticateClientAsync(new ClientRequest
         {
@@ -135,13 +234,16 @@ public class ClientAssertionMayTightenItselfTests
         });
     }
 
-    private static JsonWebToken CreateAssertion(DateTimeOffset issuedAt)
+    private static JsonWebToken CreateAssertion(
+        DateTimeOffset? issuedAt,
+        DateTimeOffset? expiresAt,
+        DateTimeOffset? notBefore)
     {
         var token = new JsonWebToken
         {
             Header = new JsonWebTokenHeader(new JsonObject
             {
-                [JwtClaimTypes.Algorithm] = "RS256",
+                [JwtClaimTypes.Algorithm] = "HS256",
                 [JwtClaimTypes.Type] = "JWT",
             }),
             Payload = new JsonWebTokenPayload(new JsonObject
@@ -152,31 +254,13 @@ public class ClientAssertionMayTightenItselfTests
             }),
         };
 
-        token.Payload.IssuedAt = issuedAt;
-        token.Payload.ExpiresAt = Now.AddHours(1);
+        token.Payload.IssuedAt = issuedAt ?? Now;
+        token.Payload.ExpiresAt = expiresAt ?? Now.AddHours(1);
+        if (notBefore.HasValue)
+            token.Payload.NotBefore = notBefore.Value;
+
         token.Payload.Audiences = [Issuer];
         return token;
-    }
-
-    private (PrivateKeyJwtAuthenticator, Mock<IReplayCache>) CreateAuthenticator()
-    {
-        var replayCache = new Mock<IReplayCache>(MockBehavior.Strict);
-        replayCache
-            .Setup(r => r.TryReserveAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
-            .ReturnsAsync(true);
-
-        var services = new ServiceCollection();
-        services.AddScoped(_ => validator.Object);
-
-        var authenticator = new PrivateKeyJwtAuthenticator(
-            Mock.Of<ILogger<PrivateKeyJwtAuthenticator>>(),
-            replayCache.Object,
-            services.BuildServiceProvider(),
-            Mock.Of<IIssuerProvider>(p => p.GetIssuer() == Issuer),
-            Options.Create(new OidcOptions { DefaultSecurityProfile = ClientSecurityProfile.None }),
-            new FixedClock(Now));
-
-        return (authenticator, replayCache);
     }
 
     private sealed class FixedClock(DateTimeOffset now) : TimeProvider

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAssertionMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/ClientAssertionMayTightenItselfTests.cs
@@ -1,0 +1,186 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Jwt.ReplayPrevention;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Features.ClientAuthentication;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Validation;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
+
+/// <summary>
+/// A client assertion is validated before anyone knows whose it is: the client is identified from
+/// the assertion itself, so the clock tolerance applied while validating it can only be the
+/// deployment's. A client asking to be held to a tighter profile could not be heard on this path.
+/// </summary>
+/// <remarks>
+/// The answer is a second pass once the client is known. These cases are about that pass: every
+/// assertion here carries the identifier and the expiry the specification demands and names the
+/// issuer as its audience, so the only thing separating acceptance from refusal is which profile the
+/// client names for itself.
+/// </remarks>
+public class ClientAssertionMayTightenItselfTests
+{
+    private const string ClientId = "tightening_client";
+    private static readonly string Issuer = TestConstants.DefaultIssuer.ToString();
+    private const string JwtAssertion = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Dated ahead of every profile this server carries, and inside the window a deployment holding
+    /// clients to nothing grants.
+    /// </summary>
+    private static readonly TimeSpan AheadOfEveryProfileButNone = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// The case this exists for: a client naming FAPI 2.0 under a deployment naming nothing is held
+    /// to the seconds section 5.3.2.1 grants, not to the minutes the deployment would. Before the
+    /// second pass this assertion authenticated the client.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_IsHeldToItUnderADeploymentNamingNothing()
+    {
+        var (authenticator, replayCache) = CreateAuthenticator();
+
+        var result = await Authenticate(
+            authenticator,
+            ClientSecurityProfile.Fapi2,
+            Now + AheadOfEveryProfileButNone);
+
+        Assert.Null(result);
+
+        // The refusal lands before the identifier is reserved: a reservation is spent and cannot be
+        // given back, so burning it on an assertion this pass rejects would refuse the client's next
+        // attempt with the same identifier for the wrong reason.
+        replayCache.Verify(
+            r => r.TryReserveAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// And the same assertion from a client naming nothing authenticates, without which the case
+    /// above would be satisfied by a pass refusing every assertion dated ahead at all.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingNothing_KeepsTheDeploymentsWindow()
+    {
+        var (authenticator, _) = CreateAuthenticator();
+
+        var result = await Authenticate(
+            authenticator,
+            clientProfile: null,
+            issuedAt: Now + AheadOfEveryProfileButNone);
+
+        Assert.NotNull(result);
+    }
+
+    /// <summary>
+    /// And an assertion inside the tighter window authenticates the FAPI client too, or the case
+    /// above would be satisfied by a pass refusing every assertion from a client naming a profile.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_KeepsAnAssertionInsideItsOwnWindow()
+    {
+        var (authenticator, _) = CreateAuthenticator();
+
+        var result = await Authenticate(
+            authenticator,
+            ClientSecurityProfile.Fapi2,
+            Now.AddSeconds(5));
+
+        Assert.NotNull(result);
+    }
+
+    private readonly Mock<IClientJwtValidator> validator = new(MockBehavior.Strict);
+
+    private async Task<ClientInfo?> Authenticate(
+        PrivateKeyJwtAuthenticator authenticator,
+        ClientSecurityProfile? clientProfile,
+        DateTimeOffset issuedAt)
+    {
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.PrivateKeyJwt,
+            SecurityProfile = clientProfile,
+        };
+
+        validator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationOptions>()))
+            .ReturnsAsync(new ValidJsonWebToken(CreateAssertion(issuedAt), clientInfo));
+
+        return await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+    }
+
+    private static JsonWebToken CreateAssertion(DateTimeOffset issuedAt)
+    {
+        var token = new JsonWebToken
+        {
+            Header = new JsonWebTokenHeader(new JsonObject
+            {
+                [JwtClaimTypes.Algorithm] = "RS256",
+                [JwtClaimTypes.Type] = "JWT",
+            }),
+            Payload = new JsonWebTokenPayload(new JsonObject
+            {
+                [JwtClaimTypes.Issuer] = ClientId,
+                [JwtClaimTypes.Subject] = ClientId,
+                [JwtClaimTypes.JwtId] = "assertion-identifier",
+            }),
+        };
+
+        token.Payload.IssuedAt = issuedAt;
+        token.Payload.ExpiresAt = Now.AddHours(1);
+        token.Payload.Audiences = [Issuer];
+        return token;
+    }
+
+    private (PrivateKeyJwtAuthenticator, Mock<IReplayCache>) CreateAuthenticator()
+    {
+        var replayCache = new Mock<IReplayCache>(MockBehavior.Strict);
+        replayCache
+            .Setup(r => r.TryReserveAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(true);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => validator.Object);
+
+        var authenticator = new PrivateKeyJwtAuthenticator(
+            Mock.Of<ILogger<PrivateKeyJwtAuthenticator>>(),
+            replayCache.Object,
+            services.BuildServiceProvider(),
+            Mock.Of<IIssuerProvider>(p => p.GetIssuer() == Issuer),
+            Options.Create(new OidcOptions { DefaultSecurityProfile = ClientSecurityProfile.None }),
+            new FixedClock(Now));
+
+        return (authenticator, replayCache);
+    }
+
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/PrivateKeyJwtAuthenticatorTests.cs
@@ -697,7 +697,8 @@ public class PrivateKeyJwtAuthenticatorTests
             replayCache.Object,
             serviceProvider,
             Mock.Of<IIssuerProvider>(p => p.GetIssuer() == "https://issuer.example.com"),
-            Options.Create(new OidcOptions { DefaultSecurityProfile = profile }));
+            Options.Create(new OidcOptions { DefaultSecurityProfile = profile }),
+            TimeProvider.System);
 
         var mocks = new Mocks
         {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/ProfileClockSkewReachesValidationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/ProfileClockSkewReachesValidationTests.cs
@@ -166,7 +166,8 @@ public class ProfileClockSkewReachesValidationTests
             new Mock<IClientKeysProvider>().Object,
             issuerProvider.Object,
             serviceKeys.Object,
-            Options.Create(new OidcOptions { DefaultSecurityProfile = profile }));
+            Options.Create(new OidcOptions { DefaultSecurityProfile = profile }),
+             TimeProvider.System);
 
         await validator.ValidateAsync("header.payload.signature");
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/ProfileClockSkewReachesValidationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientInformation/ProfileClockSkewReachesValidationTests.cs
@@ -167,7 +167,7 @@ public class ProfileClockSkewReachesValidationTests
             issuerProvider.Object,
             serviceKeys.Object,
             Options.Create(new OidcOptions { DefaultSecurityProfile = profile }),
-             TimeProvider.System);
+            TimeProvider.System);
 
         await validator.ValidateAsync("header.payload.signature");
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
@@ -70,7 +70,8 @@ public class ClientJwtValidatorTests
             _clientKeysProvider.Object,
             issuerProvider.Object,
             _serviceKeysProvider.Object,
-            Options.Create(new OidcOptions()));
+            Options.Create(new OidcOptions()),
+             TimeProvider.System);
     }
 
     #region Audience Validation Tests

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientJwtValidatorTests.cs
@@ -71,7 +71,7 @@ public class ClientJwtValidatorTests
             issuerProvider.Object,
             _serviceKeysProvider.Object,
             Options.Create(new OidcOptions()),
-             TimeProvider.System);
+            TimeProvider.System);
     }
 
     #region Audience Validation Tests

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
@@ -56,7 +56,9 @@ public class ClientMayTightenItselfTests
     private static async Task<Result<ValidJsonWebToken, JwtValidationError>> Validate(
         ClientSecurityProfile? clientProfile,
         ClientSecurityProfile deploymentProfile,
-        DateTimeOffset issuedAt)
+        DateTimeOffset? issuedAt = null,
+        DateTimeOffset? expiresAt = null,
+        DateTimeOffset? notBefore = null)
     {
         var token = new JsonWebToken
         {
@@ -65,11 +67,14 @@ public class ClientMayTightenItselfTests
             {
                 Issuer = ClientId,
                 ClientId = ClientId,
-                IssuedAt = issuedAt,
-                ExpiresAt = Now.AddHours(1),
+                IssuedAt = issuedAt ?? Now,
+                ExpiresAt = expiresAt ?? Now.AddHours(1),
                 Audiences = [Issuer],
             },
         };
+
+        if (notBefore.HasValue)
+            token.Payload.NotBefore = notBefore.Value;
 
         var clientInfo = new ClientInfo(ClientId) { SecurityProfile = clientProfile };
 
@@ -165,6 +170,67 @@ public class ClientMayTightenItselfTests
             clientProfile: ClientSecurityProfile.Fapi2,
             deploymentProfile: ClientSecurityProfile.None,
             issuedAt: Now.AddSeconds(5));
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// The backward half, which is the larger of the two shifts: FAPI 2.0 grants a token no life at
+    /// all past the expiry its issuer chose, where a deployment naming nothing grants minutes.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_IsHeldToItsOwnExpiry()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            expiresAt: Now.AddSeconds(-1));
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Contains("expired", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// And the same expired token from a client naming nothing is accepted, which is what makes the
+    /// case above a statement about the profile rather than about expiry.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingNothing_KeepsTheDeploymentsExpiryTolerance()
+    {
+        var result = await Validate(
+            clientProfile: null,
+            deploymentProfile: ClientSecurityProfile.None,
+            expiresAt: Now.AddSeconds(-1));
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// The forward direction reaches <c>nbf</c> as well as <c>iat</c>: FAPI 2.0 section 5.3.2.1
+    /// names both, and this is the clause that answers for the first of them.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_IsHeldToItsOwnWindowOnNotBefore()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            notBefore: Now + AheadOfEveryProfileButNone);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Contains("not yet valid", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// And the same post-dated token from a client naming nothing is accepted.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingNothing_KeepsTheDeploymentsWindowOnNotBefore()
+    {
+        var result = await Validate(
+            clientProfile: null,
+            deploymentProfile: ClientSecurityProfile.None,
+            notBefore: Now + AheadOfEveryProfileButNone);
 
         Assert.True(result.TryGetSuccess(out _));
     }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
@@ -268,7 +268,7 @@ public class ClientMayTightenItselfTests
             clientProfile: ClientSecurityProfile.Fapi2,
             deploymentProfile: ClientSecurityProfile.None,
             unreadableIssuedAt: true,
-            options: ValidationOptions.RequireValidSignedTokens);
+            options: ValidationOptions.Default & ~ValidationOptions.ValidateLifetime);
 
         Assert.True(result.TryGetSuccess(out _));
     }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
@@ -58,7 +58,9 @@ public class ClientMayTightenItselfTests
         ClientSecurityProfile deploymentProfile,
         DateTimeOffset? issuedAt = null,
         DateTimeOffset? expiresAt = null,
-        DateTimeOffset? notBefore = null)
+        DateTimeOffset? notBefore = null,
+        bool unreadableIssuedAt = false,
+        ValidationOptions options = ValidationOptions.Default)
     {
         var token = new JsonWebToken
         {
@@ -75,6 +77,9 @@ public class ClientMayTightenItselfTests
 
         if (notBefore.HasValue)
             token.Payload.NotBefore = notBefore.Value;
+
+        if (unreadableIssuedAt)
+            token.Payload.Json[JwtClaimTypes.IssuedAt] = 99999999999999;
 
         var clientInfo = new ClientInfo(ClientId) { SecurityProfile = clientProfile };
 
@@ -108,7 +113,7 @@ public class ClientMayTightenItselfTests
             Options.Create(new OidcOptions { DefaultSecurityProfile = deploymentProfile }),
             new FixedClock(Now));
 
-        return await validator.ValidateAsync("header.payload.signature");
+        return await validator.ValidateAsync("header.payload.signature", options);
     }
 
     /// <summary>
@@ -231,6 +236,39 @@ public class ClientMayTightenItselfTests
             clientProfile: null,
             deploymentProfile: ClientSecurityProfile.None,
             notBefore: Now + AheadOfEveryProfileButNone);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// The forward direction accepts an <c>nbf</c> inside the tighter window, without which the
+    /// refusal above would be satisfied by a clause refusing on the mere presence of the claim.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_KeepsANotBeforeInsideItsOwnWindow()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            notBefore: Now.AddSeconds(5));
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// A caller that did not ask for lifetime validation does not get it, and - the reason the pass
+    /// is written as a condition rather than run unconditionally - does not meet the timestamp
+    /// accessors either. This token's <c>iat</c> is outside the range <see cref="DateTimeOffset"/>
+    /// can hold, so reading it at all throws rather than refusing.
+    /// </summary>
+    [Fact]
+    public async Task ACallerNotAskingForLifetimeValidation_IsNotGivenIt()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            unreadableIssuedAt: true,
+            options: ValidationOptions.RequireValidSignedTokens);
 
         Assert.True(result.TryGetSuccess(out _));
     }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
@@ -1,0 +1,176 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Features.Tokens.Validation;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Abblix.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.Tokens.Validation;
+
+/// <summary>
+/// A deployment-wide profile is a floor, so a client may ask to be held to more than the deployment
+/// demands. On this path it could not be heard: the client is identified from the token being
+/// validated, so its profile is unknown until the validation has finished, and the tolerance had to
+/// be chosen before that.
+/// </summary>
+/// <remarks>
+/// The answer is a second pass once the client is known. These cases are about that pass, not about
+/// the first one: every token here is signed and addressed correctly, and the only thing separating
+/// acceptance from refusal is which profile the client names for itself.
+/// </remarks>
+public class ClientMayTightenItselfTests
+{
+    private const string ClientId = TestConstants.DefaultClientId;
+    private static readonly string Issuer = TestConstants.DefaultIssuer.ToString();
+
+    /// <summary>
+    /// A token dated a minute ahead, which no profile in this server accepts and the empty profile
+    /// does: five minutes each way is what a deployment holding clients to nothing grants.
+    /// </summary>
+    private static readonly TimeSpan AheadOfEveryProfileButNone = TimeSpan.FromMinutes(1);
+
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Runs the validator over a token the first pass accepts, with the client resolving to the
+    /// profile named. The token validator is a stub: what is under test is the pass AFTER it.
+    /// </summary>
+    private static async Task<Result<ValidJsonWebToken, JwtValidationError>> Validate(
+        ClientSecurityProfile? clientProfile,
+        ClientSecurityProfile deploymentProfile,
+        DateTimeOffset issuedAt)
+    {
+        var token = new JsonWebToken
+        {
+            Header = { Algorithm = SigningAlgorithms.RS256 },
+            Payload =
+            {
+                Issuer = ClientId,
+                ClientId = ClientId,
+                IssuedAt = issuedAt,
+                ExpiresAt = Now.AddHours(1),
+                Audiences = [Issuer],
+            },
+        };
+
+        var clientInfo = new ClientInfo(ClientId) { SecurityProfile = clientProfile };
+
+        var clientInfoProvider = new Mock<IClientInfoProvider>();
+        clientInfoProvider.Setup(p => p.TryFindClientAsync(ClientId)).ReturnsAsync(clientInfo);
+
+        var tokenValidator = new Mock<IJsonWebTokenValidator>();
+        tokenValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<string>(), It.IsAny<ValidationParameters>()))
+            .ReturnsAsync(token);
+
+        var requestInfoProvider = new Mock<IRequestInfoProvider>();
+        requestInfoProvider.Setup(p => p.RequestUri).Returns(Issuer);
+
+        var issuerProvider = new Mock<IIssuerProvider>();
+        issuerProvider.Setup(p => p.GetIssuer()).Returns(Issuer);
+
+        var serviceKeys = new Mock<IAuthServiceKeysProvider>();
+        serviceKeys
+            .Setup(p => p.GetEncryptionKeys(It.IsAny<bool>()))
+            .Returns(AsyncEnumerable.Empty<JsonWebKey>());
+
+        var validator = new ClientJwtValidator(
+            NullLogger<ClientJwtValidator>.Instance,
+            requestInfoProvider.Object,
+            tokenValidator.Object,
+            clientInfoProvider.Object,
+            new Mock<IClientKeysProvider>().Object,
+            issuerProvider.Object,
+            serviceKeys.Object,
+            Options.Create(new OidcOptions { DefaultSecurityProfile = deploymentProfile }),
+            new FixedClock(Now));
+
+        return await validator.ValidateAsync("header.payload.signature");
+    }
+
+    /// <summary>
+    /// The case this exists for: a client naming FAPI 2.0 under a deployment naming nothing is held
+    /// to the ten seconds section 5.3.2.1 grants, not to the five minutes the deployment would.
+    /// Before the second pass this token was accepted.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_IsHeldToItUnderADeploymentNamingNothing()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            issuedAt: Now + AheadOfEveryProfileButNone);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Contains("issued in the future", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// And the same token from a client naming nothing is accepted, without which the case above
+    /// would be satisfied by a pass that refuses every token dated ahead at all.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingNothing_KeepsTheDeploymentsWindow()
+    {
+        var result = await Validate(
+            clientProfile: null,
+            deploymentProfile: ClientSecurityProfile.None,
+            issuedAt: Now + AheadOfEveryProfileButNone);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// A client naming the empty profile is not heard either way: it cannot loosen what the
+    /// deployment demands, and it demands nothing of its own. The same token is accepted, which is
+    /// the floor working rather than the tightening.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingTheEmptyProfile_IsTreatedAsNamingNothing()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.None,
+            deploymentProfile: ClientSecurityProfile.None,
+            issuedAt: Now + AheadOfEveryProfileButNone);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// And a token inside the tighter window passes for the FAPI client too, or the case above would
+    /// be satisfied by a pass that refuses every token from a client naming a profile.
+    /// </summary>
+    [Fact]
+    public async Task AClientNamingFapi2_KeepsATokenInsideItsOwnWindow()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            issuedAt: Now.AddSeconds(5));
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(157, EventIds().Count);
+        Assert.Equal(159, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()


### PR DESCRIPTION
A deployment-wide security profile is a floor, so a client may ask to be held to more than the deployment demands. On the paths that validate a JWT this could not be heard: the client is identified from the token being validated, so its profile is unknown until the validation has finished, and the clock tolerance had to be chosen before that. A client naming FAPI 2.0 under a deployment naming nothing was granted the wider window anyway.

Both paths gain a second pass, once the client is known.

- `ClientJwtValidator` asks it after the client has been determined.
- `JwtAssertionAuthenticatorBase` asks it after the audience check and before the assertion's identifier is reserved. A reservation is spent and cannot be given back, so a refusal after it would burn that identifier on a request this check was going to reject.

The pass only narrows. The first pass ran under the deployment's window, which is the widest any client can be given, so a client naming the deployment's profile or naming nothing at all reaches the same answer twice.

The comparison rule moves onto `ClockSkew` as `WhyRefused`, so the two passes share one reading of the boundaries rather than drifting apart where that is hardest to notice.

Registration is deliberately unchanged: at that point there is no client, so the deployment profile is the only available answer.

Two new test classes cover the pass on each path, each with a case that keeps the wider window for a client naming nothing and a case that accepts a token inside the tighter window, so neither is satisfied by a pass that refuses everything. On the assertion path a strict replay cache and `Times.Never` pin the ordering. A mutation making each pass compute its answer and never act on it reddens exactly one test on each path.
