### PR TITLE
Move the dev-build line to 3.0 and name the target frameworks once

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,12 @@
        early, the range they float on stops being filled by anybody and the fix they are waiting for
        silently never arrives - the restore keeps resolving, to the last build before the move.
 
+       A line ABANDONED rather than cut is the other way it moves, and the reason is the same read
+       backwards: nobody is waiting for a release that will not happen, so leaving the property
+       behind would publish this work under a number it will never ship as. Before moving it that
+       way, look for consumers floating on the abandoned range - a range with none is why the move
+       costs nothing, and a range with some is the case the paragraph above is about.
+
        MinVerDefaultPreReleaseIdentifiers replaces the default "alpha.0" with "dev.0", so the
        range a consumer floats on reads MAJOR.MINOR.0-dev.* and cannot be confused with an alpha. A
        tagged release drops the suffix by itself.
@@ -67,7 +73,7 @@
        zero patch, which is right whatever the tags do: NuGet floats only the release label, so a
        range written as MAJOR.MINOR.0-dev.* cannot resolve a MAJOR.MINOR.1 build. -->
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>2.5</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
     <MinVerDefaultPreReleaseIdentifiers>dev.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
+++ b/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
+++ b/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.Oidc.Server.AspNetCore/Abblix.Oidc.Server.AspNetCore.csproj
+++ b/src/Abblix.Oidc.Server.AspNetCore/Abblix.Oidc.Server.AspNetCore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/Abblix.Oidc.Server.SourceGenerators.MinimalApi/Abblix.Oidc.Server.SourceGenerators.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.SourceGenerators.MinimalApi/Abblix.Oidc.Server.SourceGenerators.MinimalApi.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <!-- Overrides the shipped set from src/Directory.Build.props: a source generator loads
+             into the compiler, which runs on netstandard2.0. -->
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Abblix.Oidc.Server.SourceGenerators.Mvc/Abblix.Oidc.Server.SourceGenerators.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.SourceGenerators.Mvc/Abblix.Oidc.Server.SourceGenerators.Mvc.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <!-- Overrides the shipped set from src/Directory.Build.props: a source generator loads
+             into the compiler, which runs on netstandard2.0. -->
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
+++ b/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <!-- Chain to the repository-wide props, for the reason spelled out under tests/: MSBuild stops
+       searching upward at the FIRST Directory.Build.props it finds, so without this import every
+       project under src/ would silently lose TreatWarningsAsErrors, MinVer and the Sonar analyzer. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
+
+  <!-- The frameworks the packages ship, in one place rather than repeated in every project. A
+       per-project copy is an enumeration, and an enumeration is escaped silently: a project added
+       later ships fewer frameworks than the rest and nothing says so, while a project MISSED by a
+       change to the set keeps building the old one and stays green. The two source generators
+       override this - they load into the compiler and must be netstandard2.0. -->
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
+++ b/tests/Abblix.DependencyInjection.UnitTests/Abblix.DependencyInjection.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj
+++ b/tests/Abblix.DocSamples.WebTemplate/Abblix.DocSamples.WebTemplate.csproj
@@ -16,7 +16,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
+++ b/tests/Abblix.DocSamples/Abblix.DocSamples.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.Jwt.Azure.UnitTests/Abblix.Jwt.Azure.UnitTests.csproj
+++ b/tests/Abblix.Jwt.Azure.UnitTests/Abblix.Jwt.Azure.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
+++ b/tests/Abblix.Jwt.UnitTests/Abblix.Jwt.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj
+++ b/tests/Abblix.Jwt.Vault.UnitTests/Abblix.Jwt.Vault.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/Abblix.Oidc.Server.AspNetCore.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/Abblix.Oidc.Server.AspNetCore.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.E2E.TestHost/Abblix.Oidc.Server.E2E.TestHost.csproj
+++ b/tests/Abblix.Oidc.Server.E2E.TestHost/Abblix.Oidc.Server.E2E.TestHost.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Abblix.Oidc.Server.E2E.Tests.csproj
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Abblix.Oidc.Server.E2E.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Abblix.Oidc.Server.MinimalApi.E2E.TestHost.csproj
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.TestHost/Abblix.Oidc.Server.MinimalApi.E2E.TestHost.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests.csproj
+++ b/tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests/Abblix.Oidc.Server.MinimalApi.E2E.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.MinimalApi.UnitTests/Abblix.Oidc.Server.MinimalApi.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.MinimalApi.UnitTests/Abblix.Oidc.Server.MinimalApi.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.Mvc.UnitTests/Abblix.Oidc.Server.Mvc.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/Abblix.SecurityEvents.CAEP.UnitTests/Abblix.SecurityEvents.CAEP.UnitTests.csproj
+++ b/tests/Abblix.SecurityEvents.CAEP.UnitTests/Abblix.SecurityEvents.CAEP.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.SecurityEvents.E2E.Tests/Abblix.SecurityEvents.E2E.Tests.csproj
+++ b/tests/Abblix.SecurityEvents.E2E.Tests/Abblix.SecurityEvents.E2E.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.SecurityEvents.RISC.UnitTests/Abblix.SecurityEvents.RISC.UnitTests.csproj
+++ b/tests/Abblix.SecurityEvents.RISC.UnitTests/Abblix.SecurityEvents.RISC.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj
+++ b/tests/Abblix.SecurityEvents.UnitTests/Abblix.SecurityEvents.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.SharedSignals.E2E.Tests/Abblix.SharedSignals.E2E.Tests.csproj
+++ b/tests/Abblix.SharedSignals.E2E.Tests/Abblix.SharedSignals.E2E.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.SharedSignals.Redis.UnitTests/Abblix.SharedSignals.Redis.UnitTests.csproj
+++ b/tests/Abblix.SharedSignals.Redis.UnitTests/Abblix.SharedSignals.Redis.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
+++ b/tests/Abblix.SharedSignals.UnitTests/Abblix.SharedSignals.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
+++ b/tests/Abblix.Utils.UnitTests/Abblix.Utils.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -14,6 +14,13 @@
        with the import and without it and nothing here can show it doing any work. -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
+  <!-- The suites run on one framework, named here for the same reason the shipped set is named
+       once under src/: a project added later inherits it, and a project missed by a change to it
+       would keep running the old one and stay green. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
   <!-- The compiler resolves a <see cref="..."/> only while it is generating the documentation
        file. Without this, a cref naming a member that exists nowhere compiles clean, so a comment
        pointing at a deleted or renamed member reads as a live pointer and the explanation behind


### PR DESCRIPTION
Two steps toward 3.0, both true whatever order the rest of the work lands in.

## The line dev builds publish under

The 2.5 line is abandoned rather than released: what accumulated for it ships as 3.0. Left where it was, this work would publish under a number it will never ship as.

The comment beside the property forbids moving it, and for a good reason that does not cover this case: it is about a line still being PREPARED, where the people floating on the range are waiting for exactly the work that would stop reaching them. An abandoned line is that argument read backwards, and the check it owes is whether anyone floats on the range being left behind. Nothing here does - the samples reference released packages. The comment now says so, because a reader finding the property moved would otherwise conclude the move was a mistake.

Verified off the built assembly rather than the property, since the property is not the version: `3.0.0-dev.0.492`.

## The target frameworks

The shipped set was written out in sixteen projects and the suites' framework in twenty-two more, with nothing tying them together. A per-project copy is an enumeration, and an enumeration is escaped silently in both directions: a project added later ships fewer frameworks than the rest and nothing says so, while a project missed by a change to the set keeps building the old one and stays green. The props file under `tests/` already argues exactly this for the documentation setting.

The two source generators now override rather than coincide. They are netstandard2.0 because they load into the compiler, and written out among the others that read as a third opinion about the set rather than as an exception to it.

## Evidence

After this change the project files no longer say what they build, so reading them proves nothing. The forty project-and-framework pairs MSBuild RESOLVES are identical before and after.

| Mutation | What it showed |
|---|---|
| a framework dropped in the one place | all sixteen shipped projects moved, the suites and the generators did not |

That is the whole claim of the change - one place to change - driven rather than asserted.

The solution builds with no warnings.
