### PR TITLE
Describe every package for the reader who finds it on nuget.org

### DIFF
--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.DependencyInjection</PackageId>
     <Title>Abblix DependencyInjection</Title>
-    <Description>Dependency-injection helpers for .NET: service aliasing, composition, decorators, and keyed registration that lets host registrations win. The DI layer behind Abblix OIDC Server, usable on its own.</Description>
+    <Description>Dependency injection extensions for Microsoft.Extensions.DependencyInjection: decorators, service aliasing, composite service families, keyed registrations that let host registrations win, and pipelines you can edit after registration.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.DependencyInjection</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Code quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Helpers a library needs to be a good citizen in a host's container. Decorate a service without re-registering it; alias one contract to another registration so both resolve to the same instance; compose a family of implementations into one composite behind its contract, then list, insert, trim or replace its members in place after registration - the same call works whether or not the family has been composed yet. Library defaults use try-add semantics, so whatever the host registered first wins. Per-call dependency overrides let a factory construct a service with one explicit value and everything else from the container. The DI layer behind Abblix OIDC Server, usable on its own. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
+++ b/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.JWT.Azure</PackageId>
     <Title>Abblix JWT Azure Key Vault Custodian</Title>
-    <Description>Azure Key Vault external-key integration for Abblix JWT and Abblix OIDC Server. Signs and unwraps with keys held in Azure Key Vault, whose private halves never enter the process, or mints keys locally and seals them to a vault key. Wired with an AddAzureCustodian call and the key placement that follows it.</Description>
+    <Description>Azure Key Vault integration for Abblix JWT and Abblix OIDC Server: sign tokens and unwrap keys with private keys that never leave the vault. Keep your OpenID Connect signing keys in Azure.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Jwt.Azure</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: Azure Key Vault custodian for Abblix JWT and Abblix OIDC Server. Signs and unwraps with keys held in the vault, whose private halves never enter the process, or mints keys locally and seals each to a vault key. Wired with AddAzureCustodian and the placement call that follows it. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Keep signing keys in Azure Key Vault. With this package Abblix JWT and Abblix OIDC Server sign tokens and unwrap encryption keys through the vault, so the private half of a key never enters the application process; only public halves reach the JWKS endpoint, and verification stays local. A key that has to be minted in the process is sealed to a vault key before it is stored. One registration call wires the custodian, and a placement call after it names the keys it holds. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
+++ b/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.JWT.Vault</PackageId>
     <Title>Abblix JWT Vault Custodian</Title>
-    <Description>HashiCorp Vault / OpenBao Transit external-key integration for Abblix JWT and Abblix OIDC Server. Signs and unwraps with keys held inside Vault Transit, whose private halves never enter the process, or mints keys locally and seals them to a Transit key. Wired with an AddVaultCustodian call and the key placement that follows it.</Description>
+    <Description>HashiCorp Vault and OpenBao Transit integration for Abblix JWT and Abblix OIDC Server: sign tokens and unwrap keys with private keys that never leave Vault. Keep your OpenID Connect signing keys in the secrets manager you already run.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Jwt.Vault</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: HashiCorp Vault and OpenBao Transit custodian for Abblix JWT and Abblix OIDC Server. Signs and unwraps with keys held inside Transit, whose private halves never enter the process, or mints keys locally and seals each to a Transit key. Wired with AddVaultCustodian and the placement call that follows it. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Keep signing keys where your secrets already live. With this package Abblix JWT and Abblix OIDC Server sign tokens and unwrap encryption keys through Vault Transit, so the private half of a key never enters the application process; only public halves reach the JWKS endpoint, and verification stays local. A key that has to be minted in the process is sealed to a Transit key before it is stored. One registration call wires the custodian, and a placement call after it names the keys it holds. Works with HashiCorp Vault and OpenBao alike. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.JWT</PackageId>
     <Title>Abblix JWT</Title>
-    <Description>A JWT and JOSE toolkit for .NET: token signing, encryption, validation, custom claims, and JSON Web Key handling. The token layer behind Abblix OIDC Server, usable on its own.</Description>
+    <Description>JWT, JWS, JWE and JWK library for .NET built on the platform's own cryptography, with no dependency on Microsoft.IdentityModel. Sign, encrypt and validate tokens, manage JSON Web Keys, and keep signing keys in HashiCorp Vault, OpenBao or Azure Key Vault.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Jwt</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>JWE-encrypted token handling, JOSE critical-header processing (RFC 7515), JWS verification key pinned to its declared algorithm (RFC 7517), enforced HMAC key length (RFC 7518), typed accessors for JWS header parameters, and granular key-resolution diagnostics. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>A JWT and JOSE toolkit that uses the .NET cryptographic primitives and System.Text.Json directly, so a token round-trips with no second serializer and no key-model translation. Sign and verify with every RSA, ECDSA and HMAC algorithm of RFC 7518; encrypt with all seventeen key-management algorithms of RFC 7516, including AES key wrapping and opt-in password-based encryption with a bounded work factor; publish and consume JSON Web Keys and key sets with thumbprints and typed header accessors; process critical headers; prevent replay of single-use tokens. Keys can live outside the process: a custodian seam lets HashiCorp Vault, OpenBao Transit or Azure Key Vault hold the private half, served by the companion packages. Clock tolerance travels as one value with separate past and future halves, so a FAPI 2.0 window is expressed exactly. The token layer behind Abblix OIDC Server, usable on its own. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -13,7 +13,7 @@
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAspNetCoreSharedInPackage</TargetsForTfmSpecificBuildOutput>
         <PackageId>Abblix.OIDC.Server.MinimalAPI</PackageId>
         <Title>Abblix OIDC Server Minimal API</Title>
-        <Description>ASP.NET Core Minimal API integration for Abblix OIDC Server, the certified OpenID Connect and OAuth 2.0 provider. Maps its protocol endpoints as Minimal API route handlers, with no MVC dependency.</Description>
+        <Description>ASP.NET Core Minimal API integration for Abblix OIDC Server, the certified OpenID Connect and OAuth 2.0 provider. Every protocol endpoint as a route handler with no MVC dependency: the lightest way to host an identity provider in .NET.</Description>
         <Authors>Abblix LLP</Authors>
         <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for the Abblix OIDC Server. Maps the OpenID Connect and OAuth 2.0 endpoints as route handlers via AddOidcMinimalApi/MapOidcEndpoints, offering the same protocol coverage as the MVC integration without a dependency on the MVC framework. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>Every protocol endpoint as a Minimal API route handler - authorization, token, introspection, revocation, discovery, keys, UserInfo, pushed authorization, device authorization, CIBA, dynamic client registration and management, end-session and check-session - with the same protocol coverage as the MVC integration and no dependency on the MVC framework. Routes can be moved through options, a default cross-origin policy lets browser clients reach the OIDC endpoints without extra configuration, and the endpoints beyond the core set are opt-in. A host references one transport adapter; referencing both is refused at startup with a message naming the package to drop. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -13,7 +13,7 @@
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeAspNetCoreSharedInPackage</TargetsForTfmSpecificBuildOutput>
         <PackageId>Abblix.OIDC.Server.MVC</PackageId>
         <Title>Abblix OIDC Server Model-View-Controller</Title>
-        <Description>ASP.NET Core MVC integration for Abblix OIDC Server, the certified OpenID Connect and OAuth 2.0 provider. Exposes its protocol endpoints through MVC controllers and routing.</Description>
+        <Description>ASP.NET Core MVC integration for Abblix OIDC Server, the certified OpenID Connect and OAuth 2.0 provider. Controllers, model binding and routing for every protocol endpoint: add it to a controller-based application and get a complete identity provider.</Description>
         <Authors>Abblix LLP</Authors>
         <PackageProjectUrl>https://www.abblix.com/abblix-oidc-server</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -22,7 +22,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>MVC integration for the server features: JARM authorization responses, JWT-secured token introspection, and Rich Authorization Requests and Token Exchange request binding. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>Every protocol endpoint as an MVC controller - authorization, token, introspection, revocation, discovery, keys, UserInfo, pushed authorization, device authorization, CIBA, dynamic client registration and management, end-session and check-session - with routes you can move, JARM and signed introspection responses, and a default cross-origin policy for the OIDC endpoints so a browser client works without extra configuration. Endpoints beyond the core set are opt-in. Referencing both transport adapters is refused at startup with a message naming the package to drop. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server.Mvc/README.md
+++ b/src/Abblix.Oidc.Server.Mvc/README.md
@@ -7,15 +7,6 @@
 ✏️ Improvements
 - Referencing both transport adapters is refused at startup with a message naming which package to drop, instead of every OIDC request failing with `AmbiguousMatchException` once the new Minimal API sibling joins the dependency graph
 
-## What's New in Version 2.3
-
-🚀 Features
-- JARM: MVC support for signed, optionally encrypted JWT authorization responses
-- JWT-secured token introspection ([RFC 9701](https://datatracker.ietf.org/doc/html/rfc9701)): content-negotiated signed introspection responses
-
-✏️ Improvements
-- Request binding for Rich Authorization Requests ([RFC 9396](https://datatracker.ietf.org/doc/html/rfc9396)) and Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693))
-
 ## Key Features
 
 - Standard MVC Integration: Uses ASP.NET controller classes, model binding, and attribute routing - no custom middleware required

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -7,7 +7,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>Abblix.OIDC.Server</PackageId>
         <Title>Abblix OIDC Server</Title>
-        <Description>A certified OpenID Connect and OAuth 2.0 provider you embed in your own ASP.NET Core app. Certified in every OpenID profile, with DPoP, PAR, JARM, and token exchange, on .NET 8, 9, and 10.</Description>
+        <Description>OpenID Connect and OAuth 2.0 server for ASP.NET Core, certified by the OpenID Foundation. Add a complete identity provider and authorization server to your own .NET application: every OIDC flow, PKCE, PAR, DPoP, JARM, CIBA, device flow, token exchange and FAPI 2.0. Runs on .NET 8, 9 and 10.</Description>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Abblix LLP</Authors>
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-        <PackageReleaseNotes>Rich Authorization Requests (RFC 9396), Token Exchange (RFC 8693), DPoP sender-constrained tokens (RFC 9449), certificate-bound access token verification (RFC 8705), JARM signed authorization responses, JWT-secured token introspection (RFC 9701), JWE-encrypted request objects (RFC 9101), signed authorization server metadata (RFC 8414), and secure-by-default hardening (Implicit Flow opt-in, Initial Access Token for client registration). Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+        <PackageReleaseNotes>Run a certified OpenID Provider inside your own ASP.NET Core application instead of operating a separate identity product. Abblix OIDC Server is a library: it builds on the standard .NET dependency injection container, stores nothing you do not choose to store, and passes the OpenID Foundation conformance suite in every login and logout profile. What you get: authorization code with PKCE, hybrid and implicit flows, client credentials, device authorization, CIBA, token exchange (RFC 8693) and Rich Authorization Requests (RFC 9396); pushed authorization requests, signed and encrypted request objects, JARM responses and sender-constrained tokens through DPoP or mutual TLS; dynamic client registration and management, discovery and Authorization Server Metadata (RFC 8414), token introspection and revocation, front-channel and back-channel logout, session management. New in 2.4: a per-client security profile that enforces the FAPI 2.0 control set as one setting, revocation of every token issued to a user or within a session, cross-client introspection for protected resources, opt-in endpoints, strict request-object processing (RFC 9101), per-client requirements for PAR, signed request objects and certificate-bound tokens, independent signing and encryption settings per token type, an allow list for outbound fetches, and refresh tokens that rotate by default (RFC 9700). Host it through the MVC or the Minimal API integration package. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Oidc.Server/README.md
+++ b/src/Abblix.Oidc.Server/README.md
@@ -9,23 +9,6 @@
 - External signing keys: private keys held in HashiCorp Vault / OpenBao Transit ([Abblix.JWT.Vault](https://www.nuget.org/packages/Abblix.JWT.Vault)) or Azure Key Vault ([Abblix.JWT.Azure](https://www.nuget.org/packages/Abblix.JWT.Azure)) - the private halves never enter the process, the public halves publish to the JWKS endpoint
 - Security events and Shared Signals: a new package family implementing Security Event Tokens ([RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417)) with Subject Identifiers ([RFC 9493](https://datatracker.ietf.org/doc/html/rfc9493)), push and poll SET delivery ([RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935), [RFC 8936](https://datatracker.ietf.org/doc/html/rfc8936)), the OpenID Shared Signals Framework 1.0 in both transmitter and receiver roles, and the CAEP 1.0 and RISC 1.0 event dictionaries
 
-## What's New in Version 2.3
-
-🚀 Features
-- Rich Authorization Requests ([RFC 9396](https://datatracker.ietf.org/doc/html/rfc9396)): fine-grained, transaction-level authorization details across the authorization endpoint, PAR, the token endpoint, CIBA, and the device grant
-- Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)): impersonation and delegation with multiple subject- and actor-token formats
-- DPoP sender-constrained tokens ([RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)): signature-based proof of possession for public clients that cannot use mTLS
-- Certificate-bound access token verification ([RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705) Section 3): resource-server check that a presented token matches the client certificate
-- JARM: signed, optionally encrypted JWT authorization responses
-- JWT-secured token introspection ([RFC 9701](https://datatracker.ietf.org/doc/html/rfc9701)): signed introspection responses via content negotiation
-- JWE-encrypted request objects ([RFC 9101](https://datatracker.ietf.org/doc/html/rfc9101)): confidential request parameters in the front channel and by reference
-- Signed authorization server metadata ([RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414)): opt-in, integrity-protected discovery document
-
-✏️ Improvements
-- Secure-by-default: Implicit Flow is now opt-in, and Dynamic Client Registration requires an Initial Access Token ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591))
-- Token-class confusion defense via opt-in token-type pinning ([RFC 8725](https://datatracker.ietf.org/doc/html/rfc8725)), JWS key pinned to its declared algorithm ([RFC 8725 Section 3.1](https://datatracker.ietf.org/doc/html/rfc8725)), enforced HMAC key length ([RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518))
-- Authorization-response issuer parameter ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207)) advertised in discovery
-
 ## Implemented Standards
 
 Abblix OIDC Server implements the following standards for authorization and security:

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SecurityEvents.CAEP</PackageId>
     <Title>Abblix Security Events CAEP</Title>
-    <Description>The OpenID Continuous Access Evaluation Profile (CAEP) 1.0 event dictionary for Abblix Security Events: typed payload models and event type identifiers for session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, session-established, session-presented and risk-level-change, registered over the Security Events core in one call.</Description>
+    <Description>OpenID CAEP 1.0 (Continuous Access Evaluation Profile) event dictionary for .NET: typed models for session revoked, token claims change, credential change, assurance level change, device compliance change, session established, session presented and risk level change, over Abblix Security Events.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.CAEP</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: the OpenID Continuous Access Evaluation Profile (CAEP) 1.0 event dictionary for Abblix Security Events. Typed payload models and event type identifiers for the eight CAEP events, registered over the Security Events core in one call. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>The eight events of the Continuous Access Evaluation Profile as typed payloads with their registered event type identifiers, so a transmitter emits and a receiver handles a session revocation or a credential change without hand-writing claim names. Registered over the Security Events core in one call; the same models serve a Shared Signals transmitter and receiver. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SecurityEvents.MinimalAPI</PackageId>
     <Title>Abblix Security Events Minimal API</Title>
-    <Description>ASP.NET Core Minimal API integration for Abblix Security Events: maps the OpenID Connect Back-Channel Logout intake as a route handler, with no MVC dependency.</Description>
+    <Description>ASP.NET Core Minimal API integration for Abblix Security Events: receive OpenID Back-Channel Logout tokens and pushed Security Event Tokens (RFC 8935) as route handlers, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.MinimalApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for Abblix Security Events. Maps the OpenID Connect Back-Channel Logout intake and the RFC 8935 push delivery endpoint as route handlers, with no MVC dependency. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>The intake side of security events as route handlers: the OpenID Back-Channel Logout endpoint a relying party exposes, and the push delivery endpoint of RFC 8935 that a transmitter posts to. Each validates the token through the Security Events core before handing it on, answers with the status codes the specifications prescribe, and needs no MVC framework in the host. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SecurityEvents.RISC</PackageId>
     <Title>Abblix Security Events RISC</Title>
-    <Description>The OpenID RISC Profile 1.0 (Risk Incident Sharing and Coordination) event dictionary for Abblix Security Events: typed payload models and event type identifiers for credential compromise, account disabling and deletion, identifier change and recycling, opt-out and recovery events, registered over the Security Events core in one call.</Description>
+    <Description>OpenID RISC 1.0 (Risk Incident Sharing and Coordination) event dictionary for .NET: typed models for credential compromise, account disabled, enabled and purged, identifier changed and recycled, opt-out and recovery events, over Abblix Security Events.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents.RISC</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: the OpenID RISC Profile 1.0 event dictionary for Abblix Security Events. Typed payload models and event type identifiers for credential compromise, account disabling and deletion, identifier change and recycling, opt-out and recovery, registered over the Security Events core in one call. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>The events of the Risk Incident Sharing and Coordination profile as typed payloads with their registered event type identifiers: credential compromise, account disabling, enabling and deletion, identifier change and recycling, opt-out and account recovery. Registered over the Security Events core in one call; the same models serve a Shared Signals transmitter and receiver, which is how an identity provider tells a relying party that an account was taken over. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
+++ b/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SecurityEvents</PackageId>
     <Title>Abblix Security Events</Title>
-    <Description>Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493) for .NET: a typed model of every registered identifier format with polymorphic JSON handling, plus a typed token model, builder and composable validation profile over the Abblix JWT core, delivery models for push (RFC 8935) and poll (RFC 8936), JWKS-based key resolution and replay protection. The event layer of the Shared Signals stack, usable on its own.</Description>
+    <Description>Security Event Tokens (RFC 8417) for .NET with Subject Identifiers (RFC 9493), push (RFC 8935) and poll (RFC 8936) delivery, and OpenID Back-Channel Logout. Build, sign, deliver and validate security events between identity providers and relying parties.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SecurityEvents</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: Security Event Tokens (RFC 8417) and Subject Identifiers (RFC 9493) for .NET. A typed token model, builder and composable validation profile over the Abblix JWT core, delivery models for push (RFC 8935) and poll (RFC 8936), JWKS-based key resolution and replay protection. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>The event layer of the Shared Signals stack, usable on its own. A typed model of a Security Event Token with a builder and a composable validation profile over Abblix JWT, so a token is refused for a missing identifier, a wrong audience or a replay before any handler sees it. Every registered Subject Identifier format has a typed model with polymorphic JSON handling. Delivery models cover push, where the transmitter posts each token, and poll, where the receiver collects and acknowledges them; keys are resolved from the counterparty's JWKS. OpenID Back-Channel Logout rides on the same core, so a relying party validates logout tokens with the same code that validates any other security event. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SharedSignals.MinimalAPI</PackageId>
     <Title>Abblix Shared Signals Minimal API</Title>
-    <Description>ASP.NET Core Minimal API integration for Abblix Shared Signals: maps the SSF 1.0 transmitter endpoints - configuration discovery, stream management, subjects, verification and poll delivery - and the receiver's push intake as route handlers, with no MVC dependency.</Description>
+    <Description>ASP.NET Core Minimal API integration for Abblix Shared Signals: the SSF 1.0 transmitter endpoints - configuration, streams, subjects, verification and poll - and the receiver push intake as route handlers, with no MVC dependency.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals.MinimalApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: ASP.NET Core Minimal API integration for Abblix Shared Signals. Maps the SSF 1.0 transmitter endpoints and the receiver's push intake as route handlers, with no MVC dependency. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>The Shared Signals endpoints as route handlers. For a transmitter: configuration discovery, stream management, subject management, verification and poll delivery. For a receiver: the push intake a transmitter posts to. Each validates through the Shared Signals and Security Events cores before handing on, declares the statuses it answers, and needs no MVC framework in the host. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SharedSignals.Redis</PackageId>
     <Title>Abblix Shared Signals Redis</Title>
-    <Description>Redis-native event outbox for Abblix Shared Signals: the transmitter's per-stream queues on Redis list and hash structures with atomic server-side operations, correct across transmitter replicas where a plain distributed-cache queue is not.</Description>
+    <Description>Redis event outbox for Abblix Shared Signals: per-stream queues on Redis lists and hashes with atomic server-side operations, so an SSF transmitter stays correct when it runs as several replicas.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals.Redis</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: a Redis-native event outbox for Abblix Shared Signals. Per-stream queues on Redis list and hash structures with atomic server-side operations, correct across transmitter replicas where a plain distributed-cache queue is not. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>A transmitter that runs as more than one replica needs a queue that every replica sees the same way. This outbox keeps each stream's pending events in Redis list and hash structures and performs enqueue, claim and acknowledge as atomic server-side operations, so two replicas cannot deliver the same event twice or lose one between them - which a queue over a plain distributed cache cannot promise. Drop-in for the default in-process outbox. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.SharedSignals</PackageId>
     <Title>Abblix Shared Signals</Title>
-    <Description>OpenID Shared Signals Framework (SSF) 1.0 for .NET: transmitter and receiver in one package - transmitter configuration discovery, event stream management, subjects and verification, plus push (RFC 8935) and poll (RFC 8936) delivery over the Abblix Security Events core.</Description>
+    <Description>OpenID Shared Signals Framework (SSF) 1.0 for .NET: transmitter and receiver in one package. Discover a transmitter, manage event streams and subjects, verify delivery, and send or receive CAEP and RISC events by push or poll.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.SharedSignals</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Initial release: the OpenID Shared Signals Framework (SSF) 1.0 for .NET, transmitter and receiver in one package. Transmitter configuration discovery, event stream management, subjects and verification, plus push (RFC 8935) and poll (RFC 8936) delivery over the Abblix Security Events core. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Both roles of the Shared Signals Framework. As a transmitter: publish configuration discovery, let receivers create, read, update and delete event streams, add and remove the subjects each stream is about, answer verification requests, and deliver events by push or hold them for poll. As a receiver: find a transmitter, open and configure a stream, manage its subjects, request verification and consume events from either delivery mode. Built over the Security Events core, with the CAEP and RISC dictionaries naming the events, so two parties agree on what an event means without a private contract. An event outbox on Redis is available for transmitters that run as several replicas. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Abblix.Utils</PackageId>
     <Title>Abblix Utils</Title>
-    <Description>Utility types shared across the Abblix OpenID Connect and OAuth 2.0 libraries: URI and string helpers, secure random generation, and custom JSON converters. Usable on its own.</Description>
+    <Description>Utility library for .NET from Abblix: a result type for validation chains, a URI builder with query composition, validation attributes, RFC 6750 authentication challenges, Base32 and Base64URL encoding, secure random values and JSON converters. Usable on its own.</Description>
     <Authors>Abblix LLP</Authors>
     <PackageProjectUrl>https://github.com/Abblix/Oidc.Server/tree/master/src/Abblix.Utils</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Abblix/Oidc.Server</RepositoryUrl>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright (c) $([System.DateTime]::Now.Year) Abblix LLP. All rights reserved.</Copyright>
-    <PackageReleaseNotes>Base64URL handling migrated to the runtime primitive (with a .NET 8 polyfill) for a cleaner allocation profile, plus code-quality improvements and dependency updates. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
+    <PackageReleaseNotes>Small types that keep protocol code readable. A result carries either a value or a typed error through a chain of checks, so a validator returns one thing and never throws for a bad input. An absolute address builder composes query strings safely; address and string extensions cover the cases that come up on the wire. Validation attributes check absolute addresses, allowed values and required elements at binding time. A challenge builder writes RFC 6750 authentication responses correctly escaped, and a sanitiser strips control characters before a value reaches a log. Secure random generation, Base32 and Base64URL encoding and custom JSON converters round it out. Full details: https://github.com/Abblix/Oidc.Server/releases/tag/v2.4</PackageReleaseNotes>
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 


### PR DESCRIPTION
The description of each package opens with what a person searching for it would type and says in one breath what it does and for whom. The release notes give the whole account of what the package offers, with what this release adds inside it rather than as a list of differences from the one before.

Five long-standing packages carried notes written for the previous release with only the link changed; the ten packages new in this release carried a first-release stub. All fifteen now describe themselves in full. The two READMEs that keep a "What's New" section keep one block, the current version's.

Every claim was checked against the code it names before it was written.
