### PR TITLE
Refuse a timestamp claim the payload cannot read, instead of throwing

### DIFF
--- a/src/Abblix.Jwt/JsonWebTokenExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebTokenExtensions.cs
@@ -24,12 +24,18 @@ public static class JsonWebTokenExtensions
     /// <param name="name">The property name containing the Unix time seconds.</param>
     /// <returns>
     /// A nullable <see cref="DateTimeOffset"/> representing the date and time of the specified property,
-    /// or <c>null</c> if the property is not present or cannot be converted.
+    /// or <c>null</c> if the property is not present.
     /// </returns>
     /// <remarks>
     /// Unix time seconds are widely used for representing date and time in JSON objects, especially in JWTs.
     /// This method simplifies retrieving such values by converting them directly to <see cref="DateTimeOffset"/>.
+    /// A value that is present and cannot be read THROWS rather than answering null: a caller judging a token
+    /// somebody else wrote reads through <see cref="JsonWebTokenPayload.TryReadTimestamp"/> instead, which
+    /// names the claim in a refusal.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">The value is not a number.</exception>
+    /// <exception cref="JsonException">The value is a JSON kind no number can be read from.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The number is outside the range a date can hold.</exception>
     public static DateTimeOffset? GetUnixTimeSeconds(this JsonObject json, string name)
     {
         var node = json[name];
@@ -39,8 +45,10 @@ public static class JsonWebTokenExtensions
         // A JsonValue parsed from text holds a JsonElement and converts to whatever numeric type is
         // asked for. One created in code holds the .NET primitive it was created from and answers
         // TryGetValue only for that exact type: a payload written as an int literal is a
-        // JsonValue<int>, which says no to long. So the integral types are asked for one by one
-        // before falling back to a double, and a decimal literal is read as a decimal first.
+        // JsonValue<int>, which says no to long. The two integral asks keep exactness for a value
+        // past what a double represents; everything else goes through serialization, which reads
+        // any numeric backing the same way rather than one primitive at a time - a list of
+        // primitives is never complete, and the one left off it is the one a consumer writes.
         var value = node.AsValue();
         if (value.TryGetValue<int>(out var intValue))
             return DateTimeOffset.FromUnixTimeSeconds(intValue);
@@ -54,10 +62,7 @@ public static class JsonWebTokenExtensions
         // toward zero, since a token does not become valid or expire between two whole seconds. A
         // value that is not a number at all still fails the read, which is what a caller catching
         // it expects.
-        var number = value.TryGetValue<decimal>(out var decimalValue)
-            ? (double)decimalValue
-            : value.GetValue<double>();
-        var fractional = Math.Truncate(number);
+        var fractional = Math.Truncate(value.Deserialize<double>());
         if (fractional < long.MinValue || long.MaxValue < fractional)
             throw new ArgumentOutOfRangeException(name, fractional, "The value is outside the range a NumericDate can hold");
 

--- a/src/Abblix.Jwt/JsonWebTokenExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebTokenExtensions.cs
@@ -36,16 +36,28 @@ public static class JsonWebTokenExtensions
         if (node == null)
             return null;
 
+        // A JsonValue parsed from text holds a JsonElement and converts to whatever numeric type is
+        // asked for. One created in code holds the .NET primitive it was created from and answers
+        // TryGetValue only for that exact type: a payload written as an int literal is a
+        // JsonValue<int>, which says no to long. So the integral types are asked for one by one
+        // before falling back to a double, and a decimal literal is read as a decimal first.
         var value = node.AsValue();
+        if (value.TryGetValue<int>(out var intValue))
+            return DateTimeOffset.FromUnixTimeSeconds(intValue);
+
         if (value.TryGetValue<long>(out var seconds))
             return DateTimeOffset.FromUnixTimeSeconds(seconds);
 
         // RFC 7519 section 2 defines NumericDate as seconds since the epoch "other than that
         // non-integer values can be represented", and a JSON number written with an exponent is a
-        // legal spelling of an integral one. Both arrive here as a double; the fraction is dropped,
-        // since a token does not become valid or expire between two whole seconds. A value that is
-        // not a number at all still fails the read, which is what a caller catching it expects.
-        var fractional = Math.Truncate(value.GetValue<double>());
+        // legal spelling of an integral one. Both arrive here as a double; the fraction is dropped
+        // toward zero, since a token does not become valid or expire between two whole seconds. A
+        // value that is not a number at all still fails the read, which is what a caller catching
+        // it expects.
+        var number = value.TryGetValue<decimal>(out var decimalValue)
+            ? (double)decimalValue
+            : value.GetValue<double>();
+        var fractional = Math.Truncate(number);
         if (fractional < long.MinValue || long.MaxValue < fractional)
             throw new ArgumentOutOfRangeException(name, fractional, "The value is outside the range a NumericDate can hold");
 

--- a/src/Abblix.Jwt/JsonWebTokenExtensions.cs
+++ b/src/Abblix.Jwt/JsonWebTokenExtensions.cs
@@ -37,8 +37,19 @@ public static class JsonWebTokenExtensions
             return null;
 
         var value = node.AsValue();
-        var seconds = value.TryGetValue<int>(out var intValue) ? intValue : value.GetValue<long>();
-        return DateTimeOffset.FromUnixTimeSeconds(seconds);
+        if (value.TryGetValue<long>(out var seconds))
+            return DateTimeOffset.FromUnixTimeSeconds(seconds);
+
+        // RFC 7519 section 2 defines NumericDate as seconds since the epoch "other than that
+        // non-integer values can be represented", and a JSON number written with an exponent is a
+        // legal spelling of an integral one. Both arrive here as a double; the fraction is dropped,
+        // since a token does not become valid or expire between two whole seconds. A value that is
+        // not a number at all still fails the read, which is what a caller catching it expects.
+        var fractional = Math.Truncate(value.GetValue<double>());
+        if (fractional < long.MinValue || long.MaxValue < fractional)
+            throw new ArgumentOutOfRangeException(name, fractional, "The value is outside the range a NumericDate can hold");
+
+        return DateTimeOffset.FromUnixTimeSeconds((long)fractional);
     }
 
     /// <summary>

--- a/src/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/src/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -5,6 +5,7 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 namespace Abblix.Jwt;
@@ -69,6 +70,53 @@ public class JsonWebTokenPayload(JsonObject json)
 	{
 		get => Json.GetUnixTimeSeconds(JwtClaimTypes.ExpiresAt);
 		set => Json.SetUnixTimeSeconds(JwtClaimTypes.ExpiresAt, value);
+	}
+
+	/// <summary>
+	/// Reads the three timestamp claims at once, answering false with the reason instead of throwing
+	/// where one of them cannot be read.
+	/// </summary>
+	/// <remarks>
+	/// The typed accessors throw on a value that is not a NumericDate - a string, an object, a number
+	/// outside the range <see cref="DateTimeOffset"/> can hold - because a caller asking for a
+	/// timestamp has nowhere to put "the token lied". A validator does: a claim it cannot read is a
+	/// refusal of the token, never an exception out of the request. This is the read a validator
+	/// makes, and it names the claim, since the sender can fix only the one it is told about.
+	/// </remarks>
+	/// <param name="notBefore">The <c>nbf</c> claim, or null where the token carries none.</param>
+	/// <param name="expiresAt">The <c>exp</c> claim, or null where the token carries none.</param>
+	/// <param name="issuedAt">The <c>iat</c> claim, or null where the token carries none.</param>
+	/// <param name="whyUnreadable">Which claim could not be read and what it held, or null where all three were read.</param>
+	/// <returns>True where every timestamp the token carries was read.</returns>
+	public bool TryReadTimestamps(
+		out DateTimeOffset? notBefore,
+		out DateTimeOffset? expiresAt,
+		out DateTimeOffset? issuedAt,
+		[NotNullWhen(false)] out string? whyUnreadable)
+	{
+		notBefore = expiresAt = issuedAt = null;
+
+		return TryReadTimestamp(JwtClaimTypes.NotBefore, out notBefore, out whyUnreadable)
+		       && TryReadTimestamp(JwtClaimTypes.ExpiresAt, out expiresAt, out whyUnreadable)
+		       && TryReadTimestamp(JwtClaimTypes.IssuedAt, out issuedAt, out whyUnreadable);
+	}
+
+	private bool TryReadTimestamp(string claim, out DateTimeOffset? value, [NotNullWhen(false)] out string? whyUnreadable)
+	{
+		try
+		{
+			value = Json.GetUnixTimeSeconds(claim);
+			whyUnreadable = null;
+			return true;
+		}
+		catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException or FormatException)
+		{
+			// The value is quoted back rather than described: "not a NumericDate" tells a sender
+			// nothing about which of its two ways of writing a date this server meant.
+			value = null;
+			whyUnreadable = $"The '{claim}' claim holds {Json[claim]?.ToJsonString()}, which cannot be read as a NumericDate";
+			return false;
+		}
 	}
 
 	/// <summary>

--- a/src/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/src/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -109,6 +109,9 @@ public class JsonWebTokenPayload(JsonObject json)
 			whyUnreadable = null;
 			return true;
 		}
+		// FormatException is what net8.0 raises for a number the reader cannot narrow, where later
+		// runtimes raise InvalidOperationException; the suite runs on the latest runtime alone, so
+		// removing that arm stays green here and breaks every net8.0 consumer.
 		catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException or FormatException)
 		{
 			// The value is quoted back rather than described: "not a NumericDate" tells a sender

--- a/src/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/src/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -101,7 +101,21 @@ public class JsonWebTokenPayload(JsonObject json)
 		       && TryReadTimestamp(JwtClaimTypes.IssuedAt, out issuedAt, out whyUnreadable);
 	}
 
-	private bool TryReadTimestamp(string claim, out DateTimeOffset? value, [NotNullWhen(false)] out string? whyUnreadable)
+	/// <summary>
+	/// Reads one timestamp claim by name, answering false with the reason instead of throwing where
+	/// it cannot be read.
+	/// </summary>
+	/// <remarks>
+	/// For a caller that judges one claim and must say nothing about the others: a DPoP proof is
+	/// refused on its <c>iat</c> alone, and a refusal naming a claim it never looked at would be
+	/// wrong twice over.
+	/// </remarks>
+	/// <param name="claim">The claim name, one of the registered timestamp claims or any other
+	/// claim holding a NumericDate.</param>
+	/// <param name="value">The claim's value, or null where the token carries none.</param>
+	/// <param name="whyUnreadable">Which claim could not be read and what it held, or null where it was read.</param>
+	/// <returns>True where the claim was read, or is absent.</returns>
+	public bool TryReadTimestamp(string claim, out DateTimeOffset? value, [NotNullWhen(false)] out string? whyUnreadable)
 	{
 		try
 		{
@@ -109,9 +123,10 @@ public class JsonWebTokenPayload(JsonObject json)
 			whyUnreadable = null;
 			return true;
 		}
-		// FormatException is what net8.0 raises for a number the reader cannot narrow, where later
-		// runtimes raise InvalidOperationException; the suite runs on the latest runtime alone, so
-		// removing that arm stays green here and breaks every net8.0 consumer.
+		// The reader beneath raises InvalidOperationException for a value that is not a number and
+		// ArgumentOutOfRangeException for one no date can hold, the same on every runtime this
+		// package targets. FormatException is the documented failure of the numeric readers this
+		// rests on, kept so a future reader change cannot turn a refusal back into an exception.
 		catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException or FormatException)
 		{
 			// The value is quoted back rather than described: "not a NumericDate" tells a sender

--- a/src/Abblix.Jwt/JsonWebTokenPayload.cs
+++ b/src/Abblix.Jwt/JsonWebTokenPayload.cs
@@ -6,6 +6,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Abblix.Jwt;
@@ -123,11 +124,12 @@ public class JsonWebTokenPayload(JsonObject json)
 			whyUnreadable = null;
 			return true;
 		}
-		// The reader beneath raises InvalidOperationException for a value that is not a number and
-		// ArgumentOutOfRangeException for one no date can hold, the same on every runtime this
-		// package targets. FormatException is the documented failure of the numeric readers this
-		// rests on, kept so a future reader change cannot turn a refusal back into an exception.
-		catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException or FormatException)
+		// The reader beneath raises InvalidOperationException or JsonException for a value that is
+		// not a number and ArgumentOutOfRangeException for one no date can hold, the same on every
+		// runtime this package targets. FormatException is the documented failure of the numeric
+		// readers this rests on, kept so a future reader change cannot turn a refusal back into an
+		// exception.
+		catch (Exception ex) when (ex is InvalidOperationException or JsonException or ArgumentOutOfRangeException or FormatException)
 		{
 			// The value is quoted back rather than described: "not a NumericDate" tells a sender
 			// nothing about which of its two ways of writing a date this server meant.

--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -618,9 +618,10 @@ internal class JsonWebTokenValidator(
             return token;
 
         // A timestamp the payload cannot read is the token's fault, not this server's, so it is
-        // refused as malformed rather than allowed to escape as an exception out of the request.
+        // refused rather than allowed to escape as an exception out of the request. The token itself
+        // parsed, which is why this is an invalid claim and not a malformed token.
         if (!token.Payload.TryReadTimestamps(out var notBefore, out var expiresAt, out var issuedAt, out var whyUnreadable))
-            return new JwtValidationError(JwtError.MalformedToken, whyUnreadable);
+            return new JwtValidationError(JwtError.InvalidToken, whyUnreadable);
 
         if (requireExpiration && !expiresAt.HasValue)
             return new JwtValidationError(JwtError.InvalidToken, "Missing expiration time in JWT payload");

--- a/src/Abblix.Jwt/JsonWebTokenValidator.cs
+++ b/src/Abblix.Jwt/JsonWebTokenValidator.cs
@@ -612,22 +612,21 @@ internal class JsonWebTokenValidator(
         var requireExpiration = parameters.Options.HasFlag(ValidationOptions.RequireExpirationTime);
         var validateLifetime = parameters.Options.HasFlag(ValidationOptions.ValidateLifetime);
 
-        // Neither flag set means the claims are not this caller's business, and reading them is
-        // not free of consequence: the accessors throw on a timestamp outside DateTimeOffset's
-        // range, which a caller who opted out of time handling should never have to meet.
+        // Neither flag set means the claims are not this caller's business, so they are not read
+        // at all: a caller who opted out of time handling is not told the token's dates are wrong.
         if (!requireExpiration && !validateLifetime)
             return token;
 
-        var notBefore = token.Payload.NotBefore;
-        var expiresAt = token.Payload.ExpiresAt;
+        // A timestamp the payload cannot read is the token's fault, not this server's, so it is
+        // refused as malformed rather than allowed to escape as an exception out of the request.
+        if (!token.Payload.TryReadTimestamps(out var notBefore, out var expiresAt, out var issuedAt, out var whyUnreadable))
+            return new JwtValidationError(JwtError.MalformedToken, whyUnreadable);
 
         if (requireExpiration && !expiresAt.HasValue)
             return new JwtValidationError(JwtError.InvalidToken, "Missing expiration time in JWT payload");
 
         if (!validateLifetime)
             return token;
-
-        var issuedAt = token.Payload.IssuedAt;
 
         if (!notBefore.HasValue && !expiresAt.HasValue && !issuedAt.HasValue)
             return token;

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -141,7 +141,14 @@ public partial class JwtBearerGrantHandler(
 	/// <summary>
 	/// Contains validated JWT data passed through the validation pipeline.
 	/// </summary>
-	private sealed record ValidationContext(JsonWebToken Jwt, string Subject, string Issuer, TrustedIssuer? TrustedIssuer);
+	private sealed record ValidationContext(JsonWebToken Jwt, string Subject, string Issuer, TrustedIssuer? TrustedIssuer)
+	{
+		/// <summary>
+		/// The assertion's expiry as ValidateExpiration read it, carried so that the replay reservation
+		/// keys off a value already read rather than reading the accessor a second time.
+		/// </summary>
+		public DateTimeOffset? ExpiresAt { get; init; }
+	}
 
 	/// <summary>
 	/// Validates that the assertion parameter is present and within size limits.
@@ -231,7 +238,7 @@ public partial class JwtBearerGrantHandler(
 			return new OidcError(ErrorCodes.InvalidGrant, whyUnreadable);
 
 		if (expiresAt.HasValue)
-			return ctx;
+			return ctx with { ExpiresAt = expiresAt };
 
 		LogMissingExpiration(clientInfo.ClientId, ctx.Issuer);
 
@@ -323,10 +330,10 @@ public partial class JwtBearerGrantHandler(
 		}
 
 		// Single atomic reserve-and-check: record the jti keyed to the assertion's own 'exp' (which
-		// ValidateExpiration guarantees is present, and has already read from this same payload, so
-		// the accessor cannot throw here) and treat "already present" as a replay. One call avoids
-		// both the lost-TTL bug of a separate mark step and the read-then-write race.
-		if (await issuerProvider.IsReplayedAsync(jti, ctx.Jwt.Payload.ExpiresAt))
+		// ValidateExpiration guarantees is present and carries on the context) and treat "already
+		// present" as a replay. One call avoids both the lost-TTL bug of a separate mark step and
+		// the read-then-write race.
+		if (await issuerProvider.IsReplayedAsync(jti, ctx.ExpiresAt))
 		{
 			LogReplayDetected(jti, clientInfo.ClientId, ctx.Issuer, ctx.Jwt.Header.KeyId ?? "none", requestInfoProvider.RemoteIpAddress);
 			return new OidcError(ErrorCodes.InvalidGrant, "The JWT assertion has already been used");

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/JwtBearerGrantHandler.cs
@@ -224,7 +224,13 @@ public partial class JwtBearerGrantHandler(
 	/// </summary>
 	private Result<ValidationContext, OidcError> ValidateExpiration(ValidationContext ctx, ClientInfo clientInfo)
 	{
-		if (ctx.Jwt.Payload.ExpiresAt.HasValue)
+		// Through the guarded reader rather than the accessor: the validator that ran first is
+		// whichever one the host registered, which may not have read this claim, and a value the
+		// issuer wrote is refused rather than thrown at.
+		if (!ctx.Jwt.Payload.TryReadTimestamp(JwtClaimTypes.ExpiresAt, out var expiresAt, out var whyUnreadable))
+			return new OidcError(ErrorCodes.InvalidGrant, whyUnreadable);
+
+		if (expiresAt.HasValue)
 			return ctx;
 
 		LogMissingExpiration(clientInfo.ClientId, ctx.Issuer);
@@ -276,7 +282,9 @@ public partial class JwtBearerGrantHandler(
 		if (options.MaxJwtAge is not { } maxAge)
 			return ctx;
 
-		var issuedAt = ctx.Jwt.Payload.IssuedAt;
+		if (!ctx.Jwt.Payload.TryReadTimestamp(JwtClaimTypes.IssuedAt, out var issuedAt, out var whyUnreadable))
+			return new OidcError(ErrorCodes.InvalidGrant, whyUnreadable);
+
 		if (issuedAt == null)
 		{
 			LogMissingIssuedAt(clientInfo.ClientId, ctx.Issuer);
@@ -315,8 +323,9 @@ public partial class JwtBearerGrantHandler(
 		}
 
 		// Single atomic reserve-and-check: record the jti keyed to the assertion's own 'exp' (which
-		// ValidateExpiration guarantees is present) and treat "already present" as a replay. One call
-		// avoids both the lost-TTL bug of a separate mark step and the read-then-write race.
+		// ValidateExpiration guarantees is present, and has already read from this same payload, so
+		// the accessor cannot throw here) and treat "already present" as a replay. One call avoids
+		// both the lost-TTL bug of a separate mark step and the read-then-write race.
 		if (await issuerProvider.IsReplayedAsync(jti, ctx.Jwt.Payload.ExpiresAt))
 		{
 			LogReplayDetected(jti, clientInfo.ClientId, ctx.Issuer, ctx.Jwt.Header.KeyId ?? "none", requestInfoProvider.RemoteIpAddress);

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.Logging.cs
@@ -95,4 +95,10 @@ partial class JwtAssertionAuthenticatorBase
         string ClientId,
         string[] Audiences,
         string IssuerIdentifier);
+
+    [LoggerMessage(
+        EventId = LogEvents.ClientAuth.JwtAssertionAuthenticatorBase.TimestampUnreadable,
+        Level = LogLevel.Warning,
+        Message = "The client assertion for {ClientId} carries a timestamp that cannot be read: {WhyUnreadable}")]
+    private partial void LogTimestampUnreadable(string ClientId, string WhyUnreadable);
 }

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -69,18 +69,18 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     /// back: a refusal after it would burn the assertion's own identifier on a request this check
     /// was going to reject.
     /// </remarks>
-    /// <param name="token">The assertion whose timestamps are being judged.</param>
+    /// <param name="timestamps">The assertion's timestamps, already read.</param>
     /// <param name="clientInfo">The client the assertion authenticates.</param>
-    private bool TimestampsSatisfyTheClientsOwnProfile(JsonWebToken token, ClientInfo clientInfo)
+    private bool TimestampsSatisfyTheClientsOwnProfile(AssertionTimestamps timestamps, ClientInfo clientInfo)
     {
         var refusal = SecurityProfileRequirements
             .For(clientInfo, options.Value.DefaultSecurityProfile)
             .ClockSkewOrDefault()
             .WhyRefused(
                 timeProvider.GetUtcNow(),
-                token.Payload.NotBefore,
-                token.Payload.ExpiresAt,
-                token.Payload.IssuedAt);
+                timestamps.NotBefore,
+                timestamps.ExpiresAt,
+                timestamps.IssuedAt);
 
         if (refusal is null)
             return true;
@@ -210,18 +210,38 @@ public abstract partial class JwtAssertionAuthenticatorBase(
             return null;
         }
 
-        if (!TimestampsSatisfyTheClientsOwnProfile(token, clientInfo))
+        // Read once for both consumers below, and refused rather than thrown where the payload
+        // cannot read them: the validator an override chose may not have looked at these claims,
+        // and a malformed date is the assertion's fault, not a fault in this server.
+        if (!token.Payload.TryReadTimestamps(out var notBefore, out var expiresAt, out var issuedAt, out var whyUnreadable))
+        {
+            LogTimestampUnreadable(clientInfo.ClientId, whyUnreadable);
+            return null;
+        }
+
+        var timestamps = new AssertionTimestamps(notBefore, expiresAt, issuedAt);
+
+        if (!TimestampsSatisfyTheClientsOwnProfile(timestamps, clientInfo))
         {
             return null;
         }
 
-        if (!await ReserveTheAssertionAsync(token, clientInfo))
+        if (!await ReserveTheAssertionAsync(token, timestamps.ExpiresAt, clientInfo))
         {
             return null;
         }
 
         return clientInfo;
     }
+
+    /// <summary>
+    /// The three timestamps an assertion may carry, read once so that no later step meets the
+    /// accessors again.
+    /// </summary>
+    private readonly record struct AssertionTimestamps(
+        DateTimeOffset? NotBefore,
+        DateTimeOffset? ExpiresAt,
+        DateTimeOffset? IssuedAt);
 
     /// <summary>
     /// Claims the assertion's identifier so it cannot be presented a second time, answering whether
@@ -233,8 +253,9 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     /// in the caller is before the call.
     /// </remarks>
     /// <param name="token">The assertion whose identifier is being claimed.</param>
+    /// <param name="expiresAt">The assertion's expiry, already read, which bounds the reservation.</param>
     /// <param name="clientInfo">The client the assertion authenticates.</param>
-    private async Task<bool> ReserveTheAssertionAsync(JsonWebToken token, ClientInfo clientInfo)
+    private async Task<bool> ReserveTheAssertionAsync(JsonWebToken token, DateTimeOffset? expiresAt, ClientInfo clientInfo)
     {
         // OIDC Core §9: the client-authentication assertion's jti is REQUIRED - "A unique
         // identifier for the token, which can be used to prevent reuse of the token". Reject an
@@ -251,7 +272,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         // which it can be used; the generic lifetime check treats a token with neither 'nbf' nor
         // 'exp' as valid, so this enforces the assertion-specific MUST and is also what bounds
         // the replay-cache entry's TTL.
-        if (token is not { Payload.ExpiresAt: { } expiresAt })
+        if (expiresAt is not { } expiry)
         {
             LogMissingExpiration(clientInfo.ClientId);
             return false;
@@ -260,7 +281,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         // Single atomic reserve-and-check: record the jti and treat "already present" as a replay.
         // One call avoids the read-then-write race a separate status check + mark step would leave
         // between two concurrent presenters of the same assertion.
-        if (!await replayCache.TryReserveAsync(jwtId, expiresAt))
+        if (!await replayCache.TryReserveAsync(jwtId, expiry))
         {
             LogReplayDetected(jwtId, clientInfo.ClientId);
             return false;

--- a/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
+++ b/src/Abblix.Oidc.Server/Features/ClientAuthentication/JwtAssertionAuthenticatorBase.cs
@@ -226,7 +226,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
             return null;
         }
 
-        if (!await ReserveTheAssertionAsync(token, timestamps.ExpiresAt, clientInfo))
+        if (!await ReserveTheAssertionAsync(token, timestamps, clientInfo))
         {
             return null;
         }
@@ -253,9 +253,9 @@ public abstract partial class JwtAssertionAuthenticatorBase(
     /// in the caller is before the call.
     /// </remarks>
     /// <param name="token">The assertion whose identifier is being claimed.</param>
-    /// <param name="expiresAt">The assertion's expiry, already read, which bounds the reservation.</param>
+    /// <param name="timestamps">The assertion's timestamps, already read; the expiry bounds the reservation.</param>
     /// <param name="clientInfo">The client the assertion authenticates.</param>
-    private async Task<bool> ReserveTheAssertionAsync(JsonWebToken token, DateTimeOffset? expiresAt, ClientInfo clientInfo)
+    private async Task<bool> ReserveTheAssertionAsync(JsonWebToken token, AssertionTimestamps timestamps, ClientInfo clientInfo)
     {
         // OIDC Core §9: the client-authentication assertion's jti is REQUIRED - "A unique
         // identifier for the token, which can be used to prevent reuse of the token". Reject an
@@ -272,7 +272,7 @@ public abstract partial class JwtAssertionAuthenticatorBase(
         // which it can be used; the generic lifetime check treats a token with neither 'nbf' nor
         // 'exp' as valid, so this enforces the assertion-specific MUST and is also what bounds
         // the replay-cache entry's TTL.
-        if (expiresAt is not { } expiry)
+        if (timestamps.ExpiresAt is not { } expiry)
         {
             LogMissingExpiration(clientInfo.ClientId);
             return false;

--- a/src/Abblix.Oidc.Server/Features/DPoP/ProofValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/DPoP/ProofValidator.cs
@@ -242,20 +242,15 @@ internal sealed class ProofValidator(
     private static ProofError? TryGetIat(JsonWebTokenPayload payload, out DateTimeOffset issuedAt)
     {
         issuedAt = default;
-        DateTimeOffset? iatNullable;
-        try
+
+        // Read through the payload's own guarded reader rather than the accessor: the proof is
+        // validated without lifetime handling, so nothing before this line has touched the claim,
+        // and the accessor throws on a value it cannot read. A private list of the exceptions it
+        // throws is what stood here before, and the list was missing the one a number outside the
+        // representable range raises.
+        if (!payload.TryReadTimestamps(out _, out _, out var iatNullable, out var whyUnreadable))
         {
-            iatNullable = payload.IssuedAt;
-        }
-        // The accessor parses a Unix-time numeric out of the underlying JsonObject; a
-        // malformed iat surfaces as one of these conversion exceptions. Anything else
-        // (OperationCanceledException, OutOfMemoryException, ...) propagates so we
-        // don't mask unrelated bugs as «invalid iat».
-        catch (Exception ex) when (ex is FormatException or InvalidOperationException or OverflowException)
-        {
-            return new ProofError(
-                ProofErrorReasons.IssuedAtInvalid,
-                "iat claim is not a valid Unix-time numeric.");
+            return new ProofError(ProofErrorReasons.IssuedAtInvalid, whyUnreadable);
         }
 
         if (iatNullable is null)

--- a/src/Abblix.Oidc.Server/Features/DPoP/ProofValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/DPoP/ProofValidator.cs
@@ -248,7 +248,7 @@ internal sealed class ProofValidator(
         // and the accessor throws on a value it cannot read. A private list of the exceptions it
         // throws is what stood here before, and the list was missing the one a number outside the
         // representable range raises.
-        if (!payload.TryReadTimestamps(out _, out _, out var iatNullable, out var whyUnreadable))
+        if (!payload.TryReadTimestamp(JwtClaimTypes.IssuedAt, out var iatNullable, out var whyUnreadable))
         {
             return new ProofError(ProofErrorReasons.IssuedAtInvalid, whyUnreadable);
         }

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoader.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoader.cs
@@ -87,11 +87,17 @@ public static class LicenseLoader
             throw new InvalidOperationException("The JWT type is not valid");
         }
 
+        if (!token.Payload.TryReadTimestamps(out var notBefore, out var expiresAt, out _, out var whyUnreadable)
+            || !token.Payload.TryReadTimestamp("grace_period", out var gracePeriod, out whyUnreadable))
+        {
+            throw new InvalidOperationException($"The license can't be validated: {whyUnreadable}");
+        }
+
         var license = new License
         {
-            NotBefore = token.Payload.NotBefore,
-            ExpiresAt = token.Payload.ExpiresAt,
-            GracePeriod = token.Payload.Json.GetUnixTimeSeconds("grace_period"),
+            NotBefore = notBefore,
+            ExpiresAt = expiresAt,
+            GracePeriod = gracePeriod,
             ClientLimit = token.Payload["client_limit"]?.GetValue<int>(),
             IssuerLimit = token.Payload["issuer_limit"]?.GetValue<int>(),
             ValidIssuers = token.Payload.Json.GetArrayOfStrings("valid_issuers").ToHashSet(StringComparer.Ordinal),

--- a/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoader.cs
+++ b/src/Abblix.Oidc.Server/Features/Licensing/LicenseLoader.cs
@@ -87,22 +87,35 @@ public static class LicenseLoader
             throw new InvalidOperationException("The JWT type is not valid");
         }
 
-        if (!token.Payload.TryReadTimestamps(out var notBefore, out var expiresAt, out _, out var whyUnreadable)
-            || !token.Payload.TryReadTimestamp("grace_period", out var gracePeriod, out whyUnreadable))
+        LicenseChecker.AddLicense(ReadLicense(token.Payload));
+    }
+
+    /// <summary>
+    /// Reads the licence terms out of a verified payload, refusing with the same message every other
+    /// licence fault gets where a timestamp cannot be read.
+    /// </summary>
+    /// <remarks>
+    /// Its own method, and internal, so that the read can be driven with a payload alone: the
+    /// verification above needs a licence signed with the licensing key, which no test holds.
+    /// </remarks>
+    /// <param name="payload">The verified licence payload.</param>
+    internal static License ReadLicense(JsonWebTokenPayload payload)
+    {
+        if (!payload.TryReadTimestamps(out var notBefore, out var expiresAt, out _, out var whyUnreadable)
+            || !payload.TryReadTimestamp("grace_period", out var gracePeriod, out whyUnreadable))
         {
             throw new InvalidOperationException($"The license can't be validated: {whyUnreadable}");
         }
 
-        var license = new License
+        return new License
         {
             NotBefore = notBefore,
             ExpiresAt = expiresAt,
             GracePeriod = gracePeriod,
-            ClientLimit = token.Payload["client_limit"]?.GetValue<int>(),
-            IssuerLimit = token.Payload["issuer_limit"]?.GetValue<int>(),
-            ValidIssuers = token.Payload.Json.GetArrayOfStrings("valid_issuers").ToHashSet(StringComparer.Ordinal),
+            ClientLimit = payload["client_limit"]?.GetValue<int>(),
+            IssuerLimit = payload["issuer_limit"]?.GetValue<int>(),
+            ValidIssuers = payload.Json.GetArrayOfStrings("valid_issuers").ToHashSet(StringComparer.Ordinal),
         };
-        LicenseChecker.AddLicense(license);
     }
 
     /// <summary>

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.Logging.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.Logging.cs
@@ -44,6 +44,12 @@ partial class ClientJwtValidator
     private partial void LogTimestampsOutsideTheClientsProfile(string ClientId, string Refusal);
 
     [LoggerMessage(
+        EventId = LogEvents.Tokens.ClientJwtValidator.TimestampUnreadable,
+        Level = LogLevel.Warning,
+        Message = "The token from {ClientId} carries a timestamp that cannot be read: {WhyUnreadable}")]
+    private partial void LogTimestampUnreadable(string ClientId, string WhyUnreadable);
+
+    [LoggerMessage(
         EventId = LogEvents.Tokens.ClientJwtValidator.AudienceValidationFailed,
         Level = LogLevel.Warning,
         Message = "Audience validation failed, token audiences: {@Audiences}, expected requestUri: {RequestUri} or issuer: {Issuer}")]

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
@@ -138,14 +138,20 @@ public partial class ClientJwtValidator(
         // since they throw on a value outside the range DateTimeOffset can hold.
         if (options.HasFlag(ValidationOptions.ValidateLifetime))
         {
+            // Read through the same door the first pass uses rather than the accessors: the first
+            // pass belongs to whichever validator the host registered, which may not have read these
+            // claims, and an unreadable one is a refusal here as it is there.
+            if (!validatedToken.Payload.TryReadTimestamps(
+                    out var notBefore, out var expiresAt, out var issuedAt, out var whyUnreadable))
+            {
+                LogTimestampsOutsideTheClientsProfile(context.ClientInfo.ClientId, whyUnreadable);
+                return new JwtValidationError(JwtError.InvalidToken, whyUnreadable);
+            }
+
             var refusal = SecurityProfileRequirements
                 .For(context.ClientInfo, oidcOptions.Value.DefaultSecurityProfile)
                 .ClockSkewOrDefault()
-                .WhyRefused(
-                    timeProvider.GetUtcNow(),
-                    validatedToken.Payload.NotBefore,
-                    validatedToken.Payload.ExpiresAt,
-                    validatedToken.Payload.IssuedAt);
+                .WhyRefused(timeProvider.GetUtcNow(), notBefore, expiresAt, issuedAt);
 
             if (refusal != null)
             {

--- a/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/Validation/ClientJwtValidator.cs
@@ -144,7 +144,7 @@ public partial class ClientJwtValidator(
             if (!validatedToken.Payload.TryReadTimestamps(
                     out var notBefore, out var expiresAt, out var issuedAt, out var whyUnreadable))
             {
-                LogTimestampsOutsideTheClientsProfile(context.ClientInfo.ClientId, whyUnreadable);
+                LogTimestampUnreadable(context.ClientInfo.ClientId, whyUnreadable);
                 return new JwtValidationError(JwtError.InvalidToken, whyUnreadable);
             }
 

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -205,6 +205,7 @@ internal static class LogEvents
             public const int OtherKindPresentedAsAssertion = Base + 11;
             public const int AudienceIsNotTheIssuerAlone = Base + 12;
             public const int TimestampsOutsideTheClientsProfile = Base + 13;
+            public const int TimestampUnreadable = Base + 14;
         }
 
         /// <summary>

--- a/src/Abblix.Oidc.Server/LogEvents.cs
+++ b/src/Abblix.Oidc.Server/LogEvents.cs
@@ -365,6 +365,7 @@ internal static class LogEvents
             public const int ValidationSucceeded = Base + 4;
             public const int AudienceValidationFailed = Base + 5;
             public const int TimestampsOutsideTheClientsProfile = Base + 6;
+            public const int TimestampUnreadable = Base + 7;
         }
 
         /// <summary>

--- a/src/Abblix.SecurityEvents/BackChannelLogout/LogoutTokenValidator.cs
+++ b/src/Abblix.SecurityEvents/BackChannelLogout/LogoutTokenValidator.cs
@@ -5,6 +5,7 @@
 // Licensed under the Apache License, Version 2.0. You may obtain a copy at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using Abblix.Jwt;
 using Abblix.Jwt.ReplayPrevention;
 using Abblix.SecurityEvents.Delivery;
 using Abblix.SecurityEvents.Infrastructure;
@@ -89,7 +90,12 @@ public sealed class LogoutTokenValidator(
                 "The Logout Token carries no jti, so it cannot be told apart from a replay of itself.");
         }
 
-        var expiresAt = token.Token.Payload.ExpiresAt
+        if (!token.Token.Payload.TryReadTimestamp(JwtClaimTypes.ExpiresAt, out var expiresAtClaim, out var whyUnreadable))
+        {
+            throw new LogoutTokenValidationException(whyUnreadable);
+        }
+
+        var expiresAt = expiresAtClaim
                         ?? throw new LogoutTokenValidationException(
                             "The Logout Token carries no expiry, so there is no window to remember it for.");
 

--- a/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, SignatureStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, AudienceStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, IssuedAtWindowStep>(),
+        ServiceDescriptor.Singleton<ISecurityEventTokenValidator, TimeOfEventStep>(),
         ServiceDescriptor.Singleton<ISecurityEventTokenValidator, PayloadDeserializationStep>(),
     ];
 
@@ -356,6 +357,7 @@ public static class ServiceCollectionExtensions
                 .Use<LogoutEventStep>()
                 .Use<AudienceStep>()
                 .Use<IssuedAtWindowStep>()
+                .Use<TimeOfEventStep>()
                 .Use<PayloadDeserializationStep>();
 
             // Declared beside the listing that adds them, so the two statements cannot drift.

--- a/src/Abblix.SecurityEvents/SecurityEventToken.cs
+++ b/src/Abblix.SecurityEvents/SecurityEventToken.cs
@@ -52,7 +52,7 @@ public sealed class SecurityEventToken(JsonWebToken token)
     /// <summary>
     /// The "iat" claim: when the SET was issued. REQUIRED (RFC 8417 Section 2.2).
     /// </summary>
-    public DateTimeOffset? IssuedAt => Token.Payload.IssuedAt;
+    public DateTimeOffset? IssuedAt => ReadOrNull(JwtClaimTypes.IssuedAt);
 
     /// <summary>
     /// The "jti" claim: the SET's unique identifier, unique within a particular event feed, by
@@ -104,7 +104,15 @@ public sealed class SecurityEventToken(JsonWebToken token)
     /// issued. OPTIONAL (RFC 8417 Section 2.2): by omitting it, the issuer declines to share an
     /// event time, and the value may be approximate where a profile says so.
     /// </summary>
-    public DateTimeOffset? TimeOfEvent => Token.Payload.Json.GetUnixTimeSeconds(IanaClaimTypes.Toe);
+    public DateTimeOffset? TimeOfEvent => ReadOrNull(IanaClaimTypes.Toe);
+
+    /// <summary>
+    /// A timestamp the transmitter wrote and the payload cannot read is not this receiver's to
+    /// throw at: the accessors answer null, as for a claim the token does not carry, and the
+    /// validation step that judges the claim has already refused the token by name.
+    /// </summary>
+    private DateTimeOffset? ReadOrNull(string claim)
+        => Token.Payload.TryReadTimestamp(claim, out var value, out _) ? value : null;
 
     private EventsCollection? _eventsView;
 

--- a/src/Abblix.SecurityEvents/SecurityEventToken.cs
+++ b/src/Abblix.SecurityEvents/SecurityEventToken.cs
@@ -104,9 +104,10 @@ public sealed class SecurityEventToken(JsonWebToken token)
     /// <summary>
     /// The "toe" claim: when the event itself occurred, as opposed to when the SET about it was
     /// issued. OPTIONAL (RFC 8417 Section 2.2): by omitting it, the issuer declines to share an
-    /// event time, and the value may be approximate where a profile says so. Null on a token the
-    /// validation pipeline has passed means exactly that omission, since the pipeline refuses a
-    /// value it cannot read; on a token constructed outside it, null may also mean such a value.
+    /// event time, and the value may be approximate where a profile says so. Null on a token a
+    /// pipeline including <see cref="Validation.Steps.TimeOfEventStep"/> has passed means exactly
+    /// that omission, since that step refuses a value it cannot read; on a token constructed outside
+    /// such a pipeline, null may also mean such a value.
     /// </summary>
     public DateTimeOffset? TimeOfEvent => ReadOrNull(IanaClaimTypes.Toe);
 

--- a/src/Abblix.SecurityEvents/SecurityEventToken.cs
+++ b/src/Abblix.SecurityEvents/SecurityEventToken.cs
@@ -50,7 +50,9 @@ public sealed class SecurityEventToken(JsonWebToken token)
     public string? Issuer => Token.Payload.Issuer;
 
     /// <summary>
-    /// The "iat" claim: when the SET was issued. REQUIRED (RFC 8417 Section 2.2).
+    /// The "iat" claim: when the SET was issued. REQUIRED (RFC 8417 Section 2.2). Null on a token
+    /// the validation pipeline has passed means the claim is absent, which the pipeline refuses; on
+    /// a token constructed outside it, null may also mean a value the payload cannot read.
     /// </summary>
     public DateTimeOffset? IssuedAt => ReadOrNull(JwtClaimTypes.IssuedAt);
 
@@ -102,14 +104,16 @@ public sealed class SecurityEventToken(JsonWebToken token)
     /// <summary>
     /// The "toe" claim: when the event itself occurred, as opposed to when the SET about it was
     /// issued. OPTIONAL (RFC 8417 Section 2.2): by omitting it, the issuer declines to share an
-    /// event time, and the value may be approximate where a profile says so.
+    /// event time, and the value may be approximate where a profile says so. Null on a token the
+    /// validation pipeline has passed means exactly that omission, since the pipeline refuses a
+    /// value it cannot read; on a token constructed outside it, null may also mean such a value.
     /// </summary>
     public DateTimeOffset? TimeOfEvent => ReadOrNull(IanaClaimTypes.Toe);
 
     /// <summary>
     /// A timestamp the transmitter wrote and the payload cannot read is not this receiver's to
-    /// throw at: the accessors answer null, as for a claim the token does not carry, and the
-    /// validation step that judges the claim has already refused the token by name.
+    /// throw at: the accessors answer null, and the validation steps that judge these two claims
+    /// have already refused such a token by name before a receiver reads it.
     /// </summary>
     private DateTimeOffset? ReadOrNull(string claim)
         => Token.Payload.TryReadTimestamp(claim, out var value, out _) ? value : null;

--- a/src/Abblix.SecurityEvents/Validation/Steps/IssuedAtWindowStep.cs
+++ b/src/Abblix.SecurityEvents/Validation/Steps/IssuedAtWindowStep.cs
@@ -31,10 +31,19 @@ public sealed class IssuedAtWindowStep(TimeProvider clock) : ISecurityEventToken
     {
         context.Require(SecurityEventTokenValidationStates.SignatureVerified);
 
+        // The token was verified without lifetime handling, so nothing before this step has read
+        // the claim, and the accessor throws on a value it cannot read. A value the transmitter
+        // wrote is the transmitter's fault and is refused, never thrown at.
+        if (!context.Token!.Token.Payload.TryReadTimestamp(JwtClaimTypes.IssuedAt, out var issuedAtClaim, out var whyUnreadable))
+        {
+            return ValueTask.FromResult<SecurityEventTokenValidationError?>(
+                new SecurityEventTokenValidationError(SecurityEventTokenErrorCode.MalformedToken, whyUnreadable));
+        }
+
         var now = clock.GetUtcNow();
         var tolerance = context.Options.IssuedAtTolerance;
 
-        var description = context.Token!.IssuedAt switch
+        var description = issuedAtClaim switch
         {
             null => $"The claims carry no '{JwtClaimTypes.IssuedAt}' member (RFC 8417 Section 2.2).",
             var issuedAt when issuedAt > now + tolerance =>

--- a/src/Abblix.SecurityEvents/Validation/Steps/TimeOfEventStep.cs
+++ b/src/Abblix.SecurityEvents/Validation/Steps/TimeOfEventStep.cs
@@ -1,0 +1,38 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using Abblix.Jwt;
+
+namespace Abblix.SecurityEvents.Validation.Steps;
+
+/// <summary>
+/// Requires the "toe" claim, where the transmitter chose to send one, to be a date the receiver can
+/// read. Its absence is allowed - it is OPTIONAL (RFC 8417 Section 2.2) - and its value is not
+/// judged, since a profile may make it approximate.
+/// </summary>
+/// <remarks>
+/// The token is verified without lifetime handling, so nothing before the receiver's own code reads
+/// this claim, and the accessor throws on a value it cannot read. Judged here, by name, so that a
+/// receiver reading <see cref="SecurityEventToken.TimeOfEvent"/> afterwards meets either a date or
+/// the absence the specification allows - never a value the transmitter wrote and nobody refused.
+/// </remarks>
+public sealed class TimeOfEventStep : ISecurityEventTokenValidator
+{
+    /// <inheritdoc />
+    public ValueTask<SecurityEventTokenValidationError?> ValidateAsync(
+        SecurityEventTokenValidationContext context,
+        CancellationToken cancellationToken)
+    {
+        context.Require(SecurityEventTokenValidationStates.Parsed);
+
+        var error = context.Token!.Token.Payload.TryReadTimestamp(IanaClaimTypes.Toe, out _, out var whyUnreadable)
+            ? null
+            : new SecurityEventTokenValidationError(SecurityEventTokenErrorCode.MalformedToken, whyUnreadable);
+
+        return ValueTask.FromResult(error);
+    }
+}

--- a/src/Abblix.SecurityEvents/Validation/Steps/TimeOfEventStep.cs
+++ b/src/Abblix.SecurityEvents/Validation/Steps/TimeOfEventStep.cs
@@ -27,7 +27,9 @@ public sealed class TimeOfEventStep : ISecurityEventTokenValidator
         SecurityEventTokenValidationContext context,
         CancellationToken cancellationToken)
     {
-        context.Require(SecurityEventTokenValidationStates.Parsed);
+        // A refusal on a claim's value is a judgement of the issuer's words, and those are only the
+        // issuer's once the signature has been checked: the same precondition its neighbour holds.
+        context.Require(SecurityEventTokenValidationStates.SignatureVerified);
 
         var error = context.Token!.Token.Payload.TryReadTimestamp(IanaClaimTypes.Toe, out _, out var whyUnreadable)
             ? null

--- a/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SharedSignals/Infrastructure/ServiceCollectionExtensions.cs
@@ -196,6 +196,7 @@ public static class ServiceCollectionExtensions
                 .Use<AudienceStep>()
                 .Use<StreamIssuerStep>()
                 .Use<IssuedAtWindowStep>()
+                .Use<TimeOfEventStep>()
                 .Use<PayloadDeserializationStep>()
                 .Use<CriticalSubjectMembersStep>();
 

--- a/tests/Abblix.Jwt.UnitTests/InMemoryTimestampTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/InMemoryTimestampTests.cs
@@ -1,0 +1,53 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// A payload built in code holds the .NET primitive each claim was written as, and such a value
+/// answers a typed read only for its own type. A token off the wire never has this shape, so the
+/// suite that validates compact tokens cannot see a reader that stopped accepting one of them.
+/// </summary>
+public class InMemoryTimestampTests
+{
+    private static readonly DateTimeOffset Expected = DateTimeOffset.FromUnixTimeSeconds(1700000000);
+
+    [Fact]
+    public void AnIntegerLiteral_ReadsAsADate()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = 1700000000 });
+
+        Assert.Equal(Expected, payload.IssuedAt);
+    }
+
+    [Fact]
+    public void ALongLiteral_ReadsAsADate()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = 1700000000L });
+
+        Assert.Equal(Expected, payload.IssuedAt);
+    }
+
+    [Fact]
+    public void ADecimalLiteral_ReadsAsADateWithTheFractionDropped()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = 1700000000.5m });
+
+        Assert.Equal(Expected, payload.IssuedAt);
+    }
+
+    [Fact]
+    public void ADoubleLiteral_ReadsAsADateWithTheFractionDropped()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = 1700000000.5 });
+
+        Assert.Equal(Expected, payload.IssuedAt);
+    }
+}

--- a/tests/Abblix.Jwt.UnitTests/InMemoryTimestampTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/InMemoryTimestampTests.cs
@@ -43,6 +43,34 @@ public class InMemoryTimestampTests
         Assert.Equal(Expected, payload.IssuedAt);
     }
 
+    /// <summary>
+    /// The backings a list of primitives leaves off: a reader that names one type at a time reads
+    /// none of these, and the one a consumer writes is the one the list forgot.
+    /// </summary>
+    [Fact]
+    public void AnUnsignedIntegerLiteral_ReadsAsADate()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = 1700000000u });
+
+        Assert.Equal(Expected, payload.IssuedAt);
+    }
+
+    [Fact]
+    public void AnUnsignedLongLiteral_ReadsAsADate()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = 1700000000ul });
+
+        Assert.Equal(Expected, payload.IssuedAt);
+    }
+
+    [Fact]
+    public void AShortLiteral_ReadsAsADate()
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject { [JwtClaimTypes.IssuedAt] = (short)1 });
+
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1), payload.IssuedAt);
+    }
+
     [Fact]
     public void ADoubleLiteral_ReadsAsADateWithTheFractionDropped()
     {

--- a/tests/Abblix.Jwt.UnitTests/UnreadableTimestampTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/UnreadableTimestampTests.cs
@@ -1,0 +1,94 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0. You may obtain a copy at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+using System.Buffers.Text;
+using System.Text;
+using Abblix.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Abblix.Jwt.UnitTests;
+
+/// <summary>
+/// A timestamp claim the payload cannot read is the token's fault, and the answer to a token's fault
+/// is a refusal. Before this the typed accessors threw out of the validator, and a request carrying
+/// such a token ended in an unhandled exception rather than in an error the sender could act on.
+/// </summary>
+/// <remarks>
+/// Two shapes of unreadable, because they fail in two different places: a number outside the range
+/// <see cref="DateTimeOffset"/> can hold fails the conversion, and a string fails the read before
+/// any conversion is attempted. A fix catching one of them reads exactly like a fix catching both.
+/// </remarks>
+public class UnreadableTimestampTests
+{
+    private static readonly DateTimeOffset Now = new(2027, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly IServiceProvider ServiceProvider = CreateServiceProvider();
+
+    private static IServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TimeProvider>(new FixedTimeProvider(Now));
+        services.AddLogging();
+        services.AddJsonWebTokens();
+        return services.BuildServiceProvider();
+    }
+
+    private static string EncodeBase64Url(string input)
+        => Base64Url.EncodeToString(Encoding.UTF8.GetBytes(input));
+
+    /// <summary>
+    /// Builds an unsigned token whose payload is written verbatim, so a case can carry a claim value
+    /// the typed accessors would never produce.
+    /// </summary>
+    private static Task<Result<JsonWebToken, JwtValidationError>> Validate(string payloadJson)
+    {
+        var jwt = EncodeBase64Url("""{"alg":"none"}""") + "." + EncodeBase64Url(payloadJson) + ".";
+
+        var validator = ServiceProvider.GetRequiredService<IJsonWebTokenValidator>();
+        return validator.ValidateAsync(jwt, new ValidationParameters
+        {
+            ValidateAudience = _ => Task.FromResult(true),
+            ValidateIssuer = _ => Task.FromResult(true),
+            ResolveIssuerSigningKeys = _ => AsyncEnumerable.Empty<JsonWebKey>(),
+            ResolveTokenDecryptionKeys = _ => AsyncEnumerable.Empty<JsonWebKey>(),
+            Options = ValidationOptions.ValidateLifetime,
+        });
+    }
+
+    [Theory]
+    [InlineData("""{"exp": 99999999999999}""", "exp")]
+    [InlineData("""{"iat": 99999999999999}""", "iat")]
+    [InlineData("""{"nbf": 99999999999999}""", "nbf")]
+    [InlineData("""{"exp": "tomorrow"}""", "exp")]
+    [InlineData("""{"iat": {"seconds": 1}}""", "iat")]
+    public async Task ATimestampThePayloadCannotRead_IsRefusedAsMalformedNamingTheClaim(string payload, string claim)
+    {
+        var result = await Validate(payload);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.MalformedToken, error.Error);
+        Assert.Contains(claim, error.ErrorDescription, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// And a token whose timestamps read is judged on them, or the cases above would be satisfied
+    /// by a validator refusing every token as malformed.
+    /// </summary>
+    [Fact]
+    public async Task AReadableTimestamp_IsJudgedRatherThanRefusedAsMalformed()
+    {
+        var result = await Validate($$"""{"exp": {{Now.AddHours(1).ToUnixTimeSeconds()}}}""");
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/Abblix.Jwt.UnitTests/UnreadableTimestampTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/UnreadableTimestampTests.cs
@@ -66,13 +66,43 @@ public class UnreadableTimestampTests
     [InlineData("""{"nbf": 99999999999999}""", "nbf")]
     [InlineData("""{"exp": "tomorrow"}""", "exp")]
     [InlineData("""{"iat": {"seconds": 1}}""", "iat")]
+    [InlineData("""{"exp": 1e30}""", "exp")]
     public async Task ATimestampThePayloadCannotRead_IsRefusedAsMalformedNamingTheClaim(string payload, string claim)
     {
         var result = await Validate(payload);
 
         Assert.True(result.TryGetFailure(out var error));
-        Assert.Equal(JwtError.MalformedToken, error.Error);
+        Assert.Equal(JwtError.InvalidToken, error.Error);
         Assert.Contains(claim, error.ErrorDescription, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// RFC 7519 section 2: a NumericDate is seconds since the epoch "other than that non-integer
+    /// values can be represented", and a JSON number written with an exponent is a legal spelling of
+    /// an integral one. Both are dates, not defects, and the token is judged on them.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"exp": 1893456000.5}""")]
+    [InlineData("""{"exp": 1.893456e9}""")]
+    [InlineData("""{"exp": 1893456000.999999}""")]
+    public async Task ANonIntegerNumericDate_IsReadAsADate(string payload)
+    {
+        var result = await Validate(payload);
+
+        Assert.True(result.TryGetSuccess(out _));
+    }
+
+    /// <summary>
+    /// And a fractional date already in the past is refused as expired, not as unreadable: the
+    /// fraction is dropped rather than the value.
+    /// </summary>
+    [Fact]
+    public async Task ANonIntegerNumericDateInThePast_IsRefusedAsExpired()
+    {
+        var result = await Validate("""{"exp": 1700000000.5}""");
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Contains("expired", error.ErrorDescription, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Token/JwtBearerGrantHandlerTests.cs
@@ -945,6 +945,31 @@ public class JwtBearerGrantHandlerTests
 	}
 
 	/// <summary>
+	/// The assertion comes from a third-party issuer through whichever validator the host registered,
+	/// so an issued-at no date can hold reaches the age check unread - and is refused as a grant
+	/// error rather than thrown out of the token endpoint.
+	/// </summary>
+	[Fact]
+	public async Task MaxJwtAge_WithAnIatOutsideTheRepresentableRange_ShouldReject()
+	{
+		var fixedTime = new DateTimeOffset(2024, 11, 20, 15, 30, 0, TimeSpan.Zero);
+		var (handler, mocks) = CreateHandler(fixedTime: fixedTime, maxJwtAge: TimeSpan.FromMinutes(10));
+		var jwt = CreateValidJwt();
+		jwt.Payload.Json[JwtClaimTypes.IssuedAt] = 99999999999999L;
+		SetupValidJwtValidation(mocks.JwtValidator, jwt);
+		SetupTrustedIssuer(mocks.IssuerProvider, Issuer);
+
+		var result = await handler.AuthorizeAsync(
+			new TokenRequest { GrantType = GrantTypes.JwtBearer, Assertion = Assertion },
+			new ClientInfo(ClientId),
+			TestContext.Current.CancellationToken);
+
+		Assert.True(result.TryGetFailure(out var error));
+		Assert.Equal(ErrorCodes.InvalidGrant, error.Error);
+		Assert.Contains(JwtClaimTypes.IssuedAt, error.ErrorDescription, StringComparison.Ordinal);
+	}
+
+	/// <summary>
 	/// Verifies that JWTs older than MaxJwtAge are rejected.
 	/// Per RFC 7523 Section 3: Authorization server MAY reject JWTs with iat too far in the past.
 	/// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/UnreadableAssertionTimestampTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/ClientAuthentication/UnreadableAssertionTimestampTests.cs
@@ -1,0 +1,157 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Abblix.Jwt;
+using Abblix.Jwt.ReplayPrevention;
+using Abblix.Oidc.Server.Common.Configuration;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Common.Interfaces;
+using Abblix.Oidc.Server.Features.ClientAuthentication;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.Issuer;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Abblix.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.ClientAuthentication;
+
+/// <summary>
+/// The assertion authenticator reads the assertion's timestamps itself, after whatever validator
+/// its override chose has run - and that validator may not have looked at them. A timestamp the
+/// payload cannot read must then be a refusal here, not an exception out of the token endpoint.
+/// </summary>
+/// <remarks>
+/// The validator is a stub that hands the token back unread, which is the position a host's own
+/// override puts this class in when it validates without lifetime handling. The <c>sub</c> read a
+/// few lines above already had this protection; the timestamps did not.
+/// </remarks>
+public class UnreadableAssertionTimestampTests
+{
+    private const string ClientId = "client_with_an_unreadable_date";
+    private static readonly string Issuer = TestConstants.DefaultIssuer.ToString();
+    private const string JwtAssertion = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Theory]
+    [InlineData(JwtClaimTypes.ExpiresAt)]
+    [InlineData(JwtClaimTypes.IssuedAt)]
+    [InlineData(JwtClaimTypes.NotBefore)]
+    public async Task AnAssertionWithATimestampOutsideTheRepresentableRange_IsRefused(string claim)
+    {
+        var (authenticator, replayCache) = Build(payload => payload[claim] = 99999999999999);
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+
+        Assert.Null(result);
+
+        // Refused before anything irreversible: the identifier of an assertion that could not even
+        // be read is not spent.
+        replayCache.Verify(
+            r => r.TryReserveAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// And the same assertion with readable dates authenticates, or the case above would be
+    /// satisfied by an authenticator refusing everything.
+    /// </summary>
+    [Fact]
+    public async Task AnAssertionWithReadableTimestamps_Authenticates()
+    {
+        var (authenticator, _) = Build(_ => { });
+
+        var result = await authenticator.TryAuthenticateClientAsync(new ClientRequest
+        {
+            ClientAssertionType = ClientAssertionTypes.JwtBearer,
+            ClientAssertion = JwtAssertion,
+        });
+
+        Assert.NotNull(result);
+    }
+
+    private static (ClientSecretJwtAuthenticator, Mock<IReplayCache>) Build(Action<JsonObject> corrupt)
+    {
+        var token = new JsonWebToken
+        {
+            Header = new JsonWebTokenHeader(new JsonObject
+            {
+                [JwtClaimTypes.Algorithm] = "HS256",
+                [JwtClaimTypes.Type] = "JWT",
+            }),
+            Payload = new JsonWebTokenPayload(new JsonObject
+            {
+                [JwtClaimTypes.Issuer] = ClientId,
+                [JwtClaimTypes.Subject] = ClientId,
+                [JwtClaimTypes.JwtId] = "assertion-identifier",
+            }),
+        };
+
+        token.Payload.IssuedAt = Now;
+        token.Payload.ExpiresAt = Now.AddHours(1);
+        token.Payload.Audiences = [Issuer];
+        corrupt(token.Payload.Json);
+
+        var clientInfo = new ClientInfo(ClientId)
+        {
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretJwt,
+        };
+
+        var clientInfoProvider = new Mock<IClientInfoProvider>(MockBehavior.Strict);
+        clientInfoProvider.Setup(p => p.TryFindClientAsync(ClientId)).ReturnsAsync(clientInfo);
+
+        // Hands the token back without reading a single claim of it, which is what leaves the
+        // timestamps to be met first by the authenticator.
+        var tokenValidator = new Mock<IJsonWebTokenValidator>(MockBehavior.Strict);
+        tokenValidator
+            .Setup(v => v.ValidateAsync(JwtAssertion, It.IsAny<ValidationParameters>()))
+            .Returns(new Func<string, ValidationParameters, Task<Result<JsonWebToken, JwtValidationError>>>(
+                async (_, parameters) =>
+                {
+                    if (parameters.ValidateIssuer != null)
+                        await parameters.ValidateIssuer(ClientId);
+
+                    return token;
+                }));
+
+        var replayCache = new Mock<IReplayCache>(MockBehavior.Strict);
+        replayCache
+            .Setup(r => r.TryReserveAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(true);
+
+        var requestInfoProvider = new Mock<IRequestInfoProvider>();
+        requestInfoProvider.Setup(p => p.RequestUri).Returns(Issuer);
+
+        var authenticator = new ClientSecretJwtAuthenticator(
+            Mock.Of<ILogger<ClientSecretJwtAuthenticator>>(),
+            tokenValidator.Object,
+            clientInfoProvider.Object,
+            requestInfoProvider.Object,
+            new FixedClock(Now),
+            replayCache.Object,
+            Mock.Of<IIssuerProvider>(p => p.GetIssuer() == Issuer),
+            Options.Create(new OidcOptions { DefaultSecurityProfile = ClientSecurityProfile.None }));
+
+        return (authenticator, replayCache);
+    }
+
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DPoP/DPoPProofBuilder.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DPoP/DPoPProofBuilder.cs
@@ -37,6 +37,12 @@ internal sealed class DPoPProofBuilder
     public string? Htu { get; init; } = "https://auth.example.com/token";
     public string? Jti { get; init; } = $"test-jti-{Guid.NewGuid():N}";
     public DateTimeOffset? Iat { get; init; }
+
+    /// <summary>
+    /// Written into the payload verbatim in place of <see cref="Iat"/>, for a case about a value the
+    /// typed accessor would never produce.
+    /// </summary>
+    public JsonNode? RawIat { get; init; }
     public string? Ath { get; init; }
     public bool CorruptSignature { get; init; }
 
@@ -72,7 +78,7 @@ internal sealed class DPoPProofBuilder
         if (Htm is not null) payload["htm"] = Htm;
         if (Htu is not null) payload["htu"] = Htu;
         if (Jti is not null) payload["jti"] = Jti;
-        payload["iat"] = (Iat ?? _now).ToUnixTimeSeconds();
+        payload["iat"] = RawIat ?? (Iat ?? _now).ToUnixTimeSeconds();
         if (Ath is not null) payload["ath"] = Ath;
 
         var headerB64 = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(header.ToJsonString()));

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/DPoP/ProofValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/DPoP/ProofValidatorTests.cs
@@ -249,6 +249,24 @@ public class ProofValidatorTests
         Assert.Equal(ProofErrorReasons.IssuedAtOutOfWindow, error.Reason);
     }
 
+    /// <summary>
+    /// A proof is validated without lifetime handling, so its issued-at is read here first - and the
+    /// proof is signed with the key in its own header, so the value is whatever the sender wrote. One
+    /// outside the range a date can hold was an unhandled exception; it is a refusal.
+    /// </summary>
+    [Theory]
+    [InlineData(99999999999999L)]
+    [InlineData(-99999999999999L)]
+    public async Task ValidateAsync_IatOutsideTheRepresentableRange_ReturnsIatInvalid(long raw)
+    {
+        var proof = new DPoPProofBuilder(_time.GetUtcNow()) { RawIat = raw }.Build();
+
+        var result = await _sut.ValidateAsync(proof, cancellationToken: Ct);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(ProofErrorReasons.IssuedAtInvalid, error.Reason);
+    }
+
     [Fact]
     public async Task ValidateAsync_IatAfterToleranceWindow_ReturnsIatOutOfWindow()
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseReadingTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Licensing/LicenseReadingTests.cs
@@ -1,0 +1,62 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Text.Json.Nodes;
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Features.Licensing;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Features.Licensing;
+
+/// <summary>
+/// The licence is verified without lifetime handling, so the loader is the first reader of its
+/// timestamps - and a licence minted with one no date can hold failed the host at startup with
+/// the accessor's own exception rather than the message every other licence fault produces.
+/// </summary>
+/// <remarks>
+/// Driven through the read alone: verification needs a licence signed with the licensing key,
+/// which no test holds, and the read is what changed.
+/// </remarks>
+public class LicenseReadingTests
+{
+    [Theory]
+    [InlineData("exp")]
+    [InlineData("nbf")]
+    [InlineData("grace_period")]
+    public void ATimestampNoDateCanHold_IsRefusedAsALicenceFaultNamingTheClaim(string claim)
+    {
+        var payload = new JsonWebTokenPayload(new JsonObject
+        {
+            ["valid_issuers"] = new JsonArray("https://auth.example.com"),
+            [claim] = 99999999999999L,
+        });
+
+        var fault = Assert.Throws<InvalidOperationException>(() => LicenseLoader.ReadLicense(payload));
+
+        Assert.StartsWith("The license can't be validated", fault.Message, StringComparison.Ordinal);
+        Assert.Contains(claim, fault.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AReadableLicence_IsRead()
+    {
+        var expiresAt = new DateTimeOffset(2126, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var payload = new JsonWebTokenPayload(new JsonObject
+        {
+            ["valid_issuers"] = new JsonArray("https://auth.example.com"),
+            ["exp"] = expiresAt.ToUnixTimeSeconds(),
+            ["issuer_limit"] = 1,
+        });
+
+        var license = LicenseLoader.ReadLicense(payload);
+
+        Assert.Equal(expiresAt, license.ExpiresAt);
+        Assert.Equal(1, license.IssuerLimit);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/Tokens/Validation/ClientMayTightenItselfTests.cs
@@ -273,6 +273,24 @@ public class ClientMayTightenItselfTests
         Assert.True(result.TryGetSuccess(out _));
     }
 
+    /// <summary>
+    /// And a caller that did ask for lifetime validation is refused, not thrown at, when the token's
+    /// timestamps cannot be read: the validator underneath is whichever one the host registered, so
+    /// this pass cannot rely on it having read the claims first.
+    /// </summary>
+    [Fact]
+    public async Task ACallerAskingForLifetimeValidation_IsRefusedForAnUnreadableTimestamp()
+    {
+        var result = await Validate(
+            clientProfile: ClientSecurityProfile.Fapi2,
+            deploymentProfile: ClientSecurityProfile.None,
+            unreadableIssuedAt: true);
+
+        Assert.True(result.TryGetFailure(out var error));
+        Assert.Equal(JwtError.InvalidToken, error.Error);
+        Assert.Contains("iat", error.ErrorDescription, StringComparison.Ordinal);
+    }
+
     private sealed class FixedClock(DateTimeOffset now) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => now;

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(160, EventIds().Count);
+        Assert.Equal(161, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/LogEventUniquenessTests.cs
@@ -59,7 +59,7 @@ public class LogEventUniquenessTests
     [Fact]
     public void TheWalkFindsEveryDeclaredEvent()
     {
-        Assert.Equal(159, EventIds().Count);
+        Assert.Equal(160, EventIds().Count);
     }
 
     private static IReadOnlyList<(int Id, string Name)> EventIds()

--- a/tests/Abblix.SecurityEvents.UnitTests/LogoutTokenReplayWindowTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/LogoutTokenReplayWindowTests.cs
@@ -84,4 +84,31 @@ public class LogoutTokenReplayWindowTests
 
         Assert.Equal(expiresAt + options.IssuedAtTolerance, cache.ReservedUntil);
     }
+
+    /// <summary>
+    /// The token was verified without lifetime handling, so this validator is the first reader of
+    /// its expiry - and a value no date can hold is the provider's fault, refused with the failure
+    /// every other defect of the token gets rather than thrown out of the intake.
+    /// </summary>
+    [Fact]
+    public async Task AnExpiryOutsideTheRepresentableRange_IsAValidationFailure()
+    {
+        var token = new JsonWebToken();
+        token.Payload.Issuer = Issuer;
+        token.Payload.Audiences = [ClientId];
+        token.Payload.JwtId = "jti-1";
+        token.Payload.Subject = "user_456";
+        token.Payload.IssuedAt = Now;
+        token.Payload.Json[JwtClaimTypes.ExpiresAt] = 99999999999999L;
+
+        var validator = new LogoutTokenValidator(
+            new AcceptingProfile(new SecurityEventToken(token)),
+            new BackChannelLogoutValidationOptions { ExpectedAudience = ClientId, ExpectedIssuers = [Issuer] },
+            new RecordingReplayCache());
+
+        var failure = await Assert.ThrowsAsync<LogoutTokenValidationException>(
+            () => validator.ValidateAsync("a.b.c", TestContext.Current.CancellationToken));
+
+        Assert.Contains(JwtClaimTypes.ExpiresAt, failure.Message, StringComparison.Ordinal);
+    }
 }

--- a/tests/Abblix.SecurityEvents.UnitTests/LogoutTokenReplayWindowTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/LogoutTokenReplayWindowTests.cs
@@ -111,4 +111,22 @@ public class LogoutTokenReplayWindowTests
 
         Assert.Contains(JwtClaimTypes.ExpiresAt, failure.Message, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// The accessors a receiver reaches for first answer null for a timestamp the transmitter wrote
+    /// and the payload cannot read, as for a claim the token does not carry: the window step has
+    /// already refused the token by name, and a handler must not be thrown at afterwards.
+    /// </summary>
+    [Theory]
+    [InlineData(JwtClaimTypes.IssuedAt)]
+    [InlineData("toe")]
+    public void AnUnreadableTimestamp_ReadsAsAbsentFromTheReceiversAccessors(string claim)
+    {
+        var token = new JsonWebToken();
+        token.Payload.Json[claim] = 99999999999999L;
+
+        var set = new SecurityEventToken(token);
+
+        Assert.Null(claim == "toe" ? set.TimeOfEvent : set.IssuedAt);
+    }
 }

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
@@ -426,7 +426,7 @@ public class SecurityEventTokenValidatorTests
         {
             Payload = new JsonWebTokenPayload(JsonNode.Parse(claimsJson)!.AsObject()),
         });
-        context.Establish(SecurityEventTokenValidationStates.Parsed);
+        context.Establish(SecurityEventTokenValidationStates.Parsed | SecurityEventTokenValidationStates.SignatureVerified);
 
         var error = await new TimeOfEventStep().ValidateAsync(context, TestContext.Current.CancellationToken);
 

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
@@ -376,6 +376,24 @@ public class SecurityEventTokenValidatorTests
         Assert.Equal(SecurityEventTokenErrorCode.IatOutOfRange, error.Code);
     }
 
+    /// <summary>
+    /// The SET is verified without lifetime handling, so the issued-at window step is the first
+    /// reader of the claim - and a value no date can hold, written by the transmitter, was an
+    /// unhandled exception out of the intake. It is a refusal naming the claim.
+    /// </summary>
+    [Fact]
+    public async Task IssuedAtOutsideTheRepresentableRange_IsMalformedNamingTheClaim()
+    {
+        var header = Base64Url.EncodeToString("""{"typ":"secevent+jwt","alg":"none"}"""u8);
+        var payload = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(
+            """{"iss":"https://tenant.example.com","jti":"1","iat":99999999999999,"aud":"https://receiver.example.com/events","events":{"https://tenant.example.com/events/membership-changed":{}}}"""));
+
+        var error = await ValidateExpectingError($"{header}.{payload}.sig");
+
+        Assert.Equal(SecurityEventTokenErrorCode.MalformedToken, error.Code);
+        Assert.Contains("iat", error.Description, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task MalformedPayloadOfARegisteredType_IsMalformedToken()
     {

--- a/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/SecurityEventTokenValidatorTests.cs
@@ -125,6 +125,7 @@ public class SecurityEventTokenValidatorTests
             new SignatureStep(verifier ?? new AcceptingVerifier()),
             new AudienceStep(),
             new IssuedAtWindowStep(new FakeTimeProvider(Now)),
+            new TimeOfEventStep(),
             new PayloadDeserializationStep(registry),
         ]);
     }
@@ -392,6 +393,44 @@ public class SecurityEventTokenValidatorTests
 
         Assert.Equal(SecurityEventTokenErrorCode.MalformedToken, error.Code);
         Assert.Contains("iat", error.Description, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The event time is optional and unjudged, so a step exists only to refuse a value the receiver
+    /// cannot read - which no other step looks at, and which a receiver's own accessor would
+    /// otherwise turn into silent absence.
+    /// </summary>
+    [Fact]
+    public async Task TimeOfEventOutsideTheRepresentableRange_IsMalformedNamingTheClaim()
+    {
+        var header = Base64Url.EncodeToString("""{"typ":"secevent+jwt","alg":"none"}"""u8);
+        var payload = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(
+            """{"iss":"https://tenant.example.com","jti":"1","iat":1754040000,"toe":99999999999999,"aud":"https://receiver.example.com/events","events":{"https://tenant.example.com/events/membership-changed":{}}}"""));
+
+        var error = await ValidateExpectingError($"{header}.{payload}.sig");
+
+        Assert.Equal(SecurityEventTokenErrorCode.MalformedToken, error.Code);
+        Assert.Contains("toe", error.Description, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// And a readable event time, or none, passes the step: the step judges readability alone.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"toe": 1754040000}""")]
+    [InlineData("""{}""")]
+    public async Task AReadableOrAbsentTimeOfEvent_PassesTheStep(string claimsJson)
+    {
+        var context = new SecurityEventTokenValidationContext("a.b.c", DefaultOptions());
+        context.Token = new SecurityEventToken(new JsonWebToken
+        {
+            Payload = new JsonWebTokenPayload(JsonNode.Parse(claimsJson)!.AsObject()),
+        });
+        context.Establish(SecurityEventTokenValidationStates.Parsed);
+
+        var error = await new TimeOfEventStep().ValidateAsync(context, TestContext.Current.CancellationToken);
+
+        Assert.Null(error);
     }
 
     [Fact]

--- a/tests/Abblix.SecurityEvents.UnitTests/ValidationCompositionTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/ValidationCompositionTests.cs
@@ -65,7 +65,7 @@ public class ValidationCompositionTests
     }
 
     [Fact]
-    public void DefaultPipeline_HoldsTheTenStepsInOrder()
+    public void DefaultPipeline_HoldsTheStepsInOrder()
     {
         Assert.Equal(
             [
@@ -78,6 +78,7 @@ public class ValidationCompositionTests
                 typeof(SignatureStep),
                 typeof(AudienceStep),
                 typeof(IssuedAtWindowStep),
+                typeof(TimeOfEventStep),
                 typeof(PayloadDeserializationStep),
             ],
             PipelineTypes(HostWithProfile()));

--- a/tests/Abblix.SecurityEvents.UnitTests/ValidationProfileTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/ValidationProfileTests.cs
@@ -175,6 +175,7 @@ public class ValidationProfileTests
             .Use<IssuerAllowlistStep>()
             .Use<AudienceStep>()
             .Use<IssuedAtWindowStep>()
+            .Use<TimeOfEventStep>()
             .Use<PayloadDeserializationStep>());
 
         using var provider = services.BuildServiceProvider();


### PR DESCRIPTION
The typed accessors for `exp`, `nbf` and `iat` throw on a value that is not a NumericDate - a string, an object, a number outside the range `DateTimeOffset` can hold - and nothing between them and the request caught it. A token carrying such a claim ended in an unhandled exception rather than in an error its sender could act on.

- `JsonWebTokenPayload` gains a read of all three timestamps that answers false with the reason, naming the claim and quoting what it held.
- `JsonWebTokenValidator` refuses such a token as malformed. A caller that opted out of time handling still meets no accessor: the early return for neither flag stands.
- `JwtAssertionAuthenticatorBase` reads the timestamps once through the same door, before the profile pass and before the reservation, and hands the values to both. The validator an override chose may not have looked at these claims; the `sub` read a few lines above already had this protection while the dates did not.

Tests cover both shapes of unreadable, since they fail in different places - a number the conversion rejects and a value the read rejects - across all three claims, with a readable control on each path. Putting the direct reads back reddens five cases in the JWT suite and three in the server suite.
