### PR TITLE
Warn each surface where that surface is mapped

### DIFF
--- a/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Abblix.SecurityEvents/Infrastructure/ServiceCollectionExtensions.cs
@@ -440,6 +440,15 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <remarks>
     /// <para>
+    /// What it does depends on the path, and the name promises more than one of them delivers. Where a
+    /// caller offers a token to be TRUSTED - a DPoP proof, a client assertion, a logout token - the
+    /// reservation is read, and a second use of one identifier is refused. On push delivery it is only a
+    /// record of what this receiver accepted: <c>PushDeliveryHandler</c> writes after the sink and reads
+    /// nothing, because RFC 8935 Section 2 lets a transmitter redeliver and
+    /// <see cref="Delivery.ISecurityEventSink"/> answers for that by requiring idempotent processing. Registering
+    /// this cache therefore makes deliveries auditable; it does not make a non-idempotent sink safe.
+    /// </para>
+    /// <para>
     /// The store itself is the host's choice and is deliberately not registered here:
     /// <c>AddDistributedMemoryCache()</c> gives a single-instance receiver process-local
     /// behavior, Redis or another backend gives a scaled-out one a shared memory - the same

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -439,8 +439,9 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// mapped.
     /// </summary>
     /// <remarks>
-    /// Both statements below are about creating and guarding streams, and a host may have that surface
-    /// without the document or the document without that surface: streams declared in configuration need
+    /// Both statements below are about the management routes - the scope filter guards every one of
+    /// them, reads and poll included, and the subjects mode decides what a stream created there covers.
+    /// A host may have that surface without the document or the document without that surface: streams declared in configuration need
     /// the document so a receiver can find them and never map the management routes, while a deployment
     /// whose canonical address is answered by a gateway maps the routes with
     /// <see cref="SharedSignalsEndpointOptions.MapWellKnownConfiguration"/> off. Attached to the document,

--- a/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
+++ b/src/Abblix.SharedSignals.MinimalApi/SharedSignalsEndpointRouteBuilderExtensions.cs
@@ -93,6 +93,11 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
             endpoints.MapSharedSignalsConfigurationDocument();
         }
 
+        WarnIfTheManagementApiIsOutsideTheCaepProfile(
+            endpoints.ServiceProvider,
+            endpoints.ServiceProvider.GetRequiredService<SharedSignalsTransmitterOptions>(),
+            endpointOptions);
+
         var group = endpoints.MapGroup(endpointOptions.ManagementPrefix.Value ?? string.Empty);
 
         // Every management response travels uncacheable, as the specification's own examples
@@ -270,7 +275,7 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         var options = endpoints.ServiceProvider.GetRequiredService<SharedSignalsTransmitterOptions>();
         var issuer = new Uri(options.Issuer, UriKind.Absolute);
 
-        WarnIfOutsideTheCaepProfile(endpoints.ServiceProvider, options);
+        WarnIfTheDocumentIsOutsideTheCaepProfile(endpoints.ServiceProvider, options);
         var advertisedPrefix = AdvertisedPrefixOf(endpointOptions);
 
         // Answers 200 and only 200: it takes no parameter to get wrong and no credentials to lack -
@@ -412,12 +417,10 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
     /// purpose and a warning it cannot act on is one it learns to ignore. A conformance run failing 2.3.7
     /// against a clean startup log is therefore possible, and this is the configuration that does it.
     /// </remarks>
-    private static void WarnIfOutsideTheCaepProfile(
+    private static void WarnIfTheDocumentIsOutsideTheCaepProfile(
         IServiceProvider services, SharedSignalsTransmitterOptions options)
     {
-        var logger = services.GetService<ILoggerFactory>()
-            ?.CreateLogger(typeof(SharedSignalsEndpointRouteBuilderExtensions));
-
+        var logger = LoggerOf(services);
         if (logger is null)
             return;
 
@@ -429,14 +432,40 @@ public static partial class SharedSignalsEndpointRouteBuilderExtensions
         // needing to know what.
         if (options.AuthorizationSchemes is { Count: > 0 } schemes && !schemes.Any(IsOAuth))
             LogOAuthSchemeNotAdvertised(logger, schemes.Count);
+    }
 
-        if ((services.GetService<SharedSignalsEndpointOptions>() ?? DefaultEndpointOptions)
-            .GrantedScopesSelector is null)
+    /// <summary>
+    /// The half of the profile check that is about the Stream Management API, run where that API is
+    /// mapped.
+    /// </summary>
+    /// <remarks>
+    /// Both statements below are about creating and guarding streams, and a host may have that surface
+    /// without the document or the document without that surface: streams declared in configuration need
+    /// the document so a receiver can find them and never map the management routes, while a deployment
+    /// whose canonical address is answered by a gateway maps the routes with
+    /// <see cref="SharedSignalsEndpointOptions.MapWellKnownConfiguration"/> off. Attached to the document,
+    /// these warnings were wrong in both directions at once - noise for the first host, silence for the
+    /// second - and the second is the one exposing stream creation.
+    /// </remarks>
+    private static void WarnIfTheManagementApiIsOutsideTheCaepProfile(
+        IServiceProvider services,
+        SharedSignalsTransmitterOptions options,
+        SharedSignalsEndpointOptions endpointOptions)
+    {
+        var logger = LoggerOf(services);
+        if (logger is null)
+            return;
+
+        if (endpointOptions.GrantedScopesSelector is null)
             LogScopeCheckingDisabled(logger);
 
         if (options.DefaultSubjectsMode is StreamSubjectsMode.None)
             LogNoSubjectsIncludedByDefault(logger);
     }
+
+    private static ILogger? LoggerOf(IServiceProvider services)
+        => services.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(SharedSignalsEndpointRouteBuilderExtensions));
 
     private static bool IsOAuth(JsonObject scheme)
         => scheme.TryGetPropertyValue(TransmitterConfiguration.ParameterNames.SpecUrn, out var urn)

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepWarningsReachTheirOwnSurfaceTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepWarningsReachTheirOwnSurfaceTests.cs
@@ -46,7 +46,7 @@ public sealed class CaepWarningsReachTheirOwnSurfaceTests
 
         await using var host = await StartAsync(recorder, app => app.MapSharedSignalsConfigurationDocument());
 
-        Assert.DoesNotContain(recorder.Warnings, message => message.Contains("scope"));
+        Assert.DoesNotContain(recorder.Warnings, message => message.Contains("GrantedScopesSelector"));
         Assert.DoesNotContain(recorder.Warnings, message => message.Contains("DefaultSubjectsMode"));
     }
 
@@ -78,8 +78,25 @@ public sealed class CaepWarningsReachTheirOwnSurfaceTests
             app => app.MapSharedSignalsTransmitterEndpoints(),
             new SharedSignalsEndpointOptions { MapWellKnownConfiguration = false });
 
-        Assert.Contains(recorder.Warnings, message => message.Contains("scope"));
+        Assert.Contains(recorder.Warnings, message => message.Contains("GrantedScopesSelector"));
         Assert.Contains(recorder.Warnings, message => message.Contains("DefaultSubjectsMode"));
+    }
+
+    /// <summary>
+    /// A host with both surfaces hears each warning once. This is the row a later edit would break by
+    /// moving the management checks back under the document, where they would then fire twice for the
+    /// host that maps both.
+    /// </summary>
+    [Fact]
+    public async Task AHostMappingBothSurfaces_HearsEachWarningOnce()
+    {
+        var recorder = new RecordingProvider();
+
+        await using var host = await StartAsync(recorder, app => app.MapSharedSignalsTransmitterEndpoints());
+
+        Assert.Equal(1, recorder.Warnings.Count(message => message.Contains("jwks_uri")));
+        Assert.Equal(1, recorder.Warnings.Count(message => message.Contains("GrantedScopesSelector")));
+        Assert.Equal(1, recorder.Warnings.Count(message => message.Contains("DefaultSubjectsMode")));
     }
 
     private static async Task<WebApplication> StartAsync(

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepWarningsReachTheirOwnSurfaceTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepWarningsReachTheirOwnSurfaceTests.cs
@@ -1,0 +1,166 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using Abblix.Jwt;
+using Abblix.SecurityEvents.Infrastructure;
+using Abblix.SharedSignals.Infrastructure;
+using Abblix.SharedSignals.MinimalApi;
+using Abblix.SharedSignals.Model;
+using Abblix.SharedSignals.Transmitter;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Abblix.SharedSignals.E2E.Tests;
+
+/// <summary>
+/// Each startup warning reaches the host that has the surface it is about, and no other.
+/// </summary>
+/// <remarks>
+/// The two surfaces are mapped by separate calls and a host may map either alone. A transmitter whose
+/// streams come from configuration maps the document, because that is how a receiver finds it, and never
+/// maps the management routes; a transmitter behind a gateway that answers the canonical address maps the
+/// management routes with <c>MapWellKnownConfiguration</c> off. A warning attached to the wrong call is
+/// wrong in both directions at once: noise for the first host, silence for the second, and the second is
+/// the one exposing stream creation.
+/// </remarks>
+public sealed class CaepWarningsReachTheirOwnSurfaceTests
+{
+    private const string Issuer = "https://transmitter.example";
+
+    /// <summary>
+    /// The document alone: a host with no management routes hears nothing about scope checking or the
+    /// default subjects mode, because it creates no streams and exposes no API to guard.
+    /// </summary>
+    [Fact]
+    public async Task AHostMappingOnlyTheDocument_IsNotWarnedAboutTheManagementApi()
+    {
+        var recorder = new RecordingProvider();
+
+        await using var host = await StartAsync(recorder, app => app.MapSharedSignalsConfigurationDocument());
+
+        Assert.DoesNotContain(recorder.Warnings, message => message.Contains("scope"));
+        Assert.DoesNotContain(recorder.Warnings, message => message.Contains("DefaultSubjectsMode"));
+    }
+
+    /// <summary>
+    /// The control for the row above: the same host DOES hear what the document itself is missing, so an
+    /// empty warning list cannot pass for "the right warnings were suppressed".
+    /// </summary>
+    [Fact]
+    public async Task AHostMappingOnlyTheDocument_IsStillWarnedAboutTheDocument()
+    {
+        var recorder = new RecordingProvider();
+
+        await using var host = await StartAsync(recorder, app => app.MapSharedSignalsConfigurationDocument());
+
+        Assert.Contains(recorder.Warnings, message => message.Contains("jwks_uri"));
+    }
+
+    /// <summary>
+    /// The management routes without the document: the host exposing stream creation with no scope check
+    /// is told so, which is the case that used to start in silence.
+    /// </summary>
+    [Fact]
+    public async Task AHostMappingTheManagementApiWithoutTheDocument_IsWarnedAboutScopeChecking()
+    {
+        var recorder = new RecordingProvider();
+
+        await using var host = await StartAsync(
+            recorder,
+            app => app.MapSharedSignalsTransmitterEndpoints(),
+            new SharedSignalsEndpointOptions { MapWellKnownConfiguration = false });
+
+        Assert.Contains(recorder.Warnings, message => message.Contains("scope"));
+        Assert.Contains(recorder.Warnings, message => message.Contains("DefaultSubjectsMode"));
+    }
+
+    private static async Task<WebApplication> StartAsync(
+        ILoggerProvider recorder,
+        Action<WebApplication> map,
+        SharedSignalsEndpointOptions? endpointOptions = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(recorder);
+
+        builder.Services.AddSecurityEvents(o =>
+            o.SigningKeySource = _ => Task.FromResult<JsonWebKey>(
+                JsonWebKeyFactory.CreateRsa(PublicKeyUsages.Signature, SigningAlgorithms.RS256)));
+
+        // Deliberately outside the profile on every count the checks look at, so each row below asserts
+        // which warning ARRIVES rather than which configuration is clean: no jwks_uri, no scope selector,
+        // and new streams covering no subject.
+        builder.Services.AddSharedSignalsTransmitter(new SharedSignalsTransmitterOptions
+        {
+            Issuer = Issuer,
+            DefaultSubjectsMode = StreamSubjectsMode.None,
+        });
+
+        if (endpointOptions is not null)
+        {
+            builder.Services.AddSingleton(endpointOptions);
+        }
+
+        var app = builder.Build();
+        map(app);
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class RecordingProvider : ILoggerProvider
+    {
+        private readonly List<string> _warnings = [];
+
+        public IReadOnlyList<string> Warnings
+        {
+            get
+            {
+                lock (_warnings) return _warnings.ToArray();
+            }
+        }
+
+        public ILogger CreateLogger(string categoryName) => new Recorder(_warnings);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class Recorder(List<string> warnings) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                    return;
+
+                lock (warnings) warnings.Add(formatter(state, exception));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/Abblix.SharedSignals.E2E.Tests/CaepWarningsReachTheirOwnSurfaceTests.cs
+++ b/tests/Abblix.SharedSignals.E2E.Tests/CaepWarningsReachTheirOwnSurfaceTests.cs
@@ -84,8 +84,9 @@ public sealed class CaepWarningsReachTheirOwnSurfaceTests
 
     /// <summary>
     /// A host with both surfaces hears each warning once. This is the row a later edit would break by
-    /// moving the management checks back under the document, where they would then fire twice for the
-    /// host that maps both.
+    /// duplicating the management checks under the document while leaving them where they are, so the
+    /// host that maps both hears them twice. Moving them back is a different edit, caught by the two
+    /// single-surface rows above.
     /// </summary>
     [Fact]
     public async Task AHostMappingBothSurfaces_HearsEachWarningOnce()


### PR DESCRIPTION
Closes #528.

Two of the four CAEP startup checks describe the Stream Management API, and all four ran from the mapping of the configuration document. The surfaces are mapped by separate calls, so the two reached the wrong hosts in both directions.

## What was wrong

A transmitter whose streams come from `AddSharedSignalsConfiguredStreams` maps the document, because that is how a receiver finds it, and never maps the management routes. It was warned that an API it does not expose is unguarded, and that streams it never creates would cover no subject. Neither warning is actionable there: a scope selector configures a check nothing runs, and `DefaultSubjectsMode` is read only by `StreamManagementService`, while a configured stream carries its own `SubjectsMode`.

The reverse case matters more. `MapSharedSignalsTransmitterEndpoints` maps the document only when `MapWellKnownConfiguration` is true, and that option exists for the deployment whose canonical address is answered by a gateway. With it off, the management API is mapped and the check never ran at all: stream creation exposed with no scope check, starting in silence.

## What changed

`jwks_uri` and `authorization_schemes` stay with the document. The scope selector and the default subjects mode move to the mapping of the management routes and run there whether or not the document travels alongside.

## Evidence

The reproduction is committed first and is not edited by the fix. Before the change two of its three rows failed and the third passed:

| Row | Before | After |
|---|---|---|
| document-only host is not warned about the management API | failed | passes |
| document-only host is still warned about `jwks_uri` (control) | passed | passes |
| management API without the document is warned about scope checking | failed | passes |

The control is what keeps the fix honest: a change that simply silenced the warnings would turn the middle row red.

A fourth row was added afterwards and pins the host that maps both surfaces: it hears each warning exactly once. Two edits were driven against it to establish what it guards. Duplicating the management checks under the document while leaving them in place turns it red, along with the document-only row. Moving them under the document instead leaves it green and turns the two single-surface rows red. So the fourth row guards the duplicate, and the two older rows guard the move.

Suites: `Abblix.SharedSignals.E2E.Tests` 80, `Abblix.SharedSignals.UnitTests` 216, `Abblix.SecurityEvents.UnitTests` 300, all passing.

## Also here

One comment-only commit on `AddDistributedReplayCache`. Its name reads as a device that refuses repeats, which it is where a token is offered to be trusted, and is not on push delivery: there `PushDeliveryHandler` writes after the sink and reads nothing. The summary now says which of the two a reader is getting.
