### PR TITLE
Move Result onto a C# union

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,11 @@ trim_trailing_whitespace = false
 
 [*.cs]
 csharp_style_namespace_declarations = file_scoped:suggestion
+
+# One Sonar rule CRASHES on a union declaration rather than reporting anything: the analyzer throws
+# NullReferenceException, which arrives as AD0001 and fails the build here, where warnings are errors.
+# Reproduced on the newest analyzer available as well, so it is a gap in the tool rather than a stale
+# pin. Scoped to the file that declares a union rather than turned off everywhere - the list growing is
+# the reminder that this is owed back to the analyzer, not a decision to stop checking.
+[src/Abblix.Utils/Result.cs]
+dotnet_diagnostic.S1117.severity = none

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -62,11 +62,14 @@ jobs:
           # job keeps building on the old SDK, green, until something needs the new one. The
           # version itself still moves by hand, but it moves in one place.
           #
-          # That file also turns roll-forward OFF, which is what makes "the same SDK" true rather
-          # than nearly true: with it on, the runner installed a whole feature band ahead of the
-          # version named, and the difference surfaced as an obsoletion that reproduces only on the
-          # SDK the runner chose: red here, green wherever the named version was the one installed,
-          # for a reason no diff contained.
+          # That file also sets roll-forward to "disable", which is what makes "the same SDK" true
+          # rather than nearly true. This action treats one literal value specially: on
+          # "latestFeature" it drops the pinned build and installs the newest one on that channel,
+          # which was a later prerelease of the same feature band. The difference surfaced as an
+          # obsoletion reproducing only on the SDK the runner chose - red here, green wherever the
+          # named version was the one installed, for a reason no diff contained. The tell is the
+          # "--channel" argument in this step own log rather than a version comparison: the two
+          # builds carry the same band, so comparing them says nothing happened.
           global-json-file: global.json
         timeout-minutes: 3
       - name: Cache NuGet packages

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -64,8 +64,9 @@ jobs:
           #
           # That file also turns roll-forward OFF, which is what makes "the same SDK" true rather
           # than nearly true: with it on, the runner installed a whole feature band ahead of the
-          # version named, and the difference surfaced as an obsoletion nobody could reproduce -
-          # a build red here and green on every machine, for a reason no diff contained.
+          # version named, and the difference surfaced as an obsoletion that reproduces only on the
+          # SDK the runner chose: red here, green wherever the named version was the one installed,
+          # for a reason no diff contained.
           global-json-file: global.json
         timeout-minutes: 3
       - name: Cache NuGet packages

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -60,8 +60,12 @@ jobs:
           # global.json names, which is the same file the local build resolves against. Naming a
           # version in each workflow is an enumeration - one of them is missed by a bump and that
           # job keeps building on the old SDK, green, until something needs the new one. The
-          # version itself still moves by hand - global.json names an exact build and the action
-          # installs that one - but it moves in one place.
+          # version itself still moves by hand, but it moves in one place.
+          #
+          # That file also turns roll-forward OFF, which is what makes "the same SDK" true rather
+          # than nearly true: with it on, the runner installed a whole feature band ahead of the
+          # version named, and the difference surfaced as an obsoletion nobody could reproduce -
+          # a build red here and green on every machine, for a reason no diff contained.
           global-json-file: global.json
         timeout-minutes: 3
       - name: Cache NuGet packages

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,16 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!-- Unions are a C# 15 feature and C# 15 has not shipped, so the compiler does not recognise the
+       keyword at all without this - the failure is "Identifier expected" at the declaration, which
+       reads as a syntax error in our code rather than as a language version. It comes out when the
+       language ships, and until then it also admits every other preview feature, which is the cost:
+       nothing stops a preview feature from being used by accident, and a preview feature can still
+       change under us. -->
+  <PropertyGroup>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
   <!-- MinVer derives PackageVersion / AssemblyVersion / FileVersion / InformationalVersion
        from git tags. The latest tag sets the base; commits since it bump the patch and
        append the height and the pre-release suffix.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,11 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <!-- No SourceLink package: the SDK has carried it since .NET 8, and the properties that drive it
+         (PublishRepositoryUrl, EmbedUntrackedSources) live in each project as before. Referencing it
+         explicitly pulls Microsoft.Build.Tasks.Git in, which carries an advisory - and with auditing
+         set to fail on a low-severity finding, a restore against fresh advisory data turns every
+         packable project red. -->
     <!-- xunit.v3 picks the Microsoft Testing Platform major version by package variant: the plain
          xunit.v3 metapackage targets MTP v1, while xunit.v3.mtp-v2 targets MTP v2. We reference the
          mtp-v2 variant (below) so the current Microsoft.Testing.Extensions.*, which require MTP 2.x,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,11 +37,9 @@
          ContinuousIntegrationBuild, which is what makes the shipped map portable rather than keyed on
          the directory it was built in.
 
-         Referencing it explicitly pulls in a Microsoft.Build.Tasks.Git carrying a MODERATE advisory,
-         which auditing reports at every level up to moderate - so raising NuGetAuditLevel does not
-         answer it, and what turns the report into a failure is TreatWarningsAsErrors in
-         Directory.Build.props. A restore against fresh advisory data then fails every packable
-         project; a warm cache holding advisory data older than the advisory hides it. -->
+         Referencing it explicitly pulls in a Microsoft.Build.Tasks.Git carrying a moderate advisory,
+         and warnings are errors here, so a restore against fresh advisory data fails every packable
+         project. A warm cache holding advisory data older than the advisory hides that. -->
     <!-- xunit.v3 picks the Microsoft Testing Platform major version by package variant: the plain
          xunit.v3 metapackage targets MTP v1, while xunit.v3.mtp-v2 targets MTP v2. We reference the
          mtp-v2 variant (below) so the current Microsoft.Testing.Extensions.*, which require MTP 2.x,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,8 +38,10 @@
          the directory it was built in.
 
          Referencing it explicitly pulls in a Microsoft.Build.Tasks.Git carrying a moderate advisory,
-         and warnings are errors here, so a restore against fresh advisory data fails every packable
-         project. A warm cache holding advisory data older than the advisory hides that. -->
+         and this repository audits from low upward with warnings as errors, so a restore against fresh
+         advisory data fails each project that references it. Both halves are needed: raising the audit
+         level past moderate restores clean, at the cost of every other moderate finding in the graph.
+         A warm cache holding advisory data older than the advisory hides all of it. -->
     <!-- xunit.v3 picks the Microsoft Testing Platform major version by package variant: the plain
          xunit.v3 metapackage targets MTP v1, while xunit.v3.mtp-v2 targets MTP v2. We reference the
          mtp-v2 variant (below) so the current Microsoft.Testing.Extensions.*, which require MTP 2.x,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,10 +33,15 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <!-- No SourceLink package: the SDK has carried it since .NET 8, and the properties that drive it
-         (PublishRepositoryUrl, EmbedUntrackedSources) live in each project as before. Referencing it
-         explicitly pulls Microsoft.Build.Tasks.Git in, which carries an advisory - and with auditing
-         set to fail on a low-severity finding, a restore against fresh advisory data turns every
-         packable project red. -->
+         live in each project as before - PublishRepositoryUrl and EmbedUntrackedSources, and
+         ContinuousIntegrationBuild, which is what makes the shipped map portable rather than keyed on
+         the directory it was built in.
+
+         Referencing it explicitly pulls in a Microsoft.Build.Tasks.Git carrying a MODERATE advisory,
+         which auditing reports at every level up to moderate - so raising NuGetAuditLevel does not
+         answer it, and what turns the report into a failure is TreatWarningsAsErrors in
+         Directory.Build.props. A restore against fresh advisory data then fails every packable
+         project; a warm cache holding advisory data older than the advisory hides it. -->
     <!-- xunit.v3 picks the Microsoft Testing Platform major version by package variant: the plain
          xunit.v3 metapackage targets MTP v1, while xunit.v3.mtp-v2 targets MTP v2. We reference the
          mtp-v2 variant (below) so the current Microsoft.Testing.Extensions.*, which require MTP 2.x,

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.7.26381.103",
-    "rollForward": "latestFeature",
+    "version": "11.0.100-rc.1.26425.128",
+    "rollForward": "disable",
     "allowPrerelease": true
   },
   "test": {

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -33,7 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
+++ b/src/Abblix.DependencyInjection/Abblix.DependencyInjection.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
+++ b/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
+++ b/src/Abblix.Jwt.Azure/Abblix.Jwt.Azure.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
+++ b/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
@@ -34,7 +34,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
+++ b/src/Abblix.Jwt.Vault/Abblix.Jwt.Vault.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.Jwt/Abblix.Jwt.csproj
+++ b/src/Abblix.Jwt/Abblix.Jwt.csproj
@@ -37,7 +37,6 @@
          service needs. Options carries IOptions<>, which the ring reads its rollover window from.
          Caching.Abstractions carries only IDistributedCache, the store the replay cache reserves identifiers
          in; the store itself is the host's to register. -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.Jwt/ExternalKeys/KeyPlacementChoice.cs
+++ b/src/Abblix.Jwt/ExternalKeys/KeyPlacementChoice.cs
@@ -12,8 +12,8 @@ namespace Abblix.Jwt.ExternalKeys;
 /// than at the first key operation.
 /// </summary>
 /// <remarks>
-/// Riding the options-validation pipeline is what buys the timing: <c>ValidateOnStart</c> registers an
-/// <c>IStartupValidator</c>, and the host runs it BEFORE it starts any hosted service, including the one that
+/// Riding the options-validation pipeline is what buys the timing: <c>ValidateOnStart</c> registers a
+/// startup validator, and the host runs it BEFORE it starts any hosted service, including the one that
 /// opens the HTTP port. A hosted service of our own would only run once that port is already open. The state
 /// lives here rather than on <c>OidcOptions</c> because validating those would resolve the key provider, which
 /// itself depends on those same options.

--- a/src/Abblix.Jwt/JsonArrayExtensions.cs
+++ b/src/Abblix.Jwt/JsonArrayExtensions.cs
@@ -31,6 +31,7 @@ public static class JsonArrayExtensions
     /// </summary>
     /// <param name="details">The wrapper sequence, or <c>null</c>.</param>
     /// <returns>A fresh <see cref="JsonArray"/>, or <c>null</c> when the input is <c>null</c>.</returns>
+    [return: NotNullIfNotNull(nameof(details))]
     public static JsonArray? ToRawJsonArray(this IEnumerable<AuthorizationDetail>? details)
     {
         if (details is null) return null;

--- a/src/Abblix.Oidc.Server.AspNetCore/Abblix.Oidc.Server.AspNetCore.csproj
+++ b/src/Abblix.Oidc.Server.AspNetCore/Abblix.Oidc.Server.AspNetCore.csproj
@@ -9,6 +9,15 @@
              part of each adapter's NuGet package (its assembly is embedded into them), never as a standalone
              package, so it is deliberately not packable. -->
         <IsPackable>false</IsPackable>
+        <!-- Not packable, but its assembly and its symbols ship inside the two adapter packages, so it owes
+             what every shipped assembly owes: symbols a consumer can step into, and none of this machine in
+             them. Without these the symbol file carries the directory it was built in, and a debugger that
+             steps into this code finds no source to show. -->
+        <Deterministic>true</Deterministic>
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Abblix.Oidc.Server.AspNetCore/Abblix.Oidc.Server.AspNetCore.csproj
+++ b/src/Abblix.Oidc.Server.AspNetCore/Abblix.Oidc.Server.AspNetCore.csproj
@@ -9,14 +9,6 @@
              part of each adapter's NuGet package (its assembly is embedded into them), never as a standalone
              package, so it is deliberately not packable. -->
         <IsPackable>false</IsPackable>
-        <!-- Not packable, but its assembly and its symbols ship inside the two adapter packages, so it owes
-             what every shipped assembly owes: symbols a consumer can step into, and none of this machine in
-             them. Without these the symbol file carries the directory it was built in, and a debugger that
-             steps into this code finds no source to show. -->
-        <Deterministic>true</Deterministic>
-        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
     </PropertyGroup>
 

--- a/src/Abblix.Oidc.Server.AspNetCore/AuthenticationSchemeAdapter.cs
+++ b/src/Abblix.Oidc.Server.AspNetCore/AuthenticationSchemeAdapter.cs
@@ -265,8 +265,10 @@ public class AuthenticationSchemeAdapter(
 		// empty and then serialising it puts two questions to something another request can change in
 		// between: empty at the first and filled at the second writes nothing at all, so the session
 		// comes back naming nobody and every client it touched is gone from the logout it drives.
-		// Walked rather than copied out of, because copying asks the size and then fills an array of
-		// that size, which is the same two questions again.
+		// This read asks the size too, but only as a capacity hint the answer does not depend on: what
+		// comes back is what the walk yielded. Copying out instead fills an array of the size that was
+		// answered, so a collection that has since grown overflows it and one that answered zero comes
+		// back empty however much it holds.
 		var affectedClientIds = authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal);
 		if (affectedClientIds.Count > 0)
 			properties.SetString(nameof(AuthSession.AffectedClientIds), JsonSerializer.Serialize(affectedClientIds));

--- a/src/Abblix.Oidc.Server.AspNetCore/AuthenticationSchemeAdapter.cs
+++ b/src/Abblix.Oidc.Server.AspNetCore/AuthenticationSchemeAdapter.cs
@@ -261,8 +261,15 @@ public class AuthenticationSchemeAdapter(
 		var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, authSession.IdentityProvider));
 
 		var properties = new AuthenticationProperties();
-		if (authSession is { AffectedClientIds.Count: > 0 })
-			properties.SetString(nameof(AuthSession.AffectedClientIds), JsonSerializer.Serialize(authSession.AffectedClientIds));
+		// Read once, and the decision made from what was read. Asking the live collection whether it is
+		// empty and then serialising it puts two questions to something another request can change in
+		// between: empty at the first and filled at the second writes nothing at all, so the session
+		// comes back naming nobody and every client it touched is gone from the logout it drives.
+		// Walked rather than copied out of, because copying asks the size and then fills an array of
+		// that size, which is the same two questions again.
+		var affectedClientIds = authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal);
+		if (affectedClientIds.Count > 0)
+			properties.SetString(nameof(AuthSession.AffectedClientIds), JsonSerializer.Serialize(affectedClientIds));
 
 		return HttpContext.SignInAsync(authenticationScheme, principal, properties);
 	}

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -41,7 +41,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
         <PackageReference Include="System.Linq.Async" />
         <PackageReference Update="SonarAnalyzer.CSharp">
           <PrivateAssets>all</PrivateAssets>

--- a/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
+++ b/src/Abblix.Oidc.Server.MinimalApi/Abblix.Oidc.Server.MinimalApi.csproj
@@ -25,13 +25,7 @@
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-        <!-- Deterministic builds for reproducible binaries -->
-        <Deterministic>true</Deterministic>
-        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-        <!-- SourceLink for symbol packages -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -41,7 +41,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
         <PackageReference Update="SonarAnalyzer.CSharp">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
+++ b/src/Abblix.Oidc.Server.Mvc/Abblix.Oidc.Server.Mvc.csproj
@@ -25,13 +25,7 @@
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-        <!-- Deterministic builds for reproducible binaries -->
-        <Deterministic>true</Deterministic>
-        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-        <!-- SourceLink for symbol packages -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -21,13 +21,7 @@
         <PackageIcon>Abblix.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-        <!-- Deterministic builds for reproducible binaries -->
-        <Deterministic>true</Deterministic>
-        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-        <!-- SourceLink for symbol packages -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>

--- a/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
+++ b/src/Abblix.Oidc.Server/Abblix.Oidc.Server.csproj
@@ -53,7 +53,6 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
       <PackageReference Include="Microsoft.Extensions.Http" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
       <PackageReference Update="SonarAnalyzer.CSharp">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -222,13 +222,17 @@ public class AuthorizationRequestProcessor(
 
 		// Mark the client as affected by this session and update the session's state.
 		// Ensures the client is tied to the current session, updating its state to include the session's client ID.
-		// Built from what was read before the provider saw the session, so the answer says what this
-		// server knows the session touches. The live session is still the thing that gets persisted -
-		// what a store keeps is its own business - but it is not what this response is derived from.
-		var clientIsNewToTheSession = !alreadyAffected.Contains(clientId);
-		string[] affectedClientIds = clientIsNewToTheSession ? [..alreadyAffected, clientId] : alreadyAffected;
+		// What the response tells the client to watch, built from the copy taken before the provider saw
+		// the session: this answer says what this server knows the session touches, and the provider is
+		// not one of the things it learns that from.
+		string[] affectedClientIds = alreadyAffected.Contains(clientId)
+			? alreadyAffected
+			: [..alreadyAffected, clientId];
 
-		if (clientIsNewToTheSession)
+		// Whether the session still has to be written asks the LIVE session instead, because it is a
+		// question about what is missing NOW: this list is what logout iterates to reach each client, so a
+		// provider that dropped the entry has to have it put back rather than be taken at its word.
+		if (!authSession.AffectedClientIds.Contains(clientId))
 		{
 			authSession.AffectedClientIds.Add(clientId);
 			await authSessionService.SignInAsync(authSession);

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -128,17 +128,27 @@ public class AuthorizationRequestProcessor(
 
 		// Retrieve user consents (i.e., permissions granted for requested scopes/resources/authorization_details).
 		// The 'prompt=consent' case is not forgotten but processed inside this call.
-		// lent deliberately AffectedClientIds: what the provider leaves in this list is compared against
-		// the copy above, and whatever it took out goes back before anything else runs.
-		var userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
+		UserConsents userConsents;
+		try
+		{
+			// lent deliberately AffectedClientIds: what the provider leaves in this list is compared
+			// against the copy above, and whatever it took out goes back below, whichever way this ends.
+			userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
+		}
+		finally
+		{
+			// Put back whatever the provider took out of the list of clients this session touches, before
+			// anything else can happen. That list is what logout iterates to reach each client, and the
+			// provider was never asked about the clients already on it. Only ever ADDED to: an entry the
+			// provider put there stays, since removing it would lose a client for the same reason.
+			//
+			// In a finally, because a throw is the one way out of here that no return below covers, and a
+			// host that keeps the session object between requests would carry the provider's edit onward
+			// with nothing left to undo it.
+			foreach (var id in alreadyAffected.Where(id => !authSession.AffectedClientIds.Contains(id)))
+				authSession.AffectedClientIds.Add(id);
+		}
 
-		foreach (var id in alreadyAffected.Where(id => !authSession.AffectedClientIds.Contains(id)))
-			authSession.AffectedClientIds.Add(id);
-
-		// Put back whatever the provider took out of the list of clients this session touches, before
-		// anything else can return. That list is what logout iterates to reach each client, and the
-		// provider was never asked about the clients already on it. Only ever ADDED to: an entry the
-		// provider put there stays, since removing it would lose a client for the same reason.
 		// If consent for required scopes, resources, or authorization_details is still pending, handle it.
 		if (userConsents.Pending is { Scopes.Length: > 0 }
 			or { Resources.Length: > 0 }
@@ -234,12 +244,15 @@ public class AuthorizationRequestProcessor(
 		if (!authSession.AffectedClientIds.Contains(clientId))
 			authSession.AffectedClientIds.Add(clientId);
 
-		// Written whenever the session carries more than the copy taken before the provider saw it, which
-		// is what the store handed over. Asked as one question about the SESSION rather than about this
-		// client: a provider that named another client changed the object and told the store nothing, and
-		// that client is then missing from logout exactly like one this request would have added. Nothing
-		// above removes and nothing adds twice, so a difference is a difference in count.
-		if (authSession.AffectedClientIds.Count != alreadyAffected.Length)
+		// Written whenever the session names a client the copy did not, and the copy is what the store
+		// handed over. Asked as one question about the SESSION rather than about this client: a provider
+		// that named another client changed the object and told the store nothing, and that client is then
+		// missing from logout exactly like one this request would have added.
+		//
+		// Compared as sets, because who the session touches is a set even where the collection holding
+		// them is not: a list that arrived carrying one client twice must not read as changed, and must
+		// not read as shortened when a provider drops one of the copies.
+		if (!authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal).SetEquals(alreadyAffected))
 			await authSessionService.SignInAsync(authSession);
 
 		// What the response tells the client to watch: what this server knows the session touches, which is

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -106,6 +106,16 @@ public class AuthorizationRequestProcessor(
 					$"Unexpected number of auth sessions: {authSessions.Count} or prompt: {model.Prompt}");
 		}
 
+		// What the request asked for, read BEFORE the provider sees it. The provider is a host seam and it
+		// is handed the array this request carries, while every decision below is measured against that same
+		// array: whether the end user denied everything, what the granted set is checked against, and what
+		// is emitted when the provider has no opinion of its own. A provider that narrows by editing what it
+		// was given - which is how narrowing is written throughout this repository - would otherwise move the
+		// yardstick it is being measured by, and an emptied request reads exactly like one that never asked.
+		var requestedDetails = request.AuthorizationDetails is { } asRequested
+			? (JsonArray)asRequested.DeepClone()
+			: null;
+
 		// Retrieve user consents (i.e., permissions granted for requested scopes/resources/authorization_details).
 		// The 'prompt=consent' case is not forgotten but processed inside this call.
 		var userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
@@ -139,7 +149,7 @@ public class AuthorizationRequestProcessor(
 		//                                           -> user denied every entry; fail with access_denied.
 		//   Granted.AuthorizationDetails is non-empty -> explicit consent (possibly narrowed); emit as-is.
 		if (userConsents.Granted.AuthorizationDetails is { Count: 0 }
-			&& request.AuthorizationDetails is { Count: > 0 })
+			&& requestedDetails is { Count: > 0 })
 		{
 			return new AuthorizationError(
 				model,
@@ -155,8 +165,12 @@ public class AuthorizationRequestProcessor(
 		// browser tampering it failed to intersect against the request), so it surfaces as an
 		// exception rather than an escalated grant. Symmetric with the strictly narrowing-only
 		// TokenAuthorizationContextEvaluator at the token endpoint.
+		// Handed what was asked for rather than what the provider left behind: the backstop measures the
+		// granted set against the request, and the provider it is policing can reach that array.
 		var enforcedAuthorizationDetails = await consentConstraintEnforcer.EnforceAsync(
-			request, userConsents.Granted, CancellationToken.None);
+			request with { AuthorizationDetails = requestedDetails },
+			userConsents.Granted,
+			CancellationToken.None);
 
 		// C2 (PR #135 review): the JsonArray reference passed to the consent provider and the
 		// one placed on AuthorizationContext travel through System.Text.Json on the way to the
@@ -164,7 +178,7 @@ public class AuthorizationRequestProcessor(
 		// child of its own DTO, the second serialise will throw because the JsonNode is parented
 		// twice. DeepClone defensively on the boundary so the two consumers each see independent
 		// trees -- matches the DeepClone discipline applied elsewhere (ApplyTo, resolvers).
-		var sourceAd = enforcedAuthorizationDetails ?? request.AuthorizationDetails;
+		var sourceAd = enforcedAuthorizationDetails ?? requestedDetails;
 		var emittedAuthorizationDetails = sourceAd is { Count: > 0 }
 			? (JsonArray?)sourceAd.DeepClone()
 			: null;

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -132,13 +132,13 @@ public class AuthorizationRequestProcessor(
 		// the copy above, and whatever it took out goes back before anything else runs.
 		var userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
 
+		foreach (var id in alreadyAffected.Where(id => !authSession.AffectedClientIds.Contains(id)))
+			authSession.AffectedClientIds.Add(id);
+
 		// Put back whatever the provider took out of the list of clients this session touches, before
 		// anything else can return. That list is what logout iterates to reach each client, and the
 		// provider was never asked about the clients already on it. Only ever ADDED to: an entry the
 		// provider put there stays, since removing it would lose a client for the same reason.
-		foreach (var id in alreadyAffected.Where(id => !authSession.AffectedClientIds.Contains(id)))
-			authSession.AffectedClientIds.Add(id);
-
 		// If consent for required scopes, resources, or authorization_details is still pending, handle it.
 		if (userConsents.Pending is { Scopes.Length: > 0 }
 			or { Resources.Length: > 0 }
@@ -227,15 +227,18 @@ public class AuthorizationRequestProcessor(
 			AuthorizationDetails = emittedAuthorizationDetails,
 		};
 
-		// Mark the client as affected by this session and update the session's state.
-		// Ensures the client is tied to the current session, updating its state to include the session's client ID.
-		authSession.AffectedClientIds.Add(clientId);
+		// Mark the client as affected by this session, once. The shipped session holds a set, so a second
+		// copy would be dropped for us - but the collection is public and a host may supply a list, and
+		// then every request appends another entry that is persisted and turns into another front-channel
+		// logout call for the same client.
+		if (!authSession.AffectedClientIds.Contains(clientId))
+			authSession.AffectedClientIds.Add(clientId);
 
-		// Written whenever the session now carries more than the store was holding. Asked as one question
-		// about the SESSION rather than about this client: a provider that named another client changed the
-		// object and told the store nothing, and that client is then missing from logout exactly like one
-		// this request would have added. The restore above only adds, so a difference is a difference in
-		// count.
+		// Written whenever the session carries more than the copy taken before the provider saw it, which
+		// is what the store handed over. Asked as one question about the SESSION rather than about this
+		// client: a provider that named another client changed the object and told the store nothing, and
+		// that client is then missing from logout exactly like one this request would have added. Nothing
+		// above removes and nothing adds twice, so a difference is a difference in count.
 		if (authSession.AffectedClientIds.Count != alreadyAffected.Length)
 			await authSessionService.SignInAsync(authSession);
 

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -126,11 +126,13 @@ public class AuthorizationRequestProcessor(
 		// Which clients this session already touches, read before the provider is handed the session.
 		string[] alreadyAffected = [..authSession.AffectedClientIds];
 
-		// Retrieve user consents (i.e., permissions granted for requested scopes/resources/authorization_details).
-		// The 'prompt=consent' case is not forgotten but processed inside this call.
 		UserConsents userConsents;
 		try
 		{
+			// Retrieve user consents (i.e., permissions granted for requested
+			// scopes/resources/authorization_details). The 'prompt=consent' case is not forgotten but
+			// processed inside this call.
+			//
 			// lent deliberately AffectedClientIds: what the provider leaves in this list is compared
 			// against the copy above, and whatever it took out goes back below, whichever way this ends.
 			userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
@@ -251,7 +253,9 @@ public class AuthorizationRequestProcessor(
 		//
 		// Compared as sets, because who the session touches is a set even where the collection holding
 		// them is not: a list that arrived carrying one client twice must not read as changed, and must
-		// not read as shortened when a provider drops one of the copies.
+		// not read as shortened when a provider drops one of the copies. Ordinal, matching the comparer
+		// the shipped session uses - taking the host collection's instead would put its own idea of
+		// sameness between this answer and the store's.
 		if (!authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal).SetEquals(alreadyAffected))
 			await authSessionService.SignInAsync(authSession);
 

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -128,8 +128,8 @@ public class AuthorizationRequestProcessor(
 
 		// Retrieve user consents (i.e., permissions granted for requested scopes/resources/authorization_details).
 		// The 'prompt=consent' case is not forgotten but processed inside this call.
-		// lent deliberately AffectedClientIds: what touches this list after the call is the write that
-		// gets persisted, and every answer derived from it below comes from the copy taken above.
+		// lent deliberately AffectedClientIds: what the provider left in this list is compared against
+		// what the copy above says, and the difference is put back before anything is written.
 		var userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
 
 		// If consent for required scopes, resources, or authorization_details is still pending, handle it.
@@ -222,21 +222,29 @@ public class AuthorizationRequestProcessor(
 
 		// Mark the client as affected by this session and update the session's state.
 		// Ensures the client is tied to the current session, updating its state to include the session's client ID.
-		// What the response tells the client to watch, built from the copy taken before the provider saw
-		// the session: this answer says what this server knows the session touches, and the provider is
-		// not one of the things it learns that from.
+		// What this server knows the session touches: the copy taken before the provider saw it, plus this
+		// client. It is what the response tells the client to watch, and it is what the stored session has
+		// to carry - the provider was handed the live object and is not one of the things this is learnt
+		// from.
 		string[] affectedClientIds = alreadyAffected.Contains(clientId)
 			? alreadyAffected
 			: [..alreadyAffected, clientId];
 
-		// Whether the session still has to be written asks the LIVE session instead, because it is a
-		// question about what is missing NOW: this list is what logout iterates to reach each client, so a
-		// provider that dropped the entry has to have it put back rather than be taken at its word.
-		if (!authSession.AffectedClientIds.Contains(clientId))
-		{
-			authSession.AffectedClientIds.Add(clientId);
+		// Restored into the live session, and only ever ADDED to. This list is what logout iterates to
+		// reach each client, so an entry the provider dropped goes back; an entry the provider added stays,
+		// because removing it would lose a client for exactly the same reason.
+		var missing = affectedClientIds
+			.Where(id => !authSession.AffectedClientIds.Contains(id))
+			.ToArray();
+
+		foreach (var id in missing)
+			authSession.AffectedClientIds.Add(id);
+
+		// Written when the STORED session did not name this client, or when the live one was missing
+		// anything above: a provider that added the client itself changed the object and told the store
+		// nothing, which is the same client absent from logout as one the provider removed.
+		if (!alreadyAffected.Contains(clientId) || missing.Length > 0)
 			await authSessionService.SignInAsync(authSession);
-		}
 
 		// Initialize a successful authentication result. GrantedScopes carries the consent-narrowed
 		// scope set (identical to what the issued token carries) so the response encoder advertises the

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -242,7 +242,7 @@ public class AuthorizationRequestProcessor(
 		// Mark the client as affected by this session, once. The shipped session holds a set, so a second
 		// copy would be dropped for us - but the collection is public and a host may supply a list, and
 		// then every request appends another entry that is persisted, so the stored session grows without
-		// bound and a host reading it back is handed one client named many times.
+		// bound.
 		if (!authSession.AffectedClientIds.Contains(clientId))
 			authSession.AffectedClientIds.Add(clientId);
 

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -128,9 +128,16 @@ public class AuthorizationRequestProcessor(
 
 		// Retrieve user consents (i.e., permissions granted for requested scopes/resources/authorization_details).
 		// The 'prompt=consent' case is not forgotten but processed inside this call.
-		// lent deliberately AffectedClientIds: what the provider left in this list is compared against
-		// what the copy above says, and the difference is put back before anything is written.
+		// lent deliberately AffectedClientIds: what the provider leaves in this list is compared against
+		// the copy above, and whatever it took out goes back before anything else runs.
 		var userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
+
+		// Put back whatever the provider took out of the list of clients this session touches, before
+		// anything else can return. That list is what logout iterates to reach each client, and the
+		// provider was never asked about the clients already on it. Only ever ADDED to: an entry the
+		// provider put there stays, since removing it would lose a client for the same reason.
+		foreach (var id in alreadyAffected.Where(id => !authSession.AffectedClientIds.Contains(id)))
+			authSession.AffectedClientIds.Add(id);
 
 		// If consent for required scopes, resources, or authorization_details is still pending, handle it.
 		if (userConsents.Pending is { Scopes.Length: > 0 }
@@ -222,29 +229,22 @@ public class AuthorizationRequestProcessor(
 
 		// Mark the client as affected by this session and update the session's state.
 		// Ensures the client is tied to the current session, updating its state to include the session's client ID.
-		// What this server knows the session touches: the copy taken before the provider saw it, plus this
-		// client. It is what the response tells the client to watch, and it is what the stored session has
-		// to carry - the provider was handed the live object and is not one of the things this is learnt
-		// from.
+		authSession.AffectedClientIds.Add(clientId);
+
+		// Written whenever the session now carries more than the store was holding. Asked as one question
+		// about the SESSION rather than about this client: a provider that named another client changed the
+		// object and told the store nothing, and that client is then missing from logout exactly like one
+		// this request would have added. The restore above only adds, so a difference is a difference in
+		// count.
+		if (authSession.AffectedClientIds.Count != alreadyAffected.Length)
+			await authSessionService.SignInAsync(authSession);
+
+		// What the response tells the client to watch: what this server knows the session touches, which is
+		// the copy taken before the provider saw it plus this client. The provider is not one of the things
+		// that is learnt from.
 		string[] affectedClientIds = alreadyAffected.Contains(clientId)
 			? alreadyAffected
 			: [..alreadyAffected, clientId];
-
-		// Restored into the live session, and only ever ADDED to. This list is what logout iterates to
-		// reach each client, so an entry the provider dropped goes back; an entry the provider added stays,
-		// because removing it would lose a client for exactly the same reason.
-		var missing = affectedClientIds
-			.Where(id => !authSession.AffectedClientIds.Contains(id))
-			.ToArray();
-
-		foreach (var id in missing)
-			authSession.AffectedClientIds.Add(id);
-
-		// Written when the STORED session did not name this client, or when the live one was missing
-		// anything above: a provider that added the client itself changed the object and told the store
-		// nothing, which is the same client absent from logout as one the provider removed.
-		if (!alreadyAffected.Contains(clientId) || missing.Length > 0)
-			await authSessionService.SignInAsync(authSession);
 
 		// Initialize a successful authentication result. GrantedScopes carries the consent-narrowed
 		// scope set (identical to what the issued token carries) so the response encoder advertises the

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -256,7 +256,11 @@ public class AuthorizationRequestProcessor(
 		// not read as shortened when a provider drops one of the copies. Ordinal, matching the comparer
 		// the shipped session uses - taking the host collection's instead would put its own idea of
 		// sameness between this answer and the store's.
-		if (!authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal).SetEquals(alreadyAffected))
+		// Taken the same way the copy above was, rather than walked: a host collection is not required to
+		// be safe against another thread, and enumerating one that is being changed throws where reading
+		// its count could not - after this client was added and before the store hears about it.
+		string[] nowAffected = [..authSession.AffectedClientIds];
+		if (!nowAffected.ToHashSet(StringComparer.Ordinal).SetEquals(alreadyAffected))
 			await authSessionService.SignInAsync(authSession);
 
 		// What the response tells the client to watch: what this server knows the session touches, which is

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -241,8 +241,8 @@ public class AuthorizationRequestProcessor(
 
 		// Mark the client as affected by this session, once. The shipped session holds a set, so a second
 		// copy would be dropped for us - but the collection is public and a host may supply a list, and
-		// then every request appends another entry that is persisted and turns into another front-channel
-		// logout call for the same client.
+		// then every request appends another entry that is persisted, so the stored session grows without
+		// bound and a host reading it back is handed one client named many times.
 		if (!authSession.AffectedClientIds.Contains(clientId))
 			authSession.AffectedClientIds.Add(clientId);
 

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -124,7 +124,7 @@ public class AuthorizationRequestProcessor(
 			: null;
 
 		// Which clients this session already touches, read before the provider is handed the session.
-		string[] alreadyAffected = [..authSession.AffectedClientIds];
+		var alreadyAffected = authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal);
 
 		UserConsents userConsents;
 		try
@@ -256,18 +256,20 @@ public class AuthorizationRequestProcessor(
 		// not read as shortened when a provider drops one of the copies. Ordinal, matching the comparer
 		// the shipped session uses - taking the host collection's instead would put its own idea of
 		// sameness between this answer and the store's.
-		// Taken the same way the copy above was, rather than walked: a host collection is not required to
-		// be safe against another thread, and enumerating one that is being changed throws where reading
-		// its count could not - after this client was added and before the store hears about it.
-		string[] nowAffected = [..authSession.AffectedClientIds];
-		if (!nowAffected.ToHashSet(StringComparer.Ordinal).SetEquals(alreadyAffected))
+		// Walked rather than copied out of, the same way the read above it is. Copying asks the
+		// collection its size and then fills an array of that size, which fails outright when a second
+		// request added a client in between; walking asks for a view, which the shipped collection always
+		// gives and never refuses. The window is the worst one available: this client is already on the
+		// session and the store has not been told.
+		var nowAffected = authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal);
+		if (!nowAffected.SetEquals(alreadyAffected))
 			await authSessionService.SignInAsync(authSession);
 
 		// What the response tells the client to watch: what this server knows the session touches, which is
 		// the copy taken before the provider saw it plus this client. The provider is not one of the things
 		// that is learnt from.
 		string[] affectedClientIds = alreadyAffected.Contains(clientId)
-			? alreadyAffected
+			? [..alreadyAffected]
 			: [..alreadyAffected, clientId];
 
 		// Initialize a successful authentication result. GrantedScopes carries the consent-narrowed

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/AuthorizationRequestProcessor.cs
@@ -116,8 +116,20 @@ public class AuthorizationRequestProcessor(
 			? (JsonArray)asRequested.DeepClone()
 			: null;
 
+		// The response types this request was validated for, read the same way and for the same reason:
+		// they decide which builders run, and the loop that reads them runs long after the provider held
+		// the request.
+		string[]? responseType = request.Model.ResponseType is { } asValidated
+			? [..asValidated]
+			: null;
+
+		// Which clients this session already touches, read before the provider is handed the session.
+		string[] alreadyAffected = [..authSession.AffectedClientIds];
+
 		// Retrieve user consents (i.e., permissions granted for requested scopes/resources/authorization_details).
 		// The 'prompt=consent' case is not forgotten but processed inside this call.
+		// lent deliberately AffectedClientIds: what touches this list after the call is the write that
+		// gets persisted, and every answer derived from it below comes from the copy taken above.
 		var userConsents = await consentsProvider.GetUserConsentsAsync(request, authSession);
 
 		// If consent for required scopes, resources, or authorization_details is still pending, handle it.
@@ -165,6 +177,12 @@ public class AuthorizationRequestProcessor(
 		// browser tampering it failed to intersect against the request), so it surfaces as an
 		// exception rather than an escalated grant. Symmetric with the strictly narrowing-only
 		// TokenAuthorizationContextEvaluator at the token endpoint.
+		// What the end user granted, read before the backstop runs. It is a seam of its own and it is
+		// handed the granted set to check, so the scopes and resources the token carries are taken from
+		// the answer rather than from what the check left behind.
+		ScopeDefinition[] grantedScopes = [..userConsents.Granted.Scopes];
+		ResourceDefinition[] grantedResources = [..userConsents.Granted.Resources];
+
 		// Handed what was asked for rather than what the provider left behind: the backstop measures the
 		// granted set against the request, and the provider it is policing can reach that array.
 		var enforcedAuthorizationDetails = await consentConstraintEnforcer.EnforceAsync(
@@ -190,8 +208,8 @@ public class AuthorizationRequestProcessor(
 		// the flow.
 		var authContext = new AuthorizationContext(
 			clientId,
-			userConsents.Granted.Scopes,
-			userConsents.Granted.Resources,
+			grantedScopes,
+			grantedResources,
 			model.Claims)
 		{
 			RedirectUri = model.RedirectUri,
@@ -204,7 +222,13 @@ public class AuthorizationRequestProcessor(
 
 		// Mark the client as affected by this session and update the session's state.
 		// Ensures the client is tied to the current session, updating its state to include the session's client ID.
-		if (!authSession.AffectedClientIds.Contains(clientId))
+		// Built from what was read before the provider saw the session, so the answer says what this
+		// server knows the session touches. The live session is still the thing that gets persisted -
+		// what a store keeps is its own business - but it is not what this response is derived from.
+		var clientIsNewToTheSession = !alreadyAffected.Contains(clientId);
+		string[] affectedClientIds = clientIsNewToTheSession ? [..alreadyAffected, clientId] : alreadyAffected;
+
+		if (clientIsNewToTheSession)
 		{
 			authSession.AffectedClientIds.Add(clientId);
 			await authSessionService.SignInAsync(authSession);
@@ -217,7 +241,7 @@ public class AuthorizationRequestProcessor(
 			model,
 			request.ResponseMode,
 			authSession.SessionId,
-			authSession.AffectedClientIds)
+			affectedClientIds)
 		{
 			GrantedScopes = authContext.Scope,
 		};
@@ -234,7 +258,7 @@ public class AuthorizationRequestProcessor(
 		// with unsupported_response_type.
 		foreach (var processor in responseProcessors)
 		{
-			if (!request.Model.ResponseType.HasFlag(processor.ResponseType))
+			if (!responseType.HasFlag(processor.ResponseType))
 				continue;
 
 			await processor.BuildResponseAsync(request, authorizedGrant, result);

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/ConsentConstraintEnforcer.cs
@@ -114,27 +114,16 @@ public class ConsentConstraintEnforcer(
                 revalidation.GetFailure().ErrorDescription);
         }
 
-        // Nothing at all means nothing to change, which is how the request-time, CIBA and device
-        // validators read the same result, so the granted array stands as it was - but it is re-checked
-        // all the same. A validator that narrows by editing the entry IN PLACE, which is what every
-        // narrowing fixture in this repository does, has already written into this array by the time it
-        // answers, and the types read before the call are the only untouched copy of what was granted.
-        if (revalidated is null)
-        {
-            RefuseTypesOutside(grantedTypes, grantedAuthorizationDetails, nameof(IAuthorizationDetailsPolicy));
-            return grantedAuthorizationDetails;
-        }
-
-        // An EMPTY array is a different statement, and this request has already decided what it means:
-        // a consent decision granting no entries against a request that carried some answers
-        // access_denied, one step before this call. Reaching here with one says the validators removed
-        // every entry, so returning the granted set would put back exactly what they removed.
+        // The call above is guarded on a non-empty granted set, and this request has already decided
+        // what an empty answer means: a consent decision granting no entries against a request that
+        // carried some answers access_denied, one step before this call. So reaching here with one says
+        // the validators removed every entry, and returning the granted set would put back exactly what
+        // they removed.
         if (revalidated.Count == 0)
         {
             throw new InvalidOperationException(
-                "The per-type re-validation of the granted authorization_details returned an empty set. " +
-                "A policy signals 'nothing to change' by returning null; an empty array says every entry " +
-                "was removed, and there is no set left to issue a grant for.");
+                "The per-type re-validation of the granted authorization_details returned an empty set, " +
+                "so every entry was removed and there is no set left to issue a grant for.");
         }
 
         // What comes back is the decision, not a copy of what went in: a validator narrowing an entry

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
@@ -25,6 +25,10 @@ public class AuthorizationDetailsRequestValidator(
     /// <inheritdoc/>
     public async Task<AuthorizationRequestValidationError?> ValidateAsync(AuthorizationValidationContext context)
     {
+        // Counted before the call, because the policy is handed this very array and a validator
+        // that narrows by editing in place empties it as it answers.
+        var requested = context.Request.AuthorizationDetails is { Count: > 0 };
+
         var result = await policy.ApplyAsync(
             context.Request.AuthorizationDetails,
             context.ClientInfo,
@@ -35,7 +39,7 @@ public class AuthorizationDetailsRequestValidator(
 
         if (validated.Count > 0)
             context.AuthorizationDetails = validated;
-        else if (context.Request.AuthorizationDetails is { Count: > 0 })
+        else if (requested)
             throw AuthorizationDetailsPolicyContract.EveryEntryDropped();
         return null;
     }

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
@@ -33,7 +33,7 @@ public class AuthorizationDetailsRequestValidator(
         if (!result.TryGetSuccess(out var validated))
             return context.InvalidAuthorizationDetails(result.GetFailure().ErrorDescription);
 
-        if (validated is not null)
+        if (validated.Count > 0)
             context.AuthorizationDetails = validated;
         return null;
     }

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
@@ -25,8 +25,8 @@ public class AuthorizationDetailsRequestValidator(
     /// <inheritdoc/>
     public async Task<AuthorizationRequestValidationError?> ValidateAsync(AuthorizationValidationContext context)
     {
-        // Counted before the call, because the policy is handed this very array and a validator
-        // that narrows by editing in place empties it as it answers.
+        // Whether the request carried any, read before the call: the policy is handed this very
+        // array, and a validator that narrows by editing in place empties it as it answers.
         var requested = context.Request.AuthorizationDetails is { Count: > 0 };
 
         var result = await policy.ApplyAsync(

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidator.cs
@@ -35,6 +35,8 @@ public class AuthorizationDetailsRequestValidator(
 
         if (validated.Count > 0)
             context.AuthorizationDetails = validated;
+        else if (context.Request.AuthorizationDetails is { Count: > 0 })
+            throw AuthorizationDetailsPolicyContract.EveryEntryDropped();
         return null;
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/RequestedSubjectValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Authorization/Validation/RequestedSubjectValidator.cs
@@ -45,7 +45,9 @@ public class RequestedSubjectValidator : SyncAuthorizationContextValidatorBase
         if (requested.TryGetFailure(out var reason))
             return context.InvalidRequest(reason);
 
-        context.RequestedSubjects = requested.GetSuccess();
+        // An empty set means the request named nobody in particular, and the session filter reads an
+        // absent constraint rather than an empty one - an empty array there would accept nobody.
+        context.RequestedSubjects = requested.GetSuccess() is { Length: > 0 } subjects ? subjects : null;
         return null;
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -191,10 +191,10 @@ public class BackChannelAuthenticationRequestProcessor(
 	/// what survives is their intersection - possibly nothing, which is the guaranteed mismatch Section 5.5.1
 	/// already prescribes an outcome for.
 	/// <para>
-	/// A malformed <c>claims</c> qualifier cannot be reported from here, because this runs after the request
-	/// was validated; the validator pipeline refuses one before anything reaches this method, so a failure
-	/// arriving here would mean the pipeline had changed underneath it. Treated as naming nobody, which
-	/// refuses rather than admits.
+	/// A <c>claims</c> qualifier that is malformed, or that no end user can satisfy, cannot be reported from
+	/// here, because this runs after the request was validated; the validator pipeline refuses either one
+	/// before anything reaches this method, so a failure arriving here would mean the pipeline had changed
+	/// underneath it. Treated as naming nobody, which refuses rather than admits.
 	/// </para>
 	/// </remarks>
 	private static string[]? NamedSubjects(ValidBackChannelAuthenticationRequest request)

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -63,6 +63,16 @@ public class BackChannelAuthenticationRequestProcessor(
 	{
 		request.ClientInfo.CheckClientLicense();
 
+		// Read before the handler sees the request. The handler is a host seam holding this very request,
+		// and both answers below are what the REQUEST said: whom it named, and what it asked for. A handler
+		// that narrows by editing what it was given - the way narrowing is written throughout this
+		// repository - would otherwise erase the record of both, leaving the end-user check with nobody to
+		// enforce and the widening check at completion measuring against an empty set.
+		var namedSubjects = NamedSubjects(request);
+		var requestedDetails = request.AuthorizationDetails is { } asRequested
+			? (JsonArray)asRequested.DeepClone()
+			: null;
+
 		var authResult = await userDeviceAuthenticationHandler.InitiateAuthenticationAsync(request);
 		if (authResult.TryGetFailure(out var error))
 		{
@@ -94,7 +104,6 @@ public class BackChannelAuthenticationRequestProcessor(
 		// Two parameters can name an end user and OpenID Connect Core 1.0 Section 3.1.2.2 puts both under one
 		// requirement, so both bind. Their intersection is what survives, which is the same answer the
 		// authorization endpoint reaches by filtering candidate sessions through one and then the other.
-		var namedSubjects = NamedSubjects(request);
 
 		// Answered now, because the session a handler returns here names the end user it is about to reach,
 		// not one who has already answered - the request is stored Pending either way. A handler intending
@@ -123,7 +132,7 @@ public class BackChannelAuthenticationRequestProcessor(
 			// RFC 9396 section 3: authorization_details from the CIBA request carries onto the
 			// grant byte-exact, so the access token issued via the CIBA grant emits the
 			// claim through the same pipeline as the authorization-code flow.
-			AuthorizationDetails = request.AuthorizationDetails,
+			AuthorizationDetails = requestedDetails,
 		};
 
 		var authorizedGrant = new AuthorizedGrant(authSession, authContext);
@@ -155,7 +164,7 @@ public class BackChannelAuthenticationRequestProcessor(
 			// An EMPTY array when the request carried none, never null: null is what a request written by
 			// a build without this field reads back as, and the two must not be confused. Denying such a
 			// request would refuse, mid-upgrade, every in-flight authentication the user had approved.
-			RequestedAuthorizationDetails = request.AuthorizationDetails is { } requested
+			RequestedAuthorizationDetails = requestedDetails is { } requested
 				? (JsonArray)requested.DeepClone()
 				: [],
 

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Abblix.Oidc.Server.Common;
 using Abblix.Oidc.Server.Common.Configuration;
@@ -72,6 +73,11 @@ public class BackChannelAuthenticationRequestProcessor(
 		var requestedDetails = request.AuthorizationDetails is { } asRequested
 			? (JsonArray)asRequested.DeepClone()
 			: null;
+		ScopeDefinition[] requestedScope = [..request.Scope];
+		ResourceDefinition[] requestedResources = [..request.Resources];
+		var requestedClaims = request.Model.Claims is { } claims
+			? JsonSerializer.Deserialize<RequestedClaims>(JsonSerializer.Serialize(claims))
+			: null;
 
 		var authResult = await userDeviceAuthenticationHandler.InitiateAuthenticationAsync(request);
 		if (authResult.TryGetFailure(out var error))
@@ -125,9 +131,9 @@ public class BackChannelAuthenticationRequestProcessor(
 
 		var authContext = new AuthorizationContext(
 			request.ClientInfo.ClientId,
-			request.Scope,
-			request.Resources,
-			request.Model.Claims)
+			requestedScope,
+			requestedResources,
+			requestedClaims)
 		{
 			// RFC 9396 section 3: authorization_details from the CIBA request carries onto the
 			// grant byte-exact, so the access token issued via the CIBA grant emits the

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessor.cs
@@ -202,7 +202,9 @@ public class BackChannelAuthenticationRequestProcessor(
 		var hinted = request.IdToken?.Payload.Subject is { Length: > 0 } named ? new[] { named } : null;
 
 		var requested = request.Model.Claims.RequestedSubjects();
-		var accepted = requested.TryGetSuccess(out var subjects) ? subjects : [];
+		var accepted = requested.Match<string[]?>(
+			subjects => subjects.Length > 0 ? subjects : null,
+			_ => []);
 
 		return (hinted, accepted) switch
 		{

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
@@ -26,8 +26,8 @@ public class BackChannelAuthorizationDetailsValidator(
     /// <inheritdoc/>
     public async Task<OidcError?> ValidateAsync(BackChannelAuthenticationValidationContext context)
     {
-        // Counted before the call, because the policy is handed this very array and a validator
-        // that narrows by editing in place empties it as it answers.
+        // Whether the request carried any, read before the call: the policy is handed this very
+        // array, and a validator that narrows by editing in place empties it as it answers.
         var requested = context.Request.AuthorizationDetails is { Count: > 0 };
 
         var result = await policy.ApplyAsync(

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
@@ -26,6 +26,10 @@ public class BackChannelAuthorizationDetailsValidator(
     /// <inheritdoc/>
     public async Task<OidcError?> ValidateAsync(BackChannelAuthenticationValidationContext context)
     {
+        // Counted before the call, because the policy is handed this very array and a validator
+        // that narrows by editing in place empties it as it answers.
+        var requested = context.Request.AuthorizationDetails is { Count: > 0 };
+
         var result = await policy.ApplyAsync(
             context.Request.AuthorizationDetails,
             context.ClientInfo,
@@ -36,7 +40,7 @@ public class BackChannelAuthorizationDetailsValidator(
 
         if (validated.Count > 0)
             context.AuthorizationDetails = validated;
-        else if (context.Request.AuthorizationDetails is { Count: > 0 })
+        else if (requested)
             throw AuthorizationDetailsPolicyContract.EveryEntryDropped();
         return null;
     }

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
@@ -36,6 +36,8 @@ public class BackChannelAuthorizationDetailsValidator(
 
         if (validated.Count > 0)
             context.AuthorizationDetails = validated;
+        else if (context.Request.AuthorizationDetails is { Count: > 0 })
+            throw AuthorizationDetailsPolicyContract.EveryEntryDropped();
         return null;
     }
 }

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidator.cs
@@ -34,7 +34,7 @@ public class BackChannelAuthorizationDetailsValidator(
         if (!result.TryGetSuccess(out var validated))
             return result.GetFailure();
 
-        if (validated is not null)
+        if (validated.Count > 0)
             context.AuthorizationDetails = validated;
         return null;
     }

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/RequestedSubjectValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/RequestedSubjectValidator.cs
@@ -13,8 +13,8 @@ using Abblix.Oidc.Server.Model;
 namespace Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
 
 /// <summary>
-/// Refuses a <c>claims</c> request whose <c>sub</c> qualifier is not a string, or whose qualifiers name
-/// no end user who could satisfy them both.
+/// Refuses a <c>claims</c> request whose <c>sub</c> qualifier is not a string, or whose qualifiers leave
+/// no end user who could satisfy them.
 /// </summary>
 /// <remarks>
 /// This endpoint accepts the same <c>claims</c> parameter as the authorization endpoint and honours a

--- a/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/RequestedSubjectValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/BackChannelAuthentication/Validation/RequestedSubjectValidator.cs
@@ -13,7 +13,8 @@ using Abblix.Oidc.Server.Model;
 namespace Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
 
 /// <summary>
-/// Refuses a <c>claims</c> request whose <c>sub</c> qualifier is not a string.
+/// Refuses a <c>claims</c> request whose <c>sub</c> qualifier is not a string, or whose qualifiers name
+/// no end user who could satisfy them both.
 /// </summary>
 /// <remarks>
 /// This endpoint accepts the same <c>claims</c> parameter as the authorization endpoint and honours a

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
@@ -32,7 +32,7 @@ public class DeviceAuthorizationDetailsValidator(
         if (!result.TryGetSuccess(out var validated))
             return result.GetFailure();
 
-        if (validated is not null)
+        if (validated.Count > 0)
             context.AuthorizationDetails = validated;
 
         return null;

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
@@ -24,6 +24,10 @@ public class DeviceAuthorizationDetailsValidator(
     /// <inheritdoc/>
     public async Task<OidcError?> ValidateAsync(DeviceAuthorizationValidationContext context)
     {
+        // Counted before the call, because the policy is handed this very array and a validator
+        // that narrows by editing in place empties it as it answers.
+        var requested = context.Request.AuthorizationDetails is { Count: > 0 };
+
         var result = await policy.ApplyAsync(
             context.Request.AuthorizationDetails,
             context.ClientInfo,
@@ -34,7 +38,7 @@ public class DeviceAuthorizationDetailsValidator(
 
         if (validated.Count > 0)
             context.AuthorizationDetails = validated;
-        else if (context.Request.AuthorizationDetails is { Count: > 0 })
+        else if (requested)
             throw AuthorizationDetailsPolicyContract.EveryEntryDropped();
 
         return null;

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
@@ -34,6 +34,8 @@ public class DeviceAuthorizationDetailsValidator(
 
         if (validated.Count > 0)
             context.AuthorizationDetails = validated;
+        else if (context.Request.AuthorizationDetails is { Count: > 0 })
+            throw AuthorizationDetailsPolicyContract.EveryEntryDropped();
 
         return null;
     }

--- a/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidator.cs
@@ -24,8 +24,8 @@ public class DeviceAuthorizationDetailsValidator(
     /// <inheritdoc/>
     public async Task<OidcError?> ValidateAsync(DeviceAuthorizationValidationContext context)
     {
-        // Counted before the call, because the policy is handed this very array and a validator
-        // that narrows by editing in place empties it as it answers.
+        // Whether the request carried any, read before the call: the policy is handed this very
+        // array, and a validator that narrows by editing in place empties it as it answers.
         var requested = context.Request.AuthorizationDetails is { Count: > 0 };
 
         var result = await policy.ApplyAsync(

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -51,9 +51,11 @@ public class RegisterClientRequestProcessor(
         var credentials = credentialFactory.Create(model.TokenEndpointAuthMethod, model.ClientId);
         var clientInfo = ToClientInfo(model, credentials, request.SectorIdentifier);
 
-        // lent deliberately RedirectUris: the response echoes the registered metadata, so what the
-        // store now holds is the answer - RFC 7591 section 3.2.1 asks for the server-assigned defaults
-        // to be visible to the client.
+        // lent deliberately RedirectUris, EffectiveGrantTypes, EffectiveResponseTypes, AllowedScopes,
+        // Contacts, RequestUris, AuthorizationDetailsTypes, TokenExchangeAllowedSubjectTokenTypes,
+        // TokenExchangeAllowedAudiences:
+        // the response echoes the registered metadata, so what the store now holds is the answer -
+        // RFC 7591 section 3.2.1 asks for the server-assigned defaults to be visible to the client.
         await clientInfoManager.AddClientAsync(clientInfo);
 
         // Record the jti of the issued registration access token so the management endpoint can

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/RegisterClientRequestProcessor.cs
@@ -51,6 +51,9 @@ public class RegisterClientRequestProcessor(
         var credentials = credentialFactory.Create(model.TokenEndpointAuthMethod, model.ClientId);
         var clientInfo = ToClientInfo(model, credentials, request.SectorIdentifier);
 
+        // lent deliberately RedirectUris: the response echoes the registered metadata, so what the
+        // store now holds is the answer - RFC 7591 section 3.2.1 asks for the server-assigned defaults
+        // to be visible to the client.
         await clientInfoManager.AddClientAsync(clientInfo);
 
         // Record the jti of the issued registration access token so the management endpoint can

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -166,6 +166,9 @@ public class UpdateClientRequestProcessor(
         }
 
         // Update client in storage
+        // lent deliberately RedirectUris: the response echoes the post-update registered state, so what
+        // the store now holds is the answer - RFC 7592 section 3 asks the client to be able to verify
+        // that the full replacement took effect.
         await clientInfoManager.UpdateClientAsync(updatedClient);
 
         // RFC 7592 section 5: rotate the registration access token on update. Recording a fresh jti

--- a/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/DynamicClientManagement/UpdateClientRequestProcessor.cs
@@ -166,9 +166,12 @@ public class UpdateClientRequestProcessor(
         }
 
         // Update client in storage
-        // lent deliberately RedirectUris: the response echoes the post-update registered state, so what
-        // the store now holds is the answer - RFC 7592 section 3 asks the client to be able to verify
-        // that the full replacement took effect.
+        // lent deliberately RedirectUris, EffectiveGrantTypes, EffectiveResponseTypes, AllowedScopes,
+        // Contacts, RequestUris, AuthorizationDetailsTypes, TokenExchangeAllowedSubjectTokenTypes,
+        // TokenExchangeAllowedAudiences:
+        // the response echoes the post-update registered state, so what the store now holds is the
+        // answer - RFC 7592 section 3 asks the client to be able to verify that the full replacement
+        // took effect.
         await clientInfoManager.UpdateClientAsync(updatedClient);
 
         // RFC 7592 section 5: rotate the registration access token on update. Recording a fresh jti

--- a/src/Abblix.Oidc.Server/Endpoints/EndSession/EndSessionRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/EndSession/EndSessionRequestProcessor.cs
@@ -98,8 +98,16 @@ public partial class EndSessionRequestProcessor(
 		// WaitingForActivation, not Running), leaving the POST detached and abandoned at request end.
 		// Notification is best-effort: NotifyClientSafelyAsync isolates per-client failures so an
 		// unreachable client endpoint cannot fail the end-user's logout.
+		// Read once, before the first client is asked about, and as a set. Two reasons, and each would
+		// be enough on its own. The collection is public and a host may supply a list, so the same client
+		// can be named twice - which is a second notification to a client already told, and a second
+		// identical entry in the list the browser is asked to walk. And the provider asked inside this
+		// loop is a host seam: walking the live collection while something a host wrote is answering is
+		// walking a thing it can change. Ordinal, matching the comparer the shipped session uses.
+		var clientIds = authSession.AffectedClientIds.ToHashSet(StringComparer.Ordinal);
+
 		var tasks = new List<Task>();
-		foreach (var clientId in authSession.AffectedClientIds)
+		foreach (var clientId in clientIds)
 		{
 			var clientInfo = await clientInfoProvider.TryFindClientAsync(clientId).WithLicenseCheck();
 			if (clientInfo == null)

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -101,6 +101,11 @@ public partial class BackChannelAuthenticationGrantHandler(
         if (WidensTheRequest(request, request.AuthorizedGrant))
             return NotWhatTheRequestAskedFor();
 
+        // Whom the request named, read before the processor is handed the request. The comparison below
+        // exists because what is stored can change between the two checks; taking its yardstick from the
+        // same object the processor holds would let one change move both sides together.
+        string[]? namedEndUsers = request.RequestedSubjects is { } named ? [..named] : null;
+
         var result = await processor.ProcessAuthenticatedRequestAsync(authenticationRequestId, request);
         if (result.TryGetFailure(out var error))
             return error;
@@ -112,7 +117,7 @@ public partial class BackChannelAuthenticationGrantHandler(
         // same storage through the public seam - can replace what is stored, which is the ordinary shape
         // of a retried or corrected completion rather than an attack. Approving one grant and handing over
         // another is the whole failure this comparison exists to prevent.
-        if (!NamesTheRequestedEndUser(request.RequestedSubjects, grant, clientInfo))
+        if (!NamesTheRequestedEndUser(namedEndUsers, grant, clientInfo))
             return NotTheRequestedEndUser();
 
         // And the same for what the grant authorises. The completion path judges this too, but a host can

--- a/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/Grants/BackChannelAuthenticationGrantHandler.cs
@@ -308,13 +308,11 @@ public partial class BackChannelAuthenticationGrantHandler(
         // Note: This update is not atomic with the read above, see method remarks
         await storage.UpdateAsync(authenticationRequestId, authenticationRequest, expiresIn);
 
-        if (options.Value.BackChannelAuthentication.UseLongPolling && statusNotifier != null)
+        if (options.Value.BackChannelAuthentication.UseLongPolling && statusNotifier != null
+            && await TryLongPollingAsync(authenticationRequestId, clientInfo, cancellationToken)
+                is { } result)
         {
-            var result = await TryLongPollingAsync(authenticationRequestId, clientInfo, cancellationToken);
-            if (result != null)
-            {
-                return result;
-            }
+            return result;
         }
 
         return new OidcError(

--- a/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
+++ b/src/Abblix.Oidc.Server/Endpoints/Token/TokenRequestProcessor.cs
@@ -77,6 +77,11 @@ public class TokenRequestProcessor(
 				"The requested resource is not among the resources granted by the resource owner.");
 		}
 
+		// Read before the token service is handed the context: the response advertises what was granted,
+		// and a service that narrowed the context in place would have this answer say what it decided
+		// rather than what the end user did.
+		string[] grantedScope = [..authContext.Scope];
+
 		var accessToken = await accessTokenService.CreateAccessTokenAsync(
 			request.AuthorizedGrant.AuthSession,
 			authContext,
@@ -126,7 +131,7 @@ public class TokenRequestProcessor(
 			grantType != GrantTypes.ClientCredentials &&
 			grantType != GrantTypes.TokenExchange;
 
-		if (mayIssueDerivedTokens && authContext.Scope.HasFlag(Scopes.OfflineAccess))
+		if (mayIssueDerivedTokens && grantedScope.HasFlag(Scopes.OfflineAccess))
 		{
 			var refreshContext = request.AuthorizedGrant.Context with
 			{
@@ -160,7 +165,7 @@ public class TokenRequestProcessor(
 					: null);
 		}
 
-		if (mayIssueDerivedTokens && authContext.Scope.HasFlag(Scopes.OpenId))
+		if (mayIssueDerivedTokens && grantedScope.HasFlag(Scopes.OpenId))
 		{
 			// The bindings exist only when the caller says it IS the push path. The mode could be read
 			// off clientInfo instead, and is not, so that this method does not have to know CIBA's

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/AuthorizationDetailsPolicy.cs
@@ -46,7 +46,7 @@ internal sealed class AuthorizationDetailsPolicy(
         CancellationToken token);
 
     /// <inheritdoc/>
-    public Task<Result<JsonArray?, OidcError>> ApplyAsync(
+    public Task<Result<JsonArray, OidcError>> ApplyAsync(
         JsonArray? raw,
         ClientInfo client,
         CancellationToken token)
@@ -57,7 +57,7 @@ internal sealed class AuthorizationDetailsPolicy(
             token);
 
     /// <inheritdoc/>
-    public Task<Result<JsonArray?, OidcError>> ApplyGrantedAsync(
+    public Task<Result<JsonArray, OidcError>> ApplyGrantedAsync(
         JsonArray? granted,
         ClientInfo client,
         CancellationToken token)
@@ -67,14 +67,14 @@ internal sealed class AuthorizationDetailsPolicy(
             static (validator, detail, client, token) => validator.ValidateGrantedAsync(detail, client, token),
             token);
 
-    private async Task<Result<JsonArray?, OidcError>> ApplyCoreAsync(
+    private async Task<Result<JsonArray, OidcError>> ApplyCoreAsync(
         JsonArray? raw,
         ClientInfo client,
         AskValidator ask,
         CancellationToken token)
     {
         if (raw is not { Count: > 0 })
-            return (JsonArray?)null;
+            return new JsonArray();
 
         // An entry that is not a JSON object is dropped by the conversion, so a count that shrank means the
         // client sent authorization_details this server cannot read - ["payment"] or [1,2] rather than the

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/GrantedRevalidation.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/GrantedRevalidation.cs
@@ -94,8 +94,8 @@ internal static class GrantedRevalidation
         // thing: what is stored is not what may be issued.
         //
         // Both shapes are compared, because the two ways of answering are equally common: an edit IN PLACE
-        // shows on the probe, a rewritten entry shows in what comes back. Null means nothing to change,
-        // which is how every other caller reads it.
+        // shows on the probe, a rewritten entry shows in what comes back. An empty answer means nothing
+        // to change, which is how every other caller reads it.
         //
         // Compared STRUCTURALLY rather than as text. Deserialise, validate, return a fresh entry is the
         // natural way to write a validator in C#, and the interface invites it, so a validator that changed
@@ -108,7 +108,7 @@ internal static class GrantedRevalidation
         // runtimes will disagree about the same validator, which is worth knowing when one does.
         var revalidated = result.GetSuccess();
         var changed = !JsonNode.DeepEquals(probe, asStored) ||
-                      (revalidated is not null && !JsonNode.DeepEquals(revalidated, asStored));
+                      (revalidated.Count > 0 && !JsonNode.DeepEquals(revalidated, asStored));
 
         return changed
             ? Refusal(

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/GrantedRevalidation.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/GrantedRevalidation.cs
@@ -94,8 +94,9 @@ internal static class GrantedRevalidation
         // thing: what is stored is not what may be issued.
         //
         // Both shapes are compared, because the two ways of answering are equally common: an edit IN PLACE
-        // shows on the probe, a rewritten entry shows in what comes back. An empty answer means nothing
-        // to change, which is how every other caller reads it.
+        // shows on the probe, a rewritten entry shows in what comes back. An answer with every entry
+        // removed is a refusal like any other change, and it is the one the probe cannot show: a policy
+        // that deleted everything without touching what it was handed leaves the probe identical.
         //
         // Compared STRUCTURALLY rather than as text. Deserialise, validate, return a fresh entry is the
         // natural way to write a validator in C#, and the interface invites it, so a validator that changed
@@ -108,7 +109,7 @@ internal static class GrantedRevalidation
         // runtimes will disagree about the same validator, which is worth knowing when one does.
         var revalidated = result.GetSuccess();
         var changed = !JsonNode.DeepEquals(probe, asStored) ||
-                      (revalidated.Count > 0 && !JsonNode.DeepEquals(revalidated, asStored));
+                      !JsonNode.DeepEquals(revalidated, asStored);
 
         return changed
             ? Refusal(

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
@@ -51,8 +51,9 @@ public interface IAuthorizationDetailsPolicy
     /// On success - the raw <see cref="JsonArray"/> that survived validation, empty only when the input
     /// carried no entries to begin with, since there is nothing to forward in that case. An
     /// implementation that would leave nothing of a non-empty input refuses instead: dropping every entry
-    /// says the request may not be honoured as asked, and callers read an empty answer to a non-empty
-    /// input as a fault rather than as consent. On failure - a fully-formed <see cref="OidcError"/> with
+    /// says the request may not be honoured as asked, and every caller treats an empty answer to a
+    /// non-empty input as a fault - see <see cref="AuthorizationDetailsPolicyContract.EveryEntryDropped"/>.
+    /// On failure - a fully-formed <see cref="OidcError"/> with
     /// <c>error = invalid_authorization_details</c> (RFC 9396 section 5) and the rejection
     /// description; the endpoint adapter forwards it as-is when its error type is
     /// <see cref="OidcError"/>, or re-wraps the description otherwise.
@@ -91,4 +92,29 @@ public interface IAuthorizationDetailsPolicy
         ClientInfo client,
         CancellationToken token)
         => ApplyAsync(granted, client, token);
+}
+
+/// <summary>
+/// The refusal every caller of <see cref="IAuthorizationDetailsPolicy"/> owes when an implementation
+/// breaks the one part of its contract nothing else can catch.
+/// </summary>
+internal static class AuthorizationDetailsPolicyContract
+{
+    /// <summary>
+    /// A policy answered with nothing to a request that carried entries.
+    /// </summary>
+    /// <remarks>
+    /// Dropping every entry says the request may not be honoured as asked, which is a refusal, and the
+    /// contract says so. Read as consent instead, it authorizes the request with its
+    /// <c>authorization_details</c> silently gone - the one outcome neither the client nor the resource
+    /// server can detect. The shipped policy cannot produce it, so reaching this means a host
+    /// implementation or a decorator did.
+    /// </remarks>
+    /// <returns>The exception to throw.</returns>
+    public static InvalidOperationException EveryEntryDropped()
+        => new(
+            $"An {nameof(IAuthorizationDetailsPolicy)} implementation answered with an empty set for a "
+            + "request that carried authorization_details. Dropping every entry is a refusal and has to "
+            + "be returned as one, because forwarding the request without them authorizes something "
+            + "nobody asked for.");
 }

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
@@ -48,9 +48,11 @@ public interface IAuthorizationDetailsPolicy
     /// drives the allowlist branch.</param>
     /// <param name="token">Cancellation token forwarded to per-type validators.</param>
     /// <returns>
-    /// On success - the raw <see cref="JsonArray"/> that survived validation, empty when there is
-    /// nothing to forward: the input carried no entries, or validation left none. On failure - a
-    /// fully-formed <see cref="OidcError"/> with
+    /// On success - the raw <see cref="JsonArray"/> that survived validation, empty only when the input
+    /// carried no entries to begin with, since there is nothing to forward in that case. An
+    /// implementation that would leave nothing of a non-empty input refuses instead: dropping every entry
+    /// says the request may not be honoured as asked, and callers read an empty answer to a non-empty
+    /// input as a fault rather than as consent. On failure - a fully-formed <see cref="OidcError"/> with
     /// <c>error = invalid_authorization_details</c> (RFC 9396 section 5) and the rejection
     /// description; the endpoint adapter forwards it as-is when its error type is
     /// <see cref="OidcError"/>, or re-wraps the description otherwise.

--- a/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
+++ b/src/Abblix.Oidc.Server/Features/RichAuthorizationRequests/IAuthorizationDetailsPolicy.cs
@@ -48,14 +48,14 @@ public interface IAuthorizationDetailsPolicy
     /// drives the allowlist branch.</param>
     /// <param name="token">Cancellation token forwarded to per-type validators.</param>
     /// <returns>
-    /// On success - the raw <see cref="JsonArray"/> that survived validation (or <c>null</c>
-    /// when the input was null / empty / contained no typed entries - there is nothing to
-    /// forward in that case). On failure - a fully-formed <see cref="OidcError"/> with
+    /// On success - the raw <see cref="JsonArray"/> that survived validation, empty when there is
+    /// nothing to forward: the input carried no entries, or validation left none. On failure - a
+    /// fully-formed <see cref="OidcError"/> with
     /// <c>error = invalid_authorization_details</c> (RFC 9396 section 5) and the rejection
     /// description; the endpoint adapter forwards it as-is when its error type is
     /// <see cref="OidcError"/>, or re-wraps the description otherwise.
     /// </returns>
-    Task<Result<JsonArray?, OidcError>> ApplyAsync(
+    Task<Result<JsonArray, OidcError>> ApplyAsync(
         JsonArray? raw,
         ClientInfo client,
         CancellationToken token);
@@ -84,7 +84,7 @@ public interface IAuthorizationDetailsPolicy
     /// <param name="token">Cancellation token forwarded to per-type validators.</param>
     /// <returns>The same shape as <see cref="ApplyAsync"/>: the post-validation array on success, or
     /// an <see cref="OidcError"/> naming the entry that was refused.</returns>
-    Task<Result<JsonArray?, OidcError>> ApplyGrantedAsync(
+    Task<Result<JsonArray, OidcError>> ApplyGrantedAsync(
         JsonArray? granted,
         ClientInfo client,
         CancellationToken token)

--- a/src/Abblix.Oidc.Server/Features/SessionManagement/AuthorizationRequestProcessorDecorator.cs
+++ b/src/Abblix.Oidc.Server/Features/SessionManagement/AuthorizationRequestProcessorDecorator.cs
@@ -37,12 +37,16 @@ public class AuthorizationRequestProcessorDecorator(
     /// </returns>
     public async Task<AuthorizationResponse> ProcessAsync(ValidAuthorizationRequest request)
     {
+        // Read before the inner processor is handed the request: it is the seam a host replaces or wraps,
+        // and whether this response carries session state is decided from what the request asked for.
+        var asksForOpenId = request.Model.Scope.HasFlag(Scopes.OpenId);
+
         var response = await inner.ProcessAsync(request);
 
         // Append session state to the response if session management is enabled and the request qualifies
         if (sessionManagementService.Enabled &&
             response is SuccessfullyAuthenticated success && success.SessionId.HasValue() &&
-            request.Model.Scope.HasFlag(Scopes.OpenId))
+            asksForOpenId)
         {
             success.SessionState = sessionManagementService.GetSessionState(request.Model, success.SessionId);
         }

--- a/src/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
+++ b/src/Abblix.Oidc.Server/Features/Tokens/IdentityTokenService.cs
@@ -86,6 +86,12 @@ internal class IdentityTokenService(
 			scope = scope.Except([Scopes.Profile, Scopes.Email, Scopes.Address]).ToArray();
 		}
 
+		// Read before the claims provider is handed the session: it is a host seam, and this is what the
+		// id_token reports about how the end user authenticated.
+		string[]? authenticationMethods = authSession.AuthenticationMethodReferences is { } methods
+			? [..methods]
+			: null;
+
 		var userInfo = await userClaimsProvider.GetUserClaimsAsync(
 			authSession,
 			scope,
@@ -116,7 +122,7 @@ internal class IdentityTokenService(
 				SessionId = authSession.SessionId,
 				AuthenticationTime = authSession.AuthenticationTime,
 				AuthContextClassRef = authSession.AuthContextClassRef,
-				AuthenticationMethodReferences = authSession.AuthenticationMethodReferences,
+				AuthenticationMethodReferences = authenticationMethods,
 
 				Audiences = [authContext.ClientId],
 				Nonce = authContext.Nonce,

--- a/src/Abblix.Oidc.Server/Model/RequestedClaimsExtensions.cs
+++ b/src/Abblix.Oidc.Server/Model/RequestedClaimsExtensions.cs
@@ -19,9 +19,8 @@ namespace Abblix.Oidc.Server.Model;
 public static class RequestedClaimsExtensions
 {
     /// <summary>
-    /// The end users this request will accept for <c>sub</c>: <c>null</c> when it named none in particular,
-    /// an empty array when it named a combination nobody can satisfy, or a failure describing a malformed
-    /// qualifier.
+    /// The end users this request will accept for <c>sub</c>: an empty array when it named none in
+    /// particular, or a failure describing a qualifier that is malformed or that nobody can satisfy.
     /// </summary>
     /// <remarks>
     /// OpenID Connect Core 1.0 Section 3.1.2.2 names this and <c>id_token_hint</c> as two ways to make one
@@ -34,7 +33,9 @@ public static class RequestedClaimsExtensions
     /// Section 5.5.1 defines both qualifiers as OPTIONAL and says nothing about carrying them together, so a
     /// request doing so is read as stating both constraints: the subject has to be the one named by
     /// <c>value</c> AND one of those listed in <c>values</c>. Incompatible constraints leave nothing
-    /// acceptable, which is the guaranteed mismatch that same section already prescribes an outcome for.
+    /// acceptable, which is the guaranteed mismatch that same section prescribes an outcome for - said
+    /// here as a refusal naming the contradiction, rather than as a set that silently matches no session
+    /// and sends the end user to authenticate for a request that can never be answered.
     /// </para>
     /// <para>
     /// Only the <c>id_token</c> member is read, deliberately. Section 3.1.2.2 scopes the requirement to a
@@ -43,12 +44,12 @@ public static class RequestedClaimsExtensions
     /// mismatch rule then governs that response, not the authentication.
     /// </para>
     /// </remarks>
-    public static Result<string[]?, string> RequestedSubjects(this RequestedClaims? claims)
+    public static Result<string[], string> RequestedSubjects(this RequestedClaims? claims)
     {
         if (claims?.IdToken is not { } requested ||
             !requested.TryGetValue(IanaClaimTypes.Sub, out var details) ||
             details is null)
-            return (string[]?)null;
+            return Array.Empty<string>();
 
         string? value = null;
         if (details.Value is not null && !TryReadSubject(details.Value, out value))
@@ -69,14 +70,20 @@ public static class RequestedClaimsExtensions
 
         return (value, values) switch
         {
-            (null, null) => (string[]?)null,
+            (null, null) => Array.Empty<string>(),
+            (null, []) => NoAcceptableSubject,
             (null, { } many) => many,
-            ({ } one, null) => [one],
-            ({ } one, { } many) => many.Contains(one, StringComparer.Ordinal) ? [one] : [],
+            ({ } one, null) => new[] { one },
+            ({ } one, { } many) => many.Contains(one, StringComparer.Ordinal)
+                ? new[] { one }
+                : NoAcceptableSubject,
         };
     }
 
     private const string MalformedSubject = "The sub claim was requested with a value that is not a string";
+
+    private const string NoAcceptableSubject =
+        "The sub claim was requested with qualifiers no end user can satisfy at once";
 
     /// <summary>
     /// Reads a requested <c>sub</c> value, failing when the qualifier is not a string.

--- a/src/Abblix.Oidc.Server/Model/RequestedClaimsExtensions.cs
+++ b/src/Abblix.Oidc.Server/Model/RequestedClaimsExtensions.cs
@@ -83,7 +83,7 @@ public static class RequestedClaimsExtensions
     private const string MalformedSubject = "The sub claim was requested with a value that is not a string";
 
     private const string NoAcceptableSubject =
-        "The sub claim was requested with qualifiers no end user can satisfy at once";
+        "The sub claim was requested with qualifiers no end user can satisfy";
 
     /// <summary>
     /// Reads a requested <c>sub</c> value, failing when the qualifier is not a string.

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -33,7 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
+++ b/src/Abblix.SecurityEvents.CAEP/Abblix.SecurityEvents.CAEP.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
+++ b/src/Abblix.SecurityEvents.MinimalApi/Abblix.SecurityEvents.MinimalApi.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -33,7 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
+++ b/src/Abblix.SecurityEvents.RISC/Abblix.SecurityEvents.RISC.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
+++ b/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
+++ b/src/Abblix.SecurityEvents/Abblix.SecurityEvents.csproj
@@ -37,7 +37,6 @@
          ActivatorUtilities, the options pattern, the LoggerMessage source generator - rather than
          leaning on what happens to flow transitively through Abblix.Jwt today. -->
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
+++ b/src/Abblix.SharedSignals.MinimalApi/Abblix.SharedSignals.MinimalApi.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -33,7 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
+++ b/src/Abblix.SharedSignals.Redis/Abblix.SharedSignals.Redis.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -34,7 +34,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
+++ b/src/Abblix.SharedSignals/Abblix.SharedSignals.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers; buildtransitive</IncludeAssets>

--- a/src/Abblix.Utils/Abblix.Utils.csproj
+++ b/src/Abblix.Utils/Abblix.Utils.csproj
@@ -21,13 +21,7 @@
     <PackageIcon>Abblix.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <!-- Deterministic builds for reproducible binaries -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-    <!-- SourceLink for symbol packages -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Abblix.Utils/Result.cs
+++ b/src/Abblix.Utils/Result.cs
@@ -31,11 +31,11 @@ namespace Abblix.Utils;
 /// null, so <c>Success(null)</c> - or a conversion from a null value - lands in the same state rather
 /// than in a success whose value is absent. A case that can be null therefore cannot be carried here,
 /// which is a property of the union rather than a rule this type imposes.
+/// </para>
 /// <para>
 /// A member that must yield a value throws rather than inventing one; the <c>TryGet</c> pair answers
 /// <c>false</c> to both questions, deconstruction yields two defaults, and <c>ToString</c> says which
 /// state it found.
-/// </para>
 /// </para>
 /// </remarks>
 /// <typeparam name="TSuccess">The type of the success value.</typeparam>
@@ -350,7 +350,8 @@ public union Result<TSuccess, TFailure>(TSuccess, TFailure)
             _ => "a result carrying neither case",
         };
     /// <summary>
-    /// The refusal for a result carrying neither case, which is what <c>default</c> of this type is.
+    /// The refusal for a result carrying neither case: a value left unset, or a case built from an
+    /// empty reference.
     /// </summary>
     /// <remarks>
     /// Not defensive programming: a struct has a default value whether or not anything means to produce

--- a/src/Abblix.Utils/Result.cs
+++ b/src/Abblix.Utils/Result.cs
@@ -26,10 +26,16 @@ namespace Abblix.Utils;
 /// on which both accessors answer yes. Choose the failure type so that cannot happen.
 /// </para>
 /// <para>
-/// A union is a struct, so <c>default</c> is a value of this type that carries neither case, and nothing
-/// here produces one - the old hierarchy could not express that state at all. A member that must yield a
-/// value throws rather than inventing one; the <c>TryGet</c> pair answers <c>false</c> to both questions,
-/// deconstruction yields two defaults, and <c>ToString</c> says which state it found.
+/// A union is a struct, so <c>default</c> is a value of this type that carries neither case, and the old
+/// hierarchy could not express that state at all. It has a second door: a type pattern does not match
+/// null, so <c>Success(null)</c> - or a conversion from a null value - lands in the same state rather
+/// than in a success whose value is absent. A case that can be null therefore cannot be carried here,
+/// which is a property of the union rather than a rule this type imposes.
+/// <para>
+/// A member that must yield a value throws rather than inventing one; the <c>TryGet</c> pair answers
+/// <c>false</c> to both questions, deconstruction yields two defaults, and <c>ToString</c> says which
+/// state it found.
+/// </para>
 /// </para>
 /// </remarks>
 /// <typeparam name="TSuccess">The type of the success value.</typeparam>
@@ -352,5 +358,8 @@ public union Result<TSuccess, TFailure>(TSuccess, TFailure)
     /// a failure nobody produced into a caller's hands.
     /// </remarks>
     private static InvalidOperationException NeitherCase()
-        => new("The result carries neither a success nor a failure, which is what default(Result<,>) is.");
+        => new(
+            "The result carries neither a success nor a failure. Either it is the default value of the "
+            + "type, or a case was built from a null value - a union stores its content as an object and "
+            + "a type pattern does not match null, so the two are the same state.");
 }

--- a/src/Abblix.Utils/Result.cs
+++ b/src/Abblix.Utils/Result.cs
@@ -19,14 +19,17 @@ namespace Abblix.Utils;
 /// The pattern applies to the contained value, so a caller writes the case types themselves rather than
 /// wrappers around them.
 /// <para>
-/// The two case types must be DISTINCT for a given instantiation. <c>Result&lt;string, string&gt;</c>
-/// does not compile - the conversion from a string would be ambiguous - and that is a property of the
-/// union rather than a rule this type imposes.
+/// The two case types must be DISTINCT for a given instantiation, because a union tells its cases apart
+/// by type. Writing <c>Result&lt;string, string&gt;</c> outright does not compile - the conversion from a
+/// string would be ambiguous - but the combinators can still FORM one, since a generic instantiation is
+/// not checked that way: <c>Result&lt;int, string&gt;.MapSuccess</c> returning a string produces a value
+/// on which both accessors answer yes. Choose the failure type so that cannot happen.
 /// </para>
 /// <para>
-/// A union is a struct, so <c>default</c> is a value of this type that carries neither case. Nothing
-/// here produces one, and every member below refuses it rather than inventing an answer; the old
-/// hierarchy could not express that state at all, and this is what replaces its closedness.
+/// A union is a struct, so <c>default</c> is a value of this type that carries neither case, and nothing
+/// here produces one - the old hierarchy could not express that state at all. A member that must yield a
+/// value throws rather than inventing one; the <c>TryGet</c> pair answers <c>false</c> to both questions,
+/// deconstruction yields two defaults, and <c>ToString</c> says which state it found.
 /// </para>
 /// </remarks>
 /// <typeparam name="TSuccess">The type of the success value.</typeparam>
@@ -194,9 +197,12 @@ public union Result<TSuccess, TFailure>(TSuccess, TFailure)
     /// <returns>The success value.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the result is a failure.</exception>
     public TSuccess GetSuccess()
-        => Value is TSuccess success
-            ? success
-            : throw new InvalidOperationException("The result is not a success.");
+        => Value switch
+        {
+            TSuccess success => success,
+            TFailure => throw new InvalidOperationException("The result is not a success."),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Gets the failure value.
@@ -204,9 +210,12 @@ public union Result<TSuccess, TFailure>(TSuccess, TFailure)
     /// <returns>The failure value.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the result is a success.</exception>
     public TFailure GetFailure()
-        => Value is TFailure failure
-            ? failure
-            : throw new InvalidOperationException("The result is not a failure.");
+        => Value switch
+        {
+            TFailure failure => failure,
+            TSuccess => throw new InvalidOperationException("The result is not a failure."),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Determines whether the result is a failure.

--- a/src/Abblix.Utils/Result.cs
+++ b/src/Abblix.Utils/Result.cs
@@ -10,41 +10,42 @@ using System.Diagnostics.CodeAnalysis;
 namespace Abblix.Utils;
 
 /// <summary>
-/// Represents a result of an operation that can either succeed with a value of type <typeparamref name="TSuccess"/>
-/// or fail with a value of type <typeparamref name="TFailure"/>.
+/// The outcome of an operation: either a value of type <typeparamref name="TSuccess"/> or one of type
+/// <typeparamref name="TFailure"/>, never both.
 /// </summary>
-/// <typeparam name="TSuccess">The type of the success result.</typeparam>
-/// <typeparam name="TFailure">The type of the failure result.</typeparam>
-public abstract record Result<TSuccess, TFailure>
+/// <remarks>
+/// A union rather than a hierarchy, so that a caller naming both cases is checked by the compiler: a
+/// <c>switch</c> over the two case types that forgets one is an error here, where warnings are errors.
+/// The pattern applies to the contained value, so a caller writes the case types themselves rather than
+/// wrappers around them.
+/// <para>
+/// The two case types must be DISTINCT for a given instantiation. <c>Result&lt;string, string&gt;</c>
+/// does not compile - the conversion from a string would be ambiguous - and that is a property of the
+/// union rather than a rule this type imposes.
+/// </para>
+/// <para>
+/// A union is a struct, so <c>default</c> is a value of this type that carries neither case. Nothing
+/// here produces one, and every member below refuses it rather than inventing an answer; the old
+/// hierarchy could not express that state at all, and this is what replaces its closedness.
+/// </para>
+/// </remarks>
+/// <typeparam name="TSuccess">The type of the success value.</typeparam>
+/// <typeparam name="TFailure">The type of the failure value.</typeparam>
+public union Result<TSuccess, TFailure>(TSuccess, TFailure)
 {
-    private Result() { }
-
     /// <summary>
     /// Creates a successful result with the specified value.
     /// </summary>
     /// <param name="value">The success value.</param>
     /// <returns>A <see cref="Result{TSuccess, TFailure}"/> representing a successful result.</returns>
-    public static Result<TSuccess, TFailure> Success(TSuccess value) => new SuccessResult(value);
+    public static Result<TSuccess, TFailure> Success(TSuccess value) => value;
 
     /// <summary>
     /// Creates a failed result with the specified value.
     /// </summary>
     /// <param name="value">The failure value.</param>
     /// <returns>A <see cref="Result{TSuccess, TFailure}"/> representing a failed result.</returns>
-    public static Result<TSuccess, TFailure> Failure(TFailure value) => new FailureResult(value);
-
-
-    /// <summary>
-    /// Implicitly converts a value of type <typeparamref name="TSuccess"/> to a successful result.
-    /// </summary>
-    /// <param name="value">The success value.</param>
-    public static implicit operator Result<TSuccess, TFailure>(TSuccess value) => Success(value);
-
-    /// <summary>
-    /// Implicitly converts a value of type <typeparamref name="TFailure"/> to a failed result.
-    /// </summary>
-    /// <param name="error">The failure value.</param>
-    public static implicit operator Result<TSuccess, TFailure>(TFailure error) => Failure(error);
+    public static Result<TSuccess, TFailure> Failure(TFailure value) => value;
 
     /// <summary>
     /// Matches the result and invokes the appropriate function depending on whether the result is a success or failure.
@@ -53,7 +54,19 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="onSuccess">The function to invoke if the result is a success.</param>
     /// <param name="onFailure">The function to invoke if the result is a failure.</param>
     /// <returns>The result of the matching function.</returns>
-    public abstract T Match<T>(Func<TSuccess, T> onSuccess, Func<TFailure, T> onFailure);
+    /// <remarks>
+    /// Matched on <see cref="Value"/> rather than on the union, because a union pattern cannot declare a
+    /// variable when the case is a type parameter. The cost is the arm below: inside a generic member the
+    /// compiler cannot prove the two parameters cover the value, so exhaustiveness is checked here at run
+    /// time. At a call site naming the case types it is checked by the compiler, which is the point.
+    /// </remarks>
+    public T Match<T>(Func<TSuccess, T> onSuccess, Func<TFailure, T> onFailure)
+        => Value switch
+        {
+            TSuccess success => onSuccess(success),
+            TFailure failure => onFailure(failure),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Asynchronously matches the result and invokes the appropriate function.
@@ -62,7 +75,13 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="onSuccess">The asynchronous function to invoke if the result is a success.</param>
     /// <param name="onFailure">The function to invoke if the result is a failure.</param>
     /// <returns>A task representing the result of the matching function.</returns>
-    public abstract Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, T> onFailure);
+    public Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, T> onFailure)
+        => Value switch
+        {
+            TSuccess success => onSuccess(success),
+            TFailure failure => Task.FromResult(onFailure(failure)),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Asynchronously matches the result and invokes the appropriate asynchronous function.
@@ -71,39 +90,69 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="onSuccess">The asynchronous function to invoke if the result is a success.</param>
     /// <param name="onFailure">The asynchronous function to invoke if the result is a failure.</param>
     /// <returns>A task representing the result of the matching function.</returns>
-    public abstract Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, Task<T>> onFailure);
+    public Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, Task<T>> onFailure)
+        => Value switch
+        {
+            TSuccess success => onSuccess(success),
+            TFailure failure => onFailure(failure),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
-    /// Asynchronously maps a successful result to another type.
+    /// Asynchronously maps the success value to a new type, leaving a failure untouched.
     /// </summary>
     /// <typeparam name="T">The type to map the success value to.</typeparam>
     /// <param name="onSuccess">The asynchronous mapping function.</param>
-    /// <returns>A new result with the mapped success value or the original failure.</returns>
-    public abstract Task<Result<T, TFailure>> MapSuccessAsync<T>(Func<TSuccess, Task<T>> onSuccess);
+    /// <returns>A task representing the mapped result.</returns>
+    public async Task<Result<T, TFailure>> MapSuccessAsync<T>(Func<TSuccess, Task<T>> onSuccess)
+        => Value switch
+        {
+            TSuccess success => await onSuccess(success),
+            TFailure failure => failure,
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
-    /// Synchronously maps a successful result to another type.
+    /// Maps the success value to a new type, leaving a failure untouched.
     /// </summary>
     /// <typeparam name="T">The type to map the success value to.</typeparam>
     /// <param name="onSuccess">The mapping function.</param>
-    /// <returns>A new result with the mapped success value or the original failure.</returns>
-    public abstract Result<T, TFailure> MapSuccess<T>(Func<TSuccess, T> onSuccess);
+    /// <returns>The mapped result.</returns>
+    public Result<T, TFailure> MapSuccess<T>(Func<TSuccess, T> onSuccess)
+        => Value switch
+        {
+            TSuccess success => onSuccess(success),
+            TFailure failure => failure,
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
-    /// Asynchronously maps a failure result to another type.
+    /// Asynchronously maps the failure value to a new type, leaving a success untouched.
     /// </summary>
     /// <typeparam name="T">The type to map the failure value to.</typeparam>
     /// <param name="onFailure">The asynchronous mapping function.</param>
-    /// <returns>A new result with the mapped failure value or the original success.</returns>
-    public abstract Task<Result<TSuccess, T>> MapFailureAsync<T>(Func<TFailure, Task<T>> onFailure);
+    /// <returns>A task representing the mapped result.</returns>
+    public async Task<Result<TSuccess, T>> MapFailureAsync<T>(Func<TFailure, Task<T>> onFailure)
+        => Value switch
+        {
+            TSuccess success => success,
+            TFailure failure => await onFailure(failure),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
-    /// Synchronously maps a failed result to another type.
+    /// Maps the failure value to a new type, leaving a success untouched.
     /// </summary>
     /// <typeparam name="T">The type to map the failure value to.</typeparam>
     /// <param name="onFailure">The mapping function.</param>
-    /// <returns>A new result with the mapped failure value or the original success.</returns>
-    public abstract Result<TSuccess, T> MapFailure<T>(Func<TFailure, T> onFailure);
+    /// <returns>The mapped result.</returns>
+    public Result<TSuccess, T> MapFailure<T>(Func<TFailure, T> onFailure)
+        => Value switch
+        {
+            TSuccess success => success,
+            TFailure failure => onFailure(failure),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Maps both success and failure values to new types.
@@ -127,21 +176,37 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="value">When this method returns, contains the success value if the result is successful;
     /// otherwise, the default value.</param>
     /// <returns><c>true</c> if the result is a success; otherwise, <c>false</c>.</returns>
-    public abstract bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value);
+    public bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value)
+    {
+        if (Value is TSuccess success)
+        {
+            value = success;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
 
     /// <summary>
     /// Gets the success value.
     /// </summary>
     /// <returns>The success value.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the result is a failure.</exception>
-    public abstract TSuccess GetSuccess();
+    public TSuccess GetSuccess()
+        => Value is TSuccess success
+            ? success
+            : throw new InvalidOperationException("The result is not a success.");
 
     /// <summary>
     /// Gets the failure value.
     /// </summary>
     /// <returns>The failure value.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the result is a success.</exception>
-    public abstract TFailure GetFailure();
+    public TFailure GetFailure()
+        => Value is TFailure failure
+            ? failure
+            : throw new InvalidOperationException("The result is not a failure.");
 
     /// <summary>
     /// Determines whether the result is a failure.
@@ -149,7 +214,17 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="value">When this method returns, contains the failure value if the result is a failure;
     /// otherwise, the default value.</param>
     /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
-    public abstract bool TryGetFailure([MaybeNullWhen(false)] out TFailure value);
+    public bool TryGetFailure([MaybeNullWhen(false)] out TFailure value)
+    {
+        if (Value is TFailure failure)
+        {
+            value = failure;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
 
     /// <summary>
     /// Binds the result to a function that returns a new result, allowing chaining of operations.
@@ -157,14 +232,28 @@ public abstract record Result<TSuccess, TFailure>
     /// <typeparam name="TNext">The type of the success value in the returned result.</typeparam>
     /// <param name="func">The function to apply to the success value.</param>
     /// <returns>The result of applying the function if successful; otherwise, the original failure.</returns>
-    public abstract Result<TNext, TFailure> Bind<TNext>(Func<TSuccess, Result<TNext, TFailure>> func);
+    public Result<TNext, TFailure> Bind<TNext>(Func<TSuccess, Result<TNext, TFailure>> func)
+        => Value switch
+        {
+            TSuccess success => func(success),
+            TFailure failure => failure,
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Executes the specified action if the result is successful, and returns the original result.
     /// </summary>
     /// <param name="action">The action to execute if the result is successful.</param>
     /// <returns>The original result after executing the action if successful; otherwise, the failure result.</returns>
-    public abstract Result<TSuccess, TFailure> Bind(Action<TSuccess> action);
+    public Result<TSuccess, TFailure> Bind(Action<TSuccess> action)
+    {
+        if (Value is TSuccess success)
+            action(success);
+        else if (Value is not TFailure)
+            throw NeitherCase();
+
+        return this;
+    }
 
     /// <summary>
     /// Asynchronously binds the result to a function that returns a new result, allowing chaining of operations.
@@ -172,14 +261,28 @@ public abstract record Result<TSuccess, TFailure>
     /// <typeparam name="TNext">The type of the success value in the returned result.</typeparam>
     /// <param name="func">The asynchronous function to apply to the success value.</param>
     /// <returns>A task representing the result of applying the function if successful; otherwise, the original failure.</returns>
-    public abstract Task<Result<TNext, TFailure>> BindAsync<TNext>(Func<TSuccess, Task<Result<TNext, TFailure>>> func);
+    public Task<Result<TNext, TFailure>> BindAsync<TNext>(Func<TSuccess, Task<Result<TNext, TFailure>>> func)
+        => Value switch
+        {
+            TSuccess success => func(success),
+            TFailure failure => Task.FromResult<Result<TNext, TFailure>>(failure),
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Asynchronously executes the specified action if the result is successful, and returns the original result.
     /// </summary>
     /// <param name="action">The asynchronous action to execute if the result is successful.</param>
     /// <returns>A task representing the operation, with the original result.</returns>
-    public abstract Task<Result<TSuccess, TFailure>> BindAsync(Func<TSuccess, Task> action);
+    public async Task<Result<TSuccess, TFailure>> BindAsync(Func<TSuccess, Task> action)
+    {
+        if (Value is TSuccess success)
+            await action(success);
+        else if (Value is not TFailure)
+            throw NeitherCase();
+
+        return this;
+    }
 
     /// <summary>
     /// Ensures that the success value satisfies the specified predicate; otherwise, returns a failure result.
@@ -187,14 +290,24 @@ public abstract record Result<TSuccess, TFailure>
     /// <param name="predicate">The predicate to evaluate the success value.</param>
     /// <param name="failure">The failure value to return if the predicate is not satisfied.</param>
     /// <returns>The original success result if the predicate is satisfied; otherwise, a failure result.</returns>
-    public abstract Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, TFailure failure);
+    public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
+        => Value switch
+        {
+            TSuccess success => predicate(success) ? this : failure,
+            TFailure => this,
+            _ => throw NeitherCase(),
+        };
 
     /// <summary>
     /// Deconstructs the result into separate success and failure values.
     /// </summary>
     /// <param name="success">The success value if available; otherwise, <c>null</c>.</param>
     /// <param name="failure">The failure value if available; otherwise, <c>null</c>.</param>
-    public abstract void Deconstruct(out TSuccess? success, out TFailure? failure);
+    public void Deconstruct(out TSuccess? success, out TFailure? failure)
+    {
+        success = Value is TSuccess s ? s : default;
+        failure = Value is TFailure f ? f : default;
+    }
 
     /// <summary>
     /// Converts the result explicitly to the success value.
@@ -204,296 +317,31 @@ public abstract record Result<TSuccess, TFailure>
     /// <exception cref="InvalidOperationException">Thrown if the result is a failure.</exception>
     public static explicit operator TSuccess(Result<TSuccess, TFailure> result) => result.GetSuccess();
 
-        /// <summary>
-    /// Represents a successful result.
-    /// </summary>
-    private sealed record SuccessResult : Result<TSuccess, TFailure>
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Result{TSuccess,TFailure}.SuccessResult"/>
-        /// record with the specified value.
-        /// </summary>
-        /// <param name="value">The success value.</param>
-        public SuccessResult(TSuccess value)
-        {
-            Value = value;
-        }
-
-        /// <summary>The success value.</summary>
-        public TSuccess Value { get; }
-
-        /// <inheritdoc />
-        public override TSuccess GetSuccess() => Value;
-
-        /// <inheritdoc />
-        public override TFailure GetFailure() => throw new InvalidOperationException("The operation was successful");
-
-        /// <inheritdoc />
-        public override string ToString() => Value?.ToString() ?? string.Empty;
-
-        /// <summary>
-        /// Determines whether the result is a success.
-        /// </summary>
-        /// <param name="value">When this method returns, contains the success value if the result is successful;
-        /// otherwise, the default value.</param>
-        /// <returns><c>true</c> if the result is a success; otherwise, <c>false</c>.</returns>
-        public override bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value)
-        {
-            value = Value;
-            return true;
-        }
-
-        /// <summary>
-        /// Determines whether the result is a failure.
-        /// </summary>
-        /// <param name="value">When this method returns, contains the failure value if the result is a failure;
-        /// otherwise, the default value.</param>
-        /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
-        public override bool TryGetFailure([MaybeNullWhen(false)] out TFailure value)
-        {
-            value = default!;
-            return false;
-        }
-
-        /// <summary>
-        /// Matches the result and invokes the appropriate function depending on whether the result is a success or failure.
-        /// </summary>
-        /// <typeparam name="T">The return type of the matching functions.</typeparam>
-        /// <param name="onSuccess">The function to invoke if the result is a success.</param>
-        /// <param name="onFailure">The function to invoke if the result is a failure.</param>
-        /// <returns>The result of the matching function.</returns>
-        public override T Match<T>(Func<TSuccess, T> onSuccess, Func<TFailure, T> onFailure) => onSuccess(Value);
-
-        /// <summary>
-        /// Asynchronously matches the result and invokes the appropriate function.
-        /// </summary>
-        /// <typeparam name="T">The return type of the matching functions.</typeparam>
-        /// <param name="onSuccess">The asynchronous function to invoke if the result is a success.</param>
-        /// <param name="onFailure">The function to invoke if the result is a failure.</param>
-        /// <returns>A task representing the result of the matching function.</returns>
-        public override Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, T> onFailure)
-            => onSuccess(Value);
-
-        /// <summary>
-        /// Asynchronously matches the result and invokes the appropriate asynchronous function.
-        /// </summary>
-        /// <typeparam name="T">The return type of the matching functions.</typeparam>
-        /// <param name="onSuccess">The asynchronous function to invoke if the result is a success.</param>
-        /// <param name="onFailure">The asynchronous function to invoke if the result is a failure.</param>
-        /// <returns>A task representing the result of the matching function.</returns>
-        public override Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, Task<T>> onFailure)
-            => onSuccess(Value);
-
-        /// <summary>
-        /// Asynchronously maps a successful result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the success value to.</typeparam>
-        /// <param name="onSuccess">The asynchronous mapping function.</param>
-        /// <returns>A new result with the mapped success value or the original failure.</returns>
-        public override async Task<Result<T, TFailure>> MapSuccessAsync<T>(Func<TSuccess, Task<T>> onSuccess)
-            => await onSuccess(Value);
-
-        /// <summary>
-        /// Synchronously maps a successful result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the success value to.</typeparam>
-        /// <param name="onSuccess">The mapping function.</param>
-        /// <returns>A new result with the mapped success value or the original failure.</returns>
-        public override Result<T, TFailure> MapSuccess<T>(Func<TSuccess, T> onSuccess)
-            => onSuccess(Value);
-
-        /// <summary>
-        /// Asynchronously maps a failure result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the failure value to.</typeparam>
-        /// <param name="onFailure">The asynchronous mapping function.</param>
-        /// <returns>A new result with the mapped failure value or the original success.</returns>
-        public override Task<Result<TSuccess, T>> MapFailureAsync<T>(Func<TFailure, Task<T>> onFailure)
-            => Task.FromResult<Result<TSuccess, T>>(Value);
-
-        /// <summary>
-        /// Synchronously maps a failed result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the failure value to.</typeparam>
-        /// <param name="onFailure">The mapping function.</param>
-        /// <returns>A new result with the mapped failure value or the original success.</returns>
-        public override Result<TSuccess, T> MapFailure<T>(Func<TFailure, T> onFailure)
-            => Value;
-
-        /// <inheritdoc />
-        public override Result<TNext, TFailure> Bind<TNext>(Func<TSuccess, Result<TNext, TFailure>> func)
-            => func(Value);
-
-        /// <inheritdoc />
-        public override Result<TSuccess, TFailure> Bind(Action<TSuccess> action)
-        {
-            action(Value);
-            return this;
-        }
-
-        /// <inheritdoc />
-        public override async Task<Result<TNext, TFailure>> BindAsync<TNext>(Func<TSuccess, Task<Result<TNext, TFailure>>> func)
-            => await func(Value);
-
-        /// <inheritdoc />
-        public override async Task<Result<TSuccess, TFailure>> BindAsync(Func<TSuccess, Task> action)
-        {
-            await action(Value);
-            return this;
-        }
-
-        /// <inheritdoc />
-        public override Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
-            => predicate(Value) ? this : Failure(failure);
-
-        /// <inheritdoc />
-        public override void Deconstruct(out TSuccess? success, out TFailure? failure)
-        {
-            success = Value;
-            failure = default;
-        }
-    }
-
     /// <summary>
-    /// Represents a failed result.
+    /// The text of whichever value is there, rather than of the result around it.
     /// </summary>
-    private sealed record FailureResult : Result<TSuccess, TFailure>
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Result{TSuccess,TFailure}.FailureResult"/>
-        /// record with the specified value.
-        /// </summary>
-        /// <param name="value">The failure value.</param>
-        public FailureResult(TFailure value)
+    /// <remarks>
+    /// A log line carrying a result should read as the thing that happened, not as a type name with a
+    /// payload nested inside it. The record this replaced gave that away; a union does not, so it is
+    /// written out.
+    /// </remarks>
+    /// <returns>The text of the success or failure value, or a description of a result carrying
+    /// neither.</returns>
+    public override string ToString()
+        => Value switch
         {
-            Value = value;
-        }
-
-        /// <summary>The failure value.</summary>
-        public TFailure Value { get; }
-
-        /// <inheritdoc />
-        public override TSuccess GetSuccess() => throw new InvalidOperationException("The operation was not successful");
-
-        /// <inheritdoc />
-        public override TFailure GetFailure() => Value;
-
-        /// <inheritdoc />
-        public override string ToString() => Value?.ToString() ?? string.Empty;
-
-        /// <summary>
-        /// Determines whether the result is a success.
-        /// </summary>
-        /// <param name="value">When this method returns, contains the success value if the result is successful;
-        /// otherwise, the default value.</param>
-        /// <returns><c>true</c> if the result is a success; otherwise, <c>false</c>.</returns>
-        public override bool TryGetSuccess([MaybeNullWhen(false)] out TSuccess value)
-        {
-            value = default!;
-            return false;
-        }
-
-        /// <summary>
-        /// Determines whether the result is a failure.
-        /// </summary>
-        /// <param name="value">When this method returns, contains the failure value if the result is a failure;
-        /// otherwise, the default value.</param>
-        /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
-        public override bool TryGetFailure([MaybeNullWhen(false)] out TFailure value)
-        {
-            value = Value;
-            return true;
-        }
-
-        /// <summary>
-        /// Matches the result and invokes the appropriate function depending on whether the result is a success or failure.
-        /// </summary>
-        /// <typeparam name="T">The return type of the matching functions.</typeparam>
-        /// <param name="onSuccess">The function to invoke if the result is a success.</param>
-        /// <param name="onFailure">The function to invoke if the result is a failure.</param>
-        /// <returns>The result of the matching function.</returns>
-        public override T Match<T>(Func<TSuccess, T> onSuccess, Func<TFailure, T> onFailure) => onFailure(Value);
-
-        /// <summary>
-        /// Asynchronously matches the result and invokes the appropriate function.
-        /// </summary>
-        /// <typeparam name="T">The return type of the matching functions.</typeparam>
-        /// <param name="onSuccess">The asynchronous function to invoke if the result is a success.</param>
-        /// <param name="onFailure">The function to invoke if the result is a failure.</param>
-        /// <returns>A task representing the result of the matching function.</returns>
-        public override Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, T> onFailure)
-            => Task.FromResult(onFailure(Value));
-
-        /// <summary>
-        /// Asynchronously matches the result and invokes the appropriate asynchronous function.
-        /// </summary>
-        /// <typeparam name="T">The return type of the matching functions.</typeparam>
-        /// <param name="onSuccess">The asynchronous function to invoke if the result is a success.</param>
-        /// <param name="onFailure">The asynchronous function to invoke if the result is a failure.</param>
-        /// <returns>A task representing the result of the matching function.</returns>
-        public override Task<T> MatchAsync<T>(Func<TSuccess, Task<T>> onSuccess, Func<TFailure, Task<T>> onFailure)
-            => onFailure(Value);
-
-        /// <summary>
-        /// Asynchronously maps a successful result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the success value to.</typeparam>
-        /// <param name="onSuccess">The asynchronous mapping function.</param>
-        /// <returns>A new result with the mapped success value or the original failure.</returns>
-        public override Task<Result<T, TFailure>> MapSuccessAsync<T>(Func<TSuccess, Task<T>> onSuccess)
-            => Task.FromResult<Result<T, TFailure>>(Value);
-
-        /// <summary>
-        /// Synchronously maps a successful result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the success value to.</typeparam>
-        /// <param name="onSuccess">The mapping function.</param>
-        /// <returns>A new result with the mapped success value or the original failure.</returns>
-        public override Result<T, TFailure> MapSuccess<T>(Func<TSuccess, T> onSuccess)
-            => Value;
-
-        /// <summary>
-        /// Asynchronously maps a failure result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the failure value to.</typeparam>
-        /// <param name="onFailure">The asynchronous mapping function.</param>
-        /// <returns>A new result with the mapped failure value or the original success.</returns>
-        public override async Task<Result<TSuccess, T>> MapFailureAsync<T>(Func<TFailure, Task<T>> onFailure)
-            => await onFailure(Value);
-
-        /// <summary>
-        /// Synchronously maps a failed result to another type.
-        /// </summary>
-        /// <typeparam name="T">The type to map the failure value to.</typeparam>
-        /// <param name="onFailure">The mapping function.</param>
-        /// <returns>A new result with the mapped failure value or the original success.</returns>
-        public override Result<TSuccess, T> MapFailure<T>(Func<TFailure, T> onFailure)
-            => onFailure(Value);
-
-        /// <inheritdoc />
-        public override Result<TNext, TFailure> Bind<TNext>(Func<TSuccess, Result<TNext, TFailure>> func)
-            => Value;
-
-        /// <inheritdoc />
-        public override Result<TSuccess, TFailure> Bind(Action<TSuccess> action) => this;
-
-        /// <inheritdoc />
-        public override Task<Result<TNext, TFailure>> BindAsync<TNext>(Func<TSuccess, Task<Result<TNext, TFailure>>> func)
-            => Task.FromResult<Result<TNext, TFailure>>(Value);
-
-        /// <inheritdoc />
-        public override Task<Result<TSuccess, TFailure>> BindAsync(Func<TSuccess, Task> action)
-            => Task.FromResult<Result<TSuccess, TFailure>>(this);
-
-        /// <inheritdoc />
-        public override Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
-            => this;
-
-        /// <inheritdoc />
-        public override void Deconstruct(out TSuccess? success, out TFailure? failure)
-        {
-            success = default;
-            failure = Value;
-        }
-    }
+            TSuccess success => success?.ToString() ?? string.Empty,
+            TFailure failure => failure?.ToString() ?? string.Empty,
+            _ => "a result carrying neither case",
+        };
+    /// <summary>
+    /// The refusal for a result carrying neither case, which is what <c>default</c> of this type is.
+    /// </summary>
+    /// <remarks>
+    /// Not defensive programming: a struct has a default value whether or not anything means to produce
+    /// one, and the alternative to refusing it is answering as though it were a failure, which would put
+    /// a failure nobody produced into a caller's hands.
+    /// </remarks>
+    private static InvalidOperationException NeitherCase()
+        => new("The result carries neither a success nor a failure, which is what default(Result<,>) is.");
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,4 +14,17 @@
     <TargetFrameworks>net11.0</TargetFrameworks>
   </PropertyGroup>
 
+  <!-- What every assembly that ships owes, whether or not it is packed on its own: a build that does
+       not depend on the directory it ran in, and symbols that point at this repository rather than at
+       the machine. Kept here rather than per project because the per-project copy was escaped once
+       already - the shared transport assembly ships inside both adapter packages and had none of it,
+       so its published symbols named the maintainer's build directory, and a consumer who happened to
+       have a checkout at that path was shown source from whatever revision was sitting there. -->
+  <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,12 +14,12 @@
     <TargetFrameworks>net11.0</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- What every assembly that ships owes, whether or not it is packed on its own: a build that does
+  <!-- What every assembly built here owes, whether or not it is packed on its own: a build that does
        not depend on the directory it ran in, and symbols that point at this repository rather than at
-       the machine. Kept here rather than per project because the per-project copy was escaped once
-       already - the shared transport assembly ships inside both adapter packages and had none of it,
-       so its published symbols named the maintainer's build directory, and a consumer who happened to
-       have a checkout at that path was shown source from whatever revision was sitting there. -->
+       the machine. Kept here rather than per project because a per-project copy is an enumeration and
+       this one had already been escaped twice - by the shared transport assembly, which ships inside
+       both adapter packages and whose published symbols therefore named a build directory, and by the
+       two source generators, which ship nowhere but were built the same way. -->
   <PropertyGroup>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/tests/Abblix.Jwt.UnitTests/KeyPlacementWiringTests.cs
+++ b/tests/Abblix.Jwt.UnitTests/KeyPlacementWiringTests.cs
@@ -53,7 +53,7 @@ public class KeyPlacementWiringTests
     }
 
     [Fact]
-    public void StartupValidationPasses_WhenAJwtOnlyHostChoosesAPlacement()
+    public async Task StartupValidationPasses_WhenAJwtOnlyHostChoosesAPlacement()
     {
         var services = WithCustodian();
         services.AddJsonWebTokens();
@@ -61,11 +61,12 @@ public class KeyPlacementWiringTests
 
         using var provider = services.BuildServiceProvider();
 
-        provider.GetRequiredService<IStartupValidator>().Validate();
+        await provider.GetRequiredService<IAsyncStartupValidator>()
+            .ValidateAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public void StartupValidationFails_WhenNoPlacementIsChosen()
+    public async Task StartupValidationFails_WhenNoPlacementIsChosen()
     {
         var services = WithCustodian();
         services.AddJsonWebTokens();
@@ -73,8 +74,9 @@ public class KeyPlacementWiringTests
 
         using var provider = services.BuildServiceProvider();
 
-        var error = Assert.Throws<OptionsValidationException>(
-            provider.GetRequiredService<IStartupValidator>().Validate);
+        var error = await Assert.ThrowsAsync<OptionsValidationException>(
+            () => provider.GetRequiredService<IAsyncStartupValidator>()
+                .ValidateAsync(TestContext.Current.CancellationToken));
 
         // The message must name a call the host can actually write. Asserting a substring of a message is only
         // worth anything when the substring is the method name, which the compiler then keeps honest.
@@ -86,7 +88,7 @@ public class KeyPlacementWiringTests
     [Theory]
     [InlineData(KeyPlacement.Custodian)]
     [InlineData(KeyPlacement.InProcess)]
-    public void EachPlacementIsRecorded_AndSatisfiesTheGuard(KeyPlacement placement)
+    public async Task EachPlacementIsRecorded_AndSatisfiesTheGuard(KeyPlacement placement)
     {
         var services = WithCustodian();
         services.AddJsonWebTokens();
@@ -108,7 +110,8 @@ public class KeyPlacementWiringTests
             provider.GetRequiredService<IOptions<KeyPlacementChoice>>().Value.ChosenPlacement);
 
         // And the positive branch of every startup validator both placements arm, which a refusal test cannot reach.
-        provider.GetRequiredService<IStartupValidator>().Validate();
+        await provider.GetRequiredService<IAsyncStartupValidator>()
+            .ValidateAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -247,7 +250,7 @@ public class KeyPlacementWiringTests
     }
 
     [Fact]
-    public void CustodianIsDiConstructed_WhenRegisteredByType()
+    public async Task CustodianIsDiConstructed_WhenRegisteredByType()
     {
         var services = new ServiceCollection();
         services.AddJsonWebTokens();
@@ -263,7 +266,8 @@ public class KeyPlacementWiringTests
         var custodian = Assert.IsType<DependentCustodian>(provider.GetRequiredService<IKeyCustodian>());
         Assert.Same(provider.GetRequiredService<TimeProvider>(), custodian.TimeProvider);
 
-        provider.GetRequiredService<IStartupValidator>().Validate();
+        await provider.GetRequiredService<IAsyncStartupValidator>()
+            .ValidateAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -293,7 +297,7 @@ public class KeyPlacementWiringTests
     }
 
     [Fact]
-    public void MintingPlacementRefusesWithoutAStore_BecauseAnUnsharedRingFailsOnFirstUse()
+    public async Task MintingPlacementRefusesWithoutAStore_BecauseAnUnsharedRingFailsOnFirstUse()
     {
         var services = WithCustodian();
         services.AddJsonWebTokens();
@@ -301,8 +305,9 @@ public class KeyPlacementWiringTests
 
         using var provider = services.BuildServiceProvider();
 
-        var error = Assert.Throws<OptionsValidationException>(
-            provider.GetRequiredService<IStartupValidator>().Validate);
+        var error = await Assert.ThrowsAsync<OptionsValidationException>(
+            () => provider.GetRequiredService<IAsyncStartupValidator>()
+                .ValidateAsync(TestContext.Current.CancellationToken));
 
         Assert.Contains(nameof(IKeyRingStore), Assert.Single(error.Failures));
     }

--- a/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/AuthenticationSchemeAdapterTests.cs
+++ b/tests/Abblix.Oidc.Server.AspNetCore.UnitTests/AuthenticationSchemeAdapterTests.cs
@@ -6,6 +6,7 @@
 // Licensing terms, including free-of-charge use, are stated in LICENSE.md
 // in the official repository at https://github.com/Abblix/Oidc.Server
 
+using System.Collections;
 using System.Security.Claims;
 using System.Text.Json.Nodes;
 using Abblix.Jwt;
@@ -191,6 +192,57 @@ public class AuthenticationSchemeAdapterTests
 
 		Assert.Equal(["pwd", "otp"], result!.AuthenticationMethodReferences);
 		Assert.Equal(["client-a", "client-b"], result.AffectedClientIds);
+	}
+	/// <summary>
+	/// A client list that was empty when its size was asked still reaches the other side whole.
+	/// </summary>
+	/// <remarks>
+	/// The size and the content were two questions put to a live collection, and a request adding the
+	/// first client between them left the property unwritten altogether - so the session came back
+	/// naming nobody, and every client it touched was gone from the logout that session drives. The
+	/// fixture is that moment made deterministic: zero to the first question, the truth afterwards.
+	/// </remarks>
+	[Fact]
+	public async Task RoundTrip_AClientListFilledAfterItsSizeWasAsked_IsStillCarried()
+	{
+		var input = Session() with
+		{
+			AffectedClientIds = new EmptyOnFirstMeasure("client-a", "client-b"),
+		};
+
+		var result = await RoundTripAsync(input);
+
+		Assert.Equal(["client-a", "client-b"], result!.AffectedClientIds);
+	}
+
+	/// <summary>
+	/// Answers zero the first time it is asked its size, and truthfully after.
+	/// </summary>
+	private sealed class EmptyOnFirstMeasure(params string[] items) : ICollection<string>
+	{
+		private readonly List<string> _items = [..items];
+		private bool _asked;
+
+		public int Count
+		{
+			get
+			{
+				if (_asked)
+					return _items.Count;
+
+				_asked = true;
+				return 0;
+			}
+		}
+
+		public bool IsReadOnly => false;
+		public void Add(string item) => _items.Add(item);
+		public void Clear() => _items.Clear();
+		public bool Contains(string item) => _items.Contains(item);
+		public void CopyTo(string[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+		public bool Remove(string item) => _items.Remove(item);
+		public IEnumerator<string> GetEnumerator() => _items.ToArray().AsEnumerable().GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 
 	[Fact]

--- a/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RequestedEndUserTests.cs
+++ b/tests/Abblix.Oidc.Server.E2E.Tests/Scenarios/RequestedEndUserTests.cs
@@ -232,23 +232,23 @@ public class RequestedEndUserTests(TestFactory factory) : TestBase(factory)
     }
 
     /// <summary>
-    /// One <c>claims</c> request whose own two qualifiers disagree accepts nobody.
+    /// One <c>claims</c> request whose own two qualifiers disagree is refused rather than answered.
     /// </summary>
     /// <remarks>
-    /// The unit tests assert that this records an empty constraint; only here is the empty constraint shown
-    /// to mean "accept nobody" at the point that decides. Both named users are signed in, so a filter that
-    /// read the empty array as "no constraint" would answer the request rather than refuse it, and would do
-    /// so for an end user the request explicitly ruled out - what
+    /// The unit tests assert the refusal at the validator; only here is it shown to hold at the point that
+    /// decides. Both named users are signed in, so a server that read the contradiction as "no constraint"
+    /// would answer the request rather than refuse it, and would do so for an end user the request
+    /// explicitly ruled out - what
     /// <see href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</see>
     /// Section 5.5.1 calls a mismatch that "MUST cause the authentication to fail".
     /// <para>
-    /// This is the case the guard in the validator was written to survive: changing the filter's condition
-    /// from a null check to a length check would silently turn the refusal back into a positive response, and
-    /// every unit test would still pass.
+    /// This is the case the guard was written to survive, and it is why the contradiction is stated as a
+    /// refusal rather than carried as an empty set: an empty set travelling to the session filter is one
+    /// condition away from being read as no condition at all, and every unit test would still pass.
     /// </para>
     /// </remarks>
     [Fact]
-    public async Task One_request_whose_qualifiers_disagree_answers_login_required()
+    public async Task One_request_whose_qualifiers_disagree_is_an_invalid_request()
     {
         await using var host = CreateHost(out var sessions);
         var client = CreateClientFor(host);
@@ -262,7 +262,7 @@ public class RequestedEndUserTests(TestFactory factory) : TestBase(factory)
         var error = await AuthorizeAndExtractErrorAsync(
             client, discovery, With(SilentRenewal(), AuthorizationRequest.Parameters.Claims, claims));
 
-        Assert.Equal(ErrorCodes.LoginRequired, error);
+        Assert.Equal(ErrorCodes.InvalidRequest, error);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
+++ b/tests/Abblix.Oidc.Server.UnitTests/Abblix.Oidc.Server.UnitTests.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Read by the architecture test that walks the library's own sources: the shape it looks for is
+         an ORDER of statements inside one method, which a text search cannot see. Already managed for
+         the source generators, so this reference adds no dependency to the graph. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />

--- a/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
@@ -78,13 +78,11 @@ public class ValueHandedToAHostSeamTests
     /// </remarks>
     private static string[] MembersDeclaredOn(SyntaxNode statement)
     {
-        var trivia = statement.GetLeadingTrivia().ToString();
-        if (!trivia.Contains(Declared, StringComparison.Ordinal)) return [];
+        var joined = string.Join(' ', statement.GetLeadingTrivia()
+            .Where(trivia => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
+            .Select(trivia => trivia.ToString().Trim()[2..]));
 
-        var joined = string.Join(' ', trivia
-            .Split('\n')
-            .Select(line => line.Trim())
-            .Select(line => line.StartsWith("//", StringComparison.Ordinal) ? line[2..] : line));
+        if (!joined.Contains(Declared, StringComparison.Ordinal)) return [];
 
         var start = joined.IndexOf(Declared, StringComparison.Ordinal);
         if (start < 0) return [];
@@ -96,15 +94,27 @@ public class ValueHandedToAHostSeamTests
             : names[..end].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
-    /// <summary>The members the site around one call declares.</summary>
-    private static IReadOnlyCollection<string> DeclaredMembers(SyntaxNode call)
+    /// <summary>The statement a call belongs to, which is what a declaration is attached to.</summary>
+    private static StatementSyntax? EnclosingStatement(SyntaxNode call)
     {
         for (var node = call; node is not null; node = node.Parent)
         {
-            if (node is StatementSyntax) return MembersDeclaredOn(node);
+            if (node is StatementSyntax statement) return statement;
         }
 
-        return [];
+        return null;
+    }
+
+    /// <summary>One site and member, named the same way wherever it is counted.</summary>
+    /// <remarks>
+    /// Built once and used by both sides. Two keys assembled independently agree only while nothing
+    /// moves: one built from the call and one from the statement disagree the moment a statement wraps,
+    /// and one carrying a full path disagrees on whichever platform does not spell paths that way.
+    /// </remarks>
+    private static string SiteOf(StatementSyntax statement, string member)
+    {
+        var line = statement.SyntaxTree.GetLineSpan(statement.Span).StartLinePosition.Line + 1;
+        return $"{Path.GetFileName(statement.SyntaxTree.FilePath)}({line}):{member}";
     }
 
     private static string RepositoryRoot()
@@ -167,17 +177,44 @@ public class ValueHandedToAHostSeamTests
                 found.TryAdd(member, access);
         }
 
-        foreach (var pattern in After(body, call).OfType<IsPatternExpressionSyntax>())
+        IEnumerable<(SyntaxNode Subject, PatternSyntax Pattern)> Patterns()
         {
-            if (!RootedAtTheLoan(pattern.Expression)) continue;
+            foreach (var node in After(body, call))
+                switch (node)
+                {
+                    case IsPatternExpressionSyntax test:
+                        yield return (test.Expression, test.Pattern);
+                        break;
 
-            foreach (var named in pattern.Pattern.DescendantNodesAndSelf())
+                    case SwitchExpressionSyntax choice:
+                        foreach (var arm in choice.Arms)
+                            yield return (choice.GoverningExpression, arm.Pattern);
+                        break;
+
+                    case SwitchStatementSyntax choice:
+                        foreach (var label in choice.Sections
+                            .SelectMany(section => section.Labels)
+                            .OfType<CasePatternSwitchLabelSyntax>())
+                            yield return (choice.Expression, label.Pattern);
+                        break;
+                }
+        }
+
+        foreach (var (subject, pattern) in Patterns())
+        {
+            if (!RootedAtTheLoan(subject)) continue;
+
+            // Only a PROPERTY pattern names members. The elements of a positional one carry the names
+            // of deconstruction parameters, which read like members and are not.
+            foreach (var named in pattern.DescendantNodesAndSelf()
+                .OfType<SubpatternSyntax>()
+                .Where(sub => sub.Parent is PropertyPatternClauseSyntax))
             {
                 var member = named switch
                 {
-                    NameColonSyntax name => name.Name.Identifier.ValueText,
-                    ExpressionColonSyntax { Expression: IdentifierNameSyntax id } => id.Identifier.ValueText,
-                    ExpressionColonSyntax { Expression: MemberAccessExpressionSyntax access }
+                    { NameColon: { } name } => name.Name.Identifier.ValueText,
+                    { ExpressionColon.Expression: IdentifierNameSyntax id } => id.Identifier.ValueText,
+                    { ExpressionColon.Expression: MemberAccessExpressionSyntax access }
                         => Normalized(access).Split('.')[0],
                     _ => null,
                 };
@@ -189,6 +226,15 @@ public class ValueHandedToAHostSeamTests
 
         return found.Select(entry => (entry.Key, entry.Value));
     }
+
+    /// <summary>How many calls a host could answer this statement makes.</summary>
+    private static int SeamCallsIn(SyntaxNode statement, IReadOnlySet<string> seamMethods)
+        => statement.DescendantNodes()
+            .OfType<AwaitExpressionSyntax>()
+            .Select(awaited => awaited.Expression)
+            .OfType<InvocationExpressionSyntax>()
+            .Count(call => call.Expression is MemberAccessExpressionSyntax access
+                           && seamMethods.Contains(access.Name.Identifier.ValueText));
 
     /// <summary>
     /// Every offence, and every declared member that still describes a read.
@@ -221,6 +267,9 @@ public class ValueHandedToAHostSeamTests
         var offences = new List<string>();
         var honoured = new HashSet<string>(StringComparer.Ordinal);
 
+        // The refusal below belongs to the STATEMENT, and the loop reaches it once per call on it.
+        var refused = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (var (path, root) in roots)
         foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
         {
@@ -236,8 +285,23 @@ public class ValueHandedToAHostSeamTests
 
                 if (!seamMethods.Contains(called)) continue;
 
-                var declared = DeclaredMembers(call);
-                var lentAt = call.SyntaxTree.GetLineSpan(call.Span).StartLinePosition.Line + 1;
+                if (EnclosingStatement(call) is not { } statement) continue;
+
+                var declared = MembersDeclaredOn(statement);
+                var lentAt = statement.SyntaxTree.GetLineSpan(statement.Span).StartLinePosition.Line + 1;
+
+                // A declaration is attached to a statement, so a statement carrying two seam calls would
+                // have one declaration excusing both. Refused rather than silently obeyed: the marker
+                // says which members it excuses and cannot say which call it means.
+                if (declared.Length > 0 && SeamCallsIn(statement, seamMethods) > 1)
+                {
+                    if (refused.Add($"{path}({lentAt})"))
+                        offences.Add(
+                            $"{Path.GetFileName(path)}({lentAt}): a deliberate loan is declared on a "
+                            + "statement carrying more than one call, so it cannot say which one it excuses");
+
+                    continue;
+                }
 
                 foreach (var argument in call.ArgumentList.Arguments)
                 {
@@ -250,7 +314,7 @@ public class ValueHandedToAHostSeamTests
                     {
                         if (declared.Contains(member))
                         {
-                            honoured.Add($"{path}({lentAt}):{member}");
+                            honoured.Add(SiteOf(statement, member));
                             continue;
                         }
 
@@ -266,6 +330,97 @@ public class ValueHandedToAHostSeamTests
         return (offences, honoured);
     }
 
+    /// <summary>
+    /// One source of its own, so the walker's reach is pinned by what it CAN see rather than by what
+    /// the library happens to contain today.
+    /// </summary>
+    /// <remarks>
+    /// A capability proved only by a real site stops being proved the moment that site is rewritten, and
+    /// the walker then loses it silently - which is the failure it exists to catch, in the instrument.
+    /// The probe declares its own seam and its own lendable member, so nothing about it depends on the
+    /// library either.
+    /// </remarks>
+    private static IReadOnlyList<string> OffencesIn(string body, string declaration = "")
+    {
+        var source = $$"""
+                       using System.Threading.Tasks;
+
+                       interface ISeam { Task KeepAsync(Thing thing); }
+
+                       class Thing { public string[] Names { get; set; } = []; }
+
+                       class Caller
+                       {
+                           private readonly ISeam seam = null!;
+
+                           public async Task Run(Thing thing, Thing other)
+                           {
+                               {{declaration}}
+                               {{body}}
+                           }
+                       }
+                       """;
+
+        var tree = CSharpSyntaxTree.ParseText(source, path: "Probe.cs");
+        Assert.DoesNotContain(tree.GetDiagnostics(), d => d.Severity == DiagnosticSeverity.Error);
+
+        return Walk([("Probe.cs", tree)]).Offences;
+    }
+
+    /// <summary>Every spelling of the same read that the walker claims to catch.</summary>
+    [Theory]
+    [InlineData("var n = thing.Names.Length;")]
+    [InlineData("if (thing is { Names.Length: 0 }) { }")]
+    [InlineData("var n = thing switch { { Names.Length: 0 } => 1, _ => 2 };")]
+    [InlineData("switch (thing) { case { Names.Length: 0 }: break; }")]
+    public void AReadAfterTheLoanIsCaughtHoweverItIsWritten(string read)
+    {
+        var offences = OffencesIn($"await seam.KeepAsync(thing);{Environment.NewLine}{read}");
+
+        Assert.Single(offences);
+        Assert.Contains("read Names", offences[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>What the walker must NOT report, so its silence means something.</summary>
+    [Theory]
+    // Read before the loan: the callee never had the chance.
+    [InlineData("var n = thing.Names.Length;\nawait seam.KeepAsync(thing);", "")]
+    // Another object entirely.
+    [InlineData("await seam.KeepAsync(thing);\nvar n = other.Names.Length;", "")]
+    // A positional pattern names deconstruction parameters, which read like members and are not.
+    [InlineData("await seam.KeepAsync(thing);\nif (thing is (Names: 1, Other: 2)) { }", "")]
+    // Declared, and the declaration names the member.
+    [InlineData("await seam.KeepAsync(thing);\nvar n = thing.Names.Length;", "// lent deliberately Names: the reason.")]
+    public void WhatIsNotAnOffence(string body, string declaration)
+        => Assert.Empty(OffencesIn(body.Replace("\\n", Environment.NewLine), declaration));
+
+    /// <summary>A declaration only counts where a declaration is written.</summary>
+    /// <remarks>
+    /// A documentation comment opens with the same two characters, and the tools that read documentation
+    /// put it where a reader of the code does not look for a decision about the code.
+    /// </remarks>
+    [Fact]
+    public void ADeclarationInADocumentationCommentDoesNotSilence()
+    {
+        var offences = OffencesIn(
+            $"await seam.KeepAsync(thing);{Environment.NewLine}var n = thing.Names.Length;",
+            "/// lent deliberately Names: written where it does not belong.");
+
+        Assert.Single(offences);
+    }
+
+    /// <summary>A declaration on a statement making two calls cannot say which one it excuses.</summary>
+    [Fact]
+    public void ADeclarationOnAStatementWithTwoCallsIsRefused()
+    {
+        var offences = OffencesIn(
+            $"var pair = (await seam.KeepAsync(thing), await seam.KeepAsync(other));"
+            + $"{Environment.NewLine}var n = thing.Names.Length;",
+            "// lent deliberately Names: written for the first call only.");
+
+        Assert.Single(offences);
+        Assert.Contains("more than one call", offences[0], StringComparison.Ordinal);
+    }
     /// <summary>
     /// Nothing hands a value to a replaceable implementation and then measures anything against it.
     /// </summary>
@@ -301,9 +456,7 @@ public class ValueHandedToAHostSeamTests
         var written = sources
             .SelectMany(s => s.Tree.GetRoot().DescendantNodes().OfType<StatementSyntax>())
             .SelectMany(statement => MembersDeclaredOn(statement)
-                .Select(member => $"{Path.GetFileName(statement.SyntaxTree.FilePath)}"
-                    + $"({statement.SyntaxTree.GetLineSpan(statement.Span).StartLinePosition.Line + 1})"
-                    + $":{member}"))
+                .Select(member => SiteOf(statement, member)))
             .ToArray();
 
         Assert.True(
@@ -312,8 +465,7 @@ public class ValueHandedToAHostSeamTests
 
         // Named rather than counted: a number tells you the two disagree, and the name tells you which
         // declaration stopped describing a read.
-        var describing = honoured.Select(entry => entry[(entry.LastIndexOf('\\') + 1)..]).ToHashSet();
-        var stale = written.Where(entry => !describing.Contains(entry)).Order().ToArray();
+        var stale = written.Where(entry => !honoured.Contains(entry)).Order().ToArray();
 
         Assert.True(
             stale.Length == 0,
@@ -338,13 +490,14 @@ public class ValueHandedToAHostSeamTests
     [Fact]
     public void EverySourceIsParsedOrKnownToBeUnreadable()
     {
+        var root = RepositoryRoot();
         var unreadable = LibrarySources()
             .Where(s => s.Tree.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
-            .Select(s => Path.GetFileName(s.Path))
+            .Select(s => Path.GetRelativePath(root, s.Path).Replace('\\', '/'))
             .Order(StringComparer.Ordinal)
             .ToArray();
 
-        Assert.Equal(["Result.cs"], unreadable);
+        Assert.Equal(["src/Abblix.Utils/Result.cs"], unreadable);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
@@ -612,6 +612,15 @@ public class ValueHandedToAHostSeamTests
     /// <para>
     /// It reports on branches that cannot both run, since it compares positions rather than paths.
     /// </para>
+    /// <para>
+    /// Two shapes it missed on real code, named because a clean run had already been read as covering
+    /// them. ENUMERATION is not a member access, so a loop over a lent value whose body calls the seam
+    /// is invisible here even though the value is being walked while an implementation answers - that
+    /// was the end-session notification loop. And a value re-read WITHOUT any seam call between the
+    /// two reads is outside this walker entirely: asking a live collection its size and then
+    /// serialising it loses the whole property when another request fills it in between, and no host
+    /// implementation is involved for this walker to anchor on.
+    /// </para>
     /// </remarks>
     [Fact]
     public void TheShapesThisWalkerCannotSee()

--- a/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
@@ -1,0 +1,245 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Architecture;
+
+/// <summary>
+/// A value handed to a replaceable implementation, and then read back by the caller that handed it over.
+/// </summary>
+/// <remarks>
+/// Everything reached through an interface here is a seam a host can occupy, and narrowing by editing what
+/// you were given is how narrowing is written throughout this repository. So a caller that hands an object
+/// to such a call and afterwards measures anything against that same object is asking a question whose
+/// answer the callee has already had the chance to change - and the failure is silent: the value still
+/// looks like a request, it just no longer says what was asked for.
+/// <para>
+/// The shape is an ORDER of statements inside one method, which is why this walks the syntax rather than
+/// the text. What it does NOT see is listed on <see cref="TheShapesThisTestCannotSee"/>.
+/// </para>
+/// </remarks>
+public class ValueHandedToAHostSeamTests
+{
+    /// <summary>
+    /// A member whose value can be edited without replacing it, so handing it over lends it out.
+    /// </summary>
+    private static bool IsMutableInPlace(TypeSyntax? type)
+    {
+        if (type is null) return false;
+
+        var text = type.ToString().TrimEnd('?');
+        if (text.EndsWith("[]", StringComparison.Ordinal)) return true;
+
+        var generic = text.Split('<')[0];
+        return generic is "JsonArray" or "JsonObject" or "JsonNode"
+            or "List" or "Dictionary" or "HashSet" or "SortedSet" or "SortedDictionary"
+            or "ICollection" or "IList" or "IDictionary" or "ISet";
+    }
+
+    private static string Normalized(SyntaxNode node)
+        => string.Concat(node.ToString().Where(c => !char.IsWhiteSpace(c)));
+
+    /// <summary>
+    /// The marker a site uses to say the read-back is the point, and why.
+    /// </summary>
+    /// <remarks>
+    /// Touching a value after handing it to a store is sometimes the whole intent - echoing what was
+    /// registered, including the defaults the server assigned, or writing the change that gets
+    /// persisted. The walker cannot tell that from a yardstick somebody moved, so the site says which
+    /// it is, at the site, with a reason.
+    /// <para>
+    /// The marker NAMES the member it excuses, so it stays a silence about one thing rather than about
+    /// the call: a read of something else added later is reported as if the marker were not there. And
+    /// a marker describing nothing fails, so one left behind by a later edit is not a silence anybody
+    /// keeps.
+    /// </para>
+    /// </remarks>
+    private const string Declared = "// lent deliberately";
+
+    private static bool IsDeclared(SyntaxNode call, string member)
+    {
+        for (var node = call; node is not null; node = node.Parent)
+        {
+            if (node is not StatementSyntax) continue;
+
+            var leading = node.GetLeadingTrivia().ToString();
+            return leading.Contains($"{Declared} {member}:", StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Abblix.Oidc.slnx")))
+            directory = directory.Parent;
+
+        Assert.NotNull(directory);
+        return directory.FullName;
+    }
+
+    private static IReadOnlyList<(string Path, CompilationUnitSyntax Root)> LibrarySources()
+    {
+        var source = Path.Combine(RepositoryRoot(), "src");
+        var files = Directory
+            .EnumerateFiles(source, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                           && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            .ToArray();
+
+        // A file that cannot be read hides every occurrence in it from every walker, and reads exactly
+        // like a clean one - so the count is asserted rather than trusted.
+        Assert.True(files.Length > 1000, $"only {files.Length} library sources found - wrong root?");
+
+        return files
+            .Select(path => (path, (CompilationUnitSyntax)CSharpSyntaxTree.ParseText(File.ReadAllText(path)).GetRoot()))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Every offending pair, as "file(line): the call, then the read".
+    /// </summary>
+    private static (IReadOnlyList<string> Offences, int Declared) Walk(
+        IReadOnlyList<(string Path, CompilationUnitSyntax Root)> sources)
+    {
+        // The population comes from the artefact, never from a list somebody appends to: a method declared
+        // on an interface is a method a host can supply the body of.
+        var seamMethods = sources
+            .SelectMany(s => s.Root.DescendantNodes().OfType<InterfaceDeclarationSyntax>())
+            .SelectMany(i => i.Members.OfType<MethodDeclarationSyntax>())
+            .Select(m => m.Identifier.ValueText)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var mutableMembers = sources
+            .SelectMany(s => s.Root.DescendantNodes())
+            .SelectMany(node => node switch
+            {
+                PropertyDeclarationSyntax p when IsMutableInPlace(p.Type) => new[] { p.Identifier.ValueText },
+                FieldDeclarationSyntax f when IsMutableInPlace(f.Declaration.Type)
+                    => f.Declaration.Variables.Select(v => v.Identifier.ValueText).ToArray(),
+                ParameterSyntax r when IsMutableInPlace(r.Type) => [r.Identifier.ValueText],
+                _ => [],
+            })
+            .ToHashSet(StringComparer.Ordinal);
+
+        var offences = new List<string>();
+        var declared = 0;
+
+        foreach (var (path, root) in sources)
+        foreach (var body in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            if (body.Body is not { } statements) continue;
+
+            foreach (var awaited in statements.DescendantNodes().OfType<AwaitExpressionSyntax>())
+            {
+                if (awaited.Expression is not InvocationExpressionSyntax
+                    {
+                        Expression: MemberAccessExpressionSyntax { Name.Identifier.ValueText: var called },
+                    } call)
+                    continue;
+
+                if (!seamMethods.Contains(called)) continue;
+
+                foreach (var argument in call.ArgumentList.Arguments)
+                {
+                    var lent = Normalized(argument.Expression);
+                    if (lent.Length == 0 || argument.Expression is LiteralExpressionSyntax) continue;
+
+                    var readBack = statements
+                        .DescendantNodes()
+                        .Where(node => node.SpanStart > awaited.Span.End)
+                        .OfType<MemberAccessExpressionSyntax>()
+                        .FirstOrDefault(access =>
+                            mutableMembers.Contains(access.Name.Identifier.ValueText)
+                            && (Normalized(access) == lent
+                                || Normalized(access).StartsWith(lent + ".", StringComparison.Ordinal)));
+
+                    if (readBack is null) continue;
+
+                    if (IsDeclared(call, readBack.Name.Identifier.ValueText))
+                    {
+                        declared++;
+                        break;
+                    }
+
+                    var lentAt = call.SyntaxTree.GetLineSpan(call.Span).StartLinePosition.Line + 1;
+                    var readAt = readBack.SyntaxTree.GetLineSpan(readBack.Span).StartLinePosition.Line + 1;
+                    offences.Add(
+                        $"{Path.GetFileName(path)}({lentAt}): {called} was handed {lent}, "
+                        + $"then line {readAt} read {Normalized(readBack)}");
+                    break;
+                }
+            }
+        }
+
+        return (offences, declared);
+    }
+
+    /// <summary>
+    /// Nothing hands a value to a replaceable implementation and then measures anything against it.
+    /// </summary>
+    [Fact]
+    public void NothingIsMeasuredAgainstAValueAlreadyLentOut()
+    {
+        var (offences, _) = Walk(LibrarySources());
+
+        Assert.True(
+            offences.Count == 0,
+            "A value was handed to an implementation a host can replace, and then read back:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offences));
+    }
+
+    /// <summary>
+    /// Every declaration that the read-back is deliberate describes a read-back that is still there.
+    /// </summary>
+    /// <remarks>
+    /// A marker is a silence, so it has to expire on its own. Left behind by an edit that removed the
+    /// read it excused, it would go on excusing whatever lands there next - and the walker would report
+    /// clean about a site nobody has looked at since.
+    /// </remarks>
+    [Fact]
+    public void EveryDeclarationOfADeliberateLoanStillDescribesOne()
+    {
+        var sources = LibrarySources();
+        var (_, declared) = Walk(sources);
+
+        var written = sources
+            .SelectMany(s => s.Root.DescendantTrivia())
+            .Count(trivia => trivia.ToString().Contains(Declared, StringComparison.Ordinal));
+
+        Assert.Equal(written, declared);
+    }
+
+    /// <summary>
+    /// What this walker is blind to, said out loud so a clean run is not read as a clean repository.
+    /// </summary>
+    /// <remarks>
+    /// It sees only awaited calls, so a synchronous seam passes; only calls written as a member access, so
+    /// one through a delegate or an extension-method chain passes; and only reads in the same method body,
+    /// so a value stored on a field and read by another member passes. It also decides mutability from the
+    /// declared type text rather than from a resolved symbol, so a type alias or a custom collection is not
+    /// recognised.
+    /// </remarks>
+    [Fact]
+    public void TheShapesThisTestCannotSee()
+    {
+        // A statement of scope rather than a check, and it is here so the list has a place a reader lands
+        // on from the failure message above.
+        Assert.True(true);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
@@ -28,7 +28,8 @@ namespace Abblix.Oidc.Server.UnitTests.Architecture;
 /// looks like a request, it just no longer says what was asked for.
 /// <para>
 /// The shape is an ORDER of statements inside one method, which is why this walks the syntax rather than
-/// the text. What it does NOT see is listed on <see cref="TheShapesThisTestCannotSee"/>.
+/// the text. What it does NOT see is listed on <see cref="TheShapesThisWalkerCannotSee"/>, and what it
+/// cannot even READ is asserted by <see cref="EverySourceIsParsedOrKnownToBeUnreadable"/>.
 /// </para>
 /// </remarks>
 public class ValueHandedToAHostSeamTests
@@ -53,33 +54,57 @@ public class ValueHandedToAHostSeamTests
         => string.Concat(node.ToString().Where(c => !char.IsWhiteSpace(c)));
 
     /// <summary>
-    /// The marker a site uses to say the read-back is the point, and why.
+    /// The marker a site uses to say that touching the value afterwards is the point, and why.
     /// </summary>
     /// <remarks>
-    /// Touching a value after handing it to a store is sometimes the whole intent - echoing what was
-    /// registered, including the defaults the server assigned, or writing the change that gets
-    /// persisted. The walker cannot tell that from a yardstick somebody moved, so the site says which
+    /// Reading a value back after handing it to a store is sometimes the whole intent - echoing what was
+    /// registered, including the defaults the server assigned - and so is writing the change that gets
+    /// persisted. The walker cannot tell either from a yardstick somebody moved, so the site says which
     /// it is, at the site, with a reason.
     /// <para>
-    /// The marker NAMES the member it excuses, so it stays a silence about one thing rather than about
-    /// the call: a read of something else added later is reported as if the marker were not there. And
-    /// a marker describing nothing fails, so one left behind by a later edit is not a silence anybody
-    /// keeps.
+    /// The marker NAMES the members it excuses, comma-separated, so it stays a silence about those and not
+    /// about the call: a read of anything else is reported as if the marker were not there. And every name
+    /// it carries must match a read that is still there, so a marker outliving what it excused fails
+    /// rather than going on excusing whatever lands next.
     /// </para>
     /// </remarks>
-    private const string Declared = "// lent deliberately";
+    private const string Declared = "lent deliberately ";
 
-    private static bool IsDeclared(SyntaxNode call, string member)
+    /// <summary>The members a statement declares, as written above it.</summary>
+    /// <remarks>
+    /// The comment block above the statement is read as ONE line, so a list too long for a line of code
+    /// wraps the way prose does. The names run to the colon, and what follows the colon is the reason,
+    /// which nothing here reads - it is for whoever arrives at the site.
+    /// </remarks>
+    private static string[] MembersDeclaredOn(SyntaxNode statement)
+    {
+        var trivia = statement.GetLeadingTrivia().ToString();
+        if (!trivia.Contains(Declared, StringComparison.Ordinal)) return [];
+
+        var joined = string.Join(' ', trivia
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Select(line => line.StartsWith("//", StringComparison.Ordinal) ? line[2..] : line));
+
+        var start = joined.IndexOf(Declared, StringComparison.Ordinal);
+        if (start < 0) return [];
+
+        var names = joined[(start + Declared.Length)..];
+        var end = names.IndexOf(':');
+        return end < 0
+            ? []
+            : names[..end].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>The members the site around one call declares.</summary>
+    private static IReadOnlyCollection<string> DeclaredMembers(SyntaxNode call)
     {
         for (var node = call; node is not null; node = node.Parent)
         {
-            if (node is not StatementSyntax) continue;
-
-            var leading = node.GetLeadingTrivia().ToString();
-            return leading.Contains($"{Declared} {member}:", StringComparison.Ordinal);
+            if (node is StatementSyntax) return MembersDeclaredOn(node);
         }
 
-        return false;
+        return [];
     }
 
     private static string RepositoryRoot()
@@ -92,7 +117,7 @@ public class ValueHandedToAHostSeamTests
         return directory.FullName;
     }
 
-    private static IReadOnlyList<(string Path, CompilationUnitSyntax Root)> LibrarySources()
+    private static IReadOnlyList<(string Path, SyntaxTree Tree)> LibrarySources()
     {
         var source = Path.Combine(RepositoryRoot(), "src");
         var files = Directory
@@ -101,30 +126,87 @@ public class ValueHandedToAHostSeamTests
                            && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
             .ToArray();
 
-        // A file that cannot be read hides every occurrence in it from every walker, and reads exactly
-        // like a clean one - so the count is asserted rather than trusted.
+        // A file that cannot be read hides every occurrence in it from every walker, and reads exactly like
+        // a clean one - so the count is asserted rather than trusted. It is a weak control on its own; the
+        // one that proves the matcher reaches a positive is the declaration count.
         Assert.True(files.Length > 1000, $"only {files.Length} library sources found - wrong root?");
 
         return files
-            .Select(path => (path, (CompilationUnitSyntax)CSharpSyntaxTree.ParseText(File.ReadAllText(path)).GetRoot()))
+            // The path travels with the tree, so a node can say which file it came from - two of the
+            // assertions below name a site, and a tree parsed without one names nothing.
+            .Select(path => (path, CSharpSyntaxTree.ParseText(File.ReadAllText(path), path: path)))
             .ToArray();
     }
 
+    private static IEnumerable<SyntaxNode> After(SyntaxNode body, SyntaxNode call)
+        => body.DescendantNodes().Where(node => node.SpanStart > call.Span.End);
+
     /// <summary>
-    /// Every offending pair, as "file(line): the call, then the read".
+    /// Every lendable member of <paramref name="lent"/> read after the call, once each.
     /// </summary>
-    private static (IReadOnlyList<string> Offences, int Declared) Walk(
-        IReadOnlyList<(string Path, CompilationUnitSyntax Root)> sources)
+    /// <remarks>
+    /// Two shapes, because the repository writes both: an ordinary member access, and a property pattern,
+    /// where the member never appears as an access rooted at the value - <c>x is { Members.Count: 0 }</c>
+    /// carries the same read and none of the syntax the first shape is found by.
+    /// </remarks>
+    private static IEnumerable<(string Member, SyntaxNode Where)> ReadsAfter(
+        SyntaxNode body, SyntaxNode call, string lent, IReadOnlySet<string> lendable)
     {
+        var found = new Dictionary<string, SyntaxNode>(StringComparer.Ordinal);
+
+        bool RootedAtTheLoan(SyntaxNode expression)
+        {
+            var text = Normalized(expression);
+            return text == lent || text.StartsWith(lent + ".", StringComparison.Ordinal);
+        }
+
+        foreach (var access in After(body, call).OfType<MemberAccessExpressionSyntax>())
+        {
+            var member = access.Name.Identifier.ValueText;
+            if (lendable.Contains(member) && RootedAtTheLoan(access))
+                found.TryAdd(member, access);
+        }
+
+        foreach (var pattern in After(body, call).OfType<IsPatternExpressionSyntax>())
+        {
+            if (!RootedAtTheLoan(pattern.Expression)) continue;
+
+            foreach (var named in pattern.Pattern.DescendantNodesAndSelf())
+            {
+                var member = named switch
+                {
+                    NameColonSyntax name => name.Name.Identifier.ValueText,
+                    ExpressionColonSyntax { Expression: IdentifierNameSyntax id } => id.Identifier.ValueText,
+                    ExpressionColonSyntax { Expression: MemberAccessExpressionSyntax access }
+                        => Normalized(access).Split('.')[0],
+                    _ => null,
+                };
+
+                if (member is not null && lendable.Contains(member))
+                    found.TryAdd(member, named);
+            }
+        }
+
+        return found.Select(entry => (entry.Key, entry.Value));
+    }
+
+    /// <summary>
+    /// Every offence, and every declared member that still describes a read.
+    /// </summary>
+    private static (IReadOnlyList<string> Offences, IReadOnlySet<string> Honoured) Walk(
+        IReadOnlyList<(string Path, SyntaxTree Tree)> sources)
+    {
+        var roots = sources.Select(s => (s.Path, Root: s.Tree.GetRoot())).ToArray();
+
         // The population comes from the artefact, never from a list somebody appends to: a method declared
         // on an interface is a method a host can supply the body of.
-        var seamMethods = sources
+        var seamMethods = roots
             .SelectMany(s => s.Root.DescendantNodes().OfType<InterfaceDeclarationSyntax>())
             .SelectMany(i => i.Members.OfType<MethodDeclarationSyntax>())
             .Select(m => m.Identifier.ValueText)
             .ToHashSet(StringComparer.Ordinal);
 
-        var mutableMembers = sources
+        var lendable = roots
             .SelectMany(s => s.Root.DescendantNodes())
             .SelectMany(node => node switch
             {
@@ -137,14 +219,14 @@ public class ValueHandedToAHostSeamTests
             .ToHashSet(StringComparer.Ordinal);
 
         var offences = new List<string>();
-        var declared = 0;
+        var honoured = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var (path, root) in sources)
-        foreach (var body in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        foreach (var (path, root) in roots)
+        foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
         {
-            if (body.Body is not { } statements) continue;
+            if (method.Body is not { } body) continue;
 
-            foreach (var awaited in statements.DescendantNodes().OfType<AwaitExpressionSyntax>())
+            foreach (var awaited in body.DescendantNodes().OfType<AwaitExpressionSyntax>())
             {
                 if (awaited.Expression is not InvocationExpressionSyntax
                     {
@@ -154,39 +236,34 @@ public class ValueHandedToAHostSeamTests
 
                 if (!seamMethods.Contains(called)) continue;
 
+                var declared = DeclaredMembers(call);
+                var lentAt = call.SyntaxTree.GetLineSpan(call.Span).StartLinePosition.Line + 1;
+
                 foreach (var argument in call.ArgumentList.Arguments)
                 {
+                    if (argument.Expression is LiteralExpressionSyntax) continue;
+
                     var lent = Normalized(argument.Expression);
-                    if (lent.Length == 0 || argument.Expression is LiteralExpressionSyntax) continue;
+                    if (lent.Length == 0) continue;
 
-                    var readBack = statements
-                        .DescendantNodes()
-                        .Where(node => node.SpanStart > awaited.Span.End)
-                        .OfType<MemberAccessExpressionSyntax>()
-                        .FirstOrDefault(access =>
-                            mutableMembers.Contains(access.Name.Identifier.ValueText)
-                            && (Normalized(access) == lent
-                                || Normalized(access).StartsWith(lent + ".", StringComparison.Ordinal)));
-
-                    if (readBack is null) continue;
-
-                    if (IsDeclared(call, readBack.Name.Identifier.ValueText))
+                    foreach (var (member, where) in ReadsAfter(body, awaited, lent, lendable))
                     {
-                        declared++;
-                        break;
-                    }
+                        if (declared.Contains(member))
+                        {
+                            honoured.Add($"{path}({lentAt}):{member}");
+                            continue;
+                        }
 
-                    var lentAt = call.SyntaxTree.GetLineSpan(call.Span).StartLinePosition.Line + 1;
-                    var readAt = readBack.SyntaxTree.GetLineSpan(readBack.Span).StartLinePosition.Line + 1;
-                    offences.Add(
-                        $"{Path.GetFileName(path)}({lentAt}): {called} was handed {lent}, "
-                        + $"then line {readAt} read {Normalized(readBack)}");
-                    break;
+                        var readAt = where.SyntaxTree.GetLineSpan(where.Span).StartLinePosition.Line + 1;
+                        offences.Add(
+                            $"{Path.GetFileName(path)}({lentAt}): {called} was handed {lent}, "
+                            + $"then line {readAt} read {member}");
+                    }
                 }
             }
         }
 
-        return (offences, declared);
+        return (offences, honoured);
     }
 
     /// <summary>
@@ -205,24 +282,69 @@ public class ValueHandedToAHostSeamTests
     }
 
     /// <summary>
-    /// Every declaration that the read-back is deliberate describes a read-back that is still there.
+    /// Every member a site declares deliberate is a member it still reads.
     /// </summary>
     /// <remarks>
-    /// A marker is a silence, so it has to expire on its own. Left behind by an edit that removed the
-    /// read it excused, it would go on excusing whatever lands there next - and the walker would report
-    /// clean about a site nobody has looked at since.
+    /// A marker is a silence, so it has to expire on its own. Left behind by an edit that removed the read
+    /// it excused, it would go on excusing whatever lands there next - and the walker would report clean
+    /// about a site nobody has looked at since. This is also the walker's real positive control: it proves
+    /// the matcher reaches a positive on named sites, which a file count cannot.
     /// </remarks>
     [Fact]
-    public void EveryDeclarationOfADeliberateLoanStillDescribesOne()
+    public void EveryDeclaredMemberStillDescribesARead()
     {
         var sources = LibrarySources();
-        var (_, declared) = Walk(sources);
+        var (_, honoured) = Walk(sources);
 
+        // Counted the way the walker reads them, over the same statements, so the two cannot disagree
+        // about what a declaration says - only about whether it still describes anything.
         var written = sources
-            .SelectMany(s => s.Root.DescendantTrivia())
-            .Count(trivia => trivia.ToString().Contains(Declared, StringComparison.Ordinal));
+            .SelectMany(s => s.Tree.GetRoot().DescendantNodes().OfType<StatementSyntax>())
+            .SelectMany(statement => MembersDeclaredOn(statement)
+                .Select(member => $"{Path.GetFileName(statement.SyntaxTree.FilePath)}"
+                    + $"({statement.SyntaxTree.GetLineSpan(statement.Span).StartLinePosition.Line + 1})"
+                    + $":{member}"))
+            .ToArray();
 
-        Assert.Equal(written, declared);
+        Assert.True(
+            written.Length > 0,
+            "no site declares a deliberate loan, so nothing proves the walker matches");
+
+        // Named rather than counted: a number tells you the two disagree, and the name tells you which
+        // declaration stopped describing a read.
+        var describing = honoured.Select(entry => entry[(entry.LastIndexOf('\\') + 1)..]).ToHashSet();
+        var stale = written.Where(entry => !describing.Contains(entry)).Order().ToArray();
+
+        Assert.True(
+            stale.Length == 0,
+            "A site declares a deliberate loan of a member it no longer reads:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, stale));
+    }
+
+    /// <summary>
+    /// Every source parses, except the ones this walker knows its parser is too old to read.
+    /// </summary>
+    /// <remarks>
+    /// Syntax-tree error recovery is silent: a file the parser cannot read produces a tree with nothing in
+    /// it and is walked exactly like an empty one, so the walker reports clean about whatever it contains.
+    /// The analyzer package pinned for this suite predates the union syntax the library is written in,
+    /// which is why the list below is not empty.
+    /// <para>
+    /// The list is exact on purpose. When the parser learns the syntax, this assertion is what fails, and
+    /// the failure says to delete the entry rather than leaving a permanent hole nobody re-reads.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EverySourceIsParsedOrKnownToBeUnreadable()
+    {
+        var unreadable = LibrarySources()
+            .Where(s => s.Tree.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+            .Select(s => Path.GetFileName(s.Path))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["Result.cs"], unreadable);
     }
 
     /// <summary>
@@ -231,12 +353,17 @@ public class ValueHandedToAHostSeamTests
     /// <remarks>
     /// It sees only awaited calls, so a synchronous seam passes; only calls written as a member access, so
     /// one through a delegate or an extension-method chain passes; and only reads in the same method body,
-    /// so a value stored on a field and read by another member passes. It also decides mutability from the
-    /// declared type text rather than from a resolved symbol, so a type alias or a custom collection is not
-    /// recognised.
+    /// so a value stored on a field and read by another member passes. A read reached through a LOCAL ALIAS
+    /// passes as well, since the walker matches the text of the expression rather than following what it
+    /// refers to, and one assignment defeats it. It also decides lendability from the declared type text
+    /// rather than from a resolved symbol, so a type alias or a custom collection is not recognised, while
+    /// a name declared mutably ANYWHERE counts as mutable everywhere - which errs towards reporting.
+    /// <para>
+    /// It reports on branches that cannot both run, since it compares positions rather than paths.
+    /// </para>
     /// </remarks>
     [Fact]
-    public void TheShapesThisTestCannotSee()
+    public void TheShapesThisWalkerCannotSee()
     {
         // A statement of scope rather than a check, and it is here so the list has a place a reader lands
         // on from the failure message above.

--- a/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Architecture/ValueHandedToAHostSeamTests.cs
@@ -107,15 +107,25 @@ public class ValueHandedToAHostSeamTests
 
     /// <summary>One site and member, named the same way wherever it is counted.</summary>
     /// <remarks>
-    /// Built once and used by both sides. Two keys assembled independently agree only while nothing
-    /// moves: one built from the call and one from the statement disagree the moment a statement wraps,
-    /// and one carrying a full path disagrees on whichever platform does not spell paths that way.
+    /// Built once and used by both sides, because two keys assembled independently agree only while
+    /// nothing moves - one built from the call and one from the statement part company the moment a
+    /// statement wraps. The file is named by its place in the repository rather than by its own name:
+    /// two files sharing a name would be one key, and a declaration at the same line in each would
+    /// silence the other, which is nobody's intent and nothing's failure.
     /// </remarks>
     private static string SiteOf(StatementSyntax statement, string member)
     {
         var line = statement.SyntaxTree.GetLineSpan(statement.Span).StartLinePosition.Line + 1;
-        return $"{Path.GetFileName(statement.SyntaxTree.FilePath)}({line}):{member}";
+        return $"{Located(statement.SyntaxTree.FilePath)}({line}):{member}";
     }
+
+    /// <summary>Where a file sits in the repository, spelled the same way on every platform.</summary>
+    private static string Located(string path)
+        => Path.IsPathRooted(path)
+            ? Path.GetRelativePath(Root.Value, path).Replace('\\', '/')
+            : path;
+
+    private static readonly Lazy<string> Root = new(RepositoryRoot);
 
     private static string RepositoryRoot()
     {
@@ -177,7 +187,7 @@ public class ValueHandedToAHostSeamTests
                 found.TryAdd(member, access);
         }
 
-        IEnumerable<(SyntaxNode Subject, PatternSyntax Pattern)> Patterns()
+        IEnumerable<(ExpressionSyntax Subject, PatternSyntax Pattern)> Patterns()
         {
             foreach (var node in After(body, call))
                 switch (node)
@@ -200,9 +210,21 @@ public class ValueHandedToAHostSeamTests
                 }
         }
 
-        foreach (var (subject, pattern) in Patterns())
+        void Collect(ExpressionSyntax subject, PatternSyntax pattern)
         {
-            if (!RootedAtTheLoan(subject)) continue;
+            // A tuple subject is matched element by element, because the loan is one of the elements and
+            // the whole tuple is never rooted at it. This file's own subject reads that way.
+            if (pattern is RecursivePatternSyntax { PositionalPatternClause: { } positional }
+                && subject is TupleExpressionSyntax tuple
+                && tuple.Arguments.Count == positional.Subpatterns.Count)
+            {
+                for (var i = 0; i < tuple.Arguments.Count; i++)
+                    Collect(tuple.Arguments[i].Expression, positional.Subpatterns[i].Pattern);
+
+                return;
+            }
+
+            if (!RootedAtTheLoan(subject)) return;
 
             // Only a PROPERTY pattern names members. The elements of a positional one carry the names
             // of deconstruction parameters, which read like members and are not.
@@ -224,17 +246,27 @@ public class ValueHandedToAHostSeamTests
             }
         }
 
+        foreach (var (subject, pattern) in Patterns())
+            Collect(subject, pattern);
+
         return found.Select(entry => (entry.Key, entry.Value));
     }
 
-    /// <summary>How many calls a host could answer this statement makes.</summary>
-    private static int SeamCallsIn(SyntaxNode statement, IReadOnlySet<string> seamMethods)
+    /// <summary>How many calls a host could answer belong to this statement itself.</summary>
+    /// <remarks>
+    /// A call in the header of an <c>if</c> or a <c>foreach</c> belongs to the whole statement, block
+    /// included, so counting the subtree counts the calls INSIDE the block as well - and each of those
+    /// is a statement of its own that can carry its own declaration. Counted that way, a declaration on
+    /// the header is called ambiguous when there is exactly one call it could mean.
+    /// </remarks>
+    private static int SeamCallsIn(StatementSyntax statement, IReadOnlySet<string> seamMethods)
         => statement.DescendantNodes()
             .OfType<AwaitExpressionSyntax>()
             .Select(awaited => awaited.Expression)
             .OfType<InvocationExpressionSyntax>()
             .Count(call => call.Expression is MemberAccessExpressionSyntax access
-                           && seamMethods.Contains(access.Name.Identifier.ValueText));
+                           && seamMethods.Contains(access.Name.Identifier.ValueText)
+                           && EnclosingStatement(call) == statement);
 
     /// <summary>
     /// Every offence, and every declared member that still describes a read.
@@ -342,10 +374,23 @@ public class ValueHandedToAHostSeamTests
     /// </remarks>
     private static IReadOnlyList<string> OffencesIn(string body, string declaration = "")
     {
-        var source = $$"""
+        var tree = Parsed(ProbeSource(body, declaration), "Probe.cs");
+        Assert.DoesNotContain(tree.GetDiagnostics(), d => d.Severity == DiagnosticSeverity.Error);
+
+        return Walk([("Probe.cs", tree)]).Offences;
+    }
+
+    private static SyntaxTree Parsed(string source, string path)
+        => CSharpSyntaxTree.ParseText(
+            source, path: path, cancellationToken: TestContext.Current.CancellationToken);
+
+    /// <summary>One source declaring its own seam and its own lendable member.</summary>
+    private static string ProbeSource(string body, string declaration = "")
+    {
+        return $$"""
                        using System.Threading.Tasks;
 
-                       interface ISeam { Task KeepAsync(Thing thing); }
+                       interface ISeam { Task KeepAsync(Thing thing); Task<object?> AskAsync(Thing thing); }
 
                        class Thing { public string[] Names { get; set; } = []; }
 
@@ -360,11 +405,6 @@ public class ValueHandedToAHostSeamTests
                            }
                        }
                        """;
-
-        var tree = CSharpSyntaxTree.ParseText(source, path: "Probe.cs");
-        Assert.DoesNotContain(tree.GetDiagnostics(), d => d.Severity == DiagnosticSeverity.Error);
-
-        return Walk([("Probe.cs", tree)]).Offences;
     }
 
     /// <summary>Every spelling of the same read that the walker claims to catch.</summary>
@@ -373,6 +413,9 @@ public class ValueHandedToAHostSeamTests
     [InlineData("if (thing is { Names.Length: 0 }) { }")]
     [InlineData("var n = thing switch { { Names.Length: 0 } => 1, _ => 2 };")]
     [InlineData("switch (thing) { case { Names.Length: 0 }: break; }")]
+    // A tuple subject is read element by element, which is how this repository writes one.
+    [InlineData("switch ((1, thing)) { case (_, { Names.Length: 0 }): break; default: break; }")]
+    [InlineData("if ((1, thing) is (_, { Names.Length: 0 })) { }")]
     public void AReadAfterTheLoanIsCaughtHoweverItIsWritten(string read)
     {
         var offences = OffencesIn($"await seam.KeepAsync(thing);{Environment.NewLine}{read}");
@@ -394,6 +437,53 @@ public class ValueHandedToAHostSeamTests
     public void WhatIsNotAnOffence(string body, string declaration)
         => Assert.Empty(OffencesIn(body.Replace("\\n", Environment.NewLine), declaration));
 
+
+    /// <summary>A call in a statement HEADER is one call, whatever the block below it does.</summary>
+    /// <remarks>
+    /// The header and its block are one statement, so counting the subtree would call this declaration
+    /// ambiguous - and the block's own call is a statement of its own that can declare for itself. The
+    /// shape is ordinary here.
+    /// </remarks>
+    [Fact]
+    public void ADeclarationOnAStatementHeaderIsNotAmbiguous()
+    {
+        var offences = OffencesIn(
+            "if (await seam.AskAsync(thing) is not null)"
+            + $"{Environment.NewLine}{{"
+            + $"{Environment.NewLine}    await seam.KeepAsync(other);"
+            + $"{Environment.NewLine}}}"
+            + $"{Environment.NewLine}var n = thing.Names.Length;",
+            "// lent deliberately Names: one call in the header.");
+
+        Assert.Empty(offences);
+    }
+
+    /// <summary>Two files sharing a name are two sites, so neither can silence the other.</summary>
+    /// <remarks>
+    /// The site is named by where the file sits, not by what it is called. Keyed by name, a declaration
+    /// at the same line in a file of the same name elsewhere reads as the same declaration, and the one
+    /// that stopped describing a read is answered by the one that still does.
+    /// </remarks>
+    [Fact]
+    public void ADeclarationIsNotAnsweredByASameNamedFileElsewhere()
+    {
+        var reads = ProbeSource("await seam.KeepAsync(thing);"
+            + $"{Environment.NewLine}var n = thing.Names.Length;",
+            "// lent deliberately Names: still read here.");
+
+        var doesNot = ProbeSource(
+            "await seam.KeepAsync(thing);",
+            "// lent deliberately Names: nothing reads it any more.");
+
+        var (written, stale) = Declarations([
+            ("/repo/one/Same.cs", Parsed(reads, "/repo/one/Same.cs")),
+            ("/repo/two/Same.cs", Parsed(doesNot, "/repo/two/Same.cs")),
+        ]);
+
+        Assert.Equal(2, written);
+        Assert.Single(stale);
+        Assert.Contains("two/Same.cs", stale[0], StringComparison.Ordinal);
+    }
     /// <summary>A declaration only counts where a declaration is written.</summary>
     /// <remarks>
     /// A documentation comment opens with the same two characters, and the tools that read documentation
@@ -449,29 +539,37 @@ public class ValueHandedToAHostSeamTests
     public void EveryDeclaredMemberStillDescribesARead()
     {
         var sources = LibrarySources();
+        var (written, stale) = Declarations(sources);
+
+        Assert.True(
+            written > 0,
+            "no site declares a deliberate loan, so nothing proves the walker matches");
+
+        Assert.True(
+            stale.Count == 0,
+            "A site declares a deliberate loan of a member it no longer reads:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, stale));
+    }
+
+    /// <summary>How many members are declared, and which of them no longer describe a read.</summary>
+    /// <remarks>
+    /// Counted the way the walker reads them, over the same statements, so the two sides cannot disagree
+    /// about what a declaration SAYS - only about whether it still describes anything. Named rather than
+    /// counted, because a number says the two disagree and a name says which declaration went quiet.
+    /// </remarks>
+    private static (int Written, IReadOnlyList<string> Stale) Declarations(
+        IReadOnlyList<(string Path, SyntaxTree Tree)> sources)
+    {
         var (_, honoured) = Walk(sources);
 
-        // Counted the way the walker reads them, over the same statements, so the two cannot disagree
-        // about what a declaration says - only about whether it still describes anything.
         var written = sources
             .SelectMany(s => s.Tree.GetRoot().DescendantNodes().OfType<StatementSyntax>())
             .SelectMany(statement => MembersDeclaredOn(statement)
                 .Select(member => SiteOf(statement, member)))
             .ToArray();
 
-        Assert.True(
-            written.Length > 0,
-            "no site declares a deliberate loan, so nothing proves the walker matches");
-
-        // Named rather than counted: a number tells you the two disagree, and the name tells you which
-        // declaration stopped describing a read.
-        var stale = written.Where(entry => !honoured.Contains(entry)).Order().ToArray();
-
-        Assert.True(
-            stale.Length == 0,
-            "A site declares a deliberate loan of a member it no longer reads:"
-            + Environment.NewLine
-            + string.Join(Environment.NewLine, stale));
+        return (written.Length, written.Where(entry => !honoured.Contains(entry)).Order().ToArray());
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1742,10 +1742,11 @@ public class AuthorizationRequestProcessorTests
     /// every time instead of one run in a thousand. The shipped collection hands a walker a snapshot
     /// and cannot refuse one, while copying out reads the size first and takes the contents after.
     /// </remarks>
-    private sealed class GrowsWhileMeasured(params string[] items) : ICollection<string>
+    private sealed class GrowsWhileMeasured(int growOnMeasure, params string[] items)
+        : ICollection<string>
     {
         private readonly List<string> _items = [..items];
-        private bool _grown;
+        private int _measures;
 
         public int Count
         {
@@ -1753,11 +1754,8 @@ public class AuthorizationRequestProcessorTests
             {
                 var answer = _items.Count;
 
-                if (!_grown)
-                {
-                    _grown = true;
-                    _items.Add("arrived-during-the-read");
-                }
+                if (++_measures == growOnMeasure)
+                    _items.Add($"arrived-during-read-{growOnMeasure}");
 
                 return answer;
             }
@@ -1779,18 +1777,24 @@ public class AuthorizationRequestProcessorTests
     /// <remarks>
     /// The question is not what the list says but HOW it is read. Asking for the size and then copying
     /// into an array of that size fails when the size moved in between; walking the collection asks it
-    /// for a view it is prepared to give, which the shipped one always is. The window is the one that
-    /// matters: this request's client is already recorded on the session and the store has not been
-    /// told, so a read that throws here loses the request AND the record, and the client is missing
-    /// from the logout that session drives.
+    /// for a view it is prepared to give, which the shipped collection always is.
+    /// <para>
+    /// Driven at both reads, because they are two different moments and only one of them is the bad
+    /// one. The first happens before the provider is handed the session; the second after this
+    /// request's client is already recorded and before the store has been told, so a read that throws
+    /// there loses the request AND the record, and the client is missing from the logout that session
+    /// drives. A fixture growing under the first read leaves the second one unguarded.
+    /// </para>
     /// </remarks>
-    [Fact]
-    public async Task ProcessAsync_ASessionGrowingWhileItIsRead_IsStillProcessed()
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task ProcessAsync_ASessionGrowingWhileItIsRead_IsStillProcessed(int whichRead)
     {
         var request = CreateRequest();
         var session = CreateAuthSession() with
         {
-            AffectedClientIds = new GrowsWhileMeasured(TestConstants.DefaultClientId),
+            AffectedClientIds = new GrowsWhileMeasured(whichRead, TestConstants.DefaultClientId),
         };
 
         var consents = CreateConsents();
@@ -1833,6 +1837,11 @@ public class AuthorizationRequestProcessorTests
         Assert.NotNull(capture.Grant);
         Assert.Equal(2, session.AffectedClientIds.Count);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
+
+        // What the response tells the client to watch names each client once, however many times the
+        // session happens to list it - one client does not deserve two front-channel logout calls.
+        var authenticated = Assert.IsType<SuccessfullyAuthenticated>(await _processor.ProcessAsync(request));
+        Assert.Equal([TestConstants.DefaultClientId], authenticated.AffectedClientIds);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -109,11 +109,14 @@ public class AuthorizationRequestProcessorTests
         JsonArray? authorizationDetails = null,
         TimeSpan? defaultMaxAge = null,
         string[]? defaultAcrValues = null,
-        string? idTokenHintSubject = null)
+        string? idTokenHintSubject = null,
+        string? clientId = null)
     {
+        clientId ??= TestConstants.DefaultClientId;
+
         var authRequest = new AuthorizationRequest
         {
-            ClientId = TestConstants.DefaultClientId,
+            ClientId = clientId,
             ResponseType = responseType ?? [ResponseTypes.Code],
             RedirectUri = TestConstants.DefaultRedirectUri,
             Scope = scope ?? [Scopes.OpenId],
@@ -123,7 +126,7 @@ public class AuthorizationRequestProcessorTests
             AuthorizationDetails = authorizationDetails,
         };
 
-        var clientInfo = new ClientInfo(TestConstants.DefaultClientId)
+        var clientInfo = new ClientInfo(clientId)
         {
             AuthorizationCodeExpiresIn = TimeSpan.FromMinutes(10),
             DefaultMaxAge = defaultMaxAge,
@@ -1607,9 +1610,9 @@ public class AuthorizationRequestProcessorTests
     /// <remarks>
     /// The shipped session holds a set, so a second copy is dropped before anything notices - and the
     /// collection is public with an initialiser, so a host may supply a list. Then every request appends
-    /// another entry, the session is written because it now carries more than the store held, and logout
-    /// emits one front-channel call per entry: the same client, told to log out as many times as it has
-    /// ever authorized.
+    /// another entry and the session is written because it now carries more than the store held, so the
+    /// stored session grows without bound and every host reading it back is handed a list naming one
+    /// client as many times as it has ever authorized.
     /// </remarks>
     [Fact]
     public async Task ProcessAsync_ASessionWhoseListAcceptsDuplicates_RecordsTheClientOnce()
@@ -1621,10 +1624,12 @@ public class AuthorizationRequestProcessorTests
         };
 
         var consents = CreateConsents();
-        SetupSuccessfulAuthCodeFlow(request, session, consents);
+        var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
 
         await _processor.ProcessAsync(request);
 
+        // The negative says nothing on its own unless the request reached the point that would write.
+        Assert.NotNull(capture.Grant);
         Assert.Single(session.AffectedClientIds);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
     }
@@ -1809,15 +1814,17 @@ public class AuthorizationRequestProcessorTests
         Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
 
         // The case numbers are positions in the sequence of size reads, not the sites themselves, so
-        // another read anywhere on this path moves both cases onto a different pair and leaves the
-        // guarded one unguarded with the theory still green. Pinning the count turns that into a
-        // failure. Taken before the assertions above, so it counts what the request did.
+        // a read added AHEAD of them moves both cases onto a different pair and leaves the guarded
+        // one unguarded with the theory still green. Pinning the count turns that into a failure,
+        // and catches a read added anywhere else as well. Taken before the assertions above, so it
+        // counts what the request did.
         Assert.Equal(2, measures);
 
         // The two cases differ in what the store is told, and that difference is the point of the
         // second window: an arrival inside both snapshots leaves the session unchanged, while one
-        // landing between them is a real change and must be written. Without this, taking both
-        // snapshots from the same read would leave every case passing.
+        // landing between them is a real change and must be written. This is the line that fails
+        // when the write stops depending on the comparison at all - collapsing the two snapshots
+        // onto one read fails the count above instead, before this is reached.
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Exactly(expectedWrites));
     }
 
@@ -1854,7 +1861,7 @@ public class AuthorizationRequestProcessorTests
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
 
         // The response names each client once, however many times the session happens to list it.
-        // The end-session processor walks the session own list rather than this one, so no
+        // The end-session processor walks the session's own list rather than this one, so no
         // notification the library sends is saved here; what changes is what a host reading the
         // response is told to watch.
         var authenticated = Assert.IsType<SuccessfullyAuthenticated>(result);
@@ -2006,9 +2013,9 @@ public class AuthorizationRequestProcessorTests
     /// <para>
     /// The second pair is here because no case-only pair can show it: the two names carry the same
     /// accented letter written two ways, which a culture-sensitive comparison calls one name and an
-    /// ordinal one calls two. Both spellings arrive over the request, so a host is free to register
-    /// either. Written as escapes so the file stays ASCII and no encoding can change what is being
-    /// compared.
+    /// ordinal one calls two. Both spellings can be registered, since nothing here normalises a
+    /// client name. The two literals are written as escapes, so what is being compared is fixed by
+    /// the compiler rather than by however this file happens to be decoded.
     /// </para>
     /// </remarks>
     [Theory]
@@ -2034,6 +2041,36 @@ public class AuthorizationRequestProcessorTests
 
         Assert.Contains(one, session.AffectedClientIds);
         Assert.Contains(other, session.AffectedClientIds);
+    }
+    /// <summary>
+    /// A client colliding with one already on the session only under a coarser comparison is still
+    /// written to the store.
+    /// </summary>
+    /// <remarks>
+    /// The other half of the same choice, and it needs its own row: the theory above drives the copy
+    /// the restore reads from, and swapping the comparer that answers "did this session change"
+    /// leaves that theory green. A session naming one spelling and a request registered under the
+    /// other are two clients; a comparison folding them into one reads the session as unchanged, so
+    /// nothing is written and the newcomer is missing from what logout walks on the next request,
+    /// having been recorded only in memory.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AClientCollidingOnlyUnderACoarserComparison_IsWritten()
+    {
+        const string composed = "caf\u00e9-client";
+        const string decomposed = "cafe\u0301-client";
+
+        var request = CreateRequest(clientId: decomposed);
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(composed);
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Contains(decomposed, session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
     }
     /// <summary>
     /// Wires up the strict Mocks for a successful authorization-code flow and returns a

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1568,6 +1568,63 @@ public class AuthorizationRequestProcessorTests
     }
 
     /// <summary>
+    /// A consent provider that adds the client itself does not excuse the session from being written.
+    /// </summary>
+    /// <remarks>
+    /// The list on the object says the client is there; the store has never been told. Asking only the
+    /// object leaves the session unwritten, which is the same client missing from logout as when the
+    /// provider removes the entry - the failure reached from the other side.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AConsentProviderAddingTheClientItself_StillWritesTheSession()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Add(TestConstants.DefaultClientId))
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+    }
+
+    /// <summary>
+    /// A consent provider that empties the list does not take the other clients with it.
+    /// </summary>
+    /// <remarks>
+    /// The session is persisted whole, so whatever the provider left behind is what the store keeps.
+    /// Every client the session already touched has to be reachable at logout, and the provider was
+    /// never asked about them - so what this server knew is put back before anything is written.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AConsentProviderEmptyingTheClientList_KeepsTheOtherClients()
+    {
+        const string another = "another-client";
+
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(another);
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Clear())
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Contains(another, session.AffectedClientIds);
+        Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+    }
+    /// <summary>
     /// Wires up the strict Mocks for a successful authorization-code flow and returns a
     /// <see cref="GrantCapture"/> that fills in once <see cref="AuthorizationRequestProcessor.ProcessAsync"/>
     /// reaches the code-issuance step. Eliminates the four-line Setup boilerplate from

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1994,6 +1994,48 @@ public class AuthorizationRequestProcessorTests
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
     }
     /// <summary>
+    /// Two clients whose names an ordinal comparison keeps apart both survive a consent provider
+    /// that empties the list.
+    /// </summary>
+    /// <remarks>
+    /// The copy the restore reads from is a set, and a set is only as discriminating as its
+    /// comparer: one that folds case, or one that compares by culture, merges such a pair into a
+    /// single entry and puts exactly one of the two names back. The other is gone from the session
+    /// for good, and the client behind it is never told to log out - the same outcome the restore
+    /// exists to prevent, arriving through the comparer instead of through the provider.
+    /// <para>
+    /// The second pair is here because no case-only pair can show it: the two names carry the same
+    /// accented letter written two ways, which a culture-sensitive comparison calls one name and an
+    /// ordinal one calls two. Both spellings arrive over the request, so a host is free to register
+    /// either. Written as escapes so the file stays ASCII and no encoding can change what is being
+    /// compared.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("Client-Case", "client-case")]
+    [InlineData("caf\u00e9-client", "cafe\u0301-client")]
+    public async Task ProcessAsync_TwoClientsAnOrdinalComparerKeepsApart_BothSurviveAnEmptyingProvider(
+        string one, string other)
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(one);
+        session.AffectedClientIds.Add(other);
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Clear())
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Contains(one, session.AffectedClientIds);
+        Assert.Contains(other, session.AffectedClientIds);
+    }
+    /// <summary>
     /// Wires up the strict Mocks for a successful authorization-code flow and returns a
     /// <see cref="GrantCapture"/> that fills in once <see cref="AuthorizationRequestProcessor.ProcessAsync"/>
     /// reaches the code-issuance step. Eliminates the four-line Setup boilerplate from

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1611,8 +1611,7 @@ public class AuthorizationRequestProcessorTests
     /// The shipped session holds a set, so a second copy is dropped before anything notices - and the
     /// collection is public with an initialiser, so a host may supply a list. Then every request appends
     /// another entry and the session is written because it now carries more than the store held, so the
-    /// stored session grows without bound and every host reading it back is handed a list naming one
-    /// client as many times as it has ever authorized.
+    /// stored session grows without bound.
     /// </remarks>
     [Fact]
     public async Task ProcessAsync_ASessionWhoseListAcceptsDuplicates_RecordsTheClientOnce()

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Globalization;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -1540,16 +1541,20 @@ public class AuthorizationRequestProcessorTests
     /// </summary>
     /// <remarks>
     /// The provider is handed the live session, and the list of clients a session touches is what logout
-    /// iterates to reach them. Taken at its word, the object would carry one client fewer than the store
-    /// does, and any later write would push that loss out. Put back, the session says what it said when
-    /// the store handed it over - so there is also nothing to tell the store, which is asserted here
-    /// because a write nobody needs is how the loss would reach it anyway.
+    /// iterates to reach them. Put back, the session says what it said when the store handed it over, so
+    /// there is nothing to tell the store either - asserted here because that is the whole claim: the
+    /// restore leaves no difference behind, and a write would say there was one. The client this request
+    /// is for is deliberately not the one removed, or the line that records it would answer this test
+    /// instead of the restore.
     /// </remarks>
     [Fact]
-    public async Task ProcessAsync_AConsentProviderRemovingTheClient_RecordsItAnyway()
+    public async Task ProcessAsync_AConsentProviderRemovingAnotherClient_RecordsItAnyway()
     {
+        const string bystander = "bystander-client";
+
         var request = CreateRequest();
         var session = CreateAuthSession();
+        session.AffectedClientIds.Add(bystander);
         session.AffectedClientIds.Add(TestConstants.DefaultClientId);
 
         var consents = CreateConsents();
@@ -1557,12 +1562,12 @@ public class AuthorizationRequestProcessorTests
 
         _consentsProvider
             .Setup(p => p.GetUserConsentsAsync(request, session))
-            .Callback(() => session.AffectedClientIds.Remove(TestConstants.DefaultClientId))
+            .Callback(() => session.AffectedClientIds.Remove(bystander))
             .ReturnsAsync(consents);
 
         await _processor.ProcessAsync(request);
 
-        Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
+        Assert.Contains(bystander, session.AffectedClientIds);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
         Assert.NotNull(capture.Grant);
     }
@@ -1593,6 +1598,67 @@ public class AuthorizationRequestProcessorTests
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
     }
 
+    /// <summary>
+    /// The client is recorded once, on a session whose collection does not do that for us.
+    /// </summary>
+    /// <remarks>
+    /// The shipped session holds a set, so a second copy is dropped before anything notices - and the
+    /// collection is public with an initialiser, so a host may supply a list. Then every request appends
+    /// another entry, the session is written because it now carries more than the store held, and logout
+    /// emits one front-channel call per entry: the same client, told to log out as many times as it has
+    /// ever authorized.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ASessionWhoseListAcceptsDuplicates_RecordsTheClientOnce()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession() with
+        {
+            AffectedClientIds = new List<string> { TestConstants.DefaultClientId },
+        };
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Single(session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
+    }
+    /// <summary>
+    /// A request that ends in a refusal still leaves the session carrying what the store gave it.
+    /// </summary>
+    /// <remarks>
+    /// Most ways out of this method are refusals - consent is pending, interaction is not allowed, the
+    /// end user denied the requested details - and each of them returns before anything else runs. So the
+    /// list is put back where it is repaired rather than where the request succeeds: a session object a
+    /// host keeps between requests would otherwise carry the provider's edit with nothing left to undo it.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ARefusedRequest_StillKeepsTheClientsTheStoreGave()
+    {
+        const string bystander = "bystander-client";
+
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(bystander);
+
+        var consents = CreateConsents(pendingScopes: [new ScopeDefinition(Scopes.Profile)]);
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(new[] { session }.ToAsyncEnumerable());
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Clear())
+            .ReturnsAsync(consents);
+
+        Assert.IsType<ConsentRequired>(await _processor.ProcessAsync(request));
+
+        Assert.Contains(bystander, session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
+    }
     /// <summary>
     /// A client the provider adds is written too, even when this request's client was already stored.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Collections;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -1701,6 +1702,74 @@ public class AuthorizationRequestProcessorTests
         // The half the restore owes: the copy this provider dropped is back, beside what it added.
         Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+    }
+
+    /// <summary>
+    /// A collection that gains an entry while it is being asked how large it is.
+    /// </summary>
+    /// <remarks>
+    /// The same order of events a second request produces against a session a host keeps, arriving
+    /// every time instead of one run in a thousand. The shipped collection hands a walker a snapshot
+    /// and cannot refuse one, while copying out reads the size first and takes the contents after.
+    /// </remarks>
+    private sealed class GrowsWhileMeasured(params string[] items) : ICollection<string>
+    {
+        private readonly List<string> _items = [..items];
+        private bool _grown;
+
+        public int Count
+        {
+            get
+            {
+                var answer = _items.Count;
+
+                if (!_grown)
+                {
+                    _grown = true;
+                    _items.Add("arrived-during-the-read");
+                }
+
+                return answer;
+            }
+        }
+
+        public bool IsReadOnly => false;
+        public void Add(string item) => _items.Add(item);
+        public void Clear() => _items.Clear();
+        public bool Contains(string item) => _items.Contains(item);
+        public void CopyTo(string[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+        public bool Remove(string item) => _items.Remove(item);
+        public IEnumerator<string> GetEnumerator() => _items.ToArray().AsEnumerable().GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// A session growing while it is read is still processed, and the client is still recorded.
+    /// </summary>
+    /// <remarks>
+    /// The question is not what the list says but HOW it is read. Asking for the size and then copying
+    /// into an array of that size fails when the size moved in between; walking the collection asks it
+    /// for a view it is prepared to give, which the shipped one always is. The window is the one that
+    /// matters: this request's client is already recorded on the session and the store has not been
+    /// told, so a read that throws here loses the request AND the record, and the client is missing
+    /// from the logout that session drives.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ASessionGrowingWhileItIsRead_IsStillProcessed()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession() with
+        {
+            AffectedClientIds = new GrowsWhileMeasured(TestConstants.DefaultClientId),
+        };
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        var result = await _processor.ProcessAsync(request);
+
+        Assert.IsType<SuccessfullyAuthenticated>(result);
+        Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1536,6 +1536,38 @@ public class AuthorizationRequestProcessorTests
     }
 
     /// <summary>
+    /// A consent provider that drops the client from the session leaves it recorded there all the same.
+    /// </summary>
+    /// <remarks>
+    /// The provider is handed the live session, and the list of clients a session touches is what logout
+    /// iterates to reach them. Whether this client still has to be written is a question about the
+    /// session as it now stands, not about the copy taken before the provider saw it: judged from the
+    /// copy, a client the provider removed reads as one already recorded, so nothing is written and the
+    /// end user's logout never reaches it.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AConsentProviderRemovingTheClient_RecordsItAnyway()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(TestConstants.DefaultClientId);
+
+        var consents = CreateConsents();
+        var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Remove(TestConstants.DefaultClientId))
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+        Assert.NotNull(capture.Grant);
+    }
+
+    /// <summary>
     /// Wires up the strict Mocks for a successful authorization-code flow and returns a
     /// <see cref="GrantCapture"/> that fills in once <see cref="AuthorizationRequestProcessor.ProcessAsync"/>
     /// reaches the code-issuance step. Eliminates the four-line Setup boilerplate from

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1697,8 +1697,42 @@ public class AuthorizationRequestProcessorTests
         await _processor.ProcessAsync(request);
 
         Assert.Contains(newcomer, session.AffectedClientIds);
+
+        // The half the restore owes: the copy this provider dropped is back, beside what it added.
+        Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
     }
+
+    /// <summary>
+    /// A session that arrived carrying one client twice, and nobody touching it, is not written.
+    /// </summary>
+    /// <remarks>
+    /// The cell the other three leave empty, and the one a criterion counting NAMES rather than
+    /// comparing them gets wrong: a list holding two copies of this client has more entries than the
+    /// set of names does, so counted that way the session reads as changed on every request and is
+    /// written to the store each time, for nothing.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ADuplicateNobodyTouches_IsNotWritten()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession() with
+        {
+            AffectedClientIds = new List<string>
+            {
+                TestConstants.DefaultClientId,
+                TestConstants.DefaultClientId,
+            },
+        };
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        await _processor.ProcessAsync(request);
+
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
+    }
+
     /// <summary>
     /// A session that arrived carrying one client twice is neither written nor shortened.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -72,7 +72,7 @@ public class AuthorizationRequestProcessorTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => ad);
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => ad ?? new JsonArray());
 
         _timeProvider = new FakeTimeProvider();
 
@@ -1660,7 +1660,8 @@ public class AuthorizationRequestProcessorTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) => CapAmount(ad, 800m));
+            .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) =>
+                CapAmount(ad, 800m) ?? new JsonArray());
 
         var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -155,7 +155,8 @@ public class AuthorizationRequestProcessorTests
         {
             AuthContextClassRef = acr,
             // AffectedClientIds is left at its default on purpose: hard-coding a List here would test the
-            // fixture's collection rather than the one a session actually carries.
+            // fixture's collection rather than the one a session actually carries - except where that
+            // collection IS the subject, which is what the two tests about a host-supplied list are for.
         };
     }
 
@@ -1623,6 +1624,71 @@ public class AuthorizationRequestProcessorTests
         await _processor.ProcessAsync(request);
 
         Assert.Single(session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
+    }
+    /// <summary>
+    /// A consent provider that throws still leaves the session carrying what the store gave it.
+    /// </summary>
+    /// <remarks>
+    /// The one way out of the method that no refusal covers. A host that keeps the session object
+    /// between requests would otherwise carry whatever the provider did to this list onward, with
+    /// nothing left to undo it, and the clients it dropped are the ones logout can no longer reach.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AConsentProviderThatThrows_StillKeepsTheClientsTheStoreGave()
+    {
+        const string bystander = "bystander-client";
+
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(bystander);
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(new[] { session }.ToAsyncEnumerable());
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Clear())
+            .ThrowsAsync(new InvalidOperationException("the consent provider gave up"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(request));
+
+        Assert.Contains(bystander, session.AffectedClientIds);
+    }
+
+    /// <summary>
+    /// A session that arrived carrying one client twice is neither written nor shortened.
+    /// </summary>
+    /// <remarks>
+    /// Who a session touches is a set even where the collection holding them is not, and a host may
+    /// supply a list that already holds a duplicate from before this was guarded. Counted rather than
+    /// compared as a set, a provider dropping one of the copies would read as a session that lost a
+    /// client, and that shortened list would be written to the store.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ASessionArrivingWithADuplicate_IsNotWritten()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession() with
+        {
+            AffectedClientIds = new List<string>
+            {
+                TestConstants.DefaultClientId,
+                TestConstants.DefaultClientId,
+            },
+        };
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Remove(TestConstants.DefaultClientId))
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
     }
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -156,7 +156,7 @@ public class AuthorizationRequestProcessorTests
             AuthContextClassRef = acr,
             // AffectedClientIds is left at its default on purpose: hard-coding a List here would test the
             // fixture's collection rather than the one a session actually carries - except where that
-            // collection IS the subject, which is what the two tests about a host-supplied list are for.
+            // collection IS the subject, which is what the tests supplying their own collection are for.
         };
     }
 
@@ -1657,6 +1657,48 @@ public class AuthorizationRequestProcessorTests
         Assert.Contains(bystander, session.AffectedClientIds);
     }
 
+    /// <summary>
+    /// A client the provider names is written even when the session arrived carrying a duplicate.
+    /// </summary>
+    /// <remarks>
+    /// The dangerous half of the same divergence, and the one that loses a client rather than writing
+    /// one too often: a list arriving with two copies of a client, and a provider that drops one of them
+    /// while naming somebody new, keeps its length. Measured by length, the session reads as unchanged
+    /// and the newcomer never reaches the store, which is the absence from logout this whole guard is
+    /// about.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ADuplicateTradedForANewClient_IsWritten()
+    {
+        const string newcomer = "newcomer-client";
+
+        var request = CreateRequest();
+        var session = CreateAuthSession() with
+        {
+            AffectedClientIds = new List<string>
+            {
+                TestConstants.DefaultClientId,
+                TestConstants.DefaultClientId,
+            },
+        };
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() =>
+            {
+                session.AffectedClientIds.Remove(TestConstants.DefaultClientId);
+                session.AffectedClientIds.Add(newcomer);
+            })
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Contains(newcomer, session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+    }
     /// <summary>
     /// A session that arrived carrying one client twice is neither written nor shortened.
     /// </summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1540,10 +1540,10 @@ public class AuthorizationRequestProcessorTests
     /// </summary>
     /// <remarks>
     /// The provider is handed the live session, and the list of clients a session touches is what logout
-    /// iterates to reach them. Whether this client still has to be written is a question about the
-    /// session as it now stands, not about the copy taken before the provider saw it: judged from the
-    /// copy, a client the provider removed reads as one already recorded, so nothing is written and the
-    /// end user's logout never reaches it.
+    /// iterates to reach them. Taken at its word, the object would carry one client fewer than the store
+    /// does, and any later write would push that loss out. Put back, the session says what it said when
+    /// the store handed it over - so there is also nothing to tell the store, which is asserted here
+    /// because a write nobody needs is how the loss would reach it anyway.
     /// </remarks>
     [Fact]
     public async Task ProcessAsync_AConsentProviderRemovingTheClient_RecordsItAnyway()
@@ -1563,7 +1563,7 @@ public class AuthorizationRequestProcessorTests
         await _processor.ProcessAsync(request);
 
         Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
-        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
         Assert.NotNull(capture.Grant);
     }
 
@@ -1590,6 +1590,37 @@ public class AuthorizationRequestProcessorTests
 
         await _processor.ProcessAsync(request);
 
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+    }
+
+    /// <summary>
+    /// A client the provider adds is written too, even when this request's client was already stored.
+    /// </summary>
+    /// <remarks>
+    /// Whether the session has to be written is a question about the session, not about this client: a
+    /// provider that named another client changed the object and told the store nothing, and that client
+    /// is then missing from logout exactly like one the provider removed.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AConsentProviderAddingAnotherClient_WritesTheSession()
+    {
+        const string another = "another-client";
+
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(TestConstants.DefaultClientId);
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => session.AffectedClientIds.Add(another))
+            .ReturnsAsync(consents);
+
+        await _processor.ProcessAsync(request);
+
+        Assert.Contains(another, session.AffectedClientIds);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
     }
 

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1616,6 +1616,40 @@ public class AuthorizationRequestProcessorTests
         Assert.Equal(ErrorCodes.AccessDenied, error.Error);
     }
 
+    /// <summary>
+    /// A consent provider that empties the request as it answers is still answered with a denial.
+    /// </summary>
+    /// <remarks>
+    /// The provider is a host seam, and it is handed the array the request carries - so a provider that
+    /// narrows by editing what it was given, which is how narrowing is written everywhere in this
+    /// repository, empties the very set the denial is measured against. Measured afterwards, the request
+    /// looks like one that never asked for anything, the denial turns into a successful authorization,
+    /// and the token carries no authorization_details at all - which neither the client nor the resource
+    /// server can detect.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AConsentProviderEmptyingTheRequestInPlace_StillReturnsAccessDenied()
+    {
+        var requestedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+        var request = CreateRequest(authorizationDetails: requestedAd);
+        var session = CreateAuthSession();
+        var consents = CreateConsents(grantedAuthorizationDetails: new JsonArray());
+
+        _authSessionService
+            .Setup(s => s.GetAvailableAuthSessions())
+            .Returns(new[] { session }.ToAsyncEnumerable());
+
+        _consentsProvider
+            .Setup(p => p.GetUserConsentsAsync(request, session))
+            .Callback(() => requestedAd.Clear())
+            .ReturnsAsync(consents);
+
+        var result = await _processor.ProcessAsync(request);
+
+        var error = Assert.IsType<AuthorizationError>(result);
+        Assert.Equal(ErrorCodes.AccessDenied, error.Error);
+    }
+
     [Fact]
     public async Task ProcessAsync_AuthorizationDetailsNarrowedByProvider_PropagatesNarrowToContext()
     {

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1672,6 +1672,7 @@ public class AuthorizationRequestProcessorTests
     public async Task ProcessAsync_ADuplicateTradedForANewClient_IsWritten()
     {
         const string newcomer = "newcomer-client";
+        const string bystander = "bystander-client";
 
         var request = CreateRequest();
         var session = CreateAuthSession() with
@@ -1680,6 +1681,7 @@ public class AuthorizationRequestProcessorTests
             {
                 TestConstants.DefaultClientId,
                 TestConstants.DefaultClientId,
+                bystander,
             },
         };
 
@@ -1691,6 +1693,7 @@ public class AuthorizationRequestProcessorTests
             .Callback(() =>
             {
                 session.AffectedClientIds.Remove(TestConstants.DefaultClientId);
+                session.AffectedClientIds.Remove(bystander);
                 session.AffectedClientIds.Add(newcomer);
             })
             .ReturnsAsync(consents);
@@ -1699,7 +1702,34 @@ public class AuthorizationRequestProcessorTests
 
         Assert.Contains(newcomer, session.AffectedClientIds);
 
-        // The half the restore owes: the copy this provider dropped is back, beside what it added.
+        // Asked about somebody else, because the client this request is FOR comes back whatever the
+        // restore does - the line recording it puts it there, so an assertion about it cannot fail.
+        Assert.Contains(bystander, session.AffectedClientIds);
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
+    }
+
+    /// <summary>
+    /// A client whose identifier differs only in case is another client, and the store is told.
+    /// </summary>
+    /// <remarks>
+    /// Identifiers are compared the way the shipped session compares them, which is exactly. Compared
+    /// loosely instead, a session already naming <c>Client-A</c> reads as unchanged when this request
+    /// records <c>client-a</c> - the record itself still happens, because the collection does its own
+    /// comparing, so the session carries a client the store is never told about, and logout cannot
+    /// reach it.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AClientDifferingOnlyInCase_IsWritten()
+    {
+        var request = CreateRequest();
+        var session = CreateAuthSession();
+        session.AffectedClientIds.Add(TestConstants.DefaultClientId.ToUpperInvariant());
+
+        var consents = CreateConsents();
+        SetupSuccessfulAuthCodeFlow(request, session, consents);
+
+        await _processor.ProcessAsync(request);
+
         Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Once);
     }
@@ -1795,15 +1825,18 @@ public class AuthorizationRequestProcessorTests
         };
 
         var consents = CreateConsents();
-        SetupSuccessfulAuthCodeFlow(request, session, consents);
+        var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
 
         await _processor.ProcessAsync(request);
 
+        // The negative says nothing on its own unless the request reached the point that would write.
+        Assert.NotNull(capture.Grant);
+        Assert.Equal(2, session.AffectedClientIds.Count);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
     }
 
     /// <summary>
-    /// A session that arrived carrying one client twice is neither written nor shortened.
+    /// A session carrying one client twice, one copy dropped, is neither written nor shortened.
     /// </summary>
     /// <remarks>
     /// Who a session touches is a set even where the collection holding them is not, and a host may
@@ -1812,7 +1845,7 @@ public class AuthorizationRequestProcessorTests
     /// client, and that shortened list would be written to the store.
     /// </remarks>
     [Fact]
-    public async Task ProcessAsync_ASessionArrivingWithADuplicate_IsNotWritten()
+    public async Task ProcessAsync_ADuplicateWithOneCopyDropped_IsNotWritten()
     {
         var request = CreateRequest();
         var session = CreateAuthSession() with

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/AuthorizationRequestProcessorTests.cs
@@ -1048,9 +1048,10 @@ public class AuthorizationRequestProcessorTests
             .ReturnsAsync("code");
 
         // Act
-        await _processor.ProcessAsync(request);
+        var result = await _processor.ProcessAsync(request);
 
         // Assert
+        Assert.IsType<SuccessfullyAuthenticated>(result);
         _authSessionService.Verify(s => s.SignInAsync(It.IsAny<AuthSession>()), Times.Never);
     }
 
@@ -1761,6 +1762,8 @@ public class AuthorizationRequestProcessorTests
             }
         }
 
+        public int Measures => _measures;
+
         public bool IsReadOnly => false;
         public void Add(string item) => _items.Add(item);
         public void Clear() => _items.Clear();
@@ -1787,23 +1790,35 @@ public class AuthorizationRequestProcessorTests
     /// </para>
     /// </remarks>
     [Theory]
-    [InlineData(1)]
-    [InlineData(2)]
-    public async Task ProcessAsync_ASessionGrowingWhileItIsRead_IsStillProcessed(int whichRead)
+    [InlineData(1, 0)]
+    [InlineData(2, 1)]
+    public async Task ProcessAsync_ASessionGrowingWhileItIsRead_IsStillProcessed(
+        int whichRead, int expectedWrites)
     {
         var request = CreateRequest();
-        var session = CreateAuthSession() with
-        {
-            AffectedClientIds = new GrowsWhileMeasured(whichRead, TestConstants.DefaultClientId),
-        };
+        var clients = new GrowsWhileMeasured(whichRead, TestConstants.DefaultClientId);
+        var session = CreateAuthSession() with { AffectedClientIds = clients };
 
         var consents = CreateConsents();
         SetupSuccessfulAuthCodeFlow(request, session, consents);
 
         var result = await _processor.ProcessAsync(request);
+        var measures = clients.Measures;
 
         Assert.IsType<SuccessfullyAuthenticated>(result);
         Assert.Contains(TestConstants.DefaultClientId, session.AffectedClientIds);
+
+        // The case numbers are positions in the sequence of size reads, not the sites themselves, so
+        // another read anywhere on this path moves both cases onto a different pair and leaves the
+        // guarded one unguarded with the theory still green. Pinning the count turns that into a
+        // failure. Taken before the assertions above, so it counts what the request did.
+        Assert.Equal(2, measures);
+
+        // The two cases differ in what the store is told, and that difference is the point of the
+        // second window: an arrival inside both snapshots leaves the session unchanged, while one
+        // landing between them is a real change and must be written. Without this, taking both
+        // snapshots from the same read would leave every case passing.
+        _authSessionService.Verify(s => s.SignInAsync(session), Times.Exactly(expectedWrites));
     }
 
     /// <summary>
@@ -1831,16 +1846,18 @@ public class AuthorizationRequestProcessorTests
         var consents = CreateConsents();
         var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
 
-        await _processor.ProcessAsync(request);
+        var result = await _processor.ProcessAsync(request);
 
         // The negative says nothing on its own unless the request reached the point that would write.
         Assert.NotNull(capture.Grant);
         Assert.Equal(2, session.AffectedClientIds.Count);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
 
-        // What the response tells the client to watch names each client once, however many times the
-        // session happens to list it - one client does not deserve two front-channel logout calls.
-        var authenticated = Assert.IsType<SuccessfullyAuthenticated>(await _processor.ProcessAsync(request));
+        // The response names each client once, however many times the session happens to list it.
+        // The end-session processor walks the session own list rather than this one, so no
+        // notification the library sends is saved here; what changes is what a host reading the
+        // response is told to watch.
+        var authenticated = Assert.IsType<SuccessfullyAuthenticated>(result);
         Assert.Equal([TestConstants.DefaultClientId], authenticated.AffectedClientIds);
     }
 
@@ -1867,7 +1884,7 @@ public class AuthorizationRequestProcessorTests
         };
 
         var consents = CreateConsents();
-        SetupSuccessfulAuthCodeFlow(request, session, consents);
+        var capture = SetupSuccessfulAuthCodeFlow(request, session, consents);
 
         _consentsProvider
             .Setup(p => p.GetUserConsentsAsync(request, session))
@@ -1876,6 +1893,8 @@ public class AuthorizationRequestProcessorTests
 
         await _processor.ProcessAsync(request);
 
+        // The negative says nothing on its own unless the request reached the point that would write.
+        Assert.NotNull(capture.Grant);
         _authSessionService.Verify(s => s.SignInAsync(session), Times.Never);
     }
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -333,9 +333,9 @@ public class ConsentConstraintEnforcerTests
     public async Task EnforceAsync_ValidatorEditsTheTypeInPlace_Throws()
     {
         // Every narrowing validator in this repository's own fixtures edits the entry IN PLACE and
-        // returns the same wrapper, and the typed wrappers alias the source nodes - so a policy that
-        // changed nothing it was asked about can still have rewritten the array it was handed. The
-        // types read before the call are the only untouched copy, and that path has to be guarded too.
+        // returns the same wrapper, and the typed wrappers alias the source nodes - so what a policy
+        // answers with can be the very array it rewrote, carrying a type nobody granted. The types read
+        // before the call are the only untouched copy, and that path has to be guarded too.
         var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
         var request = CreateRequest(authorizationDetails:
             new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/ConsentConstraintEnforcerTests.cs
@@ -81,7 +81,7 @@ public class ConsentConstraintEnforcerTests
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) =>
-                Result<JsonArray?, OidcError>.Success(ad));
+                Result<JsonArray, OidcError>.Success(ad ?? new JsonArray()));
 
     [Fact]
     public async Task EnforceAsync_GrantedEqualsRequested_DoesNotThrow()
@@ -160,7 +160,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Failure(
+            .ReturnsAsync(Result<JsonArray, OidcError>.Failure(
                 new OidcError(ErrorCodes.InvalidAuthorizationDetails, "amount exceeds the client's cap")));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -182,7 +182,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(capped));
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(capped));
 
         var enforced = await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
 
@@ -206,7 +206,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(new JsonArray(
                 new JsonObject { ["type"] = "payment_initiation" },
                 new JsonObject { ["type"] = "account_information" })));
 
@@ -230,7 +230,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(
                 new JsonArray(new JsonObject { ["amount"] = "999999" })));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -273,7 +273,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(new JsonArray(
                 new JsonObject { ["type"] = standIn },
                 new JsonObject { ["amount"] = "999999" })));
 
@@ -297,7 +297,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(new JsonArray(
                 new JsonObject { ["type"] = "payment_initiation" },
                 new JsonObject { ["type"] = "admin_access" })));
 
@@ -321,7 +321,7 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray(
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(new JsonArray(
                 new JsonObject { ["type"] = "payment_initiation" },
                 JsonValue.Create("payment_initiation"))));
 
@@ -330,12 +330,12 @@ public class ConsentConstraintEnforcerTests
     }
 
     [Fact]
-    public async Task EnforceAsync_ValidatorEditsTheTypeInPlaceAndReturnsNothing_Throws()
+    public async Task EnforceAsync_ValidatorEditsTheTypeInPlace_Throws()
     {
         // Every narrowing validator in this repository's own fixtures edits the entry IN PLACE and
         // returns the same wrapper, and the typed wrappers alias the source nodes - so a policy that
-        // answers "nothing to change" can still have rewritten the array it was handed. The types read
-        // before the call are the only untouched copy, and that path has to be guarded too.
+        // changed nothing it was asked about can still have rewritten the array it was handed. The
+        // types read before the call are the only untouched copy, and that path has to be guarded too.
         var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
         var request = CreateRequest(authorizationDetails:
             new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
@@ -347,7 +347,7 @@ public class ConsentConstraintEnforcerTests
             .ReturnsAsync((JsonArray? ad, ClientInfo _, CancellationToken _) =>
             {
                 ad![0]!["type"] = "wire_transfer";
-                return Result<JsonArray?, OidcError>.Success(null);
+                return Result<JsonArray, OidcError>.Success(ad);
             });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -359,9 +359,9 @@ public class ConsentConstraintEnforcerTests
     [Fact]
     public async Task EnforceAsync_PolicyReturnsAnEmptySet_Throws()
     {
-        // Null and empty are different statements. Empty says every entry was removed, and this same
-        // request answers access_denied to a consent decision that granted none - so emitting the
-        // granted set here would put back exactly what the validators took out.
+        // The call is made only for a non-empty granted set, so an empty answer says every entry was
+        // removed - and this same request answers access_denied to a consent decision that granted
+        // none, so emitting the granted set here would put back exactly what the validators took out.
         var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
         var request = CreateRequest(authorizationDetails:
             new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
@@ -370,32 +370,10 @@ public class ConsentConstraintEnforcerTests
         _authorizationDetailsPolicy
             .Setup(p => p.ApplyGrantedAsync(
                 It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(new JsonArray()));
+            .ReturnsAsync(Result<JsonArray, OidcError>.Success(new JsonArray()));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => _enforcer.EnforceAsync(request, granted, CancellationToken.None));
-    }
-
-    [Fact]
-    public async Task EnforceAsync_PolicyReturnsNothing_KeepsTheGrantedSet()
-    {
-        // A null result means "nothing to change" everywhere else this policy is consumed - the
-        // request-time, CIBA and device validators all keep what they had - so reading it here as
-        // "the validators emptied the set" would drop authorization_details RFC 9396 section 7
-        // obliges the server to return, on a path where nobody can tell.
-        var grantedAd = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
-        var request = CreateRequest(authorizationDetails:
-            new JsonArray(new JsonObject { ["type"] = "payment_initiation" }));
-        var granted = Granted(authorizationDetails: grantedAd);
-
-        _authorizationDetailsPolicy
-            .Setup(p => p.ApplyGrantedAsync(
-                It.IsAny<JsonArray?>(), It.IsAny<ClientInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<JsonArray?, OidcError>.Success(null));
-
-        var enforced = await _enforcer.EnforceAsync(request, granted, CancellationToken.None);
-
-        Assert.Same(grantedAd, enforced);
     }
 
     [Fact]

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidatorTests.cs
@@ -129,11 +129,16 @@ public class AuthorizationDetailsRequestValidatorTests
     public async Task APolicyThatEmptiesTheRequestAsItAnswers_IsAFault()
     {
         var context = Context((JsonArray)Requested.DeepClone());
-        var validator = new AuthorizationDetailsRequestValidator(
-            StubAuthorizationDetailsPolicy.ClearingInPlace);
+        var policy = StubAuthorizationDetailsPolicy.ClearingInPlace;
+        var validator = new AuthorizationDetailsRequestValidator(policy);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => validator.ValidateAsync(context));
 
         Assert.Null(context.AuthorizationDetails);
+
+        // The premise the guard rests on: the policy is handed the live array, and this shape empties
+        // the very thing a guard reading the request afterwards would count.
+        Assert.Same(context.Request.AuthorizationDetails, policy.LastSeen);
+        Assert.Empty(context.Request.AuthorizationDetails!);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidatorTests.cs
@@ -1,0 +1,118 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.Authorization.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.Authorization.Validation;
+
+/// <summary>
+/// What the authorization endpoint records from the <c>authorization_details</c> policy, and what it
+/// refuses to record.
+/// </summary>
+/// <remarks>
+/// The policy itself is covered in <c>AuthorizationDetailsPolicyTests</c>; this is the adapter between it
+/// and the request context, and the reason it needs tests of its own is that the two are separately
+/// replaceable. <see cref="IAuthorizationDetailsPolicy"/> is public and registered with TryAdd, so a host
+/// supplies its own or wraps ours, and the adapter is where that answer meets the request.
+/// </remarks>
+public class AuthorizationDetailsRequestValidatorTests
+{
+    private static readonly JsonArray Requested = new(new JsonObject { ["type"] = "payment_initiation" });
+
+    private static AuthorizationValidationContext Context(JsonArray? authorizationDetails)
+        => new(
+            new AuthorizationRequest
+            {
+                ClientId = TestConstants.DefaultClientId,
+                ResponseType = [ResponseTypes.Code],
+                RedirectUri = TestConstants.DefaultRedirectUri,
+                Scope = [Scopes.OpenId],
+                AuthorizationDetails = authorizationDetails,
+            })
+        {
+            ClientInfo = new ClientInfo(TestConstants.DefaultClientId),
+            ResponseMode = ResponseModes.Query,
+        };
+
+    /// <summary>
+    /// What survived validation is what the request carries onward.
+    /// </summary>
+    [Fact]
+    public async Task WhatThePolicyAccepts_IsRecorded()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new AuthorizationDetailsRequestValidator(StubAuthorizationDetailsPolicy.Accepting);
+
+        Assert.Null(await validator.ValidateAsync(context));
+
+        Assert.NotNull(context.AuthorizationDetails);
+        Assert.Single(context.AuthorizationDetails);
+    }
+
+    /// <summary>
+    /// A request that carried none records none, which is the only shape an empty answer may mean.
+    /// </summary>
+    [Fact]
+    public async Task ARequestWithoutAuthorizationDetails_RecordsNothing()
+    {
+        var context = Context(null);
+        var validator = new AuthorizationDetailsRequestValidator(StubAuthorizationDetailsPolicy.Accepting);
+
+        Assert.Null(await validator.ValidateAsync(context));
+
+        Assert.Null(context.AuthorizationDetails);
+    }
+
+    /// <summary>
+    /// The policy's refusal reaches the client as the error the specification names for it.
+    /// </summary>
+    [Fact]
+    public async Task WhatThePolicyRefuses_IsAnInvalidAuthorizationDetailsError()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new AuthorizationDetailsRequestValidator(
+            StubAuthorizationDetailsPolicy.Refusing("amount exceeds the client's cap"));
+
+        var error = await validator.ValidateAsync(context);
+
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, error.Error);
+    }
+
+    /// <summary>
+    /// A policy that drops every entry of a request that carried some is a fault, not consent.
+    /// </summary>
+    /// <remarks>
+    /// Dropping every entry says the request may not be honoured as asked, which the contract requires to
+    /// be returned as a refusal. Recorded as "nothing to forward" instead, the request would be authorized
+    /// with its <c>authorization_details</c> gone, and neither the client nor the resource server can see
+    /// that it happened - so the fault is raised where it can still be read, rather than at the resource
+    /// server wondering why a payment carried no amount.
+    /// </remarks>
+    [Fact]
+    public async Task APolicyThatDropsEveryEntry_IsAFault()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new AuthorizationDetailsRequestValidator(StubAuthorizationDetailsPolicy.Emptying);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => validator.ValidateAsync(context));
+
+        Assert.Contains(nameof(IAuthorizationDetailsPolicy), thrown.Message, StringComparison.Ordinal);
+        Assert.Null(context.AuthorizationDetails);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/AuthorizationDetailsRequestValidatorTests.cs
@@ -115,4 +115,25 @@ public class AuthorizationDetailsRequestValidatorTests
         Assert.Contains(nameof(IAuthorizationDetailsPolicy), thrown.Message, StringComparison.Ordinal);
         Assert.Null(context.AuthorizationDetails);
     }
+
+    /// <summary>
+    /// A policy that empties the request as it answers is the same fault, read the same way.
+    /// </summary>
+    /// <remarks>
+    /// The adapter hands the policy the live array, and every narrowing validator in this repository
+    /// edits what it is handed - so what the request carried has to be counted BEFORE the call. Counted
+    /// after, a policy that emptied the array in place answers a guard that has already been given the
+    /// same answer, and the request is authorized with its entries gone.
+    /// </remarks>
+    [Fact]
+    public async Task APolicyThatEmptiesTheRequestAsItAnswers_IsAFault()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new AuthorizationDetailsRequestValidator(
+            StubAuthorizationDetailsPolicy.ClearingInPlace);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => validator.ValidateAsync(context));
+
+        Assert.Null(context.AuthorizationDetails);
+    }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/RequestedSubjectValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/Authorization/Validation/RequestedSubjectValidatorTests.cs
@@ -117,40 +117,46 @@ public class RequestedSubjectValidatorTests
     }
 
     /// <summary>
-    /// Both qualifiers disagreeing accept nobody, which is a request that cannot be answered positively.
+    /// Both qualifiers disagreeing is refused outright, since no end user can satisfy them at once.
     /// </summary>
     /// <remarks>
-    /// Recorded as an empty constraint rather than discarded as nonsense, because Section 5.5.1 already
-    /// prescribes the outcome: "If the Claim was sub, a mismatch MUST cause the authentication to fail".
-    /// Discarding it would answer the request for whichever end user happened to be logged in - the exact
-    /// failure the requirement exists to prevent.
+    /// Section 5.5.1 prescribes the outcome for a mismatch: "If the Claim was sub, a mismatch MUST cause
+    /// the authentication to fail". Discarding the constraint instead would answer the request for
+    /// whichever end user happened to be logged in - the exact failure the requirement exists to prevent.
+    /// The failure is stated here rather than left to the session filter finding nothing, which would send
+    /// the end user to authenticate for a request no authentication could ever answer.
     /// </remarks>
     [Fact]
-    public async Task BothQualifiersDisagreeing_AcceptNobody()
+    public async Task BothQualifiersDisagreeing_IsAnInvalidRequest()
     {
         var context = Context("""{"id_token":{"sub":{"value":"carol","values":["bob","alice"]}}}""");
 
-        Assert.Null(await _validator.ValidateAsync(context));
-        Assert.NotNull(context.RequestedSubjects);
-        Assert.Empty(context.RequestedSubjects);
+        var error = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+        Assert.Null(context.RequestedSubjects);
     }
 
     /// <summary>
-    /// An empty <c>values</c> array accepts nobody, rather than reading as no constraint.
+    /// An empty <c>values</c> array is refused, rather than reading as no constraint.
     /// </summary>
     /// <remarks>
     /// A client that wrote <c>"values": []</c> stated a constraint with nothing in it. Reading that as "no
     /// constraint" would answer the request for whoever is logged in - the inversion this parameter exists
-    /// to prevent - so the fail-closed reading is the only safe one.
+    /// to prevent - so the only safe readings are a refusal or a set nobody satisfies, and the refusal is
+    /// the one the client can act on.
     /// </remarks>
     [Fact]
-    public async Task AnEmptyValuesArray_AcceptsNobody()
+    public async Task AnEmptyValuesArray_IsAnInvalidRequest()
     {
         var context = Context("""{"id_token":{"sub":{"values":[]}}}""");
 
-        Assert.Null(await _validator.ValidateAsync(context));
-        Assert.NotNull(context.RequestedSubjects);
-        Assert.Empty(context.RequestedSubjects);
+        var error = await _validator.ValidateAsync(context);
+
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidRequest, error.Error);
+        Assert.Null(context.RequestedSubjects);
     }
 
     /// <summary>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/BackChannelAuthenticationRequestProcessorTests.cs
@@ -116,6 +116,51 @@ public class BackChannelAuthenticationRequestProcessorTests
     }
 
     /// <summary>
+    /// A handler that empties the request while it authenticates leaves the requested set untouched.
+    /// </summary>
+    /// <remarks>
+    /// The whole request is handed to the handler, which is a host seam, and what the request asked for
+    /// is read back afterwards - both onto the grant and as the baseline the completion-time widening
+    /// check measures against. A handler that edits what it was given, which is how narrowing is written
+    /// throughout this repository, would otherwise erase the record of what was asked for and leave that
+    /// check comparing an empty set against whatever arrives.
+    /// </remarks>
+    [Fact]
+    public async Task AHandlerEmptyingTheRequestWhileItAuthenticates_LeavesTheRequestedDetailsAsTheyWere()
+    {
+        var requested = new JsonArray(new JsonObject { ["type"] = "payment_initiation" });
+
+        Result<AuthSession, OidcError> session = new AuthSession(
+            Subject: Approved,
+            SessionId: "session-1",
+            AuthenticationTime: DateTimeOffset.UnixEpoch,
+            IdentityProvider: "test");
+
+        _handler.Setup(h => h.InitiateAuthenticationAsync(It.IsAny<ValidBackChannelAuthenticationRequest>()))
+            .Callback((ValidBackChannelAuthenticationRequest r) => r.AuthorizationDetails?.Clear())
+            .Returns(Task.FromResult(session));
+
+        StoredRequest? stored = null;
+        _storage
+            .Setup(s => s.StoreAsync(It.IsAny<StoredRequest>(), It.IsAny<TimeSpan>()))
+            .Callback((StoredRequest request, TimeSpan _) => stored = request)
+            .ReturnsAsync("auth-req-id");
+
+        var result = await _processor.ProcessAsync(Request(null, authorizationDetails: requested));
+
+        Assert.True(result.TryGetSuccess(out _));
+        Assert.NotNull(stored);
+
+        Assert.Equal(
+            """[{"type":"payment_initiation"}]""",
+            stored.RequestedAuthorizationDetails!.ToJsonString());
+
+        Assert.Equal(
+            """[{"type":"payment_initiation"}]""",
+            stored.AuthorizedGrant.Context.AuthorizationDetails!.ToJsonString());
+    }
+
+    /// <summary>
     /// Rewriting the grant's <c>authorization_details</c> in place leaves the requested set untouched.
     /// </summary>
     /// <remarks>

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidatorTests.cs
@@ -1,0 +1,99 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.BackChannelAuthentication.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.BackChannelAuthentication.Validation;
+
+/// <summary>
+/// What the decoupled endpoint records from the <c>authorization_details</c> policy, and what it refuses
+/// to record.
+/// </summary>
+/// <remarks>
+/// The same adapter shape as the authorization endpoint's, against a different context, and it needs
+/// tests of its own for the reason a shared guard usually fails: written once and driven on one of the
+/// paths it was added to.
+/// </remarks>
+public class BackChannelAuthorizationDetailsValidatorTests
+{
+    private static readonly JsonArray Requested = new(new JsonObject { ["type"] = "payment_initiation" });
+
+    private static BackChannelAuthenticationValidationContext Context(JsonArray? authorizationDetails)
+        => new(
+            new BackChannelAuthenticationRequest { AuthorizationDetails = authorizationDetails },
+            new ClientRequest())
+        {
+            ClientInfo = new ClientInfo(TestConstants.DefaultClientId),
+        };
+
+    /// <summary>
+    /// What survived validation is what the request carries onward.
+    /// </summary>
+    [Fact]
+    public async Task WhatThePolicyAccepts_IsRecorded()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new BackChannelAuthorizationDetailsValidator(StubAuthorizationDetailsPolicy.Accepting);
+
+        Assert.Null(await validator.ValidateAsync(context));
+
+        Assert.NotNull(context.AuthorizationDetails);
+        Assert.Single(context.AuthorizationDetails);
+    }
+
+    /// <summary>
+    /// The policy's refusal travels as the error the specification names for it.
+    /// </summary>
+    [Fact]
+    public async Task WhatThePolicyRefuses_IsAnInvalidAuthorizationDetailsError()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new BackChannelAuthorizationDetailsValidator(
+            StubAuthorizationDetailsPolicy.Refusing("amount exceeds the client's cap"));
+
+        var error = await validator.ValidateAsync(context);
+
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, error.Error);
+    }
+
+    /// <summary>
+    /// A policy that drops every entry of a request that carried some is a fault, not consent.
+    /// </summary>
+    /// <remarks>
+    /// Driven in both shapes, because the two are told apart only by WHERE the request is counted: a
+    /// policy answering with a fresh empty array, and one that empties the array it was handed as it
+    /// answers. The second is what every narrowing validator in this repository looks like.
+    /// </remarks>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task APolicyThatDropsEveryEntry_IsAFault(bool inPlace)
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new BackChannelAuthorizationDetailsValidator(
+            inPlace
+                ? StubAuthorizationDetailsPolicy.ClearingInPlace
+                : StubAuthorizationDetailsPolicy.Emptying);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => validator.ValidateAsync(context));
+
+        Assert.Contains(nameof(IAuthorizationDetailsPolicy), thrown.Message, StringComparison.Ordinal);
+        Assert.Null(context.AuthorizationDetails);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/BackChannelAuthentication/Validation/BackChannelAuthorizationDetailsValidatorTests.cs
@@ -85,15 +85,21 @@ public class BackChannelAuthorizationDetailsValidatorTests
     public async Task APolicyThatDropsEveryEntry_IsAFault(bool inPlace)
     {
         var context = Context((JsonArray)Requested.DeepClone());
-        var validator = new BackChannelAuthorizationDetailsValidator(
-            inPlace
-                ? StubAuthorizationDetailsPolicy.ClearingInPlace
-                : StubAuthorizationDetailsPolicy.Emptying);
+        var policy = inPlace
+            ? StubAuthorizationDetailsPolicy.ClearingInPlace
+            : StubAuthorizationDetailsPolicy.Emptying;
+        var validator = new BackChannelAuthorizationDetailsValidator(policy);
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
             () => validator.ValidateAsync(context));
 
         Assert.Contains(nameof(IAuthorizationDetailsPolicy), thrown.Message, StringComparison.Ordinal);
         Assert.Null(context.AuthorizationDetails);
+
+        // The premise the guard rests on: the policy is handed the live array, so the in-place shape
+        // empties the very thing a guard reading the request afterwards would count.
+        Assert.Same(context.Request.AuthorizationDetails, policy.LastSeen);
+        if (inPlace)
+            Assert.Empty(context.Request.AuthorizationDetails!);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidatorTests.cs
@@ -1,0 +1,97 @@
+// Abblix OIDC Server Library
+// SPDX-FileCopyrightText: Copyright (c) Abblix LLP
+// SPDX-License-Identifier: LicenseRef-Abblix-EULA
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// Licensing terms, including free-of-charge use, are stated in LICENSE.md
+// in the official repository at https://github.com/Abblix/Oidc.Server
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Abblix.Oidc.Server.Common.Constants;
+using Abblix.Oidc.Server.Endpoints.DeviceAuthorization.Validation;
+using Abblix.Oidc.Server.Features.ClientInformation;
+using Abblix.Oidc.Server.Features.RichAuthorizationRequests;
+using Abblix.Oidc.Server.Model;
+using Abblix.Oidc.Server.UnitTests.TestInfrastructure;
+using Xunit;
+
+namespace Abblix.Oidc.Server.UnitTests.Endpoints.DeviceAuthorization.Validation;
+
+/// <summary>
+/// What the device endpoint records from the <c>authorization_details</c> policy, and what it refuses to
+/// record.
+/// </summary>
+/// <remarks>
+/// The third of three adapters around one policy. They are separately replaceable and separately wrong,
+/// so each drives the guard it carries rather than inheriting confidence from its neighbours.
+/// </remarks>
+public class DeviceAuthorizationDetailsValidatorTests
+{
+    private static readonly JsonArray Requested = new(new JsonObject { ["type"] = "payment_initiation" });
+
+    private static DeviceAuthorizationValidationContext Context(JsonArray? authorizationDetails)
+        => new(
+            new DeviceAuthorizationRequest { AuthorizationDetails = authorizationDetails },
+            new ClientRequest())
+        {
+            ClientInfo = new ClientInfo(TestConstants.DefaultClientId),
+        };
+
+    /// <summary>
+    /// What survived validation is what the request carries onward.
+    /// </summary>
+    [Fact]
+    public async Task WhatThePolicyAccepts_IsRecorded()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new DeviceAuthorizationDetailsValidator(StubAuthorizationDetailsPolicy.Accepting);
+
+        Assert.Null(await validator.ValidateAsync(context));
+
+        Assert.NotNull(context.AuthorizationDetails);
+        Assert.Single(context.AuthorizationDetails);
+    }
+
+    /// <summary>
+    /// The policy's refusal travels as the error the specification names for it.
+    /// </summary>
+    [Fact]
+    public async Task WhatThePolicyRefuses_IsAnInvalidAuthorizationDetailsError()
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new DeviceAuthorizationDetailsValidator(
+            StubAuthorizationDetailsPolicy.Refusing("amount exceeds the client's cap"));
+
+        var error = await validator.ValidateAsync(context);
+
+        Assert.NotNull(error);
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, error.Error);
+    }
+
+    /// <summary>
+    /// A policy that drops every entry of a request that carried some is a fault, not consent.
+    /// </summary>
+    /// <remarks>
+    /// Both shapes, since the two are told apart only by where the request is counted: an answer built
+    /// fresh, and one that empties the array the adapter handed over.
+    /// </remarks>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task APolicyThatDropsEveryEntry_IsAFault(bool inPlace)
+    {
+        var context = Context((JsonArray)Requested.DeepClone());
+        var validator = new DeviceAuthorizationDetailsValidator(
+            inPlace
+                ? StubAuthorizationDetailsPolicy.ClearingInPlace
+                : StubAuthorizationDetailsPolicy.Emptying);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => validator.ValidateAsync(context));
+
+        Assert.Contains(nameof(IAuthorizationDetailsPolicy), thrown.Message, StringComparison.Ordinal);
+        Assert.Null(context.AuthorizationDetails);
+    }
+}

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidatorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/DeviceAuthorization/Validation/DeviceAuthorizationDetailsValidatorTests.cs
@@ -83,15 +83,21 @@ public class DeviceAuthorizationDetailsValidatorTests
     public async Task APolicyThatDropsEveryEntry_IsAFault(bool inPlace)
     {
         var context = Context((JsonArray)Requested.DeepClone());
-        var validator = new DeviceAuthorizationDetailsValidator(
-            inPlace
-                ? StubAuthorizationDetailsPolicy.ClearingInPlace
-                : StubAuthorizationDetailsPolicy.Emptying);
+        var policy = inPlace
+            ? StubAuthorizationDetailsPolicy.ClearingInPlace
+            : StubAuthorizationDetailsPolicy.Emptying;
+        var validator = new DeviceAuthorizationDetailsValidator(policy);
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
             () => validator.ValidateAsync(context));
 
         Assert.Contains(nameof(IAuthorizationDetailsPolicy), thrown.Message, StringComparison.Ordinal);
         Assert.Null(context.AuthorizationDetails);
+
+        // The premise the guard rests on: the policy is handed the live array, so the in-place shape
+        // empties the very thing a guard reading the request afterwards would count.
+        Assert.Same(context.Request.AuthorizationDetails, policy.LastSeen);
+        if (inPlace)
+            Assert.Empty(context.Request.AuthorizationDetails!);
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/EndSessionRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/EndSessionRequestProcessorTests.cs
@@ -526,6 +526,55 @@ public class EndSessionRequestProcessorTests
             Times.Once);
         Assert.Single(response.FrontChannelLogoutRequestUris);
     }
+    /// <summary>
+    /// A client provider that adds to the session while it answers does not fault the logout.
+    /// </summary>
+    /// <remarks>
+    /// The provider is a host seam and it is asked inside this walk, so walking the collection the
+    /// session carries is walking something an implementation can change mid-iteration. What makes
+    /// the walk immune is that the list is taken ONCE, eagerly, before the first client is asked
+    /// about: a lazy read written in the same place reads the live collection just as the plain loop
+    /// did, and passes every other row here. The failure is not a client quietly lost but a faulted
+    /// request, arriving after the end user is already signed out and their tokens revoked.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_AClientProviderGrowingTheSessionWhileItAnswers_StillCompletes()
+    {
+        // Arrange
+        var request = CreateValidEndSessionRequest();
+        var authSession = CreateAuthSession() with
+        {
+            AffectedClientIds = new List<string> { "client_1" },
+        };
+
+        _authSessionService
+            .Setup(s => s.AuthenticateAsync())
+            .ReturnsAsync(authSession);
+
+        _authSessionService
+            .Setup(s => s.SignOutAsync())
+            .Returns(Task.CompletedTask);
+
+        _issuerProvider
+            .Setup(p => p.GetIssuer())
+            .Returns(Issuer);
+
+        _clientInfoProvider
+            .Setup(p => p.TryFindClientAsync("client_1"))
+            .Callback(() => authSession.AffectedClientIds.Add("arrived-while-answering"))
+            .ReturnsAsync(new ClientInfo("client_1"));
+
+        _logoutNotifier
+            .Setup(n => n.NotifyClientAsync(It.IsAny<ClientInfo>(), It.IsAny<LogoutContext>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _processor.ProcessAsync(request);
+
+        // Assert
+        Assert.True(result.TryGetSuccess(out _));
+        Assert.Contains("arrived-while-answering", authSession.AffectedClientIds);
+    }
 
     /// <summary>
     /// Verifies sign out is called before client notification.

--- a/tests/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/EndSessionRequestProcessorTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Endpoints/EndSession/EndSessionRequestProcessorTests.cs
@@ -470,6 +470,62 @@ public class EndSessionRequestProcessorTests
         Assert.Single(response.FrontChannelLogoutRequestUris);
         Assert.Equal("https://client1.example.com/logout", response.FrontChannelLogoutRequestUris[0].ToString());
     }
+    /// <summary>
+    /// A session naming one client twice tells that client once.
+    /// </summary>
+    /// <remarks>
+    /// The collection is public and a host may supply a list, so the same client can be named more
+    /// than once - the authorization endpoint records each client once but cannot stop a host from
+    /// handing over a session that already repeats one. Walked as it arrives, that is a second
+    /// notification to a client that has already been told, and a second identical entry in the
+    /// list the browser is asked to walk.
+    /// </remarks>
+    [Fact]
+    public async Task ProcessAsync_ASessionNamingOneClientTwice_TellsItOnce()
+    {
+        // Arrange
+        var request = CreateValidEndSessionRequest();
+        var authSession = CreateAuthSession() with
+        {
+            AffectedClientIds = new List<string> { "client_1", "client_1" },
+        };
+
+        var client1 = new ClientInfo("client_1");
+
+        _authSessionService
+            .Setup(s => s.AuthenticateAsync())
+            .ReturnsAsync(authSession);
+
+        _authSessionService
+            .Setup(s => s.SignOutAsync())
+            .Returns(Task.CompletedTask);
+
+        _issuerProvider
+            .Setup(p => p.GetIssuer())
+            .Returns(Issuer);
+
+        _clientInfoProvider
+            .Setup(p => p.TryFindClientAsync("client_1"))
+            .ReturnsAsync(client1);
+
+        _logoutNotifier
+            .Setup(n => n.NotifyClientAsync(It.IsAny<ClientInfo>(), It.IsAny<LogoutContext>()))
+            .Callback<ClientInfo, LogoutContext>((_, context) =>
+            {
+                context.FrontChannelLogoutRequestUris.Add(new Uri("https://client1.example.com/logout"));
+            })
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _processor.ProcessAsync(request);
+
+        // Assert
+        Assert.True(result.TryGetSuccess(out var response));
+        _logoutNotifier.Verify(
+            n => n.NotifyClientAsync(client1, It.IsAny<LogoutContext>()),
+            Times.Once);
+        Assert.Single(response.FrontChannelLogoutRequestUris);
+    }
 
     /// <summary>
     /// Verifies sign out is called before client notification.

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/AuthorizationDetailsPolicyTests.cs
@@ -227,18 +227,18 @@ public class AuthorizationDetailsPolicyTests
     }
 
     [Fact]
-    public async Task ApplyAsync_returns_null_when_raw_is_null_or_empty()
+    public async Task ApplyAsync_returns_an_empty_set_when_raw_is_null_or_empty()
     {
         var sp = BuildProvider();
         var composite = sp.GetRequiredService<IAuthorizationDetailsPolicy>();
 
         var resultNull = await composite.ApplyAsync(null, TestClient, TestContext.Current.CancellationToken);
         Assert.True(resultNull.TryGetSuccess(out var validatedNull));
-        Assert.Null(validatedNull);
+        Assert.Empty(validatedNull);
 
         var resultEmpty = await composite.ApplyAsync(new JsonArray(), TestClient, TestContext.Current.CancellationToken);
         Assert.True(resultEmpty.TryGetSuccess(out var validatedEmpty));
-        Assert.Null(validatedEmpty);
+        Assert.Empty(validatedEmpty);
     }
 
     [Fact]
@@ -608,13 +608,13 @@ public class AuthorizationDetailsPolicyTests
 
         public ClientInfo? LastClient { get; private set; }
 
-        public Task<Result<JsonArray?, OidcError>> ApplyAsync(
+        public Task<Result<JsonArray, OidcError>> ApplyAsync(
             JsonArray? raw, ClientInfo client, CancellationToken token)
         {
             LastRaw = raw;
             LastClient = client;
 
-            return Task.FromResult<Result<JsonArray?, OidcError>>(
+            return Task.FromResult<Result<JsonArray, OidcError>>(
                 new OidcError(ErrorCodes.InvalidAuthorizationDetails, Reason));
         }
     }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/GrantedRevalidationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/GrantedRevalidationTests.cs
@@ -191,16 +191,16 @@ public class GrantedRevalidationTests
         }
     }
 
-    /// <summary>A dispatch of the shape a host may register: edits what it is handed, answers null.</summary>
+    /// <summary>A dispatch of the shape a host may register: edits what it is handed, answers an empty set.</summary>
     private sealed class InPlaceEditingPolicy : IAuthorizationDetailsPolicy
     {
-        public Task<Result<JsonArray?, OidcError>> ApplyAsync(
+        public Task<Result<JsonArray, OidcError>> ApplyAsync(
             JsonArray? raw, ClientInfo client, CancellationToken token)
         {
             if (raw?[0] is JsonObject entry)
                 entry["instructedAmount"]!["amount"] = "100.00";
 
-            return Task.FromResult<Result<JsonArray?, OidcError>>((JsonArray?)null);
+            return Task.FromResult<Result<JsonArray, OidcError>>(new JsonArray());
         }
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/GrantedRevalidationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/GrantedRevalidationTests.cs
@@ -118,13 +118,35 @@ public class GrantedRevalidationTests
     /// <remarks>
     /// The other half, which the shipped composite cannot produce - it always returns a fresh array - so it
     /// takes a policy of its own to reach. <see cref="IAuthorizationDetailsPolicy"/> is public and
-    /// registered with TryAdd, so a host may supply exactly this shape, and without the probe comparison
-    /// the edit would travel into the token unseen.
+    /// registered with TryAdd, so a host may supply exactly this shape. Both halves of the comparison fire
+    /// on it; what the probe comparison alone catches is
+    /// <see cref="ADispatchThatEditsInPlaceAndAnswersACopyOfWhatItWasGiven_IsARefusal"/>.
     /// </remarks>
     [Fact]
     public async Task ADispatchThatEditsInPlaceAndAnswersAnEmptySet_IsARefusal()
     {
         IAuthorizationDetailsPolicy policy = new InPlaceEditingPolicy();
+
+        var refusal = await policy.RefuseAsync(
+            GrantWith(WorkedExample), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(refusal);
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, refusal!.Value.Error.Error);
+    }
+
+    /// <summary>
+    /// A dispatch that edits in place and answers with what it was given BEFORE editing is a refusal.
+    /// </summary>
+    /// <remarks>
+    /// The one shape only the probe comparison can catch: the answer is equal to what is stored, so
+    /// reading the answer alone says nothing changed, while the array the policy was handed now carries an
+    /// amount the validators would cap. Without this the probe comparison can be deleted and every other
+    /// test still passes, which is how a guard loses its guard.
+    /// </remarks>
+    [Fact]
+    public async Task ADispatchThatEditsInPlaceAndAnswersACopyOfWhatItWasGiven_IsARefusal()
+    {
+        IAuthorizationDetailsPolicy policy = new EditingInPlaceAndAnsweringTheOriginalPolicy();
 
         var refusal = await policy.RefuseAsync(
             GrantWith(WorkedExample), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
@@ -232,5 +254,22 @@ public class GrantedRevalidationTests
         public Task<Result<JsonArray, OidcError>> ApplyAsync(
             JsonArray? raw, ClientInfo client, CancellationToken token)
             => Task.FromResult<Result<JsonArray, OidcError>>(new JsonArray());
+    }
+
+    /// <summary>
+    /// A dispatch that edits what it was handed and answers with a copy taken before the edit.
+    /// </summary>
+    private sealed class EditingInPlaceAndAnsweringTheOriginalPolicy : IAuthorizationDetailsPolicy
+    {
+        public Task<Result<JsonArray, OidcError>> ApplyAsync(
+            JsonArray? raw, ClientInfo client, CancellationToken token)
+        {
+            var asGiven = (JsonArray)raw!.DeepClone();
+
+            if (raw[0] is JsonObject entry)
+                entry["instructedAmount"]!["amount"] = "100.00";
+
+            return Task.FromResult<Result<JsonArray, OidcError>>(asGiven);
+        }
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/GrantedRevalidationTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/AuthorizationDetails/GrantedRevalidationTests.cs
@@ -113,7 +113,7 @@ public class GrantedRevalidationTests
     }
 
     /// <summary>
-    /// A dispatch that edits in place and answers "nothing to change" is a refusal too.
+    /// A dispatch that edits in place and answers an empty set is a refusal too.
     /// </summary>
     /// <remarks>
     /// The other half, which the shipped composite cannot produce - it always returns a fresh array - so it
@@ -122,9 +122,31 @@ public class GrantedRevalidationTests
     /// the edit would travel into the token unseen.
     /// </remarks>
     [Fact]
-    public async Task ADispatchThatEditsInPlaceAndAnswersNull_IsARefusal()
+    public async Task ADispatchThatEditsInPlaceAndAnswersAnEmptySet_IsARefusal()
     {
         IAuthorizationDetailsPolicy policy = new InPlaceEditingPolicy();
+
+        var refusal = await policy.RefuseAsync(
+            GrantWith(WorkedExample), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(refusal);
+        Assert.Equal(ErrorCodes.InvalidAuthorizationDetails, refusal!.Value.Error.Error);
+    }
+
+    /// <summary>
+    /// A dispatch that removes every entry is a refusal, even though it touched nothing it was handed.
+    /// </summary>
+    /// <remarks>
+    /// Removing an entry is how a validator says the grant may not be issued as stored, so answering an
+    /// empty set is a refusal however it is reached. The probe comparison cannot see this one - the array
+    /// the policy was handed comes back untouched - so the answer itself has to be read, and reading it by
+    /// COUNT is what makes an empty answer indistinguishable from "nothing to change". Without this the
+    /// grant is spent carrying exactly the entries the deployment's own policy deleted.
+    /// </remarks>
+    [Fact]
+    public async Task ADispatchThatRemovesEveryEntry_IsARefusal()
+    {
+        IAuthorizationDetailsPolicy policy = new EmptyingPolicy();
 
         var refusal = await policy.RefuseAsync(
             GrantWith(WorkedExample), new ClientInfo(ClientId), TestContext.Current.CancellationToken);
@@ -202,5 +224,13 @@ public class GrantedRevalidationTests
 
             return Task.FromResult<Result<JsonArray, OidcError>>(new JsonArray());
         }
+    }
+
+    /// <summary>A dispatch that leaves its input alone and answers with every entry removed.</summary>
+    private sealed class EmptyingPolicy : IAuthorizationDetailsPolicy
+    {
+        public Task<Result<JsonArray, OidcError>> ApplyAsync(
+            JsonArray? raw, ClientInfo client, CancellationToken token)
+            => Task.FromResult<Result<JsonArray, OidcError>>(new JsonArray());
     }
 }

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/UserAuthentication/AffectedClientIdsConcurrencyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/UserAuthentication/AffectedClientIdsConcurrencyTests.cs
@@ -74,8 +74,7 @@ public class AffectedClientIdsConcurrencyTests
 
     /// <summary>
     /// The same client id arriving from several threads at once is stored once. A duplicate is not cosmetic:
-    /// it is persisted, so the stored session grows on every request and a host reading it back is handed
-    /// one client named twice.
+    /// it is persisted, so the stored session grows on every request.
     /// </summary>
     [Fact]
     public async Task The_same_client_added_concurrently_is_stored_once()

--- a/tests/Abblix.Oidc.Server.UnitTests/Features/UserAuthentication/AffectedClientIdsConcurrencyTests.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/Features/UserAuthentication/AffectedClientIdsConcurrencyTests.cs
@@ -74,7 +74,8 @@ public class AffectedClientIdsConcurrencyTests
 
     /// <summary>
     /// The same client id arriving from several threads at once is stored once. A duplicate is not cosmetic:
-    /// the end-session endpoint notifies per entry, so a client would be asked to log out twice.
+    /// it is persisted, so the stored session grows on every request and a host reading it back is handed
+    /// one client named twice.
     /// </summary>
     [Fact]
     public async Task The_same_client_added_concurrently_is_stored_once()

--- a/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/StubAuthorizationDetailsPolicy.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/StubAuthorizationDetailsPolicy.cs
@@ -44,8 +44,15 @@ internal sealed class StubAuthorizationDetailsPolicy : IAuthorizationDetailsPoli
     public static StubAuthorizationDetailsPolicy Capping(string member, string value) =>
         new() { _cap = (member, value) };
 
+    /// <summary>
+    /// Answers with every entry removed - the shape the contract forbids, which a host implementation
+    /// can still produce and which reads as "nothing to forward" wherever it is not refused.
+    /// </summary>
+    public static StubAuthorizationDetailsPolicy Emptying => new() { _empty = true };
+
     private string? _refusal;
     private (string Member, string Value)? _cap;
+    private bool _empty;
 
     /// <summary>What the last call was handed, so a test can see whether it was the live array.</summary>
     public JsonArray? LastSeen { get; private set; }
@@ -67,7 +74,8 @@ internal sealed class StubAuthorizationDetailsPolicy : IAuthorizationDetailsPoli
                     entry[cap.Member] = cap.Value;
             }
 
-            return Task.FromResult<Result<JsonArray, OidcError>>(raw ?? new JsonArray());
+            return Task.FromResult<Result<JsonArray, OidcError>>(
+                _empty ? new JsonArray() : raw ?? new JsonArray());
         }
 
         return Task.FromResult<Result<JsonArray, OidcError>>(

--- a/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/StubAuthorizationDetailsPolicy.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/StubAuthorizationDetailsPolicy.cs
@@ -53,7 +53,7 @@ internal sealed class StubAuthorizationDetailsPolicy : IAuthorizationDetailsPoli
     /// <summary>How many times the granted-phase question was asked.</summary>
     public int GrantedCalls { get; private set; }
 
-    public Task<Result<JsonArray?, OidcError>> ApplyAsync(
+    public Task<Result<JsonArray, OidcError>> ApplyAsync(
         JsonArray? raw,
         ClientInfo client,
         CancellationToken token)
@@ -67,14 +67,14 @@ internal sealed class StubAuthorizationDetailsPolicy : IAuthorizationDetailsPoli
                     entry[cap.Member] = cap.Value;
             }
 
-            return Task.FromResult<Result<JsonArray?, OidcError>>(raw);
+            return Task.FromResult<Result<JsonArray, OidcError>>(raw ?? new JsonArray());
         }
 
-        return Task.FromResult<Result<JsonArray?, OidcError>>(
+        return Task.FromResult<Result<JsonArray, OidcError>>(
             new OidcError(ErrorCodes.InvalidAuthorizationDetails, _refusal));
     }
 
-    public Task<Result<JsonArray?, OidcError>> ApplyGrantedAsync(
+    public Task<Result<JsonArray, OidcError>> ApplyGrantedAsync(
         JsonArray? granted,
         ClientInfo client,
         CancellationToken token)

--- a/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/StubAuthorizationDetailsPolicy.cs
+++ b/tests/Abblix.Oidc.Server.UnitTests/TestInfrastructure/StubAuthorizationDetailsPolicy.cs
@@ -50,9 +50,16 @@ internal sealed class StubAuthorizationDetailsPolicy : IAuthorizationDetailsPoli
     /// </summary>
     public static StubAuthorizationDetailsPolicy Emptying => new() { _empty = true };
 
+    /// <summary>
+    /// Answers with every entry removed, having removed them from the array it was handed - which is how
+    /// every narrowing validator in this repository edits, so it is the likelier of the two shapes.
+    /// </summary>
+    public static StubAuthorizationDetailsPolicy ClearingInPlace => new() { _empty = true, _clear = true };
+
     private string? _refusal;
     private (string Member, string Value)? _cap;
     private bool _empty;
+    private bool _clear;
 
     /// <summary>What the last call was handed, so a test can see whether it was the live array.</summary>
     public JsonArray? LastSeen { get; private set; }
@@ -73,6 +80,9 @@ internal sealed class StubAuthorizationDetailsPolicy : IAuthorizationDetailsPoli
                 foreach (var entry in raw.OfType<JsonObject>())
                     entry[cap.Member] = cap.Value;
             }
+
+            if (_clear)
+                raw?.Clear();
 
             return Task.FromResult<Result<JsonArray, OidcError>>(
                 _empty ? new JsonArray() : raw ?? new JsonArray());

--- a/tests/Abblix.SecurityEvents.UnitTests/CustodianHeldSigningTests.cs
+++ b/tests/Abblix.SecurityEvents.UnitTests/CustodianHeldSigningTests.cs
@@ -89,7 +89,8 @@ public class CustodianHeldSigningTests
         resolved = host;
 
         // Startup validation is satisfied: the guard the custodian registration armed has an answer.
-        host.GetRequiredService<IStartupValidator>().Validate();
+        await host.GetRequiredService<IAsyncStartupValidator>()
+            .ValidateAsync(TestContext.Current.CancellationToken);
 
         var compact = await new SecurityEventTokenBuilder()
             .WithIssuer(Issuer)

--- a/tests/Abblix.Utils.UnitTests/ResultExtensionsTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ResultExtensionsTests.cs
@@ -20,7 +20,14 @@ namespace Abblix.Utils.UnitTests;
 /// </remarks>
 public class ResultExtensionsTests
 {
-    private const string Failure = "refused";
+    /// <summary>A failure that is not a string, because the success here is one.</summary>
+    /// <remarks>
+    /// The two arms of a result are told apart by their type, so a result whose arms are the same type
+    /// cannot say which one it carries - and every accessor on it answers yes.
+    /// </remarks>
+    private sealed record Refusal(string Reason);
+
+    private static readonly Refusal Failure = new("refused");
 
     [Fact]
     public void Ensure_ASatisfiedPredicate_KeepsTheValue()

--- a/tests/Abblix.Utils.UnitTests/ResultTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ResultTests.cs
@@ -293,10 +293,14 @@ public class ResultTests
     /// the factory is told nothing at the point where it could still be fixed - the refusal arrives at
     /// whoever reads the result.
     /// </remarks>
-    [Fact]
-    public void ACaseBuiltFromNullIsTheValueCarryingNeitherArm()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ACaseBuiltFromNullIsTheValueCarryingNeitherArm(bool asSuccess)
     {
-        var fromNull = Result<string, int>.Success(null!);
+        var fromNull = asSuccess
+            ? Result<string, string[]>.Success(null!)
+            : Result<string, string[]>.Failure(null!);
 
         Assert.False(fromNull.TryGetSuccess(out _));
         Assert.False(fromNull.TryGetFailure(out _));

--- a/tests/Abblix.Utils.UnitTests/ResultTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ResultTests.cs
@@ -254,12 +254,13 @@ public class ResultTests
         var neither = default(Result<int, string>);
 
         // The getters name the state they met, rather than the arm the caller happened to ask for: a
-        // message saying "not a failure" sends whoever reads it to audit the failure path.
+        // message saying "not a failure" sends whoever reads it to audit the failure path. Asserted by
+        // what the message must SAY - a pair of "does not contain" passes for an empty message too.
         var onSuccess = Assert.Throws<InvalidOperationException>(() => neither.GetSuccess());
         var onFailure = Assert.Throws<InvalidOperationException>(() => neither.GetFailure());
         Assert.Equal(onSuccess.Message, onFailure.Message);
-        Assert.DoesNotContain("not a success", onSuccess.Message);
-        Assert.DoesNotContain("not a failure", onFailure.Message);
+        Assert.StartsWith(
+            "The result carries neither a success nor a failure.", onSuccess.Message, StringComparison.Ordinal);
 
         Assert.Throws<InvalidOperationException>(() => (int)neither);
         Assert.Throws<InvalidOperationException>(
@@ -276,9 +277,32 @@ public class ResultTests
         Assert.False(neither.TryGetFailure(out _));
 
         var (value, error) = neither;
-        Assert.Equal(default, value);
+        Assert.Equal(0, value);
         Assert.Null(error);
 
         Assert.Equal("a result carrying neither case", neither.ToString());
+    }
+
+    /// <summary>
+    /// A case built from a null value lands in that same state, rather than in a case whose value is null.
+    /// </summary>
+    /// <remarks>
+    /// The second door into it, and the one a caller can walk through by accident: a union stores its
+    /// content as an object and a type pattern does not match null, so there is nothing to tell the two
+    /// apart afterwards. Driven because the type documents it, and because a producer that hands null to
+    /// the factory is told nothing at the point where it could still be fixed - the refusal arrives at
+    /// whoever reads the result.
+    /// </remarks>
+    [Fact]
+    public void ACaseBuiltFromNullIsTheValueCarryingNeitherArm()
+    {
+        var fromNull = Result<string, int>.Success(null!);
+
+        Assert.False(fromNull.TryGetSuccess(out _));
+        Assert.False(fromNull.TryGetFailure(out _));
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => fromNull.GetSuccess());
+        Assert.StartsWith(
+            "The result carries neither a success nor a failure.", thrown.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/Abblix.Utils.UnitTests/ResultTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ResultTests.cs
@@ -154,13 +154,13 @@ public class ResultTests
     public void BindContinuesOnSuccessAndStopsOnFailure()
     {
         Assert.Equal(
-            "42", Ok().Bind(value => Result<string, string>.Success(value.ToString())).GetSuccess());
+            42L, Ok().Bind(value => Result<long, string>.Success(value)).GetSuccess());
 
         Assert.Equal(
-            "refused", No().Bind(value => Result<string, string>.Success(value.ToString())).GetFailure());
+            "refused", No().Bind(value => Result<long, string>.Success(value)).GetFailure());
 
         // A step that refuses turns the chain into that refusal.
-        Assert.Equal("second step said no", Ok().Bind(_ => Result<string, string>.Failure("second step said no"))
+        Assert.Equal("second step said no", Ok().Bind(_ => Result<long, string>.Failure("second step said no"))
             .GetFailure());
     }
 
@@ -180,13 +180,13 @@ public class ResultTests
     public async Task BindingAsynchronouslyContinuesOnSuccessAndStopsOnFailure()
     {
         Assert.Equal(
-            "42",
-            (await Ok().BindAsync(value => Task.FromResult(Result<string, string>.Success(value.ToString()))))
+            42L,
+            (await Ok().BindAsync(value => Task.FromResult(Result<long, string>.Success(value))))
             .GetSuccess());
 
         Assert.Equal(
             "refused",
-            (await No().BindAsync(value => Task.FromResult(Result<string, string>.Success(value.ToString()))))
+            (await No().BindAsync(value => Task.FromResult(Result<long, string>.Success(value))))
             .GetFailure());
     }
 

--- a/tests/Abblix.Utils.UnitTests/ResultTests.cs
+++ b/tests/Abblix.Utils.UnitTests/ResultTests.cs
@@ -234,4 +234,51 @@ public class ResultTests
         Assert.Equal("42", Ok().ToString());
         Assert.Equal("refused", No().ToString());
     }
+
+    /// <summary>
+    /// The value carrying neither arm, which a union has and the hierarchy it replaced did not.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in the library produces one, so every assertion here is about a value that arrives by
+    /// accident: an uninitialised field, a loose mock answering with the default of the return type, or
+    /// <c>GetValueOrDefault</c> on a nullable result. Each of those reads as an ordinary result at the
+    /// call site, so what the members do with it decides whether the mistake is reported or travels.
+    /// <para>
+    /// Driven because the type's own documentation says what this state does, and a sentence about a
+    /// state no test constructs is a claim rather than a behaviour.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheValueCarryingNeitherArmIsRefusedRatherThanAnswered()
+    {
+        var neither = default(Result<int, string>);
+
+        // The getters name the state they met, rather than the arm the caller happened to ask for: a
+        // message saying "not a failure" sends whoever reads it to audit the failure path.
+        var onSuccess = Assert.Throws<InvalidOperationException>(() => neither.GetSuccess());
+        var onFailure = Assert.Throws<InvalidOperationException>(() => neither.GetFailure());
+        Assert.Equal(onSuccess.Message, onFailure.Message);
+        Assert.DoesNotContain("not a success", onSuccess.Message);
+        Assert.DoesNotContain("not a failure", onFailure.Message);
+
+        Assert.Throws<InvalidOperationException>(() => (int)neither);
+        Assert.Throws<InvalidOperationException>(
+            () => neither.Match(value => $"ok:{value}", error => $"no:{error}"));
+        Assert.Throws<InvalidOperationException>(() => neither.MapSuccess(value => value + 1));
+        Assert.Throws<InvalidOperationException>(() => neither.MapFailure(error => error.Length));
+        Assert.Throws<InvalidOperationException>(
+            () => neither.Bind(value => Result<long, string>.Success(value)));
+        Assert.Throws<InvalidOperationException>(() => neither.Ensure(value => value > 0, "refused"));
+
+        // The pair that answers a question rather than producing a value says no to both, which is the
+        // only answer that is true of a value carrying neither arm.
+        Assert.False(neither.TryGetSuccess(out _));
+        Assert.False(neither.TryGetFailure(out _));
+
+        var (value, error) = neither;
+        Assert.Equal(default, value);
+        Assert.Null(error);
+
+        Assert.Equal("a result carrying neither case", neither.ToString());
+    }
 }


### PR DESCRIPTION
Result carried every protocol decision this library makes as an abstract record with two sealed cases. C# 15 has unions and 3.0 targets .NET 11, so the type is now

```csharp
public union Result<TSuccess, TFailure>(TSuccess, TFailure)
```

with the case records gone and every combinator kept: `Match`, `MapSuccess`, `MapFailure`, `Map`, `Bind`, `BindAsync`, `Ensure`, `TryGetSuccess`, `TryGetFailure`, deconstruction, the explicit conversion to the success value, and the conversions that let a method body return either arm bare.

## What the union cannot express, and what it cost

A union stores its content as an object and a type pattern never matches null, so a success whose value is null has no representation. Two places had one, and they meant opposite things.

The authorization-details policy answered null for "nothing to forward", which its callers already read as emptiness. Its success is a non-nullable `JsonArray` now; the callers test the count, and an implementation that would leave nothing of a non-empty input is treated as a fault, because dropping every entry says the request may not be honoured as asked. One branch of the consent enforcer went with it: that call is guarded on a non-empty granted set, so the policy could never have answered null there.

The requested-subject reader answered null for "the request named nobody" and an empty set for "it named a combination nobody can satisfy". At the session filter those are opposites, so the second is now a refusal naming the contradiction rather than a set that matches no session and sends the end user to authenticate for a request no authentication could answer. OpenID Connect Core 1.0 section 5.5.1 already prescribes the outcome: a `sub` mismatch "MUST cause the authentication to fail".

A union also tells its arms apart by type, so `Result<T, T>` cannot say which arm it carries and every accessor on it answers yes. It occurred only in the tests of `Result` itself, which now use distinct arms. And a case built from a null value lands in the same state as `default`, which the type documents and a test drives.

## Behaviour a deployment will notice

- A `claims` request whose `sub` qualifiers name nobody who can satisfy them all, or that carries an empty list of acceptable values, is answered `invalid_request` at both endpoints that accept the parameter.
- An implementation of `IAuthorizationDetailsPolicy` that answers with nothing for a request carrying entries is treated as a fault rather than as consent.
- `Result` is a value type now, so a host writing against these interfaces has nothing to test for absence, and a value carrying neither arm raises an error naming that state when it is read.
- The list of clients a session touches is read by walking it rather than by copying out of it, so a second request adding a client while the first reads no longer fails that first request after its own client was recorded and before the store was told.
- Every path that reads that list reads it once. A host-supplied list naming one client twice produces one logout notification and one entry in the response rather than a pair of each, and the platform adapter carries the whole list across a sign-in instead of dropping the property when the list was empty at the moment its size was asked and filled a moment after. Each of those outcomes is a client left signed in after the end user has logged out, which nothing downstream reports.

Release notes for 3.0 carry these, plus the platform line.

## A class the review found, and the walker that keeps it closed

Everything reached through an interface here is a seam a host can occupy, and narrowing by editing what you were given is how narrowing is written throughout this repository. So a caller that hands an object to such a call and afterwards measures anything against that same object is asking a question the callee has already had the chance to change the answer to - and nothing says so.

The sharpest instance: the authorization endpoint handed the consent provider the array the request carries and then decided from that same array whether the end user had denied everything. A provider that narrows by emptying it turned the denial into a successful authorization carrying no `authorization_details` at all, which neither the client nor the resource server can detect. The list of clients a session touches had the mirror of it - a provider that removed an entry, added another, or cleared the list changed what logout could reach, in one direction or the other.

`ValueHandedToAHostSeamTests` walks the library's sources for that shape. Its population comes from the artefact rather than a list: a method declared on an interface is a method a host can supply the body of, and a member is lendable when its declared type can be edited in place. Everything it found now decides from a value read before the call, except the registration endpoints, which read back on purpose and say so at the site, in a declaration that names every member it excuses and fails when it stops describing a real read. The walker has its own probes over a synthetic source, so its reach is pinned by what it can see rather than by what the library happens to contain, and the shapes it is blind to are written into the test rather than left implied. Two sites it could not see were found by review and closed here: enumeration is not a member access, so a loop over a lent value whose body calls the seam is outside its reach, and a value re-read with no seam call between the reads is outside it entirely. Both are now named where that list of blind spots is, because a clean run of an instrument means only as much as the questions it asked.

## Build changes

One analyser rule crashes on a union declaration rather than reporting anything: it throws, which arrives as `AD0001` and fails a build that treats warnings as errors. It reproduces on the newest analyser available, so it is a gap in the tool rather than a stale pin. The rule is switched off for the one file that declares a union, not everywhere, so the length of that list stays the reminder that this is owed back upstream.

A restore against fresh advisory data failed every packable project: the explicit SourceLink reference pulls in a package carrying a moderate advisory, which auditing reports at every level up to moderate, and warnings are errors here. The build only looked green because the advisory data in the local cache predated the advisory. The SDK has carried SourceLink since .NET 8 and this repository targets .NET 11, so the package is gone and the generated source-link map still names the repository and the commit being built.

The properties that make a build independent of the directory it ran in were pasted into every project, and that enumeration had already been escaped: the shared transport assembly ships inside both adapter packages and carried none of them, so its published symbols named a build directory, and a consumer who happened to hold a checkout at that path was shown source from whatever revision sat there. They live in one file for the whole of `src` now.

`global.json` named a preview SDK and left roll-forward on, so the runners resolved a whole feature band ahead of it and built on the release candidate, where the synchronous startup-validation interface is obsolete: six errors no local build could produce, and every measurement taken on this branch made against an SDK no runner uses. The file names the release candidate exactly now, with roll-forward off, so a machine without that build refuses instead of substituting its own, and the startup validation the affected tests drive is awaited through the interface that replaces the obsolete one.

## Verification

Full suite on the .NET 11 release candidate named in `global.json`: green, with no build warnings. Every guard added here was driven by deleting or inverting it and reading what went red, at each call site separately; every capability of the walker likewise.


