### PR TITLE
Bring the three versioned READMEs up to what 2.4 ships

### DIFF
--- a/src/Abblix.Jwt/README.md
+++ b/src/Abblix.Jwt/README.md
@@ -2,6 +2,18 @@
 
 A JWT and JOSE toolkit for .NET, built entirely on the platform's cryptographic primitives and `System.Text.Json.Nodes` - no dependency on `Microsoft.IdentityModel.Tokens`. It implements JWS ([RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)), JWE ([RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516)), JWK ([RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)) and JWA ([RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518)), and is the token layer behind Abblix OIDC Server, usable on its own.
 
+## What's New in Version 2.4
+
+🚀 Features
+- Complete JWE key management: all seventeen key-management algorithms of [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518) section 4, including AES key wrapping ([RFC 3394](https://datatracker.ietf.org/doc/html/rfc3394)) and opt-in password-based encryption with a bounded work factor
+- External signing keys: a custodian seam through which the private half of a key is held outside the process, served by [Abblix.JWT.Vault](https://www.nuget.org/packages/Abblix.JWT.Vault) for HashiCorp Vault and OpenBao Transit and [Abblix.JWT.Azure](https://www.nuget.org/packages/Abblix.JWT.Azure) for Azure Key Vault
+- Replay prevention for single-use tokens, with one store serving every token profile
+
+✏️ Improvements
+- Clock tolerance travels as one value with separate past and future halves, so a window such as the one FAPI 2.0 prescribes is expressed exactly
+- A NumericDate is read as [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) section 2 defines it: a fractional or exponent-written number is a date, and a claim that cannot be read is refused by name rather than thrown
+- The signed discovery document uses the standard algorithm for a key that declares none ([RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517) section 4.4)
+
 ## Install
 
 ```bash

--- a/src/Abblix.Oidc.Server.Mvc/README.md
+++ b/src/Abblix.Oidc.Server.Mvc/README.md
@@ -4,7 +4,12 @@
 
 ## What's New in Version 2.4
 
+🚀 Features
+- Opt-in registration of the endpoints beyond the core set: dynamic client registration, CIBA, check session, revocation, introspection and device authorization
+- Authorization Server Metadata served at its OAuth 2.0 well-known address ([RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414))
+
 ✏️ Improvements
+- A default cross-origin policy for the OIDC endpoints, so a browser client reads discovery, the key set and the token and UserInfo responses without the host configuring anything
 - Referencing both transport adapters is refused at startup with a message naming which package to drop, instead of every OIDC request failing with `AmbiguousMatchException` once the new Minimal API sibling joins the dependency graph
 
 ## Key Features

--- a/src/Abblix.Oidc.Server/README.md
+++ b/src/Abblix.Oidc.Server/README.md
@@ -8,6 +8,10 @@
 - Minimal API integration: every OIDC endpoint as ASP.NET Core route handlers via the new [Abblix.OIDC.Server.MinimalAPI](https://www.nuget.org/packages/Abblix.OIDC.Server.MinimalAPI) package, with full protocol parity with the MVC integration
 - External signing keys: private keys held in HashiCorp Vault / OpenBao Transit ([Abblix.JWT.Vault](https://www.nuget.org/packages/Abblix.JWT.Vault)) or Azure Key Vault ([Abblix.JWT.Azure](https://www.nuget.org/packages/Abblix.JWT.Azure)) - the private halves never enter the process, the public halves publish to the JWKS endpoint
 - Security events and Shared Signals: a new package family implementing Security Event Tokens ([RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417)) with Subject Identifiers ([RFC 9493](https://datatracker.ietf.org/doc/html/rfc9493)), push and poll SET delivery ([RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935), [RFC 8936](https://datatracker.ietf.org/doc/html/rfc8936)), the OpenID Shared Signals Framework 1.0 in both transmitter and receiver roles, and the CAEP 1.0 and RISC 1.0 event dictionaries
+- A per-client security profile enforcing the [FAPI 2.0 Security Profile](https://openid.net/specs/fapi-security-profile-2_0.html) control set as one setting: a server-wide profile is a floor no client can step under, and a client may hold itself to more
+- Revocation of every token issued to a user or within one session, and cross-client token introspection for protected resources ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662))
+- Opt-in endpoint registration, Authorization Server Metadata at its OAuth 2.0 well-known address ([RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414)), strict request-object processing ([RFC 9101](https://datatracker.ietf.org/doc/html/rfc9101)), and per-client requirements for pushed authorization requests, signed request objects and certificate-bound tokens
+- Independent signing and encryption settings per token type, an allow list for outbound fetches, and refresh tokens that rotate by default ([RFC 9700](https://datatracker.ietf.org/doc/html/rfc9700))
 
 ## Implemented Standards
 


### PR DESCRIPTION
The JWT package README had no section for this release, though it gained the whole of JWE key management and the custodian seam. The server README named three of the eleven things the release notes list; the MVC README named one of four. Each block now says what its package gained, in the words of the release notes, with every claim checked against the code. The other twelve READMEs describe first releases and stay as they are.
