### PR TITLE
Run the release suite as the shards every pull request runs

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -81,7 +81,9 @@ jobs:
           fi
           echo "MinVer override version: $VERSION_FULL"
 
-          PREVIOUS_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # The release's own tag is on HEAD by now, so it is excluded - otherwise the release
+          # is reported as its own predecessor and the fallback changelog spans nothing.
+          PREVIOUS_VERSION=$(git describe --tags --abbrev=0 --exclude "v$VERSION" 2>/dev/null || echo "")
           if [ -n "$PREVIOUS_VERSION" ]; then
             PREVIOUS_VERSION=${PREVIOUS_VERSION#v}
             echo "Previous version: $PREVIOUS_VERSION"
@@ -139,13 +141,19 @@ jobs:
         timeout-minutes: 3
       - name: Build
         run: dotnet build --no-restore -c Release -p:MinVerVersionOverride="$VERSION_FULL"
-        timeout-minutes: 3
+        # Above the step baseline: the whole solution builds here in one job, and the baseline is
+        # what killed a release build that needed most of it.
+        timeout-minutes: 10
       - name: Test
         run: |
           dotnet test --no-build -c Release --verbosity normal -- \
             --report-trx --report-trx-filename test-results.trx \
             --results-directory ./tests/results
-        timeout-minutes: 3
+        # Above the step baseline: every test project of the solution runs here in ONE job, where
+        # the pull-request pipeline shards them across many. The baseline cancelled a release run
+        # mid-suite, which the job reports as "cancelled" with the surviving suites listed as
+        # orphan processes - not as a test failure.
+        timeout-minutes: 20
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -97,8 +97,16 @@ jobs:
 
         timeout-minutes: 3
     timeout-minutes: 5
-  build-and-test:
+  # The same shards every pull request runs, one job per test project, so the release meets the
+  # suite on the rig that already proved this commit rather than on a single job with a wall of
+  # its own. The shards build each project from the same commit; what they prove is the source,
+  # and the packed binaries below are built from it once more under the release version.
+  tests:
     needs: versioning
+    uses: ./.github/workflows/test-shards.yml
+
+  build-and-pack:
+    needs: [versioning, tests]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -144,24 +152,6 @@ jobs:
         # Above the step baseline: the whole solution builds here in one job, and the baseline is
         # what killed a release build that needed most of it.
         timeout-minutes: 10
-      - name: Test
-        run: |
-          dotnet test --no-build -c Release --verbosity normal -- \
-            --report-trx --report-trx-filename test-results.trx \
-            --results-directory ./tests/results
-        # Above the step baseline: every test project of the solution runs here in ONE job, where
-        # the pull-request pipeline shards them across many. The baseline cancelled a release run
-        # mid-suite, which the job reports as "cancelled" with the surviving suites listed as
-        # orphan processes - not as a test failure.
-        timeout-minutes: 20
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results
-          path: 'tests/results/*.trx'
-          retention-days: 7
-        timeout-minutes: 3
       - name: Pack
         run: dotnet pack --no-build -c Release -o nupkg -p:MinVerVersionOverride="$VERSION_FULL"
         timeout-minutes: 3
@@ -181,7 +171,7 @@ jobs:
         timeout-minutes: 3
     timeout-minutes: 5
   test-getting-started:
-    needs: [versioning, build-and-test]
+    needs: [versioning, build-and-pack]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -255,7 +245,7 @@ jobs:
         timeout-minutes: 3
     timeout-minutes: 5
   create-release:
-    needs: [versioning, build-and-test, test-getting-started]
+    needs: [versioning, build-and-pack, test-getting-started]
     runs-on: ubuntu-latest
     environment: release-approval
     permissions:
@@ -379,7 +369,7 @@ jobs:
         timeout-minutes: 3
     timeout-minutes: 5
   publish-github-packages:
-    needs: [versioning, build-and-test, test-getting-started, create-release]
+    needs: [versioning, build-and-pack, test-getting-started, create-release]
     runs-on: ubuntu-latest
     # Same approval gate as NuGet.org: no package leaves the build for any
     # registry without passing the publish-packages environment reviewers.
@@ -433,7 +423,7 @@ jobs:
         timeout-minutes: 3
     timeout-minutes: 5
   publish-nuget-org:
-    needs: [versioning, build-and-test, test-getting-started, create-release]
+    needs: [versioning, build-and-pack, test-getting-started, create-release]
     runs-on: ubuntu-latest
     environment: publish-packages
     permissions:


### PR DESCRIPTION
Run the release suite as the shards every pull request runs

The release ran every test project in one job with a wall of its own, and
the first 2.4 run died on that wall with no test named. The suites now run
through the same reusable shard workflow the pull-request pipeline uses,
one job per test project, and packing waits for all of them. The shards
build each project from the same commit; what they prove is the source,
and the packed binaries are built from it once more under the release
version.

The versioning job also reported the release as its own predecessor: its
tag is on HEAD by the time the job runs, so a plain describe finds it. The
release's own tag is excluded from that lookup.
