### PR TITLE
Compile the code samples that ship inside the packages

### DIFF
--- a/Abblix.Oidc.slnx
+++ b/Abblix.Oidc.slnx
@@ -39,7 +39,6 @@
     <Project Path="tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj" />
     <Project Path="tests/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj" />
     <Project Path="tests/Abblix.DocSamples/Abblix.DocSamples.csproj" />
-
     <Project Path="tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj" />
     <Project Path="tests/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj" />
     <Project Path="tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj" />

--- a/Abblix.Oidc.slnx
+++ b/Abblix.Oidc.slnx
@@ -39,6 +39,8 @@
     <Project Path="tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj" />
     <Project Path="tests/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj" />
     <Project Path="tests/Abblix.DocSamples/Abblix.DocSamples.csproj" />
+
+    <Project Path="tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj" />
     <Project Path="tests/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj" />
     <Project Path="tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj" />
     <Project Path="tests/Abblix.Oidc.Server.AspNetCore.UnitTests/Abblix.Oidc.Server.AspNetCore.UnitTests.csproj" />

--- a/tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj
+++ b/tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj
@@ -1,0 +1,41 @@
+<!--
+    Exists to answer one question with the SDK rather than with a memory: which namespaces does a
+    project created from the ASP.NET Core web template import without being asked?
+
+    A README snippet is written for a reader whose project came from that template, and the gate over
+    those snippets has to know what their compiler sees. A list frozen in C# states it correctly on the
+    day it is written and silently stops being true the next time the SDK moves - and it fails in the
+    quiet direction: a namespace REMOVED from the template leaves a sample leaning on an import the
+    reader no longer has, with every row still green.
+
+    So the list is not written down anywhere. This project uses the same SDK the reader's project would,
+    lets MSBuild compute @(Using) from it, and writes the result into an assembly attribute that
+    Abblix.DocSamples reads. It compiles no source of its own: the assembly exists to carry that one
+    fact.
+-->
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+
+        <!-- No sources, so nothing to document and nothing to run. The empty documentation file would
+             otherwise land beside the test output, where a row counts one file per library. -->
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+        <OutputType>Library</OutputType>
+    </PropertyGroup>
+
+    <!-- Read AFTER the SDK's own props, which is where both halves of the list are declared: the base
+         seven from Microsoft.NET.Sdk and the nine the web SDK adds on top. -->
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+            <_Parameter1>WebTemplateImplicitUsings</_Parameter1>
+            <_Parameter2>@(Using)</_Parameter2>
+        </AssemblyAttribute>
+    </ItemGroup>
+
+</Project>

--- a/tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj
+++ b/tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj
@@ -27,6 +27,10 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
         <OutputType>Library</OutputType>
+
+        <!-- Serves nothing, so the web SDK's asset manifest would arrive beside the tests for no
+             reader at all. -->
+        <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     </PropertyGroup>
 
     <!-- Read AFTER the SDK's own props, which is where both halves of the list are declared: the base

--- a/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
+++ b/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
@@ -58,10 +58,15 @@
          nothing.
 
          Ordinary metadata, NOT AdditionalProperties. Those are the global properties the referenced
-         project is BUILT with, so asking for it under a set of its own invites a second instance of it
-         writing into the same obj/ and bin/. Metadata also puts the name where somebody can find its
-         reader: the filter below matches on it, while a filter keyed on AdditionalProperties being
-         non-empty would work whatever the name said. -->
+         project is BUILT with, so a reference carrying them asks for a second instance of that project:
+         measured on a solution build, the companion was produced twice into the same bin/Debug, with
+         nothing sequencing the two writers. The line that answers this is the one naming a finished
+         assembly ("<project> -> <path>"), one per built instance and target framework; the "is building"
+         lines count REQUESTS and stay at one id however many instances there are.
+
+         Metadata also puts the name where somebody can find its reader: the filter below matches on it,
+         while a filter keyed on AdditionalProperties being non-empty would work whatever the name
+         said. -->
     <ItemGroup>
         <ProjectReference Include="..\Abblix.DocSamples.WebTemplate\Abblix.DocSamples.WebTemplate.csproj"
                           ExcludeFromReferenceList="true" />

--- a/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
+++ b/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
@@ -55,10 +55,16 @@
     <!-- The web template's implicit usings, computed by the SDK rather than written down. Kept out of
          the reference list below on purpose: that list is read by rows asserting every referenced
          project put its documentation beside the output, and this one is not a library and documents
-         nothing. -->
+         nothing.
+
+         Ordinary metadata, NOT AdditionalProperties. Those are the global properties the referenced
+         project is BUILT with, so asking for it under a set of its own invites a second instance of it
+         writing into the same obj/ and bin/. Metadata also puts the name where somebody can find its
+         reader: the filter below matches on it, while a filter keyed on AdditionalProperties being
+         non-empty would work whatever the name said. -->
     <ItemGroup>
         <ProjectReference Include="..\Abblix.DocSamples.WebTemplate\Abblix.DocSamples.WebTemplate.csproj"
-                          AdditionalProperties="ExcludeFromReferenceList=true" />
+                          ExcludeFromReferenceList="true" />
     </ItemGroup>
 
     <!-- The reference list, written by MSBuild rather than recovered from a copy of this file: a
@@ -69,7 +75,7 @@
     <ItemGroup>
         <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
             <_Parameter1>ReferencedProjects</_Parameter1>
-            <_Parameter2>@(ProjectReference->WithMetadataValue('AdditionalProperties', '')->'%(Filename)')</_Parameter2>
+            <_Parameter2>@(ProjectReference->WithMetadataValue('ExcludeFromReferenceList', '')->'%(Filename)')</_Parameter2>
         </AssemblyAttribute>
     </ItemGroup>
 

--- a/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
+++ b/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
@@ -52,6 +52,15 @@
         <ProjectReference Include="..\..\src\Abblix.Utils\Abblix.Utils.csproj" />
     </ItemGroup>
 
+    <!-- The web template's implicit usings, computed by the SDK rather than written down. Kept out of
+         the reference list below on purpose: that list is read by rows asserting every referenced
+         project put its documentation beside the output, and this one is not a library and documents
+         nothing. -->
+    <ItemGroup>
+        <ProjectReference Include="..\Abblix.DocSamples.WebTemplate\Abblix.DocSamples.WebTemplate.csproj"
+                          AdditionalProperties="ExcludeFromReferenceList=true" />
+    </ItemGroup>
+
     <!-- The reference list, written by MSBuild rather than recovered from a copy of this file: a
          test asserts every referenced project put its documentation beside the output, and hand-
          parsing Include paths meant splitting them on a separator. The previous attempt did that
@@ -60,7 +69,7 @@
     <ItemGroup>
         <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
             <_Parameter1>ReferencedProjects</_Parameter1>
-            <_Parameter2>@(ProjectReference->'%(Filename)')</_Parameter2>
+            <_Parameter2>@(ProjectReference->WithMetadataValue('AdditionalProperties', '')->'%(Filename)')</_Parameter2>
         </AssemblyAttribute>
     </ItemGroup>
 

--- a/tests/Abblix.DocSamples/DocSampleTests.cs
+++ b/tests/Abblix.DocSamples/DocSampleTests.cs
@@ -113,7 +113,12 @@ public class DocSampleTests
         // The control: the directory really was read, so an empty listing does not pass as "no orphans".
         Assert.NotEmpty(files);
 
-        var enrolled = Enrolment.Compiled.Select(sample => sample.Copy).ToHashSet(StringComparer.Ordinal);
+        // Both enrolments, because the directory holds both kinds of copy: a README copy left out of
+        // this set would be reported as an orphan, and the obvious repair - a second directory - would
+        // put it beyond the row that catches orphans at all.
+        var enrolled = Enrolment.Compiled.Select(sample => sample.Copy)
+            .Concat(Enrolment.ReadmeCompiled.Select(sample => sample.Copy))
+            .ToHashSet(StringComparer.Ordinal);
 
         var orphans = files.Where(file => !enrolled.Contains(file!)).ToArray();
 

--- a/tests/Abblix.DocSamples/DocSampleTests.cs
+++ b/tests/Abblix.DocSamples/DocSampleTests.cs
@@ -226,9 +226,15 @@ public class DocSampleTests
     public void NoStubShadowsATypeTheLibraryShips()
     {
         var beside = Path.GetDirectoryName(typeof(DocSampleTests).Assembly.Location)!;
+        // Both test assemblies are excluded, and for the same reason: neither ships, so neither can
+        // shadow a name a consumer sees. The companion carries no types at all - it exists to let the
+        // SDK state the web template's implicit usings - and counting it would put this row one above
+        // the number of libraries there are.
+        string[] notLibraries = ["Abblix.DocSamples", "Abblix.DocSamples.WebTemplate"];
+
         var libraries = Directory
             .EnumerateFiles(beside, "Abblix.*.dll")
-            .Where(path => Path.GetFileNameWithoutExtension(path) != "Abblix.DocSamples")
+            .Where(path => !notLibraries.Contains(Path.GetFileNameWithoutExtension(path)))
             .Select(Assembly.LoadFrom)
             .ToArray();
 

--- a/tests/Abblix.DocSamples/Enrolment.cs
+++ b/tests/Abblix.DocSamples/Enrolment.cs
@@ -114,4 +114,34 @@ public static class Enrolment
     /// </para>
     /// </remarks>
     public const int Unenrolled = 12;
+
+    /// <summary>
+    /// The README samples whose text is compiled, each with a copy under <c>Samples/</c>.
+    /// </summary>
+    /// <remarks>
+    /// A README ships INSIDE the package, so its snippets reach every consumer while no compiler reads
+    /// them. The quick-start below is the one that proved it: it called a constant from a library
+    /// <c>Abblix.Jwt</c> had deliberately stopped depending on, and a reader with only the packages got
+    /// a compiler error on the first line that mattered.
+    /// </remarks>
+    public static IReadOnlyList<ReadmeSample> ReadmeCompiled { get; } =
+    [
+        new("README.md", 0, "ReadmeQuickstart.cs"),
+    ];
+
+    /// <summary>
+    /// How many C# blocks the shipping READMEs carry that nothing here compiles.
+    /// </summary>
+    /// <remarks>
+    /// The same bargain as <see cref="Unenrolled"/> and for the same reason: a gate covering one snippet
+    /// out of fifty-six is honest only while the fifty-five are counted, and the count is what turns a
+    /// new uncompiled snippet into a failing row rather than into silence.
+    /// <para>
+    /// Most of the remainder are fragments rather than pastable programs - a line configuring a service
+    /// with <c>services</c> arriving from nowhere - so enrolling one means writing the wrapper that
+    /// supplies its ambient names, exactly as a doc-comment sample does. The number falls one at a time
+    /// as that work is done.
+    /// </para>
+    /// </remarks>
+    public const int ReadmeUnenrolled = 55;
 }

--- a/tests/Abblix.DocSamples/ReadmeSample.cs
+++ b/tests/Abblix.DocSamples/ReadmeSample.cs
@@ -6,6 +6,8 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Reflection;
+
 namespace Abblix.DocSamples;
 
 /// <summary>
@@ -39,8 +41,8 @@ public sealed record ReadmeSample(string Readme, int Index, string Copy)
 /// The reader's project is what a snippet has to compile in, not this one. Two differences decide
 /// everything: the reader has the packages and nothing else, and the web template hands them a set of
 /// implicit usings that this test project does not have. So a copy declares those ambient namespaces
-/// explicitly, in a marked region, and <c>ReadmeSampleTests</c> holds that region to the template's own
-/// list - measured from a generated <c>GlobalUsings.g.cs</c> rather than recalled.
+/// explicitly, in a marked region, and <c>ReadmeSampleTests</c> holds that region to the list the SDK
+/// itself computes for a web project.
 /// </para>
 /// </remarks>
 public static class ReadmeSampleReader
@@ -49,30 +51,60 @@ public static class ReadmeSampleReader
     /// The namespaces a project created from the ASP.NET Core web template imports without being asked.
     /// </summary>
     /// <remarks>
-    /// Read out of the <c>GlobalUsings.g.cs</c> that <c>dotnet new web</c> produces on the target
-    /// framework, so it states what the reader's compiler sees rather than what anybody remembers of it.
-    /// A snippet may lean on these without showing them; anything else it needs it has to show.
+    /// Computed by MSBuild from the SDK this build is using, not written down here: the companion
+    /// project <c>Abblix.DocSamples.WebTemplate</c> is a web-SDK project whose whole purpose is to let
+    /// the SDK answer, and it writes <c>@(Using)</c> into an assembly attribute this reads.
+    /// <para>
+    /// A list frozen in source would be right on the day it was typed and would fail in the QUIET
+    /// direction afterwards. An import ADDED to the template makes this row refuse a legitimate copy,
+    /// which is loud; an import REMOVED - and <c>System.Net.Http.Json</c> is one that arrived by
+    /// version - leaves a sample leaning on something the reader no longer has, with every row green.
+    /// </para>
     /// </remarks>
-    public static IReadOnlySet<string> TemplateImplicitUsings { get; } = new HashSet<string>(
-        StringComparer.Ordinal)
+    public static IReadOnlySet<string> TemplateImplicitUsings { get; } = ReadTemplateUsings();
+
+    /// <summary>
+    /// The template's imports, as the companion project's build recorded them.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The attribute is missing or empty, which means the
+    /// companion project stopped being referenced or stopped writing it - and an empty set would make
+    /// every ambient namespace look invented rather than make this row pass, so it is worth saying
+    /// which of the two happened.</exception>
+    private static IReadOnlySet<string> ReadTemplateUsings()
     {
-        "Microsoft.AspNetCore.Builder",
-        "Microsoft.AspNetCore.Hosting",
-        "Microsoft.AspNetCore.Http",
-        "Microsoft.AspNetCore.Routing",
-        "Microsoft.Extensions.Configuration",
-        "Microsoft.Extensions.DependencyInjection",
-        "Microsoft.Extensions.Hosting",
-        "Microsoft.Extensions.Logging",
-        "System",
-        "System.Collections.Generic",
-        "System.IO",
-        "System.Linq",
-        "System.Net.Http",
-        "System.Net.Http.Json",
-        "System.Threading",
-        "System.Threading.Tasks",
-    };
+        const string Companion = "Abblix.DocSamples.WebTemplate";
+
+        Assembly companion;
+        try
+        {
+            companion = Assembly.Load(Companion);
+        }
+        catch (FileNotFoundException notFound)
+        {
+            // By name rather than by path, so the runtime resolves it the way it resolves every other
+            // reference. Missing means the project reference is gone, and saying so beats a set that
+            // arrives empty and makes every ambient namespace look invented.
+            throw new InvalidOperationException(
+                $"{Companion} is not beside the tests, so the web template's imports cannot be read.",
+                notFound);
+        }
+
+        var names = companion
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Where(metadata => metadata.Key == "WebTemplateImplicitUsings")
+            .SelectMany(metadata => (metadata.Value ?? string.Empty).Split(
+                ';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (names.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "The companion project carries no implicit usings, which no web-SDK project does: its "
+                + "attribute was renamed, or its item group moved above the SDK props it reads.");
+        }
+
+        return names;
+    }
 
     /// <summary>
     /// Every README that ships with a package: the repository's own, and one per library.
@@ -83,15 +115,19 @@ public static class ReadmeSampleReader
     /// </remarks>
     public static IReadOnlyList<string> Files(string repositoryRoot)
     {
-        var files = new List<string> { "README.md" };
-
-        files.AddRange(Directory
+        // The repository's own README goes through the same existence check as the rest. Listed
+        // unconditionally it would be reported as present by a method that had merely repeated the
+        // literal back, and the row asserting it is there would have measured nothing.
+        var candidates = Directory
             .EnumerateDirectories(Path.Combine(repositoryRoot, "src"))
             .Select(directory => Path.Combine(directory, "README.md"))
-            .Where(File.Exists)
-            .Select(path => Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/')));
+            .Prepend(Path.Combine(repositoryRoot, "README.md"));
 
-        return files.OrderBy(path => path, StringComparer.Ordinal).ToArray();
+        return candidates
+            .Where(File.Exists)
+            .Select(path => Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
     }
 
     /// <summary>
@@ -114,7 +150,7 @@ public static class ReadmeSampleReader
 
             if (!inside)
             {
-                if (trimmed is "```csharp" or "```cs")
+                if (LanguageOf(trimmed) is "csharp" or "cs")
                 {
                     inside = true;
                     current = [];
@@ -149,6 +185,28 @@ public static class ReadmeSampleReader
         .Sum(file => Blocks(Path.Combine(repositoryRoot, file)).Count);
 
     /// <summary>
+    /// The language a fence opens with, or null where the line opens no fence.
+    /// </summary>
+    /// <remarks>
+    /// The first word after the backticks, because a fence may carry attributes after its language
+    /// (<c>```csharp title="Program.cs"</c> renders in several site generators). Matching the whole line
+    /// would leave such a block uncounted, and an uncounted block is exactly the silence the remainder
+    /// count exists to break.
+    /// </remarks>
+    private static string? LanguageOf(string trimmed)
+    {
+        const string Fence = "```";
+
+        if (!trimmed.StartsWith(Fence, StringComparison.Ordinal))
+            return null;
+
+        var info = trimmed[Fence.Length..].Trim();
+        var space = info.IndexOf(' ');
+
+        return space < 0 ? info : info[..space];
+    }
+
+    /// <summary>
     /// One enrolled sample, split into the imports it shows and the code under them.
     /// </summary>
     /// <exception cref="InvalidOperationException">The README has no block at that index, which means
@@ -166,6 +224,27 @@ public static class ReadmeSampleReader
         }
 
         return Split(blocks[sample.Index]);
+    }
+
+    /// <summary>
+    /// The namespace a line imports, or null where the line is not a using directive at all.
+    /// </summary>
+    /// <remarks>
+    /// A using STATEMENT opens a scope and belongs to the body; only a directive names a namespace, and
+    /// the difference is the parenthesis rather than the keyword. Shared with the row that compares a
+    /// copy's imports, which would otherwise read <c>using var scope = provider.CreateScope();</c> as a
+    /// namespace and report a mismatch nobody could act on.
+    /// </remarks>
+    public static string? NamespaceOf(string line)
+    {
+        const string Directive = "using ";
+
+        var trimmed = line.Trim();
+
+        if (!trimmed.StartsWith(Directive, StringComparison.Ordinal) || !trimmed.EndsWith(';'))
+            return null;
+
+        return trimmed.Contains('(') ? null : trimmed[..^1][Directive.Length..].Trim();
     }
 
     /// <summary>
@@ -190,15 +269,10 @@ public static class ReadmeSampleReader
             if (line.Length == 0)
                 continue;
 
-            if (!line.StartsWith("using ", StringComparison.Ordinal) || !line.EndsWith(';'))
+            if (NamespaceOf(line) is not { } imported)
                 break;
 
-            // A using STATEMENT opens a scope and belongs to the body; only a directive names a
-            // namespace, and the difference is the parenthesis rather than the keyword.
-            if (line.Contains('('))
-                break;
-
-            usings.Add(line[..^1]["using ".Length..].Trim());
+            usings.Add(imported);
         }
 
         return (usings, block.Skip(index).ToArray());

--- a/tests/Abblix.DocSamples/ReadmeSample.cs
+++ b/tests/Abblix.DocSamples/ReadmeSample.cs
@@ -1,0 +1,206 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+namespace Abblix.DocSamples;
+
+/// <summary>
+/// One enrolled README sample: the file it lives in, which of that file's C# blocks it is, and the
+/// copy under <c>Samples/</c> that carries it as compiled source.
+/// </summary>
+/// <param name="Readme">The README's path relative to the repository root, with forward slashes.</param>
+/// <param name="Index">Which fenced <c>csharp</c> block of that file, counting from zero.</param>
+/// <param name="Copy">The file under <c>Samples/</c> that carries this sample as compiled source.</param>
+/// <remarks>
+/// Keyed by position rather than by a member identifier, unlike <see cref="DocSample"/>, because a
+/// README block documents no member and has nothing else to be named by. The position is the weak part
+/// of that key: inserting a block above an enrolled one silently re-points the enrolment at different
+/// text. What catches it is the text comparison itself, which then finds two things that do not match,
+/// rather than the key.
+/// </remarks>
+public sealed record ReadmeSample(string Readme, int Index, string Copy)
+{
+    public override string ToString() => $"{Readme}#{Index}";
+}
+
+/// <summary>
+/// Reads the C# blocks out of the README files that ship with the packages.
+/// </summary>
+/// <remarks>
+/// A README travels INSIDE the package, so its snippets are read by every consumer and compiled by
+/// nothing: the quick-start called a constant from a library this one had deliberately stopped
+/// depending on, and shipped that way through a whole release. Doc comments already have a gate
+/// (<see cref="DocSampleReader"/>); this is the same idea over the other half of the prose.
+/// <para>
+/// The reader's project is what a snippet has to compile in, not this one. Two differences decide
+/// everything: the reader has the packages and nothing else, and the web template hands them a set of
+/// implicit usings that this test project does not have. So a copy declares those ambient namespaces
+/// explicitly, in a marked region, and <c>ReadmeSampleTests</c> holds that region to the template's own
+/// list - measured from a generated <c>GlobalUsings.g.cs</c> rather than recalled.
+/// </para>
+/// </remarks>
+public static class ReadmeSampleReader
+{
+    /// <summary>
+    /// The namespaces a project created from the ASP.NET Core web template imports without being asked.
+    /// </summary>
+    /// <remarks>
+    /// Read out of the <c>GlobalUsings.g.cs</c> that <c>dotnet new web</c> produces on the target
+    /// framework, so it states what the reader's compiler sees rather than what anybody remembers of it.
+    /// A snippet may lean on these without showing them; anything else it needs it has to show.
+    /// </remarks>
+    public static IReadOnlySet<string> TemplateImplicitUsings { get; } = new HashSet<string>(
+        StringComparer.Ordinal)
+    {
+        "Microsoft.AspNetCore.Builder",
+        "Microsoft.AspNetCore.Hosting",
+        "Microsoft.AspNetCore.Http",
+        "Microsoft.AspNetCore.Routing",
+        "Microsoft.Extensions.Configuration",
+        "Microsoft.Extensions.DependencyInjection",
+        "Microsoft.Extensions.Hosting",
+        "Microsoft.Extensions.Logging",
+        "System",
+        "System.Collections.Generic",
+        "System.IO",
+        "System.Linq",
+        "System.Net.Http",
+        "System.Net.Http.Json",
+        "System.Threading",
+        "System.Threading.Tasks",
+    };
+
+    /// <summary>
+    /// Every README that ships with a package: the repository's own, and one per library.
+    /// </summary>
+    /// <remarks>
+    /// Discovered rather than listed, so a new library's README is inside the count from its first
+    /// commit instead of from whenever somebody remembers to add it.
+    /// </remarks>
+    public static IReadOnlyList<string> Files(string repositoryRoot)
+    {
+        var files = new List<string> { "README.md" };
+
+        files.AddRange(Directory
+            .EnumerateDirectories(Path.Combine(repositoryRoot, "src"))
+            .Select(directory => Path.Combine(directory, "README.md"))
+            .Where(File.Exists)
+            .Select(path => Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/')));
+
+        return files.OrderBy(path => path, StringComparer.Ordinal).ToArray();
+    }
+
+    /// <summary>
+    /// The fenced C# blocks of one README, in the order they appear.
+    /// </summary>
+    /// <remarks>
+    /// Only <c>csharp</c> fences: a <c>shell</c> block installing a package and a <c>json</c> block of
+    /// settings are prose this gate has no compiler for, and counting them would inflate the remainder
+    /// with work nobody can do.
+    /// </remarks>
+    public static IReadOnlyList<IReadOnlyList<string>> Blocks(string path)
+    {
+        var blocks = new List<IReadOnlyList<string>>();
+        var current = new List<string>();
+        var inside = false;
+
+        foreach (var line in File.ReadAllLines(path))
+        {
+            var trimmed = line.Trim();
+
+            if (!inside)
+            {
+                if (trimmed is "```csharp" or "```cs")
+                {
+                    inside = true;
+                    current = [];
+                }
+
+                continue;
+            }
+
+            if (trimmed == "```")
+            {
+                inside = false;
+                blocks.Add(current);
+                continue;
+            }
+
+            current.Add(line);
+        }
+
+        if (inside)
+        {
+            throw new InvalidOperationException(
+                $"{path} opens a C# block that is never closed, so its blocks cannot be counted.");
+        }
+
+        return blocks;
+    }
+
+    /// <summary>
+    /// How many C# blocks the shipping READMEs carry between them.
+    /// </summary>
+    public static int BlockCount(string repositoryRoot) => Files(repositoryRoot)
+        .Sum(file => Blocks(Path.Combine(repositoryRoot, file)).Count);
+
+    /// <summary>
+    /// One enrolled sample, split into the imports it shows and the code under them.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The README has no block at that index, which means
+    /// the enrolment points at text that has been moved or deleted and is guarding nothing.</exception>
+    public static (IReadOnlyList<string> Usings, IReadOnlyList<string> Body) Read(
+        string repositoryRoot, ReadmeSample sample)
+    {
+        var path = Path.Combine(repositoryRoot, sample.Readme.Replace('/', Path.DirectorySeparatorChar));
+        var blocks = Blocks(path);
+
+        if (sample.Index >= blocks.Count)
+        {
+            throw new InvalidOperationException(
+                $"{sample} does not exist: that file carries {blocks.Count} C# block(s).");
+        }
+
+        return Split(blocks[sample.Index]);
+    }
+
+    /// <summary>
+    /// Separates a block's leading <c>using</c> directives from the code they serve.
+    /// </summary>
+    /// <remarks>
+    /// The two halves are checked differently and cannot be compared as one: a using directive is not
+    /// legal inside the method body a copy wraps its sample in, and an import the snippet omits is a
+    /// defect the body comparison cannot see. So the copy carries the imports at file scope, where the
+    /// compiler resolves them, and the body between markers, where the text is compared.
+    /// </remarks>
+    private static (IReadOnlyList<string> Usings, IReadOnlyList<string> Body) Split(
+        IReadOnlyList<string> block)
+    {
+        var usings = new List<string>();
+        var index = 0;
+
+        for (; index < block.Count; index++)
+        {
+            var line = block[index].Trim();
+
+            if (line.Length == 0)
+                continue;
+
+            if (!line.StartsWith("using ", StringComparison.Ordinal) || !line.EndsWith(';'))
+                break;
+
+            // A using STATEMENT opens a scope and belongs to the body; only a directive names a
+            // namespace, and the difference is the parenthesis rather than the keyword.
+            if (line.Contains('('))
+                break;
+
+            usings.Add(line[..^1]["using ".Length..].Trim());
+        }
+
+        return (usings, block.Skip(index).ToArray());
+    }
+}

--- a/tests/Abblix.DocSamples/ReadmeSampleTests.cs
+++ b/tests/Abblix.DocSamples/ReadmeSampleTests.cs
@@ -1,0 +1,187 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Xunit;
+
+namespace Abblix.DocSamples;
+
+/// <summary>
+/// The gate over the code samples that ship inside the packages, in the READMEs.
+/// </summary>
+/// <remarks>
+/// The same bargain as <see cref="DocSampleTests"/>: the compiler is the assertion, and it has already
+/// run by the time any row here does. What these rows add is what the compiler cannot see - that the
+/// compiled copy still says what the README says, that the copy leans only on names the reader's own
+/// project would have, and that the uncompiled remainder has not quietly grown.
+/// </remarks>
+public class ReadmeSampleTests
+{
+    /// <summary>
+    /// Every enrolled README sample and its copy carry the same lines, in the same order.
+    /// </summary>
+    /// <remarks>
+    /// Without this the copy compiles on happily while the README is edited around it, which is the
+    /// state every README in the repository was in until this project reached them.
+    /// </remarks>
+    [Fact]
+    public void EveryEnrolledSampleMatchesTheCopyTheCompilerChecked()
+    {
+        var root = RepositoryRoot();
+        var drifted = new List<string>();
+
+        foreach (var sample in Enrolment.ReadmeCompiled)
+        {
+            var (_, documented) = ReadmeSampleReader.Read(root, sample);
+            var compiled = Meaningful(Region(CopyOf(root, sample), "sample"));
+
+            if (!Meaningful(documented).SequenceEqual(compiled))
+            {
+                drifted.Add(
+                    $"{sample}: the README block and the copy's marked sample are not the same lines "
+                    + "in the same order");
+            }
+        }
+
+        Assert.Empty(drifted);
+    }
+
+    /// <summary>
+    /// A copy imports what its README shows, plus only what the web template would have imported anyway.
+    /// </summary>
+    /// <remarks>
+    /// The row that catches the defect this whole file was written for. A snippet compiles here because
+    /// the test project references every library at once; the reader has the packages the README told
+    /// them to install and the template's implicit usings, and nothing else. An import the copy adds
+    /// silently is an import the reader does not have, so the copy would build and their paste would
+    /// not - and an import the README shows but the copy drops is the mirror of it, a directive nobody
+    /// ever resolved.
+    /// <para>
+    /// Which is not a hypothetical: the quick-start carried <c>using Microsoft.IdentityModel.Tokens;</c>
+    /// for a constant that had moved into this library, and <c>Abblix.Jwt</c> states in its own package
+    /// description that it depends on no such package.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ACopyImportsWhatTheReadmeShowsAndOnlyAmbientNamesBesides()
+    {
+        var root = RepositoryRoot();
+        var wrong = new List<string>();
+
+        foreach (var sample in Enrolment.ReadmeCompiled)
+        {
+            var (documented, _) = ReadmeSampleReader.Read(root, sample);
+            var copy = CopyOf(root, sample);
+
+            var ambient = Namespaces(Region(copy, "ambient"));
+            var declared = Namespaces(File.ReadAllLines(copy)).Except(ambient, StringComparer.Ordinal);
+
+            if (!documented.OrderBy(name => name, StringComparer.Ordinal)
+                    .SequenceEqual(declared.OrderBy(name => name, StringComparer.Ordinal)))
+            {
+                wrong.Add(
+                    $"{sample}: the README shows [{string.Join(", ", documented)}] and the copy declares "
+                    + $"[{string.Join(", ", declared)}] outside its ambient region");
+            }
+
+            var invented = ambient
+                .Where(name => !ReadmeSampleReader.TemplateImplicitUsings.Contains(name))
+                .ToArray();
+
+            if (invented.Length > 0)
+            {
+                wrong.Add(
+                    $"{sample}: the copy calls [{string.Join(", ", invented)}] ambient, and the web "
+                    + "template imports no such namespace, so the reader would have to write it");
+            }
+        }
+
+        Assert.Empty(wrong);
+    }
+
+    /// <summary>
+    /// The uncompiled remainder is the number the enrolment states, and no other.
+    /// </summary>
+    /// <remarks>
+    /// A snippet added to a README is a snippet nobody has decided about, and this is what makes that
+    /// decision arrive: enrolling one without moving the number fails just as loudly as adding one.
+    /// </remarks>
+    [Fact]
+    public void TheUncompiledRemainderIsWhatTheEnrolmentSays()
+    {
+        var root = RepositoryRoot();
+        var files = ReadmeSampleReader.Files(root);
+
+        // Two controls. A root found wrong, or a src/ that stopped being walked, reports zero blocks and
+        // reads exactly like a repository whose READMEs carry no code - which is the shape every quiet
+        // failure of this kind takes.
+        Assert.Contains("README.md", files);
+        Assert.True(files.Count > 1, "only the repository's own README was found, so src/ went unread");
+
+        var total = ReadmeSampleReader.BlockCount(root);
+        Assert.True(total > Enrolment.ReadmeCompiled.Count, $"the READMEs carry {total} C# block(s)");
+
+        Assert.Equal(Enrolment.ReadmeUnenrolled, total - Enrolment.ReadmeCompiled.Count);
+    }
+
+    /// <summary>
+    /// The lines of a copy between a pair of markers.
+    /// </summary>
+    /// <remarks>
+    /// A copy without the markers is a copy nothing can check, so their absence is a failure rather than
+    /// an empty region - which would compare equal to nothing and pass.
+    /// </remarks>
+    private static IReadOnlyList<string> Region(string copyPath, string marker)
+    {
+        var lines = File.ReadAllLines(copyPath);
+        var begin = Array.FindIndex(lines, line => line.Trim() == $"// <{marker}>");
+        var end = Array.FindIndex(lines, line => line.Trim() == $"// </{marker}>");
+
+        if (begin < 0 || end < begin)
+            throw new InvalidOperationException($"{copyPath} carries no // <{marker}> region.");
+
+        return lines[(begin + 1)..end];
+    }
+
+    /// <summary>
+    /// The namespaces named by the using directives among these lines.
+    /// </summary>
+    private static IReadOnlyList<string> Namespaces(IEnumerable<string> lines) => lines
+        .Select(line => line.Trim())
+        .Where(line => line.StartsWith("using ", StringComparison.Ordinal) && line.EndsWith(';'))
+        .Select(line => line[..^1]["using ".Length..].Trim())
+        .ToArray();
+
+    /// <summary>
+    /// The lines that carry meaning: trimmed, with blank ones dropped.
+    /// </summary>
+    private static IReadOnlyList<string> Meaningful(IEnumerable<string> lines)
+        => lines.Select(line => line.Trim()).Where(line => line.Length > 0).ToArray();
+
+    /// <summary>
+    /// Where the compiled copy of a README sample lives.
+    /// </summary>
+    private static string CopyOf(string repositoryRoot, ReadmeSample sample) => Path.Combine(
+        repositoryRoot, "tests", "Abblix.DocSamples", "Samples", sample.Copy);
+
+    /// <summary>
+    /// The repository root, found by walking up from the test assembly until the sources are underneath.
+    /// </summary>
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(ReadmeSampleTests).Assembly.Location)!);
+
+        while (directory is not null && !Directory.Exists(Path.Combine(directory.FullName, "src")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new InvalidOperationException(
+            "No directory above the test assembly contains src/, so the READMEs cannot be read at all.");
+    }
+}

--- a/tests/Abblix.DocSamples/ReadmeSampleTests.cs
+++ b/tests/Abblix.DocSamples/ReadmeSampleTests.cs
@@ -116,9 +116,11 @@ public class ReadmeSampleTests
         var root = RepositoryRoot();
         var files = ReadmeSampleReader.Files(root);
 
-        // Two controls. A root found wrong, or a src/ that stopped being walked, reports zero blocks and
-        // reads exactly like a repository whose READMEs carry no code - which is the shape every quiet
-        // failure of this kind takes.
+        // Two controls, and each answers a different way of reading nothing. The repository's own
+        // README is listed only if it is really there, so the first row falls when the root is found
+        // wrong - which otherwise reads as a repository whose READMEs carry no code. The second is
+        // about the walk: src/ unread leaves exactly one file, and one file passes any assertion
+        // phrased as "some were found".
         Assert.Contains("README.md", files);
         Assert.True(files.Count > 1, "only the repository's own README was found, so src/ went unread");
 
@@ -150,10 +152,14 @@ public class ReadmeSampleTests
     /// <summary>
     /// The namespaces named by the using directives among these lines.
     /// </summary>
+    /// <remarks>
+    /// Through the same rule the reader applies to a README block, so a <c>using</c> that opens a scope
+    /// is not counted as an import on one side and skipped on the other.
+    /// </remarks>
     private static IReadOnlyList<string> Namespaces(IEnumerable<string> lines) => lines
-        .Select(line => line.Trim())
-        .Where(line => line.StartsWith("using ", StringComparison.Ordinal) && line.EndsWith(';'))
-        .Select(line => line[..^1]["using ".Length..].Trim())
+        .Select(ReadmeSampleReader.NamespaceOf)
+        .Where(name => name is not null)
+        .Select(name => name!)
         .ToArray();
 
     /// <summary>

--- a/tests/Abblix.DocSamples/Samples/ReadmeQuickstart.cs
+++ b/tests/Abblix.DocSamples/Samples/ReadmeQuickstart.cs
@@ -1,0 +1,43 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+// <ambient>
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+// </ambient>
+using Abblix.Jwt;
+using Abblix.Oidc.Server.Mvc;
+
+namespace Abblix.DocSamples.Samples;
+
+/// <summary>
+/// The compiled copy of the quick-start in the repository's README.
+/// </summary>
+/// <remarks>
+/// The imports above the ambient markers are the ones the README itself shows; the two inside them are
+/// what a project created from the web template gets without asking, and <c>ReadmeSampleTests</c> holds
+/// that region to the template's own list. A copy that quietly imports something the reader has not got
+/// would compile here and fail for them, which is exactly how the stale quick-start survived.
+/// </remarks>
+internal static class ReadmeQuickstartSample
+{
+    internal static void Configure(string[] args)
+    {
+        // <sample>
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Services.AddControllersWithViews();
+
+        // Turn your ASP.NET Core app into an OpenID Connect provider
+        builder.Services.AddOidcServices(options =>
+        {
+            options.LoginUri = new Uri("/Auth/Login", UriKind.Relative);
+            options.SigningKeys = new[] { JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature) };
+        });
+        // </sample>
+    }
+}


### PR DESCRIPTION
`Abblix.DocSamples` compiles the `<code>` blocks the compiler recorded from doc comments. Nothing reached the READMEs, and a README travels inside the package, so its snippets are read by every consumer and compiled by nobody. That is how the quick-start came to call `JsonWebKeyUseNames`, a constant belonging to a library `Abblix.Jwt` states it does not depend on, and shipped that way.

This extends the same mechanism to the READMEs that ship with the packages.

## What it does

- A README block is enrolled by file and position, and its text lives under `Samples/` as ordinary source, so the compiler answers first.
- `EveryEnrolledSampleMatchesTheCopyTheCompilerChecked` refuses the copy and the README to drift apart.
- `TheUncompiledRemainderIsWhatTheEnrolmentSays` counts the blocks nobody compiles, so a new snippet forces a decision instead of arriving in silence. Fifty-six blocks across sixteen files today, one enrolled.
- `ACopyImportsWhatTheReadmeShowsAndOnlyAmbientNamesBesides` is the row this defect asked for. A snippet compiles here because the test project references every library at once, while the reader has the packages the README named plus the web template's implicit usings. So a copy declares those ambient namespaces in a marked region, and the region is held to the template's own list.
- A fence is recognised by its first word, so one carrying attributes (```csharp title="Program.cs") opens a block and is counted rather than passing unseen. And the rule telling a using DIRECTIVE from a using STATEMENT is shared by both sides of the import comparison, so a scope-opening `using` is never read as a namespace.
- `DocSampleTests.EveryCopyIsNamedByAnEnrolment` now reads both enrolments, so a README copy is not reported as an orphan and does not need a second directory beyond that row's reach.

## Where the template's list comes from

Not from a literal. `tests/Abblix.DocSamples.WebTemplate` is a web-SDK project with no sources whose only job is to let MSBuild compute `@(Using)` and write it into an assembly attribute; the tests read that. A frozen list would be right on the day it was typed and would fail quietly afterwards: an import added to the template refuses a legitimate copy and is loud, one removed leaves a sample leaning on something the reader no longer has, with every row green. The companion ships nothing and documents nothing, so it is excluded from the two rows that count libraries and referenced projects.

## Evidence

Every row driven with the input it refuses, tree restored between runs:

| Mutation | Result |
|---|---|
| root README missing | 3 failed |
| companion stops reporting the list | 1 failed |
| README edited, copy left behind | 1 failed |
| copy imports what the README does not show | 1 failed |
| copy calls a namespace ambient that the template does not import | 1 failed |
| a titled fence nobody enrolled | 3 failed |
| tree restored | all pass |

And the claim the whole thing rests on, that this would have caught the defect: the shipped quick-start was put back with the copy kept in step, the way a careful author would have kept it. The build refuses it with `CS0234` on the import.

Two notes on instruments rather than on the gate. The first mutation script matched on `\n` against files stored with `\r\n`, so two of four edits were silent no-ops and reported a passing suite; each mutation now asserts that it changed the file. And the first version of `Files()` listed the repository's own README unconditionally, so the row asserting it is present was reading back a literal the method had just written - it goes through the same existence check as the rest now.

## What is not covered

Most of the remaining fifty-five blocks are fragments rather than pastable programs, so enrolling one means writing the wrapper that supplies its ambient names, exactly as a doc-comment sample does. A few are whole programs and are cheaper. The count is what keeps either from being forgotten.
