### PR TITLE
Name the key usage constant the library actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ dotnet add package Abblix.OIDC.Server.MVC
 ```csharp
 using Abblix.Jwt;
 using Abblix.Oidc.Server.Mvc;
-using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddOidcServices(options =>
 {
     options.LoginUri = new Uri("/Auth/Login", UriKind.Relative);
-    options.SigningKeys = new[] { JsonWebKeyFactory.CreateRsa(JsonWebKeyUseNames.Sig) };
+    options.SigningKeys = new[] { JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature) };
 });
 ```
 


### PR DESCRIPTION
The quick-start in the README signs tokens with `JsonWebKeyFactory.CreateRsa(JsonWebKeyUseNames.Sig)`. That constant belongs to `Microsoft.IdentityModel`, and `Abblix.Jwt` states in its own package description that it carries no dependency on it, so a reader who installs the Abblix packages and pastes the snippet gets `CS0103` on the line that creates the signing key. It reads as a broken package rather than a stale document.

The constant the library ships is `PublicKeyUsages.Signature`, with the same `"sig"` value, so the example behaves as before.

The second commit removes `using Microsoft.IdentityModel.Tokens;` from the same snippet. It was there for the old constant and for nothing else, so leaving it would have moved the failure from `CS0103` on the key line to `CS0246` on the directive, with the build just as red.

Measured rather than assumed: the snippet was copied whole into a project referencing only the published 2.4.0 packages, with implicit usings on as the web template has them. It fails with the old constant and builds after both commits.

Scope: this pull request changes `README.md` and nothing else. `src/Abblix.Jwt/README.md` already used the correct constant.
